### PR TITLE
Restore old file merging algorithm

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -173,28 +173,37 @@ func (c *GitCommand) MergeStatusFiles(oldFiles, newFiles []File) []File {
 		return newFiles
 	}
 
-	headResults := []File{}
-	tailResults := []File{}
+	appendedIndexes := []int{}
 
-	for _, newFile := range newFiles {
-		var isHeadResult bool
-
-		for _, oldFile := range oldFiles {
+	// retain position of files we already could see
+	result := []File{}
+	for _, oldFile := range oldFiles {
+		for newIndex, newFile := range newFiles {
 			if oldFile.Name == newFile.Name {
-				isHeadResult = true
+				result = append(result, newFile)
+				appendedIndexes = append(appendedIndexes, newIndex)
 				break
 			}
 		}
-
-		if isHeadResult {
-			headResults = append(headResults, newFile)
-			continue
-		}
-
-		tailResults = append(tailResults, newFile)
 	}
 
-	return append(headResults, tailResults...)
+	// append any new files to the end
+	for index, newFile := range newFiles {
+		if !includesInt(appendedIndexes, index) {
+			result = append(result, newFile)
+		}
+	}
+
+	return result
+}
+
+func includesInt(list []int, a int) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }
 
 // GetBranchName branch name


### PR DESCRIPTION
The old file merging algorithm, while not as elegant as the new version, was more specific in ensuring the order of files were maintained. So I'm restoring it :)

Currently if you stage/unstage random files at master, they get shuffled around.