### PR TITLE
Set minimal ubuntu version supported by ppa

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please note:
 If you get an error claiming that lazygit cannot be found or is not defined, you may need to add `~/go/bin` to your $PATH (MacOS/Linux), or `%HOME%\go\bin` (Windows)
 
 ### Ubuntu
-Packages for Ubuntu 14.04 and up are available via Launchpad PPA.
+Packages for Ubuntu 16.04 and up are available via Launchpad PPA.
 
 They are built daily, straight from master branch.
 


### PR DESCRIPTION
Lazygit needs at least golang-1.7 which is not available in trusty (14.04).