### PR TITLE
WIP: Support GPG signing when stashing

### DIFF
--- a/gitcommands.go
+++ b/gitcommands.go
@@ -188,12 +188,22 @@ func getGitStatusFiles() []GitFile {
 	return gitFiles
 }
 
-func gitStashDo(index int, method string) (string, error) {
-	return runCommand("git stash " + method + " stash@{" + fmt.Sprint(index) + "}")
+func gitStashDo(g *gocui.Gui, index int, method string) (string, error) {
+	command := "git stash " + method + " stash@{" + fmt.Sprint(index) + "}"
+	if usingGpg() {
+		runSubProcess(g, state.Platform.shell, state.Platform.shellArg, command)
+		return "", nil
+	}
+	return runCommand(command)
 }
 
-func gitStashSave(message string) (string, error) {
-	output, err := runCommand("git stash save \"" + message + "\"")
+func gitStashSave(g *gocui.Gui, message string) (string, error) {
+	command := "git stash save \"" + message + "\""
+	if usingGpg() {
+		runSubProcess(g, state.Platform.shell, state.Platform.shellArg, command)
+		return "", nil
+	}
+	output, err := runCommand(command)
 	if err != nil {
 		return output, err
 	}
@@ -412,10 +422,20 @@ func removeFile(file GitFile) error {
 	return err
 }
 
-func gitCommit(g *gocui.Gui, message string) (string, error) {
+func usingGpg() bool {
 	gpgsign, _ := gitconfig.Global("commit.gpgsign")
-	if gpgsign != "" {
-		runSubProcess(g, "git", "commit")
+	if gpgsign == "" {
+		gpgsign, _ = gitconfig.Local("commit.gpgsign")
+	}
+	if gpgsign == "" {
+		return false
+	}
+	return true
+}
+
+func gitCommit(g *gocui.Gui, message string) (string, error) {
+	if usingGpg() {
+		runSubProcess(g, state.Platform.shell, state.Platform.shellArg, "git commit -m \""+message+"\"")
 		return "", nil
 	}
 	userName, err := gitconfig.Username()

--- a/stash_panel.go
+++ b/stash_panel.go
@@ -74,7 +74,7 @@ func stashDo(g *gocui.Gui, v *gocui.View, method string) error {
 	if stashEntry == nil {
 		return createErrorPanel(g, "No stash to "+method)
 	}
-	if output, err := gitStashDo(stashEntry.Index, method); err != nil {
+	if output, err := gitStashDo(g, stashEntry.Index, method); err != nil {
 		createErrorPanel(g, output)
 	}
 	refreshStashEntries(g)
@@ -83,7 +83,7 @@ func stashDo(g *gocui.Gui, v *gocui.View, method string) error {
 
 func handleStashSave(g *gocui.Gui, filesView *gocui.View) error {
 	createPromptPanel(g, filesView, "Stash changes", func(g *gocui.Gui, v *gocui.View) error {
-		if output, err := gitStashSave(trimmedContent(v)); err != nil {
+		if output, err := gitStashSave(g, trimmedContent(v)); err != nil {
 			createErrorPanel(g, output)
 		}
 		refreshStashEntries(g)

--- a/test/repos/gpg.sh
+++ b/test/repos/gpg.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -ex; rm -rf repo; mkdir repo; cd repo
+
+git init
+
+git config gpg.program $(which gpg)
+git config user.signingkey E304229F # test key
+git config commit.gpgsign true
+
+touch foo
+git add foo
+
+touch bar
+git add bar


### PR DESCRIPTION
This PR supports GPG signing when stashing, and reverts to using a direct git commit -m for committing when using GPG rather than opening the git commit in a separate editor (which can still be done via shift+C)

I've added a test repo generator script but was not able to get it asking me for a password on stash.