### PR TITLE
Fix function comments with CodeLingo.

### DIFF
--- a/pkg/commands/commit.go
+++ b/pkg/commands/commit.go
@@ -13,6 +13,7 @@ type Commit struct {
 	DisplayString string
 }
 
+// GetDisplayStrings is a function
 func (c *Commit) GetDisplayStrings() []string {
 	red := color.New(color.FgRed)
 	yellow := color.New(color.FgGreen)

--- a/pkg/commands/commit.go
+++ b/pkg/commands/commit.go
@@ -13,7 +13,7 @@ type Commit struct {
 	DisplayString string
 }
 
-// GetDisplayStrings is a function
+// GetDisplayStrings is a function.
 func (c *Commit) GetDisplayStrings() []string {
 	red := color.New(color.FgRed)
 	yellow := color.New(color.FgGreen)

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -262,7 +262,7 @@ func (c *GitCommand) NewBranch(name string) error {
 	return c.OSCommand.RunCommand(fmt.Sprintf("git checkout -b %s", name))
 }
 
-// CurrentBranchName is a function
+// CurrentBranchName is a function.
 func (c *GitCommand) CurrentBranchName() (string, error) {
 	branchName, err := c.OSCommand.RunCommandWithOutput("git symbolic-ref --short HEAD")
 	if err != nil {

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -262,6 +262,7 @@ func (c *GitCommand) NewBranch(name string) error {
 	return c.OSCommand.RunCommand(fmt.Sprintf("git checkout -b %s", name))
 }
 
+// CurrentBranchName is a function
 func (c *GitCommand) CurrentBranchName() (string, error) {
 	branchName, err := c.OSCommand.RunCommandWithOutput("git symbolic-ref --short HEAD")
 	if err != nil {

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -23,32 +23,32 @@ type fileInfoMock struct {
 	sys         interface{}
 }
 
-// Name is a function
+// Name is a function.
 func (f fileInfoMock) Name() string {
 	return f.name
 }
 
-// Size is a function
+// Size is a function.
 func (f fileInfoMock) Size() int64 {
 	return f.size
 }
 
-// Mode is a function
+// Mode is a function.
 func (f fileInfoMock) Mode() os.FileMode {
 	return f.fileMode
 }
 
-// ModTime is a function
+// ModTime is a function.
 func (f fileInfoMock) ModTime() time.Time {
 	return f.fileModTime
 }
 
-// IsDir is a function
+// IsDir is a function.
 func (f fileInfoMock) IsDir() bool {
 	return f.isDir
 }
 
-// Sys is a function
+// Sys is a function.
 func (f fileInfoMock) Sys() interface{} {
 	return f.sys
 }
@@ -70,7 +70,7 @@ func newDummyGitCommand() *GitCommand {
 	}
 }
 
-// TestVerifyInGitRepo is a function
+// TestVerifyInGitRepo is a function.
 func TestVerifyInGitRepo(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -107,7 +107,7 @@ func TestVerifyInGitRepo(t *testing.T) {
 	}
 }
 
-// TestNavigateToRepoRootDirectory is a function
+// TestNavigateToRepoRootDirectory is a function.
 func TestNavigateToRepoRootDirectory(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -164,7 +164,7 @@ func TestNavigateToRepoRootDirectory(t *testing.T) {
 	}
 }
 
-// TestSetupRepositoryAndWorktree is a function
+// TestSetupRepositoryAndWorktree is a function.
 func TestSetupRepositoryAndWorktree(t *testing.T) {
 	type scenario struct {
 		testName          string
@@ -233,7 +233,7 @@ func TestSetupRepositoryAndWorktree(t *testing.T) {
 	}
 }
 
-// TestNewGitCommand is a function
+// TestNewGitCommand is a function.
 func TestNewGitCommand(t *testing.T) {
 	actual, err := os.Getwd()
 	assert.NoError(t, err)
@@ -281,7 +281,7 @@ func TestNewGitCommand(t *testing.T) {
 	}
 }
 
-// TestGitCommandGetStashEntries is a function
+// TestGitCommandGetStashEntries is a function.
 func TestGitCommandGetStashEntries(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -334,7 +334,7 @@ func TestGitCommandGetStashEntries(t *testing.T) {
 	}
 }
 
-// TestGitCommandGetStashEntryDiff is a function
+// TestGitCommandGetStashEntryDiff is a function.
 func TestGitCommandGetStashEntryDiff(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -349,7 +349,7 @@ func TestGitCommandGetStashEntryDiff(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestGitCommandGetStatusFiles is a function
+// TestGitCommandGetStatusFiles is a function.
 func TestGitCommandGetStatusFiles(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -436,7 +436,7 @@ func TestGitCommandGetStatusFiles(t *testing.T) {
 	}
 }
 
-// TestGitCommandStashDo is a function
+// TestGitCommandStashDo is a function.
 func TestGitCommandStashDo(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -449,7 +449,7 @@ func TestGitCommandStashDo(t *testing.T) {
 	assert.NoError(t, gitCmd.StashDo(1, "drop"))
 }
 
-// TestGitCommandStashSave is a function
+// TestGitCommandStashSave is a function.
 func TestGitCommandStashSave(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -462,7 +462,7 @@ func TestGitCommandStashSave(t *testing.T) {
 	assert.NoError(t, gitCmd.StashSave("A stash message"))
 }
 
-// TestGitCommandCommitAmend is a function
+// TestGitCommandCommitAmend is a function.
 func TestGitCommandCommitAmend(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -476,7 +476,7 @@ func TestGitCommandCommitAmend(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestGitCommandMergeStatusFiles is a function
+// TestGitCommandMergeStatusFiles is a function.
 func TestGitCommandMergeStatusFiles(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -557,7 +557,7 @@ func TestGitCommandMergeStatusFiles(t *testing.T) {
 	}
 }
 
-// TestGitCommandUpstreamDifferentCount is a function
+// TestGitCommandUpstreamDifferentCount is a function.
 func TestGitCommandUpstreamDifferentCount(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -615,7 +615,7 @@ func TestGitCommandUpstreamDifferentCount(t *testing.T) {
 	}
 }
 
-// TestGitCommandGetCommitsToPush is a function
+// TestGitCommandGetCommitsToPush is a function.
 func TestGitCommandGetCommitsToPush(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -654,7 +654,7 @@ func TestGitCommandGetCommitsToPush(t *testing.T) {
 	}
 }
 
-// TestGitCommandRenameCommit is a function
+// TestGitCommandRenameCommit is a function.
 func TestGitCommandRenameCommit(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -667,7 +667,7 @@ func TestGitCommandRenameCommit(t *testing.T) {
 	assert.NoError(t, gitCmd.RenameCommit("test"))
 }
 
-// TestGitCommandResetToCommit is a function
+// TestGitCommandResetToCommit is a function.
 func TestGitCommandResetToCommit(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -680,7 +680,7 @@ func TestGitCommandResetToCommit(t *testing.T) {
 	assert.NoError(t, gitCmd.ResetToCommit("78976bc"))
 }
 
-// TestGitCommandNewBranch is a function
+// TestGitCommandNewBranch is a function.
 func TestGitCommandNewBranch(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -693,7 +693,7 @@ func TestGitCommandNewBranch(t *testing.T) {
 	assert.NoError(t, gitCmd.NewBranch("test"))
 }
 
-// TestGitCommandDeleteBranch is a function
+// TestGitCommandDeleteBranch is a function.
 func TestGitCommandDeleteBranch(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -743,7 +743,7 @@ func TestGitCommandDeleteBranch(t *testing.T) {
 	}
 }
 
-// TestGitCommandMerge is a function
+// TestGitCommandMerge is a function.
 func TestGitCommandMerge(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -756,7 +756,7 @@ func TestGitCommandMerge(t *testing.T) {
 	assert.NoError(t, gitCmd.Merge("test"))
 }
 
-// TestGitCommandUsingGpg is a function
+// TestGitCommandUsingGpg is a function.
 func TestGitCommandUsingGpg(t *testing.T) {
 	type scenario struct {
 		testName           string
@@ -850,7 +850,7 @@ func TestGitCommandUsingGpg(t *testing.T) {
 	}
 }
 
-// TestGitCommandCommit is a function
+// TestGitCommandCommit is a function.
 func TestGitCommandCommit(t *testing.T) {
 	type scenario struct {
 		testName           string
@@ -920,7 +920,7 @@ func TestGitCommandCommit(t *testing.T) {
 	}
 }
 
-// TestGitCommandCommitAmendFromFiles is a function
+// TestGitCommandCommitAmendFromFiles is a function.
 func TestGitCommandCommitAmendFromFiles(t *testing.T) {
 	type scenario struct {
 		testName           string
@@ -990,7 +990,7 @@ func TestGitCommandCommitAmendFromFiles(t *testing.T) {
 	}
 }
 
-// TestGitCommandPush is a function
+// TestGitCommandPush is a function.
 func TestGitCommandPush(t *testing.T) {
 	type scenario struct {
 		testName  string
@@ -1050,7 +1050,7 @@ func TestGitCommandPush(t *testing.T) {
 	}
 }
 
-// TestGitCommandSquashPreviousTwoCommits is a function
+// TestGitCommandSquashPreviousTwoCommits is a function.
 func TestGitCommandSquashPreviousTwoCommits(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1114,7 +1114,7 @@ func TestGitCommandSquashPreviousTwoCommits(t *testing.T) {
 	}
 }
 
-// TestGitCommandSquashFixupCommit is a function
+// TestGitCommandSquashFixupCommit is a function.
 func TestGitCommandSquashFixupCommit(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1178,7 +1178,7 @@ func TestGitCommandSquashFixupCommit(t *testing.T) {
 	}
 }
 
-// TestGitCommandCatFile is a function
+// TestGitCommandCatFile is a function.
 func TestGitCommandCatFile(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -1193,7 +1193,7 @@ func TestGitCommandCatFile(t *testing.T) {
 	assert.Equal(t, "test", o)
 }
 
-// TestGitCommandStageFile is a function
+// TestGitCommandStageFile is a function.
 func TestGitCommandStageFile(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -1206,7 +1206,7 @@ func TestGitCommandStageFile(t *testing.T) {
 	assert.NoError(t, gitCmd.StageFile("test.txt"))
 }
 
-// TestGitCommandUnstageFile is a function
+// TestGitCommandUnstageFile is a function.
 func TestGitCommandUnstageFile(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1253,7 +1253,7 @@ func TestGitCommandUnstageFile(t *testing.T) {
 	}
 }
 
-// TestGitCommandIsInMergeState is a function
+// TestGitCommandIsInMergeState is a function.
 func TestGitCommandIsInMergeState(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1322,7 +1322,7 @@ func TestGitCommandIsInMergeState(t *testing.T) {
 	}
 }
 
-// TestGitCommandRemoveFile is a function
+// TestGitCommandRemoveFile is a function.
 func TestGitCommandRemoveFile(t *testing.T) {
 	type scenario struct {
 		testName   string
@@ -1524,7 +1524,7 @@ func TestGitCommandRemoveFile(t *testing.T) {
 	}
 }
 
-// TestGitCommandShow is a function
+// TestGitCommandShow is a function.
 func TestGitCommandShow(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -1538,7 +1538,7 @@ func TestGitCommandShow(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestGitCommandCheckout is a function
+// TestGitCommandCheckout is a function.
 func TestGitCommandCheckout(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1585,7 +1585,7 @@ func TestGitCommandCheckout(t *testing.T) {
 	}
 }
 
-// TestGitCommandGetBranchGraph is a function
+// TestGitCommandGetBranchGraph is a function.
 func TestGitCommandGetBranchGraph(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -1599,7 +1599,7 @@ func TestGitCommandGetBranchGraph(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestGitCommandGetCommits is a function
+// TestGitCommandGetCommits is a function.
 func TestGitCommandGetCommits(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1721,7 +1721,7 @@ func TestGitCommandGetCommits(t *testing.T) {
 	}
 }
 
-// TestGitCommandGetLog is a function
+// TestGitCommandGetLog is a function.
 func TestGitCommandGetLog(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1764,7 +1764,7 @@ func TestGitCommandGetLog(t *testing.T) {
 	}
 }
 
-// TestGitCommandDiff is a function
+// TestGitCommandDiff is a function.
 func TestGitCommandDiff(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1827,7 +1827,7 @@ func TestGitCommandDiff(t *testing.T) {
 	}
 }
 
-// TestGitCommandGetMergeBase is a function
+// TestGitCommandGetMergeBase is a function.
 func TestGitCommandGetMergeBase(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1917,7 +1917,7 @@ func TestGitCommandGetMergeBase(t *testing.T) {
 	}
 }
 
-// TestGitCommandCurrentBranchName is a function
+// TestGitCommandCurrentBranchName is a function.
 func TestGitCommandCurrentBranchName(t *testing.T) {
 	type scenario struct {
 		testName string

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -23,26 +23,32 @@ type fileInfoMock struct {
 	sys         interface{}
 }
 
+// Name is a function
 func (f fileInfoMock) Name() string {
 	return f.name
 }
 
+// Size is a function
 func (f fileInfoMock) Size() int64 {
 	return f.size
 }
 
+// Mode is a function
 func (f fileInfoMock) Mode() os.FileMode {
 	return f.fileMode
 }
 
+// ModTime is a function
 func (f fileInfoMock) ModTime() time.Time {
 	return f.fileModTime
 }
 
+// IsDir is a function
 func (f fileInfoMock) IsDir() bool {
 	return f.isDir
 }
 
+// Sys is a function
 func (f fileInfoMock) Sys() interface{} {
 	return f.sys
 }
@@ -64,6 +70,7 @@ func newDummyGitCommand() *GitCommand {
 	}
 }
 
+// TestVerifyInGitRepo is a function
 func TestVerifyInGitRepo(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -100,6 +107,7 @@ func TestVerifyInGitRepo(t *testing.T) {
 	}
 }
 
+// TestNavigateToRepoRootDirectory is a function
 func TestNavigateToRepoRootDirectory(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -156,6 +164,7 @@ func TestNavigateToRepoRootDirectory(t *testing.T) {
 	}
 }
 
+// TestSetupRepositoryAndWorktree is a function
 func TestSetupRepositoryAndWorktree(t *testing.T) {
 	type scenario struct {
 		testName          string
@@ -224,6 +233,7 @@ func TestSetupRepositoryAndWorktree(t *testing.T) {
 	}
 }
 
+// TestNewGitCommand is a function
 func TestNewGitCommand(t *testing.T) {
 	actual, err := os.Getwd()
 	assert.NoError(t, err)
@@ -271,6 +281,7 @@ func TestNewGitCommand(t *testing.T) {
 	}
 }
 
+// TestGitCommandGetStashEntries is a function
 func TestGitCommandGetStashEntries(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -323,6 +334,7 @@ func TestGitCommandGetStashEntries(t *testing.T) {
 	}
 }
 
+// TestGitCommandGetStashEntryDiff is a function
 func TestGitCommandGetStashEntryDiff(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -337,6 +349,7 @@ func TestGitCommandGetStashEntryDiff(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestGitCommandGetStatusFiles is a function
 func TestGitCommandGetStatusFiles(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -423,6 +436,7 @@ func TestGitCommandGetStatusFiles(t *testing.T) {
 	}
 }
 
+// TestGitCommandStashDo is a function
 func TestGitCommandStashDo(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -435,6 +449,7 @@ func TestGitCommandStashDo(t *testing.T) {
 	assert.NoError(t, gitCmd.StashDo(1, "drop"))
 }
 
+// TestGitCommandStashSave is a function
 func TestGitCommandStashSave(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -447,6 +462,7 @@ func TestGitCommandStashSave(t *testing.T) {
 	assert.NoError(t, gitCmd.StashSave("A stash message"))
 }
 
+// TestGitCommandCommitAmend is a function
 func TestGitCommandCommitAmend(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -460,6 +476,7 @@ func TestGitCommandCommitAmend(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestGitCommandMergeStatusFiles is a function
 func TestGitCommandMergeStatusFiles(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -540,6 +557,7 @@ func TestGitCommandMergeStatusFiles(t *testing.T) {
 	}
 }
 
+// TestGitCommandUpstreamDifferentCount is a function
 func TestGitCommandUpstreamDifferentCount(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -597,6 +615,7 @@ func TestGitCommandUpstreamDifferentCount(t *testing.T) {
 	}
 }
 
+// TestGitCommandGetCommitsToPush is a function
 func TestGitCommandGetCommitsToPush(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -635,6 +654,7 @@ func TestGitCommandGetCommitsToPush(t *testing.T) {
 	}
 }
 
+// TestGitCommandRenameCommit is a function
 func TestGitCommandRenameCommit(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -647,6 +667,7 @@ func TestGitCommandRenameCommit(t *testing.T) {
 	assert.NoError(t, gitCmd.RenameCommit("test"))
 }
 
+// TestGitCommandResetToCommit is a function
 func TestGitCommandResetToCommit(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -659,6 +680,7 @@ func TestGitCommandResetToCommit(t *testing.T) {
 	assert.NoError(t, gitCmd.ResetToCommit("78976bc"))
 }
 
+// TestGitCommandNewBranch is a function
 func TestGitCommandNewBranch(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -671,6 +693,7 @@ func TestGitCommandNewBranch(t *testing.T) {
 	assert.NoError(t, gitCmd.NewBranch("test"))
 }
 
+// TestGitCommandDeleteBranch is a function
 func TestGitCommandDeleteBranch(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -720,6 +743,7 @@ func TestGitCommandDeleteBranch(t *testing.T) {
 	}
 }
 
+// TestGitCommandMerge is a function
 func TestGitCommandMerge(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -732,6 +756,7 @@ func TestGitCommandMerge(t *testing.T) {
 	assert.NoError(t, gitCmd.Merge("test"))
 }
 
+// TestGitCommandUsingGpg is a function
 func TestGitCommandUsingGpg(t *testing.T) {
 	type scenario struct {
 		testName           string
@@ -825,6 +850,7 @@ func TestGitCommandUsingGpg(t *testing.T) {
 	}
 }
 
+// TestGitCommandCommit is a function
 func TestGitCommandCommit(t *testing.T) {
 	type scenario struct {
 		testName           string
@@ -894,6 +920,7 @@ func TestGitCommandCommit(t *testing.T) {
 	}
 }
 
+// TestGitCommandCommitAmendFromFiles is a function
 func TestGitCommandCommitAmendFromFiles(t *testing.T) {
 	type scenario struct {
 		testName           string
@@ -963,6 +990,7 @@ func TestGitCommandCommitAmendFromFiles(t *testing.T) {
 	}
 }
 
+// TestGitCommandPush is a function
 func TestGitCommandPush(t *testing.T) {
 	type scenario struct {
 		testName  string
@@ -1022,6 +1050,7 @@ func TestGitCommandPush(t *testing.T) {
 	}
 }
 
+// TestGitCommandSquashPreviousTwoCommits is a function
 func TestGitCommandSquashPreviousTwoCommits(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1085,6 +1114,7 @@ func TestGitCommandSquashPreviousTwoCommits(t *testing.T) {
 	}
 }
 
+// TestGitCommandSquashFixupCommit is a function
 func TestGitCommandSquashFixupCommit(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1148,6 +1178,7 @@ func TestGitCommandSquashFixupCommit(t *testing.T) {
 	}
 }
 
+// TestGitCommandCatFile is a function
 func TestGitCommandCatFile(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -1162,6 +1193,7 @@ func TestGitCommandCatFile(t *testing.T) {
 	assert.Equal(t, "test", o)
 }
 
+// TestGitCommandStageFile is a function
 func TestGitCommandStageFile(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -1174,6 +1206,7 @@ func TestGitCommandStageFile(t *testing.T) {
 	assert.NoError(t, gitCmd.StageFile("test.txt"))
 }
 
+// TestGitCommandUnstageFile is a function
 func TestGitCommandUnstageFile(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1220,6 +1253,7 @@ func TestGitCommandUnstageFile(t *testing.T) {
 	}
 }
 
+// TestGitCommandIsInMergeState is a function
 func TestGitCommandIsInMergeState(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1288,6 +1322,7 @@ func TestGitCommandIsInMergeState(t *testing.T) {
 	}
 }
 
+// TestGitCommandRemoveFile is a function
 func TestGitCommandRemoveFile(t *testing.T) {
 	type scenario struct {
 		testName   string
@@ -1489,6 +1524,7 @@ func TestGitCommandRemoveFile(t *testing.T) {
 	}
 }
 
+// TestGitCommandShow is a function
 func TestGitCommandShow(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -1502,6 +1538,7 @@ func TestGitCommandShow(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestGitCommandCheckout is a function
 func TestGitCommandCheckout(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1548,6 +1585,7 @@ func TestGitCommandCheckout(t *testing.T) {
 	}
 }
 
+// TestGitCommandGetBranchGraph is a function
 func TestGitCommandGetBranchGraph(t *testing.T) {
 	gitCmd := newDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
@@ -1561,6 +1599,7 @@ func TestGitCommandGetBranchGraph(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestGitCommandGetCommits is a function
 func TestGitCommandGetCommits(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1682,6 +1721,7 @@ func TestGitCommandGetCommits(t *testing.T) {
 	}
 }
 
+// TestGitCommandGetLog is a function
 func TestGitCommandGetLog(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1724,6 +1764,7 @@ func TestGitCommandGetLog(t *testing.T) {
 	}
 }
 
+// TestGitCommandDiff is a function
 func TestGitCommandDiff(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1786,6 +1827,7 @@ func TestGitCommandDiff(t *testing.T) {
 	}
 }
 
+// TestGitCommandGetMergeBase is a function
 func TestGitCommandGetMergeBase(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -1875,6 +1917,7 @@ func TestGitCommandGetMergeBase(t *testing.T) {
 	}
 }
 
+// TestGitCommandCurrentBranchName is a function
 func TestGitCommandCurrentBranchName(t *testing.T) {
 	type scenario struct {
 		testName string

--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -109,7 +109,7 @@ func (c *OSCommand) OpenFile(filename string) error {
 	return err
 }
 
-// OpenFile opens a file with the given
+// OpenLink opens a file with the given
 func (c *OSCommand) OpenLink(link string) error {
 	commandTemplate := c.Config.GetUserConfig().GetString("os.openLinkCommand")
 	templateValues := map[string]string{

--- a/pkg/commands/os_test.go
+++ b/pkg/commands/os_test.go
@@ -278,7 +278,7 @@ func TestOSCommandQuoteSingleQuote(t *testing.T) {
 	assert.EqualValues(t, expected, actual)
 }
 
-// TestOSCommandQuoteSingleQuote tests the quote function with " quotes explicitly for Linux
+// TestOSCommandQuoteDoubleQuote tests the quote function with " quotes explicitly for Linux
 func TestOSCommandQuoteDoubleQuote(t *testing.T) {
 	osCommand := newDummyOSCommand()
 

--- a/pkg/commands/os_test.go
+++ b/pkg/commands/os_test.go
@@ -29,6 +29,7 @@ func newDummyAppConfig() *config.AppConfig {
 	return appConfig
 }
 
+// TestOSCommandRunCommandWithOutput is a function
 func TestOSCommandRunCommandWithOutput(t *testing.T) {
 	type scenario struct {
 		command string
@@ -56,6 +57,7 @@ func TestOSCommandRunCommandWithOutput(t *testing.T) {
 	}
 }
 
+// TestOSCommandRunCommand is a function
 func TestOSCommandRunCommand(t *testing.T) {
 	type scenario struct {
 		command string
@@ -76,6 +78,7 @@ func TestOSCommandRunCommand(t *testing.T) {
 	}
 }
 
+// TestOSCommandOpenFile is a function
 func TestOSCommandOpenFile(t *testing.T) {
 	type scenario struct {
 		filename string
@@ -126,6 +129,7 @@ func TestOSCommandOpenFile(t *testing.T) {
 	}
 }
 
+// TestOSCommandEditFile is a function
 func TestOSCommandEditFile(t *testing.T) {
 	type scenario struct {
 		filename           string
@@ -255,6 +259,7 @@ func TestOSCommandEditFile(t *testing.T) {
 	}
 }
 
+// TestOSCommandQuote is a function
 func TestOSCommandQuote(t *testing.T) {
 	osCommand := newDummyOSCommand()
 
@@ -291,6 +296,7 @@ func TestOSCommandQuoteDoubleQuote(t *testing.T) {
 	assert.EqualValues(t, expected, actual)
 }
 
+// TestOSCommandUnquote is a function
 func TestOSCommandUnquote(t *testing.T) {
 	osCommand := newDummyOSCommand()
 
@@ -301,6 +307,7 @@ func TestOSCommandUnquote(t *testing.T) {
 	assert.EqualValues(t, expected, actual)
 }
 
+// TestOSCommandFileType is a function
 func TestOSCommandFileType(t *testing.T) {
 	type scenario struct {
 		path  string

--- a/pkg/commands/os_test.go
+++ b/pkg/commands/os_test.go
@@ -29,7 +29,7 @@ func newDummyAppConfig() *config.AppConfig {
 	return appConfig
 }
 
-// TestOSCommandRunCommandWithOutput is a function
+// TestOSCommandRunCommandWithOutput is a function.
 func TestOSCommandRunCommandWithOutput(t *testing.T) {
 	type scenario struct {
 		command string
@@ -57,7 +57,7 @@ func TestOSCommandRunCommandWithOutput(t *testing.T) {
 	}
 }
 
-// TestOSCommandRunCommand is a function
+// TestOSCommandRunCommand is a function.
 func TestOSCommandRunCommand(t *testing.T) {
 	type scenario struct {
 		command string
@@ -78,7 +78,7 @@ func TestOSCommandRunCommand(t *testing.T) {
 	}
 }
 
-// TestOSCommandOpenFile is a function
+// TestOSCommandOpenFile is a function.
 func TestOSCommandOpenFile(t *testing.T) {
 	type scenario struct {
 		filename string
@@ -129,7 +129,7 @@ func TestOSCommandOpenFile(t *testing.T) {
 	}
 }
 
-// TestOSCommandEditFile is a function
+// TestOSCommandEditFile is a function.
 func TestOSCommandEditFile(t *testing.T) {
 	type scenario struct {
 		filename           string
@@ -259,7 +259,7 @@ func TestOSCommandEditFile(t *testing.T) {
 	}
 }
 
-// TestOSCommandQuote is a function
+// TestOSCommandQuote is a function.
 func TestOSCommandQuote(t *testing.T) {
 	osCommand := newDummyOSCommand()
 
@@ -296,7 +296,7 @@ func TestOSCommandQuoteDoubleQuote(t *testing.T) {
 	assert.EqualValues(t, expected, actual)
 }
 
-// TestOSCommandUnquote is a function
+// TestOSCommandUnquote is a function.
 func TestOSCommandUnquote(t *testing.T) {
 	osCommand := newDummyOSCommand()
 
@@ -307,7 +307,7 @@ func TestOSCommandUnquote(t *testing.T) {
 	assert.EqualValues(t, expected, actual)
 }
 
-// TestOSCommandFileType is a function
+// TestOSCommandFileType is a function.
 func TestOSCommandFileType(t *testing.T) {
 	type scenario struct {
 		path  string

--- a/pkg/commands/pull_request_test.go
+++ b/pkg/commands/pull_request_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestGetRepoInfoFromURL is a function
+// TestGetRepoInfoFromURL is a function.
 func TestGetRepoInfoFromURL(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -42,7 +42,7 @@ func TestGetRepoInfoFromURL(t *testing.T) {
 	}
 }
 
-// TestCreatePullRequest is a function
+// TestCreatePullRequest is a function.
 func TestCreatePullRequest(t *testing.T) {
 	type scenario struct {
 		testName string

--- a/pkg/commands/pull_request_test.go
+++ b/pkg/commands/pull_request_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestGetRepoInfoFromURL is a function
 func TestGetRepoInfoFromURL(t *testing.T) {
 	type scenario struct {
 		testName string
@@ -41,6 +42,7 @@ func TestGetRepoInfoFromURL(t *testing.T) {
 	}
 }
 
+// TestCreatePullRequest is a function
 func TestCreatePullRequest(t *testing.T) {
 	type scenario struct {
 		testName string

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -82,7 +82,7 @@ func (gui *Gui) getBufferLength(view *gocui.View) string {
 	return " " + strconv.Itoa(strings.Count(view.Buffer(), "")-1) + " "
 }
 
-// RenderCommitLength is a function
+// RenderCommitLength is a function.
 func (gui *Gui) RenderCommitLength() {
 	if !gui.Config.GetUserConfig().GetBool("gui.commitLength.show") {
 		return

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -82,6 +82,7 @@ func (gui *Gui) getBufferLength(view *gocui.View) string {
 	return " " + strconv.Itoa(strings.Count(view.Buffer(), "")-1) + " "
 }
 
+// RenderCommitLength is a function
 func (gui *Gui) RenderCommitLength() {
 	if !gui.Config.GetUserConfig().GetBool("gui.commitLength.show") {
 		return

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -21,7 +21,7 @@ func (b *Binding) GetDisplayStrings() []string {
 	return []string{b.GetKey(), b.Description}
 }
 
-// GetKey is a function
+// GetKey is a function.
 func (b *Binding) GetKey() string {
 	r, ok := b.Key.(rune)
 	key := ""
@@ -35,7 +35,7 @@ func (b *Binding) GetKey() string {
 	return key
 }
 
-// GetKeybindings is a function
+// GetKeybindings is a function.
 func (gui *Gui) GetKeybindings() []*Binding {
 	bindings := []*Binding{
 		{

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -21,6 +21,7 @@ func (b *Binding) GetDisplayStrings() []string {
 	return []string{b.GetKey(), b.Description}
 }
 
+// GetKey is a function
 func (b *Binding) GetKey() string {
 	r, ok := b.Key.(rune)
 	key := ""
@@ -34,6 +35,7 @@ func (b *Binding) GetKey() string {
 	return key
 }
 
+// GetKeybindings is a function
 func (gui *Gui) GetKeybindings() []*Binding {
 	bindings := []*Binding{
 		{

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -14,7 +14,7 @@ type recentRepo struct {
 	path string
 }
 
-// GetDisplayStrings is a function
+// GetDisplayStrings is a function.
 func (r *recentRepo) GetDisplayStrings() []string {
 	yellow := color.New(color.FgMagenta)
 	base := filepath.Base(r.path)

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -14,6 +14,7 @@ type recentRepo struct {
 	path string
 }
 
+// GetDisplayStrings is a function
 func (r *recentRepo) GetDisplayStrings() []string {
 	yellow := color.New(color.FgMagenta)
 	base := filepath.Base(r.path)

--- a/pkg/i18n/i18n_test.go
+++ b/pkg/i18n/i18n_test.go
@@ -16,12 +16,13 @@ func getDummyLog() *logrus.Entry {
 	log.Out = ioutil.Discard
 	return log.WithField("test", "test")
 }
-// TestNewLocalizer is a function
+
+// TestNewLocalizer is a function.
 func TestNewLocalizer(t *testing.T) {
 	assert.NotNil(t, NewLocalizer(getDummyLog()))
 }
 
-// TestDetectLanguage is a function
+// TestDetectLanguage is a function.
 func TestDetectLanguage(t *testing.T) {
 	type scenario struct {
 		langDetector func() (string, error)
@@ -48,7 +49,7 @@ func TestDetectLanguage(t *testing.T) {
 	}
 }
 
-// TestLocalizer is a function
+// TestLocalizer is a function.
 func TestLocalizer(t *testing.T) {
 	type scenario struct {
 		userLang string

--- a/pkg/i18n/i18n_test.go
+++ b/pkg/i18n/i18n_test.go
@@ -16,10 +16,12 @@ func getDummyLog() *logrus.Entry {
 	log.Out = ioutil.Discard
 	return log.WithField("test", "test")
 }
+// TestNewLocalizer is a function
 func TestNewLocalizer(t *testing.T) {
 	assert.NotNil(t, NewLocalizer(getDummyLog()))
 }
 
+// TestDetectLanguage is a function
 func TestDetectLanguage(t *testing.T) {
 	type scenario struct {
 		langDetector func() (string, error)
@@ -46,6 +48,7 @@ func TestDetectLanguage(t *testing.T) {
 	}
 }
 
+// TestLocalizer is a function
 func TestLocalizer(t *testing.T) {
 	type scenario struct {
 		userLang string

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestSplitLines is a function
 func TestSplitLines(t *testing.T) {
 	type scenario struct {
 		multilineString string
@@ -36,6 +37,7 @@ func TestSplitLines(t *testing.T) {
 	}
 }
 
+// TestWithPadding is a function
 func TestWithPadding(t *testing.T) {
 	type scenario struct {
 		str      string
@@ -61,6 +63,7 @@ func TestWithPadding(t *testing.T) {
 	}
 }
 
+// TestTrimTrailingNewline is a function
 func TestTrimTrailingNewline(t *testing.T) {
 	type scenario struct {
 		str      string
@@ -83,6 +86,7 @@ func TestTrimTrailingNewline(t *testing.T) {
 	}
 }
 
+// TestNormalizeLinefeeds is a function
 func TestNormalizeLinefeeds(t *testing.T) {
 	type scenario struct {
 		byteArray []byte
@@ -116,6 +120,7 @@ func TestNormalizeLinefeeds(t *testing.T) {
 	}
 }
 
+// TestResolvePlaceholderString is a function
 func TestResolvePlaceholderString(t *testing.T) {
 	type scenario struct {
 		templateString string
@@ -169,6 +174,7 @@ func TestResolvePlaceholderString(t *testing.T) {
 	}
 }
 
+// TestDisplayArraysAligned is a function
 func TestDisplayArraysAligned(t *testing.T) {
 	type scenario struct {
 		input    [][]string
@@ -197,10 +203,12 @@ type myDisplayable struct {
 
 type myStruct struct{}
 
+// GetDisplayStrings is a function
 func (d *myDisplayable) GetDisplayStrings() []string {
 	return d.strings
 }
 
+// TestGetDisplayStringArrays is a function
 func TestGetDisplayStringArrays(t *testing.T) {
 	type scenario struct {
 		input    []Displayable
@@ -222,6 +230,7 @@ func TestGetDisplayStringArrays(t *testing.T) {
 	}
 }
 
+// TestRenderDisplayableList is a function
 func TestRenderDisplayableList(t *testing.T) {
 	type scenario struct {
 		input          []Displayable
@@ -263,6 +272,7 @@ func TestRenderDisplayableList(t *testing.T) {
 	}
 }
 
+// TestRenderList is a function
 func TestRenderList(t *testing.T) {
 	type scenario struct {
 		input          interface{}
@@ -301,6 +311,7 @@ func TestRenderList(t *testing.T) {
 	}
 }
 
+// TestGetPaddedDisplayStrings is a function
 func TestGetPaddedDisplayStrings(t *testing.T) {
 	type scenario struct {
 		stringArrays [][]string
@@ -321,6 +332,7 @@ func TestGetPaddedDisplayStrings(t *testing.T) {
 	}
 }
 
+// TestGetPadWidths is a function
 func TestGetPadWidths(t *testing.T) {
 	type scenario struct {
 		stringArrays [][]string
@@ -347,6 +359,7 @@ func TestGetPadWidths(t *testing.T) {
 	}
 }
 
+// TestMin is a function
 func TestMin(t *testing.T) {
 	type scenario struct {
 		a        int
@@ -377,6 +390,7 @@ func TestMin(t *testing.T) {
 	}
 }
 
+// TestIncludesString is a function
 func TestIncludesString(t *testing.T) {
 	type scenario struct {
 		list     []string

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestSplitLines is a function
+// TestSplitLines is a function.
 func TestSplitLines(t *testing.T) {
 	type scenario struct {
 		multilineString string
@@ -37,7 +37,7 @@ func TestSplitLines(t *testing.T) {
 	}
 }
 
-// TestWithPadding is a function
+// TestWithPadding is a function.
 func TestWithPadding(t *testing.T) {
 	type scenario struct {
 		str      string
@@ -63,7 +63,7 @@ func TestWithPadding(t *testing.T) {
 	}
 }
 
-// TestTrimTrailingNewline is a function
+// TestTrimTrailingNewline is a function.
 func TestTrimTrailingNewline(t *testing.T) {
 	type scenario struct {
 		str      string
@@ -86,7 +86,7 @@ func TestTrimTrailingNewline(t *testing.T) {
 	}
 }
 
-// TestNormalizeLinefeeds is a function
+// TestNormalizeLinefeeds is a function.
 func TestNormalizeLinefeeds(t *testing.T) {
 	type scenario struct {
 		byteArray []byte
@@ -120,7 +120,7 @@ func TestNormalizeLinefeeds(t *testing.T) {
 	}
 }
 
-// TestResolvePlaceholderString is a function
+// TestResolvePlaceholderString is a function.
 func TestResolvePlaceholderString(t *testing.T) {
 	type scenario struct {
 		templateString string
@@ -174,7 +174,7 @@ func TestResolvePlaceholderString(t *testing.T) {
 	}
 }
 
-// TestDisplayArraysAligned is a function
+// TestDisplayArraysAligned is a function.
 func TestDisplayArraysAligned(t *testing.T) {
 	type scenario struct {
 		input    [][]string
@@ -203,12 +203,12 @@ type myDisplayable struct {
 
 type myStruct struct{}
 
-// GetDisplayStrings is a function
+// GetDisplayStrings is a function.
 func (d *myDisplayable) GetDisplayStrings() []string {
 	return d.strings
 }
 
-// TestGetDisplayStringArrays is a function
+// TestGetDisplayStringArrays is a function.
 func TestGetDisplayStringArrays(t *testing.T) {
 	type scenario struct {
 		input    []Displayable
@@ -230,7 +230,7 @@ func TestGetDisplayStringArrays(t *testing.T) {
 	}
 }
 
-// TestRenderDisplayableList is a function
+// TestRenderDisplayableList is a function.
 func TestRenderDisplayableList(t *testing.T) {
 	type scenario struct {
 		input          []Displayable
@@ -272,7 +272,7 @@ func TestRenderDisplayableList(t *testing.T) {
 	}
 }
 
-// TestRenderList is a function
+// TestRenderList is a function.
 func TestRenderList(t *testing.T) {
 	type scenario struct {
 		input          interface{}
@@ -311,7 +311,7 @@ func TestRenderList(t *testing.T) {
 	}
 }
 
-// TestGetPaddedDisplayStrings is a function
+// TestGetPaddedDisplayStrings is a function.
 func TestGetPaddedDisplayStrings(t *testing.T) {
 	type scenario struct {
 		stringArrays [][]string
@@ -332,7 +332,7 @@ func TestGetPaddedDisplayStrings(t *testing.T) {
 	}
 }
 
-// TestGetPadWidths is a function
+// TestGetPadWidths is a function.
 func TestGetPadWidths(t *testing.T) {
 	type scenario struct {
 		stringArrays [][]string
@@ -359,7 +359,7 @@ func TestGetPadWidths(t *testing.T) {
 	}
 }
 
-// TestMin is a function
+// TestMin is a function.
 func TestMin(t *testing.T) {
 	type scenario struct {
 		a        int
@@ -390,7 +390,7 @@ func TestMin(t *testing.T) {
 	}
 }
 
-// TestIncludesString is a function
+// TestIncludesString is a function.
 func TestIncludesString(t *testing.T) {
 	type scenario struct {
 		list     []string


### PR DESCRIPTION
Use [CodeLingo](https://www.codelingo.io/) to automatically fix function comments following the
[effective go guidelines](https://golang.org/doc/effective_go.html#commentary) mentioned in [CONTRIBUTING.md](https://github.com/jesseduffield/lazygit/blob/ba7e6add8690de21239cd0f37ee52a7c50236518/CONTRIBUTING.md).

This patch was generated by running the CodeLingo Rewrite Flow over the ["comment-first-word-as-subject" Tenet](https://github.com/codelingo/codelingo/blob/master/tenets/codelingo/effective-go/comment-first-word-as-subject/codelingo.yaml).

Note: the same Tenet can be used to automate PR reviews and generate guideline docs.

Install CodeLingo: [codelingo.io](https://www.codelingo.io)