### PR TITLE
Fix function comments with CodeLingo.

### DIFF
--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -109,7 +109,7 @@ func (c *OSCommand) OpenFile(filename string) error {
 	return err
 }
 
-// OpenFile opens a file with the given
+// OpenLink opens a file with the given
 func (c *OSCommand) OpenLink(link string) error {
 	commandTemplate := c.Config.GetUserConfig().GetString("os.openLinkCommand")
 	templateValues := map[string]string{

--- a/pkg/commands/os_test.go
+++ b/pkg/commands/os_test.go
@@ -278,7 +278,7 @@ func TestOSCommandQuoteSingleQuote(t *testing.T) {
 	assert.EqualValues(t, expected, actual)
 }
 
-// TestOSCommandQuoteSingleQuote tests the quote function with " quotes explicitly for Linux
+// TestOSCommandQuoteDoubleQuote tests the quote function with " quotes explicitly for Linux
 func TestOSCommandQuoteDoubleQuote(t *testing.T) {
 	osCommand := newDummyOSCommand()
 


### PR DESCRIPTION
Use Codelingo to automatically fix function comments following the
[effective go guidelines](https://golang.org/doc/effective_go.html#commentary) mentioned in [CONTRIBUTING.md](https://github.com/jesseduffield/lazygit/blob/ba7e6add8690de21239cd0f37ee52a7c50236518/CONTRIBUTING.md).

This patch was generated by running the Codelingo Rewrite Flow over the ["comment-first-word-as-subject" Tenet](https://github.com/codelingo/codelingo/blob/master/tenets/codelingo/effective-go/comment-first-word-as-subject/codelingo.yaml).

Note: the same Tenet can be used to automate PR reviews and generate guideline docs.