### PR TITLE
Increase circleci compile speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - pkg-cache-{{ checksum "Gopkg.lock" }}
+            - pkg-cache-{{ checksum "Gopkg.lock" }}-v1
       - run:
           name: Run gofmt -s
           command: |
@@ -31,9 +31,9 @@ jobs:
           command: |
             bash <(curl -s https://codecov.io/bash)
       - save_cache:
-          key: pkg-cache-{{ checksum "Gopkg.lock" }}
+          key: pkg-cache-{{ checksum "Gopkg.lock" }}-v1
           paths:
-            - "/go/pkg"
+            - ~/.cache/go-build
 
   release:
     docker:


### PR DESCRIPTION
I tried to understand why after following circleci doc about caching, we still had long compile time and cache saved was only 32B. After bootstraping circleci on my fork, it appears the correct path is /home/circleci/.cache/go-build.

A build before : https://circleci.com/gh/antham/lazygit/8
A build after : https://circleci.com/gh/antham/lazygit/13

So from around 3mn to 1mn.

You can see it working on this repository here : https://circleci.com/gh/jesseduffield/lazygit/322
