### PR TITLE
add keybinding to open user editor when renaming last commit

### DIFF
--- a/docs/Keybindings.md
+++ b/docs/Keybindings.md
@@ -54,6 +54,7 @@
 <pre>
   <kbd>s</kbd>:       squash down (only available for topmost commit)
   <kbd>r</kbd>:       rename commit
+  <kbd>shift</kbd>+<kbd>R</kbd>: rename commit using git editor
   <kbd>g</kbd>:       reset to this commit
 </pre>
 

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -422,6 +422,11 @@ func (c *GitCommand) PrepareCommitSubProcess() *exec.Cmd {
 	return c.OSCommand.PrepareSubProcess("git", "commit")
 }
 
+// PrepareCommitAmendSubProcess prepares a subprocess for `git commit --amend --allow-empty`
+func (c *GitCommand) PrepareCommitAmendSubProcess() *exec.Cmd {
+	return c.OSCommand.PrepareSubProcess("git", "commit", "--amend", "--allow-empty")
+}
+
 // GetBranchGraph gets the color-formatted graph of the log for the given branch
 // Currently it limits the result to 100 commits, but when we get async stuff
 // working we can do lazy loading

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -189,6 +189,19 @@ func TestGitCommandStashSave(t *testing.T) {
 	assert.NoError(t, gitCmd.StashSave("A stash message"))
 }
 
+func TestGitCommandCommitAmend(t *testing.T) {
+	gitCmd := newDummyGitCommand()
+	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
+		assert.EqualValues(t, "git", cmd)
+		assert.EqualValues(t, []string{"commit", "--amend", "--allow-empty"}, args)
+
+		return exec.Command("echo")
+	}
+
+	_, err := gitCmd.PrepareCommitAmendSubProcess().CombinedOutput()
+	assert.NoError(t, err)
+}
+
 func TestGitCommandMergeStatusFiles(t *testing.T) {
 	type scenario struct {
 		oldFiles []File

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -155,6 +155,19 @@ func (gui *Gui) handleRenameCommit(g *gocui.Gui, v *gocui.View) error {
 	return nil
 }
 
+func (gui *Gui) handleRenameCommitEditor(g *gocui.Gui, v *gocui.View) error {
+	if gui.getItemPosition(v) != 0 {
+		return gui.createErrorPanel(g, gui.Tr.SLocalize("OnlyRenameTopCommit"))
+	}
+
+	gui.SubProcess = gui.GitCommand.PrepareCommitAmendSubProcess()
+	g.Update(func(g *gocui.Gui) error {
+		return gui.Errors.ErrSubProcess
+	})
+
+	return nil
+}
+
 func (gui *Gui) getSelectedCommit(g *gocui.Gui) (commands.Commit, error) {
 	v, err := g.View("commits")
 	if err != nil {

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -64,6 +64,7 @@ func (gui *Gui) keybindings(g *gocui.Gui) error {
 		{ViewName: "branches", Key: 'm', Modifier: gocui.ModNone, Handler: gui.handleMerge},
 		{ViewName: "commits", Key: 's', Modifier: gocui.ModNone, Handler: gui.handleCommitSquashDown},
 		{ViewName: "commits", Key: 'r', Modifier: gocui.ModNone, Handler: gui.handleRenameCommit},
+		{ViewName: "commits", Key: 'R', Modifier: gocui.ModNone, Handler: gui.handleRenameCommitEditor},
 		{ViewName: "commits", Key: 'g', Modifier: gocui.ModNone, Handler: gui.handleResetToCommit},
 		{ViewName: "commits", Key: 'f', Modifier: gocui.ModNone, Handler: gui.handleCommitFixup},
 		{ViewName: "stash", Key: gocui.KeySpace, Modifier: gocui.ModNone, Handler: gui.handleStashApply},


### PR DESCRIPTION
It should be quite straight-forward. Let me know what you think. Unfortunately I've not much time for writing tests today, but I'll write them in the next few days if needed.