### PR TITLE
add scroll-past-bottom configuration option

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -6,6 +6,7 @@
   gui:
     # stuff relating to the UI
     scrollHeight: 2 # how many lines you scroll by
+    scrollPastBottom: true # enable scrolling past the bottom
     theme:
       activeBorderColor:
         - white

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -214,6 +214,7 @@ func GetDefaultConfig() []byte {
 		`gui:
   ## stuff relating to the UI
   scrollHeight: 2
+  scrollPastBottom: true
   theme:
     activeBorderColor:
       - white

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -130,7 +130,12 @@ func (gui *Gui) scrollUpMain(g *gocui.Gui, v *gocui.View) error {
 func (gui *Gui) scrollDownMain(g *gocui.Gui, v *gocui.View) error {
 	mainView, _ := g.View("main")
 	ox, oy := mainView.Origin()
-	if oy < len(mainView.BufferLines()) {
+	y := oy
+	if !gui.Config.GetUserConfig().GetBool("gui.scrollPastBottom") {
+		_, sy := mainView.Size()
+		y += sy
+	}
+	if y < len(mainView.BufferLines()) {
 		return mainView.SetOrigin(ox, oy+gui.Config.GetUserConfig().GetInt("gui.scrollHeight"))
 	}
 	return nil


### PR DESCRIPTION
with gui.scrollPastBottom option true, lazygit let user scroll past the bottom - which is default
if option is false, user cannot scroll further when bottom of file has appeared in mainView

since this option seems to be in configuration file rather than passed by argument as @glvr182 pointed out in #325, this PR gets option from config.yaml file.