### PR TITLE
Generate coverage files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,4 +23,5 @@ jobs:
 
       # specify any bash command here prefixed with `run: `
       - run: go test -v ./...
+      - run: bash test/coverage.sh
       - run: bash <(curl -s https://codecov.io/bash)

--- a/test/coverage.sh
+++ b/test/coverage.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+echo "" > coverage.txt
+
+for d in $(go list ./... | grep -v vendor); do
+    go test -v -race -coverprofile=profile.out -covermode=atomic $d
+    if [ -f profile.out ]; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done


### PR DESCRIPTION
The script is pulled from this template: https://github.com/codecov/example-go.
This should fix the "No coverage report found message."