### PR TITLE
Add commit counter using subtitle

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -189,11 +189,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:145fe566d21b0e2579e1600f09e4e4b01da017676ba8e079de75a2e21111538b"
+  digest = "1:71e6c15797951d3fabaa944d70253e36a6cee96bf54ca0bc43ca3de3b4814bbb"
   name = "github.com/jesseduffield/gocui"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "c4051ef0fbcbe519bc1d082a579a38100c7cf044"
+  revision = "2cb6e95bbbf850bb32cc1799e07d08ff0f144746"
 
 [[projects]]
   digest = "1:ac6d01547ec4f7f673311b4663909269bfb8249952de3279799289467837c3cc"

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -14,6 +14,8 @@
         - white
       optionsTextColor:
         - blue
+    commitLength:
+      show: true
   update:
     method: prompt # can be: prompt | background | never
     days: 14 # how often an update is checked for

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -222,6 +222,8 @@ func GetDefaultConfig() []byte {
       - white
     optionsTextColor:
       - blue
+  commitLength:
+    show: true
 update:
   method: prompt # can be: prompt | background | never
   days: 14 # how often a update is checked for

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -1,6 +1,9 @@
 package gui
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/jesseduffield/gocui"
 )
 
@@ -30,7 +33,6 @@ func (gui *Gui) handleCommitConfirm(g *gocui.Gui, v *gocui.View) error {
 
 func (gui *Gui) handleCommitClose(g *gocui.Gui, v *gocui.View) error {
 	g.SetViewOnBottom("commitMessage")
-	g.SetViewOnBottom("commitMessageCount")
 	return gui.switchFocus(g, v, gui.getFilesView(g))
 }
 
@@ -43,4 +45,35 @@ func (gui *Gui) handleCommitFocused(g *gocui.Gui, v *gocui.View) error {
 		},
 	)
 	return gui.renderString(g, "options", message)
+}
+
+func (gui *Gui) simpleEditor(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {
+	switch {
+	case key == gocui.KeyBackspace || key == gocui.KeyBackspace2:
+		v.EditDelete(true)
+	case key == gocui.KeyDelete:
+		v.EditDelete(false)
+	case key == gocui.KeyArrowDown:
+		v.MoveCursor(0, 1, false)
+	case key == gocui.KeyArrowUp:
+		v.MoveCursor(0, -1, false)
+	case key == gocui.KeyArrowLeft:
+		v.MoveCursor(-1, 0, false)
+	case key == gocui.KeyArrowRight:
+		v.MoveCursor(1, 0, false)
+	case key == gocui.KeyTab:
+		v.EditNewLine()
+	case key == gocui.KeySpace:
+		v.EditWrite(' ')
+	case key == gocui.KeyInsert:
+		v.Overwrite = !v.Overwrite
+	default:
+		v.EditWrite(ch)
+	}
+
+	v.Subtitle = gui.getBufferLength(v)
+}
+
+func (gui *Gui) getBufferLength(view *gocui.View) string {
+	return " " + strconv.Itoa(strings.Count(view.Buffer(), "")-1) + " "
 }

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -30,12 +30,8 @@ func (gui *Gui) handleCommitConfirm(g *gocui.Gui, v *gocui.View) error {
 
 func (gui *Gui) handleCommitClose(g *gocui.Gui, v *gocui.View) error {
 	g.SetViewOnBottom("commitMessage")
+	g.SetViewOnBottom("commitMessageCount")
 	return gui.switchFocus(g, v, gui.getFilesView(g))
-}
-
-func (gui *Gui) handleNewlineCommitMessage(g *gocui.Gui, v *gocui.View) error {
-	v.EditNewLine()
-	return nil
 }
 
 func (gui *Gui) handleCommitFocused(g *gocui.Gui, v *gocui.View) error {

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -71,9 +71,17 @@ func (gui *Gui) simpleEditor(v *gocui.View, key gocui.Key, ch rune, mod gocui.Mo
 		v.EditWrite(ch)
 	}
 
-	v.Subtitle = gui.getBufferLength(v)
+	gui.RenderCommitLength()
 }
 
 func (gui *Gui) getBufferLength(view *gocui.View) string {
 	return " " + strconv.Itoa(strings.Count(view.Buffer(), "")-1) + " "
+}
+
+func (gui *Gui) RenderCommitLength() {
+	if !gui.Config.GetUserConfig().GetBool("gui.commitLength.show") {
+		return
+	}
+	v := gui.getCommitMessageView(gui.g)
+	v.Subtitle = gui.getBufferLength(v)
 }

--- a/pkg/gui/confirmation_panel.go
+++ b/pkg/gui/confirmation_panel.go
@@ -115,20 +115,6 @@ func (gui *Gui) createConfirmationPanel(g *gocui.Gui, currentView *gocui.View, t
 	return nil
 }
 
-func (gui *Gui) handleNewline(g *gocui.Gui, v *gocui.View) error {
-	// resising ahead of time so that the top line doesn't get hidden to make
-	// room for the cursor on the second line
-	x0, y0, x1, y1 := gui.getConfirmationPanelDimensions(g, v.Buffer())
-	if _, err := g.SetView("confirmation", x0, y0, x1, y1+1, 0); err != nil {
-		if err != gocui.ErrUnknownView {
-			return err
-		}
-	}
-
-	v.EditNewLine()
-	return nil
-}
-
 func (gui *Gui) setKeyBindings(g *gocui.Gui, handleConfirm, handleClose func(*gocui.Gui, *gocui.View) error) error {
 	actions := gui.Tr.TemplateLocalize(
 		"CloseConfirm",
@@ -141,9 +127,6 @@ func (gui *Gui) setKeyBindings(g *gocui.Gui, handleConfirm, handleClose func(*go
 		return err
 	}
 	if err := g.SetKeybinding("confirmation", gocui.KeyEnter, gocui.ModNone, gui.wrappedConfirmationFunction(handleConfirm)); err != nil {
-		return err
-	}
-	if err := g.SetKeybinding("confirmation", gocui.KeyTab, gocui.ModNone, gui.handleNewline); err != nil {
 		return err
 	}
 	return g.SetKeybinding("confirmation", gocui.KeyEsc, gocui.ModNone, gui.wrappedConfirmationFunction(handleClose))

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -226,7 +226,7 @@ func (gui *Gui) handleCommitPress(g *gocui.Gui, filesView *gocui.View) error {
 	g.Update(func(g *gocui.Gui) error {
 		g.SetViewOnTop("commitMessage")
 		gui.switchFocus(g, filesView, commitMessageView)
-		commitMessageView.Subtitle = gui.getBufferLength(commitMessageView)
+		gui.RenderCommitLength()
 		return nil
 	})
 	return nil

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands"
+	"strconv"
 )
 
 func (gui *Gui) stagedFiles() []commands.File {
@@ -218,6 +219,60 @@ func (gui *Gui) handleFileSelect(g *gocui.Gui, v *gocui.View) error {
 	return gui.renderString(g, "main", content)
 }
 
+func (gui *Gui) simpleEditor(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {
+	switch {
+	case key == gocui.KeyBackspace || key == gocui.KeyBackspace2:
+		v.EditDelete(true)
+	case key == gocui.KeyDelete:
+		v.EditDelete(false)
+	case key == gocui.KeyArrowDown:
+		v.MoveCursor(0, 1, false)
+	case key == gocui.KeyArrowUp:
+		v.MoveCursor(0, -1, false)
+	case key == gocui.KeyArrowLeft:
+		v.MoveCursor(-1, 0, false)
+	case key == gocui.KeyArrowRight:
+		v.MoveCursor(1, 0, false)
+	case key == gocui.KeyTab:
+		v.EditNewLine()
+	case key == gocui.KeySpace:
+		v.EditWrite(' ')
+	case key == gocui.KeyInsert:
+		v.Overwrite = !v.Overwrite
+	default:
+		v.EditWrite(ch)
+	}
+
+	gui.renderCommitCount(v)
+}
+
+func (gui *Gui) getCommitCount(view *gocui.View) int {
+	return strings.Count(view.Buffer(), "") - 1
+}
+
+func (gui *Gui) renderCommitCount(view *gocui.View) error {
+	num := 0
+	offset := 5
+	count := gui.getCommitCount(view)
+	_, y0, x1, _ := gui.getConfirmationPanelDimensions(gui.g, view.Buffer())
+
+	if count > 99 {
+		num = 3
+	} else if count > 9 {
+		num = 2
+	} else {
+		num = 1
+	}
+
+	if _, err := gui.g.SetView("commitMessageCount", x1-num-offset, y0-1, x1-offset+1, y0+1, 0); err != nil {
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+	}
+
+	return gui.renderString(gui.g, "commitMessageCount", strconv.Itoa(count))
+}
+
 func (gui *Gui) handleCommitPress(g *gocui.Gui, filesView *gocui.View) error {
 	if len(gui.stagedFiles()) == 0 && !gui.State.HasMergeConflicts {
 		return gui.createErrorPanel(g, gui.Tr.SLocalize("NoStagedFilesToCommit"))
@@ -225,7 +280,9 @@ func (gui *Gui) handleCommitPress(g *gocui.Gui, filesView *gocui.View) error {
 	commitMessageView := gui.getCommitMessageView(g)
 	g.Update(func(g *gocui.Gui) error {
 		g.SetViewOnTop("commitMessage")
+		g.SetViewOnTop("commitMessageCount")
 		gui.switchFocus(g, filesView, commitMessageView)
+		gui.renderCommitCount(commitMessageView)
 		return nil
 	})
 	return nil

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -262,6 +262,16 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			commitMessageView.Title = gui.Tr.SLocalize("CommitMessage")
 			commitMessageView.FgColor = gocui.ColorWhite
 			commitMessageView.Editable = true
+			commitMessageView.Editor = gocui.EditorFunc(gui.simpleEditor)
+		}
+		if commitMessageCountView, err := g.SetView("commitMessageCount", 0, 0, width/2, height/2, 0); err != nil {
+			if err != gocui.ErrUnknownView {
+				return err
+			}
+			g.SetViewOnBottom("commitMessageCount")
+			commitMessageCountView.Frame = false
+			commitMessageCountView.BgColor = gocui.ColorDefault
+			commitMessageCountView.FgColor = gocui.ColorWhite
 		}
 	}
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -264,15 +264,6 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			commitMessageView.Editable = true
 			commitMessageView.Editor = gocui.EditorFunc(gui.simpleEditor)
 		}
-		if commitMessageCountView, err := g.SetView("commitMessageCount", 0, 0, width/2, height/2, 0); err != nil {
-			if err != gocui.ErrUnknownView {
-				return err
-			}
-			g.SetViewOnBottom("commitMessageCount")
-			commitMessageCountView.Frame = false
-			commitMessageCountView.BgColor = gocui.ColorDefault
-			commitMessageCountView.FgColor = gocui.ColorWhite
-		}
 	}
 
 	if appStatusView, err := g.SetView("appStatus", -1, optionsTop, width, optionsTop+2, 0); err != nil {

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -70,7 +70,6 @@ func (gui *Gui) keybindings(g *gocui.Gui) error {
 		{ViewName: "stash", Key: 'd', Modifier: gocui.ModNone, Handler: gui.handleStashDrop},
 		{ViewName: "commitMessage", Key: gocui.KeyEnter, Modifier: gocui.ModNone, Handler: gui.handleCommitConfirm},
 		{ViewName: "commitMessage", Key: gocui.KeyEsc, Modifier: gocui.ModNone, Handler: gui.handleCommitClose},
-		{ViewName: "commitMessage", Key: gocui.KeyTab, Modifier: gocui.ModNone, Handler: gui.handleNewlineCommitMessage},
 	}
 
 	// Would make these keybindings global but that interferes with editing

--- a/vendor/github.com/jesseduffield/gocui/gui.go
+++ b/vendor/github.com/jesseduffield/gocui/gui.go
@@ -476,6 +476,11 @@ func (g *Gui) flush() error {
 					return err
 				}
 			}
+			if v.Subtitle != "" {
+				if err := g.drawSubtitle(v, fgColor, bgColor); err != nil {
+					return err
+				}
+			}
 		}
 		if err := g.draw(v); err != nil {
 			return err
@@ -573,6 +578,25 @@ func (g *Gui) drawTitle(v *View, fgColor, bgColor Attribute) error {
 		if x < 0 {
 			continue
 		} else if x > v.x1-2 || x >= g.maxX {
+			break
+		}
+		if err := g.SetRune(x, v.y0, ch, fgColor, bgColor); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// drawSubtitle draws the subtitle of the view.
+func (g *Gui) drawSubtitle(v *View, fgColor, bgColor Attribute) error {
+	if v.y0 < 0 || v.y0 >= g.maxY {
+		return nil
+	}
+
+	start := v.x1 - 5 - len(v.Subtitle)
+	for i, ch := range v.Subtitle {
+		x := start + i
+		if x >= v.x1 {
 			break
 		}
 		if err := g.SetRune(x, v.y0, ch, fgColor, bgColor); err != nil {

--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -77,6 +77,9 @@ type View struct {
 	// If Frame is true, Title allows to configure a title for the view.
 	Title string
 
+	// If Frame is true, Subtitle allows to configure a subtitle for the view.
+	Subtitle string
+
 	// If Mask is true, the View will display the mask instead of the real
 	// content
 	Mask rune


### PR DESCRIPTION
@dawidd6 I've branched this off of your branch, as I was trying to apply a color to the count but couldn't use the border color of the commit message panel due to gocui.Attribute (used for coloring panels) being different to color.Attribute (used for rendering strings in buffers)

So I thought to just add a subtitle field to the gocui package which is rendered in the same way the title is rendered. This means we don't need to have a new panel that we need to worry about resizing etc.

What are your thoughts on this?