### PR TITLE
Step one on restoring multiline commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Are YOU tired of typing every git command directly into the terminal, but you're
 
 ![Gif](https://image.ibb.co/mmeXho/optimisedgif.gif)
 
+[Twitch Stream](https://www.twitch.tv/jesseduffield)
+
 ## Installation
 
 ### Homebrew
@@ -74,3 +76,6 @@ We love your input! Please check out the [contributing guide](CONTRIBUTING.md).
 
 ## Work in progress
 This is still a work in progress so there's still bugs to iron out and as this is my first project in Go the code could no doubt use an increase in quality, but I'll be improving on it whenever I find the time. If you have any feedback feel free to [raise an issue](https://github.com/jesseduffield/lazygit/issues)/[submit a PR](https://github.com/jesseduffield/lazygit/pulls).
+
+## Social
+If you want to see what I (Jesse) am up to in terms of development, follow me on [twitter](https://twitter.com/DuffieldJesse) or watch me program on [twitch](https://www.twitch.tv/jesseduffield)

--- a/ZHgalGrWSF
+++ b/ZHgalGrWSF
@@ -1,0 +1,1 @@
+GaUMygWjJa

--- a/ZHgalGrWSF
+++ b/ZHgalGrWSF
@@ -1,1 +1,0 @@
-GaUMygWjJa

--- a/branches_panel.go
+++ b/branches_panel.go
@@ -30,7 +30,7 @@ func handleForceCheckout(g *gocui.Gui, v *gocui.View) error {
 }
 
 func handleCheckoutByName(g *gocui.Gui, v *gocui.View) error {
-	createPromptPanel(g, v, "Branch Name:", nil, func(g *gocui.Gui, v *gocui.View) error {
+	createPromptPanel(g, v, "Branch Name:", func(g *gocui.Gui, v *gocui.View) error {
 		if output, err := gitCheckout(trimmedContent(v), false); err != nil {
 			return createErrorPanel(g, output)
 		}
@@ -41,7 +41,7 @@ func handleCheckoutByName(g *gocui.Gui, v *gocui.View) error {
 
 func handleNewBranch(g *gocui.Gui, v *gocui.View) error {
 	branch := state.Branches[0]
-	createPromptPanel(g, v, "New Branch Name (Branch is off of "+branch.Name+")", nil, func(g *gocui.Gui, v *gocui.View) error {
+	createPromptPanel(g, v, "New Branch Name (Branch is off of "+branch.Name+")", func(g *gocui.Gui, v *gocui.View) error {
 		if output, err := gitNewBranch(trimmedContent(v)); err != nil {
 			return createErrorPanel(g, output)
 		}

--- a/commit_message_panel.go
+++ b/commit_message_panel.go
@@ -1,0 +1,43 @@
+package main
+
+import "github.com/jesseduffield/gocui"
+
+func handleCommitConfirm(g *gocui.Gui, v *gocui.View) error {
+	message := trimmedContent(v)
+	if message == "" {
+		return createErrorPanel(g, "You cannot commit without a commit message")
+	}
+	if output, err := gitCommit(g, message); err != nil {
+		if err == errNoUsername {
+			return createErrorPanel(g, err.Error())
+		}
+		return createErrorPanel(g, output)
+	}
+	refreshFiles(g)
+	g.SetViewOnBottom("commitMessage")
+	switchFocus(g, v, getFilesView(g))
+	return refreshCommits(g)
+}
+
+func handleCommitClose(g *gocui.Gui, v *gocui.View) error {
+	g.SetViewOnBottom("commitMessage")
+	return switchFocus(g, v, getFilesView(g))
+}
+
+func handleNewlineCommitMessage(g *gocui.Gui, v *gocui.View) error {
+	// resising ahead of time so that the top line doesn't get hidden to make
+	// room for the cursor on the second line
+	x0, y0, x1, y1 := getConfirmationPanelDimensions(g, v.Buffer())
+	if _, err := g.SetView("commitMessage", x0, y0, x1, y1+1, 0); err != nil {
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+	}
+
+	v.EditNewLine()
+	return nil
+}
+
+func handleCommitFocused(g *gocui.Gui, v *gocui.View) error {
+	return renderString(g, "options", "esc: close, enter: confirm")
+}

--- a/commits_panel.go
+++ b/commits_panel.go
@@ -109,7 +109,7 @@ func handleRenameCommit(g *gocui.Gui, v *gocui.View) error {
 	if getItemPosition(v) != 0 {
 		return createErrorPanel(g, "Can only rename topmost commit")
 	}
-	createPromptPanel(g, v, "Rename Commit", nil, func(g *gocui.Gui, v *gocui.View) error {
+	createPromptPanel(g, v, "Rename Commit", func(g *gocui.Gui, v *gocui.View) error {
 		if output, err := gitRenameCommit(v.Buffer()); err != nil {
 			return createErrorPanel(g, output)
 		}

--- a/files_panel.go
+++ b/files_panel.go
@@ -15,9 +15,8 @@ import (
 )
 
 var (
-	savedCommitMessage = &[]byte{}
-	errNoFiles         = errors.New("No changed files")
-	errNoUsername      = errors.New(`No username set. Please do: git config --global user.name "Your Name"`)
+	errNoFiles    = errors.New("No changed files")
+	errNoUsername = errors.New(`No username set. Please do: git config --global user.name "Your Name"`)
 )
 
 func stagedFiles(files []GitFile) []GitFile {
@@ -178,19 +177,11 @@ func handleCommitPress(g *gocui.Gui, filesView *gocui.View) error {
 	if len(stagedFiles(state.GitFiles)) == 0 && !state.HasMergeConflicts {
 		return createErrorPanel(g, "There are no staged files to commit")
 	}
-	createPromptPanel(g, filesView, "Commit message", savedCommitMessage, func(g *gocui.Gui, v *gocui.View) error {
-		message := trimmedContent(v)
-		if message == "" {
-			return createErrorPanel(g, "You cannot commit without a commit message")
-		}
-		if output, err := gitCommit(g, message); err != nil {
-			if err == errNoUsername {
-				return createErrorPanel(g, err.Error())
-			}
-			return createErrorPanel(g, output)
-		}
-		refreshFiles(g)
-		return refreshCommits(g)
+	commitMessageView := getCommitMessageView(g)
+	g.Update(func(g *gocui.Gui) error {
+		g.SetViewOnTop("commitMessage")
+		switchFocus(g, filesView, commitMessageView)
+		return nil
 	})
 	return nil
 }

--- a/gitcommands.go
+++ b/gitcommands.go
@@ -107,13 +107,11 @@ func mergeGitStatusFiles(oldGitFiles, newGitFiles []GitFile) []GitFile {
 }
 
 func runDirectCommand(command string) (string, error) {
-	timeStart := time.Now()
 	commandLog(command)
 
 	cmdOut, err := exec.
 		Command(state.Platform.shell, state.Platform.shellArg, command).
 		CombinedOutput()
-	devLog("run direct command time for command: ", command, time.Now().Sub(timeStart))
 	return sanitisedCommandOutput(cmdOut, err)
 }
 
@@ -218,12 +216,9 @@ func sanitisedCommandOutput(output []byte, err error) (string, error) {
 }
 
 func runCommand(command string) (string, error) {
-	commandStartTime := time.Now()
 	commandLog(command)
 	splitCmd := strings.Split(command, " ")
-	devLog(splitCmd)
 	cmdOut, err := exec.Command(splitCmd[0], splitCmd[1:]...).CombinedOutput()
-	devLog("run command time: ", time.Now().Sub(commandStartTime))
 	return sanitisedCommandOutput(cmdOut, err)
 }
 

--- a/gui.go
+++ b/gui.go
@@ -199,14 +199,25 @@ func layout(g *gocui.Gui) error {
 		if err != gocui.ErrUnknownView {
 			return err
 		}
-		v.BgColor = gocui.ColorDefault
 		v.FgColor = gocui.ColorBlue
 		v.Frame = false
 	}
 
-	if err = resizeConfirmationPanel(g); err != nil {
-		return err
+	if getCommitMessageView(g) == nil {
+		// doesn't matter where this view starts because it will be hidden
+		if commitMessageView, err := g.SetView("commitMessage", 0, 0, width, height, 0); err != nil {
+			if err != gocui.ErrUnknownView {
+				return err
+			}
+			g.SetViewOnBottom("commitMessage")
+			commitMessageView.Title = "Commit message"
+			commitMessageView.FgColor = gocui.ColorWhite
+			commitMessageView.Editable = true
+		}
 	}
+
+	resizeConfirmationPanel(g, "commitMessage")
+	resizeConfirmationPanel(g, "confirmation")
 
 	if v, err := g.SetView("version", width-len(version)-1, optionsTop, width, optionsTop+2, 0); err != nil {
 		if err != gocui.ErrUnknownView {

--- a/gui.go
+++ b/gui.go
@@ -216,8 +216,12 @@ func layout(g *gocui.Gui) error {
 		}
 	}
 
-	resizeConfirmationPanel(g, "commitMessage")
-	resizeConfirmationPanel(g, "confirmation")
+	if err = resizeConfirmationPanel(g, "commitMessage"); err != nil {
+		return err
+	}
+	if err = resizeConfirmationPanel(g, "confirmation"); err != nil {
+		return err
+	}
 
 	if v, err := g.SetView("version", width-len(version)-1, optionsTop, width, optionsTop+2, 0); err != nil {
 		if err != gocui.ErrUnknownView {

--- a/keybindings.go
+++ b/keybindings.go
@@ -58,6 +58,9 @@ func keybindings(g *gocui.Gui) error {
 		{ViewName: "stash", Key: gocui.KeySpace, Modifier: gocui.ModNone, Handler: handleStashApply},
 		{ViewName: "stash", Key: 'g', Modifier: gocui.ModNone, Handler: handleStashPop},
 		{ViewName: "stash", Key: 'd', Modifier: gocui.ModNone, Handler: handleStashDrop},
+		{ViewName: "commitMessage", Key: gocui.KeyEnter, Modifier: gocui.ModNone, Handler: handleCommitConfirm},
+		{ViewName: "commitMessage", Key: gocui.KeyEsc, Modifier: gocui.ModNone, Handler: handleCommitClose},
+		{ViewName: "commitMessage", Key: gocui.KeyTab, Modifier: gocui.ModNone, Handler: handleNewlineCommitMessage},
 	}
 
 	// Would make these keybindings global but that interferes with editing

--- a/stash_panel.go
+++ b/stash_panel.go
@@ -82,7 +82,7 @@ func stashDo(g *gocui.Gui, v *gocui.View, method string) error {
 }
 
 func handleStashSave(g *gocui.Gui, filesView *gocui.View) error {
-	createPromptPanel(g, filesView, "Stash changes", nil, func(g *gocui.Gui, v *gocui.View) error {
+	createPromptPanel(g, filesView, "Stash changes", func(g *gocui.Gui, v *gocui.View) error {
 		if output, err := gitStashSave(trimmedContent(v)); err != nil {
 			createErrorPanel(g, output)
 		}

--- a/status_panel.go
+++ b/status_panel.go
@@ -32,7 +32,8 @@ func refreshStatus(g *gocui.Gui) error {
 		}
 		branch := branches[0]
 		name := coloredString(branch.Name, branch.getColor())
-		fmt.Fprint(v, " "+name)
+		repo := getCurrentProject()
+		fmt.Fprint(v, " "+repo+" → "+name)
 		return nil
 	})
 

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
@@ -39,4 +42,13 @@ func coloredString(str string, colorAttribute color.Attribute) string {
 // used for aggregating a few color attributes rather than just sending a single one
 func coloredStringDirect(str string, colour *color.Color) string {
 	return colour.SprintFunc()(fmt.Sprint(str))
+}
+
+// used to get the project name
+func getCurrentProject() string {
+	pwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	return filepath.Base(pwd)
 }

--- a/view_helpers.go
+++ b/view_helpers.go
@@ -75,6 +75,8 @@ func newLineFocused(g *gocui.Gui, v *gocui.View) error {
 		return handleBranchSelect(g, v)
 	case "confirmation":
 		return nil
+	case "commitMessage":
+		return handleCommitFocused(g, v)
 	case "main":
 		// TODO: pull this out into a 'view focused' function
 		refreshMergePanel(g)
@@ -214,4 +216,20 @@ func loader() string {
 	nanos := now.UnixNano()
 	index := nanos / 50000000 % int64(len(characters))
 	return characters[index : index+1]
+}
+
+// TODO: refactor properly
+func getFilesView(g *gocui.Gui) *gocui.View {
+	v, _ := g.View("files")
+	return v
+}
+
+func getCommitsView(g *gocui.Gui) *gocui.View {
+	v, _ := g.View("commits")
+	return v
+}
+
+func getCommitMessageView(g *gocui.Gui) *gocui.View {
+	v, _ := g.View("commitMessage")
+	return v
 }


### PR DESCRIPTION
After merging the branch that added multiline commit messages and the branch that added commit message saving, I realised that the cursor position is lost between them. This PR attempts to fix that, but it's not yet working. Can anybody see what I'm doing wrong here?

I'm thinking that a better solution might be to make the commit panel a persistent panel that you just hide after closing it, so that we don't need to worry about storing and restoring the buffer in the first place.