### PR TITLE
WIP: Adding split diff view with icdiff

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -472,7 +472,7 @@ func (c *GitCommand) Show(sha string) string {
 }
 
 // Diff returns the diff of a file
-func (c *GitCommand) Diff(file File) string {
+func (c *GitCommand) Diff(file File, width int) string {
 	cachedArg := ""
 	fileName := file.Name
 	if file.HasStagedChanges && !file.HasUnstagedChanges {
@@ -489,9 +489,9 @@ func (c *GitCommand) Diff(file File) string {
 	if !file.Tracked && !file.HasStagedChanges {
 		trackedArg = "--no-index /dev/null"
 	}
-	command := fmt.Sprintf("%s %s %s %s %s", "git diff --color ", cachedArg, deletedArg, trackedArg, fileName)
 
-	// for now we assume an error means the file was deleted
-	s, _ := c.OSCommand.RunCommandWithOutput(command)
+	command := fmt.Sprintf("%s %s %s %s %s%d %s %s", "git difftool --no-prompt", cachedArg, deletedArg, trackedArg, `--extcmd="icdiff --cols=`, width, `"`, fileName)
+	s, _ := c.OSCommand.RunCommandWithArgs(c.OSCommand.Platform.shell, []string{c.OSCommand.Platform.shellArg, command})
+
 	return s
 }

--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -53,6 +53,13 @@ func (c *OSCommand) RunCommandWithOutput(command string) (string, error) {
 	return sanitisedCommandOutput(cmdOut, err)
 }
 
+// RunCommandWithArgs takes a command and explicit arguments
+func (c *OSCommand) RunCommandWithArgs(command string, args []string) (string, error) {
+	c.Log.WithField("command", command).Info("RunCommand")
+	cmdOut, err := exec.Command(command, args...).CombinedOutput()
+	return sanitisedCommandOutput(cmdOut, err)
+}
+
 // RunCommand runs a command and just returns the error
 func (c *OSCommand) RunCommand(command string) error {
 	_, err := c.RunCommandWithOutput(command)

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -187,7 +187,9 @@ func (gui *Gui) handleFileSelect(g *gocui.Gui, v *gocui.View) error {
 		return gui.refreshMergePanel(g)
 	}
 
-	content = gui.GitCommand.Diff(file)
+	mainView := gui.getMainView(g)
+	width, _ := mainView.Size()
+	content = gui.GitCommand.Diff(file, width)
 	return gui.renderString(g, "main", content)
 }
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -109,12 +109,19 @@ func max(a, b int) int {
 	return b
 }
 
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 // layout is called for every screen re-render e.g. when the screen is resized
 func (gui *Gui) layout(g *gocui.Gui) error {
 	g.Highlight = true
 	g.SelFgColor = gocui.ColorWhite | gocui.AttrBold
 	width, height := g.Size()
-	leftSideWidth := width / 3
+	leftSideWidth := min(width/3, 50)
 	statusFilesBoundary := 2
 	filesBranchesBoundary := 2 * height / 5   // height - 20
 	commitsBranchesBoundary := 3 * height / 5 // height - 10

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -230,6 +230,11 @@ func (gui *Gui) getCommitsView(g *gocui.Gui) *gocui.View {
 	return v
 }
 
+func (gui *Gui) getMainView(g *gocui.Gui) *gocui.View {
+	v, _ := g.View("main")
+	return v
+}
+
 func (gui *Gui) getCommitMessageView(g *gocui.Gui) *gocui.View {
 	v, _ := g.View("commitMessage")
 	return v


### PR DESCRIPTION
I'm kinda tentative about this one. It looks awesome to have a split diff, but it's very slow. The only implementation that I could get working was one which used icdiff, meaning any user wanting to use that will need to install it separately. Given how slow it is, I don't think it should be used by default, and it sounds like a good candidate for a 'use split diff' user config value.

What are peoples' thoughts?

(the code as it is would need to actually add the configurable stuff, and I'll do that after the config PR gets merged - if we decide to go ahead with this)

![splitdiffscreenshot](https://user-images.githubusercontent.com/8456633/44205788-f018e900-a19a-11e8-94b8-a5888b250f0a.png)
