### PR TITLE
More robust reading of reflog to get branch name

### DIFF
--- a/pkg/git/branch_list_builder.go
+++ b/pkg/git/branch_list_builder.go
@@ -144,7 +144,7 @@ func branchInfoFromLine(line string) (string, string, string) {
 	r := regexp.MustCompile("\\|.*\\s")
 	line = r.ReplaceAllString(line, " ")
 	words := strings.Split(line, " ")
-	return words[0], words[1], words[3]
+	return words[0], words[1], words[len(words)-1]
 }
 
 func abbreviatedTimeUnit(timeUnit string) string {


### PR DESCRIPTION
This should fix

https://github.com/jesseduffield/lazygit/issues/95

and 

https://github.com/jesseduffield/lazygit/blob/master/pkg/git/branch_list_builder.go#L144

but the underlying issue is based on localization issues which we will hopefully fix in our i18n stuff