### PR TITLE
Handle filenames with spaces better

### DIFF
--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -45,7 +45,7 @@ func TestDiff(t *testing.T) {
 			DisplayString:      " D deleted_staged",
 		},
 		{
-			Name:               "\"file with space staged\"",
+			Name:               "file with space staged",
 			HasStagedChanges:   true,
 			HasUnstagedChanges: false,
 			Tracked:            false,


### PR DESCRIPTION
We're now storing filenames without spaces in them, and then quoting everything when it comes time to use the filename in a command. This fixes some issues with staging/unstaging/cat'ing files, and also ensures they sort as expected