### PR TITLE
Allow to display the buiid date & hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
 # - go get -v ./...
 # - diff -u <(echo -n) <(gofmt -d .) # can't make gofmt ignore vendor directory
 # - go vet $(go list ./... | grep -v /vendor/)
-  - if [ "${LATEST}" = "true" ]; then gox -os="linux darwin windows" -arch="amd64" -output="lazygit.." -ldflags "-X main.Rev=`git rev-parse --short HEAD`" -verbose ./...; fi
+  - if [ "${LATEST}" = "true" ]; then gox -os="linux darwin windows" -arch="amd64" -output="lazygit.." -ldflags "-X main.Rev=`git rev-parse --short HEAD` -X main.builddate=`date -u +%Y%m%d.%H%M%S`" -verbose ./...; fi
 deploy:
   provider: releases
   skip_cleanup: true

--- a/main.go
+++ b/main.go
@@ -14,6 +14,10 @@ import (
 var (
 	startTime time.Time
 	debugging bool
+	Rev string
+	builddate string
+	debuggingPointer = flag.Bool("debug", false, "a boolean")
+	versionFlag = flag.Bool("v", false, "Print the current version")
 )
 
 func homeDirectory() string {
@@ -58,11 +62,14 @@ func navigateToRepoRootDirectory() {
 }
 
 func main() {
-	debuggingPointer := flag.Bool("debug", false, "a boolean")
-	flag.Parse()
+	startTime = time.Now()
 	debugging = *debuggingPointer
 	devLog("\n\n\n\n\n\n\n\n\n\n")
-	startTime = time.Now()
+	flag.Parse()
+	if *versionFlag {
+		fmt.Printf("rev=%s, build date=%s", Rev, builddate)
+		os.Exit(0)
+	}
 	verifyInGitRepo()
 	navigateToRepoRootDirectory()
 	run()


### PR DESCRIPTION
One can use `-v` or `--v` to get the revision and build date from the command line, e.g. `rev=51d3e67, build date=20180807.140953`. It might be a way to get the proper tag if available (`git describe --always --long --dirty` [see this](https://stackoverflow.com/questions/16035240/why-is-git-describe-dirty-adding-a-dirty-suffix-when-describing-a-clean-ch)) 