### PR TITLE
Change amount of diff panel lines scrolled per key stroke to 11

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -84,7 +84,7 @@ func (gui *Gui) scrollUpMain(g *gocui.Gui, v *gocui.View) error {
 	mainView, _ := g.View("main")
 	ox, oy := mainView.Origin()
 	if oy >= 1 {
-		return mainView.SetOrigin(ox, oy-1)
+		return mainView.SetOrigin(ox, oy-11)
 	}
 	return nil
 }
@@ -93,7 +93,7 @@ func (gui *Gui) scrollDownMain(g *gocui.Gui, v *gocui.View) error {
 	mainView, _ := g.View("main")
 	ox, oy := mainView.Origin()
 	if oy < len(mainView.BufferLines()) {
-		return mainView.SetOrigin(ox, oy+1)
+		return mainView.SetOrigin(ox, oy+11)
 	}
 	return nil
 }


### PR DESCRIPTION
This is an opinion thing. I think it's very tedious that when scrolling in the diff panel it goes one line per keystroke. Have a file with a hundred lines of modifications and it just takes too long.

However the proper way to do it is probably to look at screen space and scroll with a percentage of it. I think many terminal emulators scroll by a whole visible page with PgUp/PgDn, and C-u/C-d from vim behavior scrolls by half a visible page. The implementation of the scrollUpMain/scrollDownMain does it line by line, so I just upped it to a modest 11 lines because I saw that's one of the defaults in the `more` program for command line.

What do you think? I don't have experience with go so I will personally be happy just with this change.