### PR TITLE
WIP: Anonymous Error Reporting

### DIFF
--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os/user"
 
+	"github.com/rollbar/rollbar-go"
 	"github.com/shibukawa/configdir"
 	"github.com/spf13/viper"
 )
@@ -36,6 +37,22 @@ func NewAppConfig(name, version, commit, date string, debuggingFlag *bool) (*App
 	if err != nil {
 		panic(err)
 	}
+
+	rollbar.SetToken("23432119147a4367abf7c0de2aa99a2d")
+	rollbar.SetEnvironment("production") // defaults to "development"
+	rollbar.SetCodeVersion(version)
+	// rollbar.SetServerHost("web.1")                       // optional override; defaults to hostname
+	rollbar.SetServerRoot("github.com/jesseduffield/lazygit") // path of project (required for GitHub integration and non-project stacktrace collapsing)
+
+	// result, err := DoSomething()
+	// if err != nil {
+	//   rollbar.Critical(err)
+	// }
+
+	rollbar.Info("This is a test message")
+	rollbar.Critical("test error")
+
+	// rollbar.Wait()
 
 	appConfig := &AppConfig{
 		Name:       "lazygit",

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -211,6 +211,9 @@ func (gui *Gui) renderOptionsMap(g *gocui.Gui, optionsMap map[string]string) err
 	return gui.renderString(g, "options", gui.optionsMapToString(optionsMap))
 }
 
+// TODO: remove test comment for golangci
+// test two
+
 func (gui *Gui) loader() string {
 	characters := "|/-\\"
 	now := time.Now()


### PR DESCRIPTION
When the application first starts I want a prompt to come up asking whether the user is happy to send anonymous reporting data, and if they say yes then when an exception is thrown, we can send an anonymous report to rollbar. This will assist in spotting errors from builds early and in prioritising which bugs to fix first. 

The user's decision on whether to send/not-send error reports will be stored in their configuration file