### PR TITLE
main: display an error message instead of panic when setup fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -40,13 +41,13 @@ func main() {
 	}
 	appConfig, err := config.NewAppConfig("lazygit", version, commit, date, buildSource, debuggingFlag)
 	if err != nil {
-		panic(err)
+		log.Fatal(err.Error())
 	}
 
 	app, err := app.Setup(appConfig)
 	if err != nil {
 		app.Log.Error(err.Error())
-		panic(err)
+		log.Fatal(err.Error())
 	}
 
 	app.Gui.RunWithSubprocesses()


### PR DESCRIPTION
lazygit is not a library, but jsut CLI for end users. So it does not need to raise panic when config/setup fails.

For example, if I run `lazygit` in non-git directory, I'll get a following result:

```
panic: fatal: not a git repository (or any of the parent directories): .git


goroutine 1 [running]:
main.main()
	/go/src/github.com/jesseduffield/lazygit/main.go:49 +0x470
```

It seems like a bug! We can just show error message without panic, like this:

```
2018/09/14 00:29:55 fatal: not a git repository (or any of the parent directories): .git
```