### PR TITLE
Fix issues with commit message panel losing focus

### DIFF
--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -37,6 +37,10 @@ func (gui *Gui) handleCommitClose(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (gui *Gui) handleCommitFocused(g *gocui.Gui, v *gocui.View) error {
+	if _, err := g.SetViewOnTop("commitMessage"); err != nil {
+		return err
+	}
+
 	message := gui.Tr.TemplateLocalize(
 		"CloseConfirm",
 		Teml{

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -133,8 +133,15 @@ func (gui *Gui) switchFocus(g *gocui.Gui, oldView, newView *gocui.View) error {
 			},
 		)
 		gui.Log.Info(message)
-		gui.State.PreviousView = oldView.Name()
+
+		// second class panels should never have focus restored to them because
+		// once they lose focus they are effectively 'destroyed'
+		secondClassPanels := []string{"confirmation", "menu"}
+		if !utils.IncludesString(secondClassPanels, oldView.Name()) {
+			gui.State.PreviousView = oldView.Name()
+		}
 	}
+
 	newView.Highlight = true
 	message := gui.Tr.TemplateLocalize(
 		"newFocusedViewIs",

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -204,3 +204,13 @@ func getDisplayStringArrays(displayables []Displayable) [][]string {
 	}
 	return stringArrays
 }
+
+// IncludesString if the list contains the string
+func IncludesString(list []string, a string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -376,3 +376,38 @@ func TestMin(t *testing.T) {
 		assert.EqualValues(t, s.expected, Min(s.a, s.b))
 	}
 }
+
+func TestIncludesString(t *testing.T) {
+	type scenario struct {
+		list     []string
+		element  string
+		expected bool
+	}
+
+	scenarios := []scenario{
+		{
+			[]string{"a", "b"},
+			"a",
+			true,
+		},
+		{
+			[]string{"a", "b"},
+			"c",
+			false,
+		},
+		{
+			[]string{"a", "b"},
+			"",
+			false,
+		},
+		{
+			[]string{""},
+			"",
+			true,
+		},
+	}
+
+	for _, s := range scenarios {
+		assert.EqualValues(t, s.expected, IncludesString(s.list, s.element))
+	}
+}


### PR DESCRIPTION
This fixes a bug where if you're focused on the commit message panel, then say an error panel pops up, the commit message panel goes to the back of the views but then focus is returned to it 

Now we just bring that panel to the front when it's focused.

But while fixing this bug I also decided to introduce the idea of not ever returning focus to 'second class panels' which currently just contains the confirmation panel.

Can be tested with this:
```
diff --git a/pkg/gui/gui.go b/pkg/gui/gui.go
index e3cc615..2e98f16 100644
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -290,6 +290,11 @@ func (gui *Gui) layout(g *gocui.Gui) error {
                        return err
                }

+               go func() {
+                       time.Sleep(5 * time.Second)
+                       gui.createErrorPanel(g, "test")
+               }()
+
                // these are only called once (it's a place to put all the things you want
                // to happen on startup after the screen is first rendered)
                gui.Updater.CheckForNewUpdate(gui.onBackgroundUpdateCheckFinish, false)
```