### PR TITLE
prevent scrolling down after EOF appears in view

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -130,7 +130,8 @@ func (gui *Gui) scrollUpMain(g *gocui.Gui, v *gocui.View) error {
 func (gui *Gui) scrollDownMain(g *gocui.Gui, v *gocui.View) error {
 	mainView, _ := g.View("main")
 	ox, oy := mainView.Origin()
-	if oy < len(mainView.BufferLines()) {
+	_, sy := mainView.Size()
+	if oy+sy < len(mainView.BufferLines()) {
 		return mainView.SetOrigin(ox, oy+gui.Config.GetUserConfig().GetInt("gui.scrollHeight"))
 	}
 	return nil


### PR DESCRIPTION
before this commit, user can scroll down until EOF disappears.
so when scrollDownMain() checks whether user can scroll down,
let lazygit consider view size to prevent scroll down further after EOF.

- before this commit, we can scroll down until EOF disappears
![screen shot 2018-11-08 at 14 18 03](https://user-images.githubusercontent.com/18724352/48179308-ecdc6600-e361-11e8-8457-7145a73874d7.png)
(EOF locates upper than view's origin)

- so when EOF appears, prevent user to scroll down further
![screen shot 2018-11-08 at 14 18 12](https://user-images.githubusercontent.com/18724352/48179338-0f6e7f00-e362-11e8-9925-4f8e94480cdf.png)
