### PR TITLE
fix: use createErrorPanel in handleIgnoreFile when returning No changed files

### DIFF
--- a/files_panel.go
+++ b/files_panel.go
@@ -100,7 +100,7 @@ func handleFileRemove(g *gocui.Gui, v *gocui.View) error {
 func handleIgnoreFile(g *gocui.Gui, v *gocui.View) error {
 	file, err := getSelectedFile(g)
 	if err != nil {
-		return err
+		return createErrorPanel(g, err.Error())
 	}
 	if file.Tracked {
 		return createErrorPanel(g, "Cannot ignore tracked files")


### PR DESCRIPTION
When the local repository is clean, press i(ignore) will crash with panic: No changed files. So I change the code to return createErrorPanel instead of the original err to prevent it from crashing.