### PR TITLE
Fix invisible commit message panel getting focus

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -461,15 +461,6 @@ func (c *GitCommand) GetBranchGraph(branchName string) (string, error) {
 	return c.OSCommand.RunCommandWithOutput("git log --graph --color --abbrev-commit --decorate --date=relative --pretty=medium -100 " + branchName)
 }
 
-func includesString(list []string, a string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
-}
-
 // GetCommits obtains the commits of the current branch
 func (c *GitCommand) GetCommits() []Commit {
 	pushables := c.GetCommitsToPush()
@@ -480,7 +471,7 @@ func (c *GitCommand) GetCommits() []Commit {
 	for _, line := range lines {
 		splitLine := strings.Split(line, " ")
 		sha := splitLine[0]
-		pushed := includesString(pushables, sha)
+		pushed := utils.IncludesString(pushables, sha)
 		commits = append(commits, Commit{
 			Sha:           sha,
 			Name:          strings.Join(splitLine[1:], " "),

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -37,6 +37,7 @@ func (gui *Gui) handleCommitClose(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (gui *Gui) handleCommitFocused(g *gocui.Gui, v *gocui.View) error {
+	g.SetViewOnTop("commitMessage")
 	message := gui.Tr.TemplateLocalize(
 		"CloseConfirm",
 		Teml{

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -136,7 +136,7 @@ func (gui *Gui) switchFocus(g *gocui.Gui, oldView, newView *gocui.View) error {
 
 		// second class panels should never have focus restored to them because
 		// once they lose focus they are effectively 'destroyed'
-		secondClassPanels := []string{"commitMessage", "confirmation"}
+		secondClassPanels := []string{"confirmation"}
 		if !utils.IncludesString(secondClassPanels, oldView.Name()) {
 			gui.State.PreviousView = oldView.Name()
 		}

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -133,7 +133,13 @@ func (gui *Gui) switchFocus(g *gocui.Gui, oldView, newView *gocui.View) error {
 			},
 		)
 		gui.Log.Info(message)
-		gui.State.PreviousView = oldView.Name()
+
+		// second class panels should never have focus restored to them because
+		// once they lose focus they are effectively 'destroyed'
+		secondClassPanels := []string{"commitMessage", "confirmation"}
+		if !utils.IncludesString(secondClassPanels, oldView.Name()) {
+			gui.State.PreviousView = oldView.Name()
+		}
 	}
 	newView.Highlight = true
 	message := gui.Tr.TemplateLocalize(

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -99,3 +99,13 @@ func ResolvePlaceholderString(str string, arguments map[string]string) string {
 	}
 	return str
 }
+
+// IncludesString if the list contains the string
+func IncludesString(list []string, a string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This fixes a bug where if you're focused on the commit message panel, then say an error panel pops up, the commit message panel goes to the back of the views but then focus is returned to it 

Now we just bring that panel to the front when it's focused.

But while fixing this bug I also decided to introduce the idea of not ever returning focus to 'second class panels' which currently just contains the confirmation panel.

Can be tested with this:
```
diff --git a/pkg/gui/gui.go b/pkg/gui/gui.go
index e3cc615..2e98f16 100644
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -290,6 +290,11 @@ func (gui *Gui) layout(g *gocui.Gui) error {
                        return err
                }

+               go func() {
+                       time.Sleep(5 * time.Second)
+                       gui.createErrorPanel(g, "test")
+               }()
+
                // these are only called once (it's a place to put all the things you want
                // to happen on startup after the screen is first rendered)
                gui.Updater.CheckForNewUpdate(gui.onBackgroundUpdateCheckFinish, false)
```