### PR TITLE
Fix cursor positioning bugs

### DIFF
--- a/pkg/commands/branch.go
+++ b/pkg/commands/branch.go
@@ -14,9 +14,9 @@ type Branch struct {
 	Recency string
 }
 
-// GetDisplayString returns the dispaly string of branch
-func (b *Branch) GetDisplayString() string {
-	return utils.WithPadding(b.Recency, 4) + utils.ColoredString(b.Name, b.GetColor())
+// GetDisplayStrings returns the dispaly string of branch
+func (b *Branch) GetDisplayStrings() []string {
+	return []string{b.Recency, utils.ColoredString(b.Name, b.GetColor())}
 }
 
 // GetColor branch color

--- a/pkg/commands/commit.go
+++ b/pkg/commands/commit.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"github.com/fatih/color"
+)
+
+// Commit : A git commit
+type Commit struct {
+	Sha           string
+	Name          string
+	Pushed        bool
+	DisplayString string
+}
+
+func (c *Commit) GetDisplayStrings() []string {
+	red := color.New(color.FgRed)
+	yellow := color.New(color.FgYellow)
+	white := color.New(color.FgWhite)
+
+	shaColor := yellow
+	if c.Pushed {
+		shaColor = red
+	}
+
+	return []string{shaColor.Sprint(c.Sha), white.Sprint(c.Name)}
+}

--- a/pkg/commands/file.go
+++ b/pkg/commands/file.go
@@ -1,0 +1,36 @@
+package commands
+
+import "github.com/fatih/color"
+
+// File : A file from git status
+// duplicating this for now
+type File struct {
+	Name               string
+	HasStagedChanges   bool
+	HasUnstagedChanges bool
+	Tracked            bool
+	Deleted            bool
+	HasMergeConflicts  bool
+	DisplayString      string
+	Type               string // one of 'file', 'directory', and 'other'
+}
+
+// GetDisplayStrings returns the display string of a file
+func (f *File) GetDisplayStrings() []string {
+	// potentially inefficient to be instantiating these color
+	// objects with each render
+	red := color.New(color.FgRed)
+	green := color.New(color.FgGreen)
+	if !f.Tracked && !f.HasStagedChanges {
+		return []string{red.Sprint(f.DisplayString)}
+	}
+
+	output := green.Sprint(f.DisplayString[0:1])
+	output += red.Sprint(f.DisplayString[1:3])
+	if f.HasUnstagedChanges {
+		output += red.Sprint(f.Name)
+	} else {
+		output += green.Sprint(f.Name)
+	}
+	return []string{output}
+}

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -231,9 +231,9 @@ func (c *GitCommand) UpstreamDifferenceCount() (string, string) {
 	return strings.TrimSpace(pushableCount), strings.TrimSpace(pullableCount)
 }
 
-// getCommitsToPush Returns the sha's of the commits that have not yet been pushed
+// GetCommitsToPush Returns the sha's of the commits that have not yet been pushed
 // to the remote branch of the current branch, a map is returned to ease look up
-func (c *GitCommand) getCommitsToPush() map[string]bool {
+func (c *GitCommand) GetCommitsToPush() map[string]bool {
 	pushables := map[string]bool{}
 	o, err := c.OSCommand.RunCommandWithOutput("git rev-list @{u}..head --abbrev-commit")
 	if err != nil {

--- a/pkg/commands/git_structs.go
+++ b/pkg/commands/git_structs.go
@@ -1,32 +1,5 @@
 package commands
 
-// File : A staged/unstaged file
-type File struct {
-	Name               string
-	HasStagedChanges   bool
-	HasUnstagedChanges bool
-	Tracked            bool
-	Deleted            bool
-	HasMergeConflicts  bool
-	DisplayString      string
-	Type               string // one of 'file', 'directory', and 'other'
-}
-
-// Commit : A git commit
-type Commit struct {
-	Sha           string
-	Name          string
-	Pushed        bool
-	DisplayString string
-}
-
-// StashEntry : A git stash entry
-type StashEntry struct {
-	Index         int
-	Name          string
-	DisplayString string
-}
-
 // Conflict : A git conflict with a start middle and end corresponding to line
 // numbers in the file where the conflict bars appear
 type Conflict struct {

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -275,7 +275,7 @@ func TestGitCommandGetStashEntries(t *testing.T) {
 	type scenario struct {
 		testName string
 		command  func(string, ...string) *exec.Cmd
-		test     func([]StashEntry)
+		test     func([]*StashEntry)
 	}
 
 	scenarios := []scenario{
@@ -284,7 +284,7 @@ func TestGitCommandGetStashEntries(t *testing.T) {
 			func(string, ...string) *exec.Cmd {
 				return exec.Command("echo")
 			},
-			func(entries []StashEntry) {
+			func(entries []*StashEntry) {
 				assert.Len(t, entries, 0)
 			},
 		},
@@ -293,8 +293,8 @@ func TestGitCommandGetStashEntries(t *testing.T) {
 			func(string, ...string) *exec.Cmd {
 				return exec.Command("echo", "WIP on add-pkg-commands-test: 55c6af2 increase parallel build\nWIP on master: bb86a3f update github template")
 			},
-			func(entries []StashEntry) {
-				expected := []StashEntry{
+			func(entries []*StashEntry) {
+				expected := []*StashEntry{
 					{
 						0,
 						"WIP on add-pkg-commands-test: 55c6af2 increase parallel build",
@@ -341,7 +341,7 @@ func TestGitCommandGetStatusFiles(t *testing.T) {
 	type scenario struct {
 		testName string
 		command  func(string, ...string) *exec.Cmd
-		test     func([]File)
+		test     func([]*File)
 	}
 
 	scenarios := []scenario{
@@ -350,7 +350,7 @@ func TestGitCommandGetStatusFiles(t *testing.T) {
 			func(cmd string, args ...string) *exec.Cmd {
 				return exec.Command("echo")
 			},
-			func(files []File) {
+			func(files []*File) {
 				assert.Len(t, files, 0)
 			},
 		},
@@ -362,10 +362,10 @@ func TestGitCommandGetStatusFiles(t *testing.T) {
 					"MM file1.txt\nA  file3.txt\nAM file2.txt\n?? file4.txt",
 				)
 			},
-			func(files []File) {
+			func(files []*File) {
 				assert.Len(t, files, 4)
 
-				expected := []File{
+				expected := []*File{
 					{
 						Name:               "file1.txt",
 						HasStagedChanges:   true,
@@ -463,22 +463,22 @@ func TestGitCommandCommitAmend(t *testing.T) {
 func TestGitCommandMergeStatusFiles(t *testing.T) {
 	type scenario struct {
 		testName string
-		oldFiles []File
-		newFiles []File
-		test     func([]File)
+		oldFiles []*File
+		newFiles []*File
+		test     func([]*File)
 	}
 
 	scenarios := []scenario{
 		{
 			"Old file and new file are the same",
-			[]File{},
-			[]File{
+			[]*File{},
+			[]*File{
 				{
 					Name: "new_file.txt",
 				},
 			},
-			func(files []File) {
-				expected := []File{
+			func(files []*File) {
+				expected := []*File{
 					{
 						Name: "new_file.txt",
 					},
@@ -490,7 +490,7 @@ func TestGitCommandMergeStatusFiles(t *testing.T) {
 		},
 		{
 			"Several files to merge, with some identical",
-			[]File{
+			[]*File{
 				{
 					Name: "new_file1.txt",
 				},
@@ -501,7 +501,7 @@ func TestGitCommandMergeStatusFiles(t *testing.T) {
 					Name: "new_file3.txt",
 				},
 			},
-			[]File{
+			[]*File{
 				{
 					Name: "new_file4.txt",
 				},
@@ -512,8 +512,8 @@ func TestGitCommandMergeStatusFiles(t *testing.T) {
 					Name: "new_file1.txt",
 				},
 			},
-			func(files []File) {
-				expected := []File{
+			func(files []*File) {
+				expected := []*File{
 					{
 						Name: "new_file1.txt",
 					},
@@ -1223,7 +1223,7 @@ func TestGitCommandDiff(t *testing.T) {
 	gitCommand := newDummyGitCommand()
 	assert.NoError(t, test.GenerateRepo("lots_of_diffs.sh"))
 
-	files := []File{
+	files := []*File{
 		{
 			Name:               "deleted_staged",
 			HasStagedChanges:   false,

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -1225,7 +1225,7 @@ func TestGitCommandRemoveFile(t *testing.T) {
 		testName   string
 		command    func() (func(string, ...string) *exec.Cmd, *[][]string)
 		test       func(*[][]string, error)
-		file       File
+		file       *File
 		removeFile func(string) error
 	}
 
@@ -1247,7 +1247,7 @@ func TestGitCommandRemoveFile(t *testing.T) {
 					{"reset", "--", "test"},
 				})
 			},
-			File{
+			&File{
 				Name:             "test",
 				HasStagedChanges: true,
 			},
@@ -1270,7 +1270,7 @@ func TestGitCommandRemoveFile(t *testing.T) {
 				assert.EqualError(t, err, "an error occurred when removing file")
 				assert.Len(t, *cmdsCalled, 0)
 			},
-			File{
+			&File{
 				Name:    "test",
 				Tracked: false,
 			},
@@ -1295,7 +1295,7 @@ func TestGitCommandRemoveFile(t *testing.T) {
 					{"checkout", "--", "test"},
 				})
 			},
-			File{
+			&File{
 				Name:             "test",
 				Tracked:          true,
 				HasStagedChanges: false,
@@ -1321,7 +1321,7 @@ func TestGitCommandRemoveFile(t *testing.T) {
 					{"checkout", "--", "test"},
 				})
 			},
-			File{
+			&File{
 				Name:             "test",
 				Tracked:          true,
 				HasStagedChanges: false,
@@ -1348,7 +1348,7 @@ func TestGitCommandRemoveFile(t *testing.T) {
 					{"checkout", "--", "test"},
 				})
 			},
-			File{
+			&File{
 				Name:             "test",
 				Tracked:          true,
 				HasStagedChanges: true,
@@ -1374,7 +1374,7 @@ func TestGitCommandRemoveFile(t *testing.T) {
 					{"reset", "--", "test"},
 				})
 			},
-			File{
+			&File{
 				Name:             "test",
 				Tracked:          false,
 				HasStagedChanges: true,
@@ -1398,7 +1398,7 @@ func TestGitCommandRemoveFile(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Len(t, *cmdsCalled, 0)
 			},
-			File{
+			&File{
 				Name:             "test",
 				Tracked:          false,
 				HasStagedChanges: false,
@@ -1484,7 +1484,7 @@ func TestGitCommandGetCommits(t *testing.T) {
 	type scenario struct {
 		testName string
 		command  func(string, ...string) *exec.Cmd
-		test     func([]Commit)
+		test     func([]*Commit)
 	}
 
 	scenarios := []scenario{
@@ -1504,7 +1504,7 @@ func TestGitCommandGetCommits(t *testing.T) {
 
 				return nil
 			},
-			func(commits []Commit) {
+			func(commits []*Commit) {
 				assert.Len(t, commits, 0)
 			},
 		},
@@ -1524,9 +1524,9 @@ func TestGitCommandGetCommits(t *testing.T) {
 
 				return nil
 			},
-			func(commits []Commit) {
+			func(commits []*Commit) {
 				assert.Len(t, commits, 2)
-				assert.EqualValues(t, []Commit{
+				assert.EqualValues(t, []*Commit{
 					{
 						Sha:           "8a2bb0e",
 						Name:          "commit 1",

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -631,7 +631,7 @@ func TestGitCommandGetCommitsToPush(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			gitCmd := newDummyGitCommand()
 			gitCmd.OSCommand.command = s.command
-			s.test(gitCmd.getCommitsToPush())
+			s.test(gitCmd.GetCommitsToPush())
 		})
 	}
 }

--- a/pkg/commands/stash_entry.go
+++ b/pkg/commands/stash_entry.go
@@ -1,0 +1,13 @@
+package commands
+
+// StashEntry : A git stash entry
+type StashEntry struct {
+	Index         int
+	Name          string
+	DisplayString string
+}
+
+// GetDisplayStrings returns the dispaly string of branch
+func (s *StashEntry) GetDisplayStrings() []string {
+	return []string{s.DisplayString}
+}

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -152,9 +152,11 @@ func (gui *Gui) refreshBranches(g *gocui.Gui) error {
 		}
 		gui.State.Branches = builder.Build()
 		v.Clear()
+		displayStrings := []string{}
 		for _, branch := range gui.State.Branches {
-			fmt.Fprintln(v, branch.GetDisplayString())
+			displayStrings = append(displayStrings, branch.GetDisplayString())
 		}
+		fmt.Fprint(v, strings.Join(displayStrings, "\n"))
 		gui.resetOrigin(v)
 		return gui.refreshStatus(g)
 	})

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands"
 	"github.com/jesseduffield/lazygit/pkg/git"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 func (gui *Gui) handleBranchPress(g *gocui.Gui, v *gocui.View) error {
@@ -109,7 +110,7 @@ func (gui *Gui) handleMerge(g *gocui.Gui, v *gocui.View) error {
 	return nil
 }
 
-func (gui *Gui) getSelectedBranch(v *gocui.View) commands.Branch {
+func (gui *Gui) getSelectedBranch(v *gocui.View) *commands.Branch {
 	lineNumber := gui.getItemPosition(v)
 	return gui.State.Branches[lineNumber]
 }
@@ -151,12 +152,15 @@ func (gui *Gui) refreshBranches(g *gocui.Gui) error {
 			return err
 		}
 		gui.State.Branches = builder.Build()
+
 		v.Clear()
-		displayStrings := make([]string, len(gui.State.Branches))
-		for i, branch := range gui.State.Branches {
-			displayStrings[i] = branch.GetDisplayString()
+		list, err := utils.RenderList(gui.State.Branches)
+		if err != nil {
+			return err
 		}
-		fmt.Fprint(v, strings.Join(displayStrings, "\n"))
+
+		fmt.Fprint(v, list)
+
 		gui.resetOrigin(v)
 		return gui.refreshStatus(g)
 	})

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -152,9 +152,9 @@ func (gui *Gui) refreshBranches(g *gocui.Gui) error {
 		}
 		gui.State.Branches = builder.Build()
 		v.Clear()
-		displayStrings := []string{}
-		for _, branch := range gui.State.Branches {
-			displayStrings = append(displayStrings, branch.GetDisplayString())
+		displayStrings := make([]string, len(gui.State.Branches))
+		for i, branch := range gui.State.Branches {
+			displayStrings[i] = branch.GetDisplayString()
 		}
 		fmt.Fprint(v, strings.Join(displayStrings, "\n"))
 		gui.resetOrigin(v)

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -7,6 +7,7 @@ import (
 
 	// "strings"
 
+	"fmt"
 	"strings"
 
 	"github.com/fatih/color"
@@ -319,16 +320,15 @@ func (gui *Gui) refreshFiles(g *gocui.Gui) error {
 		return err
 	}
 	gui.refreshStateFiles()
-	filesView.Clear()
+
+	displayStrings := make([]string, len(gui.State.Files))
 	for i, file := range gui.State.Files {
-		str := gui.renderFile(file)
-		if i < len(gui.State.Files)-1 {
-			str += "\n"
-		}
-		if _, err := filesView.Write([]byte(str)); err != nil {
-			return err
-		}
+		displayStrings[i] = gui.renderFile(file)
 	}
+
+	filesView.Clear()
+	fmt.Fprint(filesView, strings.Join(displayStrings, "\n"))
+
 	gui.correctCursor(filesView)
 	if filesView == g.CurrentView() {
 		gui.handleFileSelect(g, filesView)

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -185,7 +185,9 @@ func (gui *Gui) handleFileSelect(g *gocui.Gui, v *gocui.View) error {
 		gui.renderString(g, "main", gui.Tr.SLocalize("NoChangedFiles"))
 		return gui.renderfilesOptions(g, nil)
 	}
-	gui.renderfilesOptions(g, file)
+	if err := gui.renderfilesOptions(g, file); err != nil {
+		return err
+	}
 	var content string
 	if file.HasMergeConflicts {
 		return gui.refreshMergePanel(g)

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -71,10 +71,10 @@ type Gui struct {
 }
 
 type guiState struct {
-	Files             []commands.File
-	Branches          []commands.Branch
-	Commits           []commands.Commit
-	StashEntries      []commands.StashEntry
+	Files             []*commands.File
+	Branches          []*commands.Branch
+	Commits           []*commands.Commit
+	StashEntries      []*commands.StashEntry
 	PreviousView      string
 	HasMergeConflicts bool
 	ConflictIndex     int
@@ -83,17 +83,17 @@ type guiState struct {
 	EditHistory       *stack.Stack
 	Platform          commands.Platform
 	Updating          bool
-	Keys              []Binding
+	Keys              []*Binding
 }
 
 // NewGui builds a new gui handler
 func NewGui(log *logrus.Entry, gitCommand *commands.GitCommand, oSCommand *commands.OSCommand, tr *i18n.Localizer, config config.AppConfigurer, updater *updates.Updater) (*Gui, error) {
 
 	initialState := guiState{
-		Files:         make([]commands.File, 0),
+		Files:         make([]*commands.File, 0),
 		PreviousView:  "files",
-		Commits:       make([]commands.Commit, 0),
-		StashEntries:  make([]commands.StashEntry, 0),
+		Commits:       make([]*commands.Commit, 0),
+		StashEntries:  make([]*commands.StashEntry, 0),
 		ConflictIndex: 0,
 		ConflictTop:   true,
 		Conflicts:     make([]commands.Conflict, 0),

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -83,7 +83,6 @@ type guiState struct {
 	EditHistory       *stack.Stack
 	Platform          commands.Platform
 	Updating          bool
-	Keys              []*Binding
 }
 
 // NewGui builds a new gui handler

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -93,7 +93,7 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			ViewName: "",
 			Key:      'x',
 			Modifier: gocui.ModNone,
-			Handler:  gui.handleMenu,
+			Handler:  gui.handleCreateOptionsMenu,
 		}, {
 			ViewName:    "status",
 			Key:         'e',
@@ -369,11 +369,6 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Key:      'q',
 			Modifier: gocui.ModNone,
 			Handler:  gui.handleMenuClose,
-		}, {
-			ViewName: "menu",
-			Key:      gocui.KeySpace,
-			Modifier: gocui.ModNone,
-			Handler:  gui.handleMenuPress,
 		},
 	}
 

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1,6 +1,8 @@
 package gui
 
-import "github.com/jesseduffield/gocui"
+import (
+	"github.com/jesseduffield/gocui"
+)
 
 // Binding - a keybinding mapping a key and modifier to a handler. The keypress
 // is only handled if the given view has focus, or handled globally if the view
@@ -14,8 +16,26 @@ type Binding struct {
 	Description string
 }
 
-func (gui *Gui) GetKeybindings() []Binding {
-	bindings := []Binding{
+// GetDisplayStrings returns the display string of a file
+func (b *Binding) GetDisplayStrings() []string {
+	return []string{b.GetKey(), b.Description}
+}
+
+func (b *Binding) GetKey() string {
+	r, ok := b.Key.(rune)
+	key := ""
+
+	if ok {
+		key = string(r)
+	} else if b.KeyReadable != "" {
+		key = b.KeyReadable
+	}
+
+	return key
+}
+
+func (gui *Gui) GetKeybindings() []*Binding {
+	bindings := []*Binding{
 		{
 			ViewName: "",
 			Key:      'q',
@@ -360,7 +380,7 @@ func (gui *Gui) GetKeybindings() []Binding {
 	// Would make these keybindings global but that interferes with editing
 	// input in the confirmation panel
 	for _, viewName := range []string{"status", "files", "branches", "commits", "stash", "menu"} {
-		bindings = append(bindings, []Binding{
+		bindings = append(bindings, []*Binding{
 			{ViewName: viewName, Key: gocui.KeyTab, Modifier: gocui.ModNone, Handler: gui.nextView},
 			{ViewName: viewName, Key: gocui.KeyArrowLeft, Modifier: gocui.ModNone, Handler: gui.previousView},
 			{ViewName: viewName, Key: gocui.KeyArrowRight, Modifier: gocui.ModNone, Handler: gui.nextView},

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -49,12 +49,11 @@ func (gui *Gui) handleMenuClose(g *gocui.Gui, v *gocui.View) error {
 	return gui.returnFocus(g, v)
 }
 
-func (gui *Gui) handleMenu(g *gocui.Gui, v *gocui.View) error {
+func (gui *Gui) getBindings(v *gocui.View) []*Binding {
 	var (
 		bindingsGlobal, bindingsPanel []*Binding
 	)
-	// clear keys slice, so we don't have ghost elements
-	gui.State.Keys = gui.State.Keys[:0]
+
 	bindings := gui.GetKeybindings()
 
 	for _, binding := range bindings {
@@ -71,7 +70,11 @@ func (gui *Gui) handleMenu(g *gocui.Gui, v *gocui.View) error {
 	// append dummy element to have a separator between
 	// panel and global keybindings
 	bindingsPanel = append(bindingsPanel, &Binding{})
-	gui.State.Keys = append(bindingsPanel, bindingsGlobal...)
+	return append(bindingsPanel, bindingsGlobal...)
+}
+
+func (gui *Gui) handleMenu(g *gocui.Gui, v *gocui.View) error {
+	gui.State.Keys = gui.getBindings(v)
 
 	list, err := utils.RenderList(gui.State.Keys)
 	if err != nil {

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -8,6 +8,12 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
+// I need to store the handler function in state and it will take an interface and do something with it
+// I need to have another function describing how to display one of the structs
+// perhaps this calls for an interface where the struct is Binding and the interface has the methods Display and Execute
+// but this means that for the one struct I can only have one possible display/execute function, but I want to use whatever I want.
+// Would I ever need to use different handlers for different things? Maybe I should assume not given that I can cross that bridge when I come to it
+
 func (gui *Gui) handleMenuPress(g *gocui.Gui, v *gocui.View) error {
 	lineNumber := gui.getItemPosition(v)
 	if gui.State.Keys[lineNumber].Key == nil {
@@ -106,11 +112,11 @@ func (gui *Gui) handleMenu(g *gocui.Gui, v *gocui.View) error {
 	content := append(contentPanel, contentGlobal...)
 	gui.State.Keys = append(bindingsPanel, bindingsGlobal...)
 	// append newline at the end so the last line would be selectable
-	contentJoined := strings.Join(content, "\n") + "\n"
+	contentJoined := strings.Join(content, "\n")
 
 	// y1-1 so there will not be an extra space at the end of panel
 	x0, y0, x1, y1 := gui.getConfirmationPanelDimensions(g, contentJoined)
-	menuView, _ := g.SetView("menu", x0, y0, x1, y1-1, 0)
+	menuView, _ := g.SetView("menu", x0, y0, x1, y1, 0)
 	menuView.Title = strings.Title(gui.Tr.SLocalize("menu"))
 	menuView.FgColor = gocui.ColorWhite
 

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -8,21 +8,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
-func (gui *Gui) handleMenuPress(g *gocui.Gui, v *gocui.View) error {
-	lineNumber := gui.getItemPosition(v)
-	if gui.State.Keys[lineNumber].Key == nil {
-		return nil
-	}
-	if len(gui.State.Keys) > lineNumber {
-		err := gui.handleMenuClose(g, v)
-		if err != nil {
-			return err
-		}
-		return gui.State.Keys[lineNumber].Handler(g, v)
-	}
-	return nil
-}
-
 func (gui *Gui) handleMenuSelect(g *gocui.Gui, v *gocui.View) error {
 	// doing nothing for now
 	// but it is needed for switch in newLineFocused
@@ -39,9 +24,9 @@ func (gui *Gui) renderMenuOptions(g *gocui.Gui) error {
 }
 
 func (gui *Gui) handleMenuClose(g *gocui.Gui, v *gocui.View) error {
-	// better to delete because for example after closing update confirmation panel,
-	// the focus isn't set back to any of panels and one is unable to even quit
-	//_, err := g.SetViewOnBottom(v.Name())
+	if err := g.DeleteKeybinding("menu", gocui.KeySpace, gocui.ModNone); err != nil {
+		return err
+	}
 	err := g.DeleteView("menu")
 	if err != nil {
 		return err
@@ -49,55 +34,38 @@ func (gui *Gui) handleMenuClose(g *gocui.Gui, v *gocui.View) error {
 	return gui.returnFocus(g, v)
 }
 
-func (gui *Gui) getBindings(v *gocui.View) []*Binding {
-	var (
-		bindingsGlobal, bindingsPanel []*Binding
-	)
-
-	bindings := gui.GetKeybindings()
-
-	for _, binding := range bindings {
-		if binding.GetKey() != "" && binding.Description != "" {
-			switch binding.ViewName {
-			case "":
-				bindingsGlobal = append(bindingsGlobal, binding)
-			case v.Name():
-				bindingsPanel = append(bindingsPanel, binding)
-			}
-		}
-	}
-
-	// append dummy element to have a separator between
-	// panel and global keybindings
-	bindingsPanel = append(bindingsPanel, &Binding{})
-	return append(bindingsPanel, bindingsGlobal...)
-}
-
-func (gui *Gui) handleMenu(g *gocui.Gui, v *gocui.View) error {
-	gui.State.Keys = gui.getBindings(v)
-
-	list, err := utils.RenderList(gui.State.Keys)
+func (gui *Gui) createMenu(items interface{}, handlePress func(int) error) error {
+	list, err := utils.RenderList(items)
 	if err != nil {
 		return err
 	}
 
-	x0, y0, x1, y1 := gui.getConfirmationPanelDimensions(g, list)
-	menuView, _ := g.SetView("menu", x0, y0, x1, y1, 0)
+	x0, y0, x1, y1 := gui.getConfirmationPanelDimensions(gui.g, list)
+	menuView, _ := gui.g.SetView("menu", x0, y0, x1, y1, 0)
 	menuView.Title = strings.Title(gui.Tr.SLocalize("menu"))
 	menuView.FgColor = gocui.ColorWhite
 	menuView.Clear()
 	fmt.Fprint(menuView, list)
 
-	if err := gui.renderMenuOptions(g); err != nil {
+	if err := gui.renderMenuOptions(gui.g); err != nil {
 		return err
 	}
 
-	g.Update(func(g *gocui.Gui) error {
-		_, err := g.SetViewOnTop("menu")
-		if err != nil {
+	wrappedHandlePress := func(g *gocui.Gui, v *gocui.View) error {
+		lineNumber := gui.getItemPosition(v)
+		return handlePress(lineNumber)
+	}
+
+	if err := gui.g.SetKeybinding("menu", gocui.KeySpace, gocui.ModNone, wrappedHandlePress); err != nil {
+		return err
+	}
+
+	gui.g.Update(func(g *gocui.Gui) error {
+		if _, err := g.SetViewOnTop("menu"); err != nil {
 			return err
 		}
-		return gui.switchFocus(g, v, menuView)
+		currentView := gui.g.CurrentView()
+		return gui.switchFocus(gui.g, currentView, menuView)
 	})
 	return nil
 }

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -8,12 +8,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
-// I need to store the handler function in state and it will take an interface and do something with it
-// I need to have another function describing how to display one of the structs
-// perhaps this calls for an interface where the struct is Binding and the interface has the methods Display and Execute
-// but this means that for the one struct I can only have one possible display/execute function, but I want to use whatever I want.
-// Would I ever need to use different handlers for different things? Maybe I should assume not given that I can cross that bridge when I come to it
-
 func (gui *Gui) handleMenuPress(g *gocui.Gui, v *gocui.View) error {
 	lineNumber := gui.getItemPosition(v)
 	if gui.State.Keys[lineNumber].Key == nil {
@@ -111,10 +105,8 @@ func (gui *Gui) handleMenu(g *gocui.Gui, v *gocui.View) error {
 
 	content := append(contentPanel, contentGlobal...)
 	gui.State.Keys = append(bindingsPanel, bindingsGlobal...)
-	// append newline at the end so the last line would be selectable
 	contentJoined := strings.Join(content, "\n")
 
-	// y1-1 so there will not be an extra space at the end of panel
 	x0, y0, x1, y1 := gui.getConfirmationPanelDimensions(g, contentJoined)
 	menuView, _ := g.SetView("menu", x0, y0, x1, y1, 0)
 	menuView.Title = strings.Title(gui.Tr.SLocalize("menu"))

--- a/pkg/gui/options_menu_panel.go
+++ b/pkg/gui/options_menu_panel.go
@@ -1,0 +1,51 @@
+package gui
+
+import (
+	"errors"
+
+	"github.com/jesseduffield/gocui"
+)
+
+func (gui *Gui) getBindings(v *gocui.View) []*Binding {
+	var (
+		bindingsGlobal, bindingsPanel []*Binding
+	)
+
+	bindings := gui.GetKeybindings()
+
+	for _, binding := range bindings {
+		if binding.GetKey() != "" && binding.Description != "" {
+			switch binding.ViewName {
+			case "":
+				bindingsGlobal = append(bindingsGlobal, binding)
+			case v.Name():
+				bindingsPanel = append(bindingsPanel, binding)
+			}
+		}
+	}
+
+	// append dummy element to have a separator between
+	// panel and global keybindings
+	bindingsPanel = append(bindingsPanel, &Binding{})
+	return append(bindingsPanel, bindingsGlobal...)
+}
+
+func (gui *Gui) handleCreateOptionsMenu(g *gocui.Gui, v *gocui.View) error {
+	bindings := gui.getBindings(v)
+
+	handleOptionsMenuPress := func(index int) error {
+		if bindings[index].Key == nil {
+			return nil
+		}
+		if index <= len(bindings) {
+			return errors.New("Index is greater than size of bindings")
+		}
+		err := gui.handleMenuClose(g, v)
+		if err != nil {
+			return err
+		}
+		return bindings[index].Handler(g, v)
+	}
+
+	return gui.createMenu(bindings, handleOptionsMenuPress)
+}

--- a/pkg/gui/stash_panel.go
+++ b/pkg/gui/stash_panel.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands"
@@ -14,10 +15,15 @@ func (gui *Gui) refreshStashEntries(g *gocui.Gui) error {
 			panic(err)
 		}
 		gui.State.StashEntries = gui.GitCommand.GetStashEntries()
-		v.Clear()
-		for _, stashEntry := range gui.State.StashEntries {
-			fmt.Fprintln(v, stashEntry.DisplayString)
+
+		displayStrings := make([]string, len(gui.State.StashEntries))
+		for i, stashEntry := range gui.State.StashEntries {
+			displayStrings[i] = stashEntry.DisplayString
 		}
+
+		v.Clear()
+		fmt.Fprint(v, strings.Join(displayStrings, "\n"))
+
 		return gui.resetOrigin(v)
 	})
 	return nil

--- a/pkg/gui/stash_panel.go
+++ b/pkg/gui/stash_panel.go
@@ -2,10 +2,10 @@ package gui
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 func (gui *Gui) refreshStashEntries(g *gocui.Gui) error {
@@ -16,13 +16,12 @@ func (gui *Gui) refreshStashEntries(g *gocui.Gui) error {
 		}
 		gui.State.StashEntries = gui.GitCommand.GetStashEntries()
 
-		displayStrings := make([]string, len(gui.State.StashEntries))
-		for i, stashEntry := range gui.State.StashEntries {
-			displayStrings[i] = stashEntry.DisplayString
-		}
-
 		v.Clear()
-		fmt.Fprint(v, strings.Join(displayStrings, "\n"))
+		list, err := utils.RenderList(gui.State.StashEntries)
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(v, list)
 
 		return gui.resetOrigin(v)
 	})
@@ -35,7 +34,7 @@ func (gui *Gui) getSelectedStashEntry(v *gocui.View) *commands.StashEntry {
 	}
 	stashView, _ := gui.g.View("stash")
 	lineNumber := gui.getItemPosition(stashView)
-	return &gui.State.StashEntries[lineNumber]
+	return gui.State.StashEntries[lineNumber]
 }
 
 func (gui *Gui) renderStashOptions(g *gocui.Gui) error {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -158,8 +158,11 @@ func renderDisplayableList(items []Displayable) (string, error) {
 }
 
 func getPadWidths(stringArrays [][]string) []int {
-	padWidths := make([]int, len(stringArrays[0]))
-	for i, _ := range padWidths {
+	if len(stringArrays[0]) <= 1 {
+		return []int{}
+	}
+	padWidths := make([]int, len(stringArrays[0])-1)
+	for i := range padWidths {
 		for _, strings := range stringArrays {
 			if len(strings[i]) > padWidths[i] {
 				padWidths[i] = len(strings[i])
@@ -172,9 +175,13 @@ func getPadWidths(stringArrays [][]string) []int {
 func getPaddedDisplayStrings(stringArrays [][]string, padWidths []int) []string {
 	paddedDisplayStrings := make([]string, len(stringArrays))
 	for i, stringArray := range stringArrays {
+		if len(stringArray) == 0 {
+			continue
+		}
 		for j, padWidth := range padWidths {
 			paddedDisplayStrings[i] += WithPadding(stringArray[j], padWidth) + " "
 		}
+		paddedDisplayStrings[i] += stringArray[len(padWidths)]
 	}
 	return paddedDisplayStrings
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -99,3 +99,11 @@ func ResolvePlaceholderString(str string, arguments map[string]string) string {
 	}
 	return str
 }
+
+// Min returns the minimum of two integers
+func Min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -346,3 +346,33 @@ func TestGetPadWidths(t *testing.T) {
 		assert.EqualValues(t, s.expected, getPadWidths(s.stringArrays))
 	}
 }
+
+func TestMin(t *testing.T) {
+	type scenario struct {
+		a        int
+		b        int
+		expected int
+	}
+
+	scenarios := []scenario{
+		{
+			1,
+			1,
+			1,
+		},
+		{
+			1,
+			2,
+			1,
+		},
+		{
+			2,
+			1,
+			1,
+		},
+	}
+
+	for _, s := range scenarios {
+		assert.EqualValues(t, s.expected, Min(s.a, s.b))
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -168,32 +169,180 @@ func TestResolvePlaceholderString(t *testing.T) {
 	}
 }
 
-func TestMin(t *testing.T) {
+func TestDisplayArraysAligned(t *testing.T) {
 	type scenario struct {
-		a        int
-		b        int
-		expected int
+		input    [][]string
+		expected bool
 	}
 
 	scenarios := []scenario{
 		{
-			2,
-			4,
-			2,
+			[][]string{{"", ""}, {"", ""}},
+			true,
 		},
 		{
-			2,
-			1,
-			1,
-		},
-		{
-			1,
-			1,
-			1,
+			[][]string{{""}, {"", ""}},
+			false,
 		},
 	}
 
 	for _, s := range scenarios {
-		assert.EqualValues(t, s.expected, Min(s.a, s.b))
+		assert.EqualValues(t, s.expected, displayArraysAligned(s.input))
+	}
+}
+
+type myDisplayable struct {
+	strings []string
+}
+
+type myStruct struct{}
+
+func (d *myDisplayable) GetDisplayStrings() []string {
+	return d.strings
+}
+
+func TestGetDisplayStringArrays(t *testing.T) {
+	type scenario struct {
+		input    []Displayable
+		expected [][]string
+	}
+
+	scenarios := []scenario{
+		{
+			[]Displayable{
+				Displayable(&myDisplayable{[]string{"a", "b"}}),
+				Displayable(&myDisplayable{[]string{"a", "b"}}),
+			},
+			[][]string{{"a", "b"}, {"c", "d"}},
+		},
+	}
+
+	for _, s := range scenarios {
+		assert.EqualValues(t, s.expected, getDisplayStringArrays(s.input))
+	}
+}
+
+func TestRenderDisplayableList(t *testing.T) {
+	type scenario struct {
+		input          []Displayable
+		expectedString string
+		expectedError  error
+	}
+
+	scenarios := []scenario{
+		{
+			[]Displayable{
+				Displayable(&myDisplayable{[]string{}}),
+				Displayable(&myDisplayable{[]string{}}),
+			},
+			"\n",
+			nil,
+		},
+		{
+			[]Displayable{
+				Displayable(&myDisplayable{[]string{"aa", "b"}}),
+				Displayable(&myDisplayable{[]string{"c", "d"}}),
+			},
+			"aa b\nc  d",
+			nil,
+		},
+		{
+			[]Displayable{
+				Displayable(&myDisplayable{[]string{"a"}}),
+				Displayable(&myDisplayable{[]string{"b", "c"}}),
+			},
+			"",
+			errors.New("Each item must return the same number of strings to display"),
+		},
+	}
+
+	for _, s := range scenarios {
+		str, err := renderDisplayableList(s.input)
+		assert.EqualValues(t, s.expectedString, str)
+		assert.EqualValues(t, s.expectedError, err)
+	}
+}
+
+func TestRenderList(t *testing.T) {
+	type scenario struct {
+		input          interface{}
+		expectedString string
+		expectedError  error
+	}
+
+	scenarios := []scenario{
+		{
+			[]*myDisplayable{
+				{[]string{"aa", "b"}},
+				{[]string{"c", "d"}},
+			},
+			"aa b\nc  d",
+			nil,
+		},
+		{
+			[]*myStruct{
+				{},
+				{},
+			},
+			"",
+			errors.New("item does not implement the Displayable interface"),
+		},
+		{
+			&myStruct{},
+			"",
+			errors.New("RenderList given a non-slice type"),
+		},
+	}
+
+	for _, s := range scenarios {
+		str, err := RenderList(s.input)
+		assert.EqualValues(t, s.expectedString, str)
+		assert.EqualValues(t, s.expectedError, err)
+	}
+}
+
+func TestGetPaddedDisplayStrings(t *testing.T) {
+	type scenario struct {
+		stringArrays [][]string
+		padWidths    []int
+		expected     []string
+	}
+
+	scenarios := []scenario{
+		{
+			[][]string{{"a", "b"}, {"c", "d"}},
+			[]int{1},
+			[]string{"a b", "c d"},
+		},
+	}
+
+	for _, s := range scenarios {
+		assert.EqualValues(t, s.expected, getPaddedDisplayStrings(s.stringArrays, s.padWidths))
+	}
+}
+
+func TestGetPadWidths(t *testing.T) {
+	type scenario struct {
+		stringArrays [][]string
+		expected     []int
+	}
+
+	scenarios := []scenario{
+		{
+			[][]string{{""}, {""}},
+			[]int{},
+		},
+		{
+			[][]string{{"a"}, {""}},
+			[]int{},
+		},
+		{
+			[][]string{{"aa", "b", "ccc"}, {"c", "d", "e"}},
+			[]int{2, 1},
+		},
+	}
+
+	for _, s := range scenarios {
+		assert.EqualValues(t, s.expected, getPadWidths(s.stringArrays))
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -167,3 +167,33 @@ func TestResolvePlaceholderString(t *testing.T) {
 		assert.EqualValues(t, string(s.expected), ResolvePlaceholderString(s.templateString, s.arguments))
 	}
 }
+
+func TestMin(t *testing.T) {
+	type scenario struct {
+		a        int
+		b        int
+		expected int
+	}
+
+	scenarios := []scenario{
+		{
+			2,
+			4,
+			2,
+		},
+		{
+			2,
+			1,
+			1,
+		},
+		{
+			1,
+			1,
+			1,
+		},
+	}
+
+	for _, s := range scenarios {
+		assert.EqualValues(t, s.expected, Min(s.a, s.b))
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -211,7 +211,7 @@ func TestGetDisplayStringArrays(t *testing.T) {
 		{
 			[]Displayable{
 				Displayable(&myDisplayable{[]string{"a", "b"}}),
-				Displayable(&myDisplayable{[]string{"a", "b"}}),
+				Displayable(&myDisplayable{[]string{"c", "d"}}),
 			},
 			[][]string{{"a", "b"}, {"c", "d"}},
 		},


### PR DESCRIPTION
There are bugs that appear when e.g. you have a heap of files in the files panel and you've selected the last one, and then the files are deleted in another terminal window, and you refresh causing a crash.

This fixes the correctCursor method to ensure that we aren't crashing here.

Unfortunately this put me on a bit of a tangent because I had to fix up the panels to stop having a trailing newline after the last items.

As part of that tangent, I've also standardised how lists are rendered for panels. So long as you have a struct where each item implements the GetDisplayStrings() method, you can easily render your list of items in a panel.