### PR TITLE
WIP: Staging Lines

### DIFF
--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -1822,7 +1822,7 @@ func TestGitCommandDiff(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			gitCmd := newDummyGitCommand()
 			gitCmd.OSCommand.command = s.command
-			gitCmd.Diff(s.file)
+			gitCmd.Diff(s.file, false)
 		})
 	}
 }

--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"errors"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -175,4 +176,29 @@ func (c *OSCommand) AppendLineToFile(filename, line string) error {
 
 	_, err = f.WriteString("\n" + line)
 	return err
+}
+
+// CreateTempFile writes a string to a new temp file and returns the file's name
+func (c *OSCommand) CreateTempFile(filename, content string) (string, error) {
+	tmpfile, err := ioutil.TempFile("", filename)
+	if err != nil {
+		c.Log.Error(err)
+		return "", err
+	}
+
+	if _, err := tmpfile.Write([]byte(content)); err != nil {
+		c.Log.Error(err)
+		return "", err
+	}
+	if err := tmpfile.Close(); err != nil {
+		c.Log.Error(err)
+		return "", err
+	}
+
+	return tmpfile.Name(), nil
+}
+
+// RemoveFile removes a file at the specified path
+func (c *OSCommand) RemoveFile(filename string) error {
+	return os.Remove(filename)
 }

--- a/pkg/commands/os_test.go
+++ b/pkg/commands/os_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -362,5 +363,36 @@ func TestOSCommandFileType(t *testing.T) {
 		s.setup()
 		s.test(newDummyOSCommand().FileType(s.path))
 		_ = os.RemoveAll(s.path)
+	}
+}
+
+func TestOSCommandCreateTempFile(t *testing.T) {
+	type scenario struct {
+		testName string
+		filename string
+		content  string
+		test     func(string, error)
+	}
+
+	scenarios := []scenario{
+		{
+			"valid case",
+			"filename",
+			"content",
+			func(path string, err error) {
+				assert.NoError(t, err)
+
+				content, err := ioutil.ReadFile(path)
+				assert.NoError(t, err)
+
+				assert.Equal(t, "content", string(content))
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			s.test(newDummyOSCommand().CreateTempFile(s.filename, s.content))
+		})
 	}
 }

--- a/pkg/git/patch_modifier.go
+++ b/pkg/git/patch_modifier.go
@@ -1,0 +1,110 @@
+package git
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+type PatchModifier struct {
+	Log *logrus.Entry
+}
+
+// NewPatchModifier builds a new branch list builder
+func NewPatchModifier(log *logrus.Entry) (*PatchModifier, error) {
+	return &PatchModifier{
+		Log: log,
+	}, nil
+}
+
+// ModifyPatch takes the original patch, which may contain several hunks,
+// and the line number of the line we want to stage
+func (p *PatchModifier) ModifyPatch(patch string, lineNumber int) (string, error) {
+	lines := strings.Split(patch, "\n")
+	headerLength := 4
+	output := strings.Join(lines[0:headerLength], "\n") + "\n"
+
+	hunkStart, err := p.getHunkStart(lines, lineNumber)
+	if err != nil {
+		return "", err
+	}
+
+	hunk, err := p.getModifiedHunk(lines, hunkStart, lineNumber)
+	if err != nil {
+		return "", err
+	}
+
+	output += strings.Join(hunk, "\n")
+
+	return output, nil
+}
+
+// getHunkStart returns the line number of the hunk we're going to be modifying
+// in order to stage our line
+func (p *PatchModifier) getHunkStart(patchLines []string, lineNumber int) (int, error) {
+	// find the hunk that we're modifying
+	hunkStart := 0
+	for index, line := range patchLines {
+		if strings.HasPrefix(line, "@@") {
+			hunkStart = index
+		}
+		if index == lineNumber {
+			return hunkStart, nil
+		}
+	}
+	return 0, errors.New("Could not find hunk")
+}
+
+func (p *PatchModifier) getModifiedHunk(patchLines []string, hunkStart int, lineNumber int) ([]string, error) {
+	lineChanges := 0
+	// strip the hunk down to just the line we want to stage
+	newHunk := []string{}
+	for offsetIndex, line := range patchLines[hunkStart:] {
+		index := offsetIndex + hunkStart
+		if index != lineNumber {
+			// we include other removals but treat them like context
+			if strings.HasPrefix(line, "-") {
+				newHunk = append(newHunk, " "+line[1:])
+				lineChanges += 1
+				continue
+			}
+			// we don't include other additions
+			if strings.HasPrefix(line, "+") {
+				lineChanges -= 1
+				continue
+			}
+		}
+		newHunk = append(newHunk, line)
+	}
+
+	var err error
+	newHunk[0], err = p.updatedHeader(newHunk[0], lineChanges)
+	if err != nil {
+		return nil, err
+	}
+
+	return newHunk, nil
+}
+
+// updatedHeader returns the hunk header with the updated line range
+// we need to update the hunk length to reflect the changes we made
+// if the hunk has three additions but we're only staging one, then
+// @@ -14,8 +14,11 @@ import (
+// becomes
+// @@ -14,8 +14,9 @@ import (
+func (p *PatchModifier) updatedHeader(currentHeader string, lineChanges int) (string, error) {
+	// current counter is the number after the second comma
+	re := regexp.MustCompile(`^[^,]+,[^,]+,(\d+)`)
+	prevLengthString := re.FindStringSubmatch(currentHeader)[1]
+
+	prevLength, err := strconv.Atoi(prevLengthString)
+	if err != nil {
+		return "", err
+	}
+	re = regexp.MustCompile(`\d+ @@`)
+	newLength := strconv.Itoa(prevLength + lineChanges)
+	return re.ReplaceAllString(currentHeader, newLength+" @@"), nil
+}

--- a/pkg/git/patch_modifier_test.go
+++ b/pkg/git/patch_modifier_test.go
@@ -1,0 +1,68 @@
+package git
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func newDummyLog() *logrus.Entry {
+	log := logrus.New()
+	log.Out = ioutil.Discard
+	return log.WithField("test", "test")
+}
+
+func newDummyPatchModifier() *PatchModifier {
+	return &PatchModifier{
+		Log: newDummyLog(),
+	}
+}
+func TestModifyPatch(t *testing.T) {
+	type scenario struct {
+		testName              string
+		patchFilename         string
+		lineNumber            int
+		shouldError           bool
+		expectedPatchFilename string
+	}
+
+	scenarios := []scenario{
+		{
+			"Removing one line",
+			"testdata/testPatchBefore.diff",
+			8,
+			false,
+			"testdata/testPatchAfter1.diff",
+		},
+		{
+			"Adding one line",
+			"testdata/testPatchBefore.diff",
+			10,
+			false,
+			"testdata/testPatchAfter2.diff",
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			p := newDummyPatchModifier()
+			beforePatch, err := ioutil.ReadFile(s.patchFilename)
+			if err != nil {
+				panic("Cannot open file at " + s.patchFilename)
+			}
+			afterPatch, err := p.ModifyPatch(string(beforePatch), s.lineNumber)
+			if s.shouldError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				expected, err := ioutil.ReadFile(s.expectedPatchFilename)
+				if err != nil {
+					panic("Cannot open file at " + s.expectedPatchFilename)
+				}
+				assert.Equal(t, string(expected), afterPatch)
+			}
+		})
+	}
+}

--- a/pkg/git/patch_modifier_test.go
+++ b/pkg/git/patch_modifier_test.go
@@ -19,7 +19,7 @@ func newDummyPatchModifier() *PatchModifier {
 		Log: newDummyLog(),
 	}
 }
-func TestModifyPatch(t *testing.T) {
+func TestModifyPatchForLine(t *testing.T) {
 	type scenario struct {
 		testName              string
 		patchFilename         string
@@ -43,6 +43,27 @@ func TestModifyPatch(t *testing.T) {
 			false,
 			"testdata/testPatchAfter2.diff",
 		},
+		{
+			"Adding one line in top hunk in diff with multiple hunks",
+			"testdata/testPatchBefore2.diff",
+			20,
+			false,
+			"testdata/testPatchAfter3.diff",
+		},
+		{
+			"Adding one line in top hunk in diff with multiple hunks",
+			"testdata/testPatchBefore2.diff",
+			53,
+			false,
+			"testdata/testPatchAfter4.diff",
+		},
+		{
+			"adding unstaged file with a single line",
+			"testdata/addedFile.diff",
+			6,
+			false,
+			"testdata/addedFile.diff",
+		},
 	}
 
 	for _, s := range scenarios {
@@ -52,7 +73,7 @@ func TestModifyPatch(t *testing.T) {
 			if err != nil {
 				panic("Cannot open file at " + s.patchFilename)
 			}
-			afterPatch, err := p.ModifyPatch(string(beforePatch), s.lineNumber)
+			afterPatch, err := p.ModifyPatchForLine(string(beforePatch), s.lineNumber)
 			if s.shouldError {
 				assert.Error(t, err)
 			} else {

--- a/pkg/git/patch_parser.go
+++ b/pkg/git/patch_parser.go
@@ -1,0 +1,35 @@
+package git
+
+import (
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+type PatchParser struct {
+	Log *logrus.Entry
+}
+
+// NewPatchParser builds a new branch list builder
+func NewPatchParser(log *logrus.Entry) (*PatchParser, error) {
+	return &PatchParser{
+		Log: log,
+	}, nil
+}
+
+func (p *PatchParser) ParsePatch(patch string) ([]int, []int, error) {
+	lines := strings.Split(patch, "\n")
+	hunkStarts := []int{}
+	stageableLines := []int{}
+	headerLength := 4
+	for offsetIndex, line := range lines[headerLength:] {
+		index := offsetIndex + headerLength
+		if strings.HasPrefix(line, "@@") {
+			hunkStarts = append(hunkStarts, index)
+		}
+		if strings.HasPrefix(line, "-") || strings.HasPrefix(line, "+") {
+			stageableLines = append(stageableLines, index)
+		}
+	}
+	return hunkStarts, stageableLines, nil
+}

--- a/pkg/git/patch_parser.go
+++ b/pkg/git/patch_parser.go
@@ -21,15 +21,16 @@ func (p *PatchParser) ParsePatch(patch string) ([]int, []int, error) {
 	lines := strings.Split(patch, "\n")
 	hunkStarts := []int{}
 	stageableLines := []int{}
-	headerLength := 4
-	for offsetIndex, line := range lines[headerLength:] {
-		index := offsetIndex + headerLength
+	pastHeader := false
+	for index, line := range lines {
 		if strings.HasPrefix(line, "@@") {
+			pastHeader = true
 			hunkStarts = append(hunkStarts, index)
 		}
-		if strings.HasPrefix(line, "-") || strings.HasPrefix(line, "+") {
+		if pastHeader && (strings.HasPrefix(line, "-") || strings.HasPrefix(line, "+")) {
 			stageableLines = append(stageableLines, index)
 		}
 	}
+	p.Log.WithField("staging", "staging").Info(stageableLines)
 	return hunkStarts, stageableLines, nil
 }

--- a/pkg/git/patch_parser_test.go
+++ b/pkg/git/patch_parser_test.go
@@ -1,0 +1,65 @@
+package git
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newDummyPatchParser() *PatchParser {
+	return &PatchParser{
+		Log: newDummyLog(),
+	}
+}
+func TestParsePatch(t *testing.T) {
+	type scenario struct {
+		testName               string
+		patchFilename          string
+		shouldError            bool
+		expectedStageableLines []int
+		expectedHunkStarts     []int
+	}
+
+	scenarios := []scenario{
+		{
+			"Diff with one hunk",
+			"testdata/testPatchBefore.diff",
+			false,
+			[]int{8, 9, 10, 11},
+			[]int{4},
+		},
+		{
+			"Diff with two hunks",
+			"testdata/testPatchBefore2.diff",
+			false,
+			[]int{8, 9, 10, 11, 12, 13, 20, 21, 22, 23, 24, 25, 26, 27, 28, 33, 34, 35, 36, 37, 45, 46, 47, 48, 49, 50, 51, 52, 53},
+			[]int{4, 41},
+		},
+		{
+			"Unstaged file",
+			"testdata/addedFile.diff",
+			false,
+			[]int{6},
+			[]int{5},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			p := newDummyPatchParser()
+			beforePatch, err := ioutil.ReadFile(s.patchFilename)
+			if err != nil {
+				panic("Cannot open file at " + s.patchFilename)
+			}
+			hunkStarts, stageableLines, err := p.ParsePatch(string(beforePatch))
+			if s.shouldError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, s.expectedStageableLines, stageableLines)
+				assert.Equal(t, s.expectedHunkStarts, hunkStarts)
+			}
+		})
+	}
+}

--- a/pkg/git/testdata/addedFile.diff
+++ b/pkg/git/testdata/addedFile.diff
@@ -1,0 +1,7 @@
+diff --git a/blah b/blah
+new file mode 100644
+index 0000000..907b308
+--- /dev/null
++++ b/blah
+@@ -0,0 +1 @@
++blah

--- a/pkg/git/testdata/testPatchAfter1.diff
+++ b/pkg/git/testdata/testPatchAfter1.diff
@@ -1,0 +1,13 @@
+diff --git a/pkg/git/branch_list_builder.go b/pkg/git/branch_list_builder.go
+index 60ec4e0..db4485d 100644
+--- a/pkg/git/branch_list_builder.go
++++ b/pkg/git/branch_list_builder.go
+@@ -14,8 +14,7 @@ import (
+ 
+ // context:
+ // we want to only show 'safe' branches (ones that haven't e.g. been deleted)
+-// which `git branch -a` gives us, but we also want the recency data that
+ // git reflog gives us.
+ // So we get the HEAD, then append get the reflog branches that intersect with
+ // our safe branches, then add the remaining safe branches, ensuring uniqueness
+ // along the way

--- a/pkg/git/testdata/testPatchAfter2.diff
+++ b/pkg/git/testdata/testPatchAfter2.diff
@@ -1,0 +1,14 @@
+diff --git a/pkg/git/branch_list_builder.go b/pkg/git/branch_list_builder.go
+index 60ec4e0..db4485d 100644
+--- a/pkg/git/branch_list_builder.go
++++ b/pkg/git/branch_list_builder.go
+@@ -14,8 +14,9 @@ import (
+ 
+ // context:
+ // we want to only show 'safe' branches (ones that haven't e.g. been deleted)
+ // which `git branch -a` gives us, but we also want the recency data that
+ // git reflog gives us.
++// test 2 - if I remove this, I decrement the end counter
+ // So we get the HEAD, then append get the reflog branches that intersect with
+ // our safe branches, then add the remaining safe branches, ensuring uniqueness
+ // along the way

--- a/pkg/git/testdata/testPatchAfter3.diff
+++ b/pkg/git/testdata/testPatchAfter3.diff
@@ -1,0 +1,25 @@
+diff --git a/pkg/git/patch_modifier.go b/pkg/git/patch_modifier.go
+index a8fc600..6d8f7d7 100644
+--- a/pkg/git/patch_modifier.go
++++ b/pkg/git/patch_modifier.go
+@@ -36,18 +36,19 @@ func (p *PatchModifier) ModifyPatchForHunk(patch string, hunkStarts []int, curre
+ 		hunkEnd = hunkStarts[nextHunkStartIndex]
+ 	}
+ 
+ 	headerLength := 4
+ 	output := strings.Join(lines[0:headerLength], "\n") + "\n"
+ 	output += strings.Join(lines[hunkStart:hunkEnd], "\n") + "\n"
+ 
+ 	return output, nil
+ }
+ 
++func getHeaderLength(patchLines []string) (int, error) {
+ // ModifyPatchForLine takes the original patch, which may contain several hunks,
+ // and the line number of the line we want to stage
+ func (p *PatchModifier) ModifyPatchForLine(patch string, lineNumber int) (string, error) {
+ 	lines := strings.Split(patch, "\n")
+ 	headerLength := 4
+ 	output := strings.Join(lines[0:headerLength], "\n") + "\n"
+ 
+ 	hunkStart, err := p.getHunkStart(lines, lineNumber)
+

--- a/pkg/git/testdata/testPatchAfter4.diff
+++ b/pkg/git/testdata/testPatchAfter4.diff
@@ -1,0 +1,19 @@
+diff --git a/pkg/git/patch_modifier.go b/pkg/git/patch_modifier.go
+index a8fc600..6d8f7d7 100644
+--- a/pkg/git/patch_modifier.go
++++ b/pkg/git/patch_modifier.go
+@@ -124,13 +140,14 @@ func (p *PatchModifier) getModifiedHunk(patchLines []string, hunkStart int, line
+ // @@ -14,8 +14,9 @@ import (
+ func (p *PatchModifier) updatedHeader(currentHeader string, lineChanges int) (string, error) {
+ 	// current counter is the number after the second comma
+ 	re := regexp.MustCompile(`^[^,]+,[^,]+,(\d+)`)
+ 	matches := re.FindStringSubmatch(currentHeader)
+ 	if len(matches) < 2 {
+ 		re = regexp.MustCompile(`^[^,]+,[^+]+\+(\d+)`)
+ 		matches = re.FindStringSubmatch(currentHeader)
+ 	}
+ 	prevLengthString := matches[1]
++	prevLengthString := re.FindStringSubmatch(currentHeader)[1]
+ 
+ 	prevLength, err := strconv.Atoi(prevLengthString)
+ 	if err != nil {

--- a/pkg/git/testdata/testPatchBefore.diff
+++ b/pkg/git/testdata/testPatchBefore.diff
@@ -1,0 +1,15 @@
+diff --git a/pkg/git/branch_list_builder.go b/pkg/git/branch_list_builder.go
+index 60ec4e0..db4485d 100644
+--- a/pkg/git/branch_list_builder.go
++++ b/pkg/git/branch_list_builder.go
+@@ -14,8 +14,8 @@ import (
+ 
+ // context:
+ // we want to only show 'safe' branches (ones that haven't e.g. been deleted)
+-// which `git branch -a` gives us, but we also want the recency data that
+-// git reflog gives us.
++// test 2 - if I remove this, I decrement the end counter
++// test
+ // So we get the HEAD, then append get the reflog branches that intersect with
+ // our safe branches, then add the remaining safe branches, ensuring uniqueness
+ // along the way

--- a/pkg/git/testdata/testPatchBefore2.diff
+++ b/pkg/git/testdata/testPatchBefore2.diff
@@ -1,0 +1,57 @@
+diff --git a/pkg/git/patch_modifier.go b/pkg/git/patch_modifier.go
+index a8fc600..6d8f7d7 100644
+--- a/pkg/git/patch_modifier.go
++++ b/pkg/git/patch_modifier.go
+@@ -36,18 +36,34 @@ func (p *PatchModifier) ModifyPatchForHunk(patch string, hunkStarts []int, curre
+ 		hunkEnd = hunkStarts[nextHunkStartIndex]
+ 	}
+ 
+-	headerLength := 4
++	headerLength, err := getHeaderLength(lines)
++	if err != nil {
++		return "", err
++	}
++
+ 	output := strings.Join(lines[0:headerLength], "\n") + "\n"
+ 	output += strings.Join(lines[hunkStart:hunkEnd], "\n") + "\n"
+ 
+ 	return output, nil
+ }
+ 
++func getHeaderLength(patchLines []string) (int, error) {
++	for index, line := range patchLines {
++		if strings.HasPrefix(line, "@@") {
++			return index, nil
++		}
++	}
++	return 0, errors.New("Could not find any hunks in this patch")
++}
++
+ // ModifyPatchForLine takes the original patch, which may contain several hunks,
+ // and the line number of the line we want to stage
+ func (p *PatchModifier) ModifyPatchForLine(patch string, lineNumber int) (string, error) {
+ 	lines := strings.Split(patch, "\n")
+-	headerLength := 4
++	headerLength, err := getHeaderLength(lines)
++	if err != nil {
++		return "", err
++	}
+ 	output := strings.Join(lines[0:headerLength], "\n") + "\n"
+ 
+ 	hunkStart, err := p.getHunkStart(lines, lineNumber)
+@@ -124,13 +140,8 @@ func (p *PatchModifier) getModifiedHunk(patchLines []string, hunkStart int, line
+ // @@ -14,8 +14,9 @@ import (
+ func (p *PatchModifier) updatedHeader(currentHeader string, lineChanges int) (string, error) {
+ 	// current counter is the number after the second comma
+-	re := regexp.MustCompile(`^[^,]+,[^,]+,(\d+)`)
+-	matches := re.FindStringSubmatch(currentHeader)
+-	if len(matches) < 2 {
+-		re = regexp.MustCompile(`^[^,]+,[^+]+\+(\d+)`)
+-		matches = re.FindStringSubmatch(currentHeader)
+-	}
+-	prevLengthString := matches[1]
++	re := regexp.MustCompile(`(\d+) @@`)
++	prevLengthString := re.FindStringSubmatch(currentHeader)[1]
+ 
+ 	prevLength, err := strconv.Atoi(prevLengthString)
+ 	if err != nil {

--- a/pkg/gui/confirmation_panel.go
+++ b/pkg/gui/confirmation_panel.go
@@ -8,6 +8,7 @@ package gui
 
 import (
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/jesseduffield/gocui"
@@ -73,6 +74,7 @@ func (gui *Gui) prepareConfirmationPanel(currentView *gocui.View, title, prompt 
 			return nil, err
 		}
 		confirmationView.Title = title
+		confirmationView.Wrap = true
 		confirmationView.FgColor = gocui.ColorWhite
 	}
 	confirmationView.Clear()
@@ -137,7 +139,15 @@ func (gui *Gui) createMessagePanel(g *gocui.Gui, currentView *gocui.View, title,
 }
 
 func (gui *Gui) createErrorPanel(g *gocui.Gui, message string) error {
-	gui.Log.Error(message)
+	go func() {
+		// when reporting is switched on this log call sometimes introduces
+		// a delay on the error panel popping up. Here I'm adding a second wait
+		// so that the error is logged while the user is reading the error message
+		time.Sleep(time.Second)
+		gui.Log.Error(message)
+	}()
+
+	// gui.Log.WithField("staging", "staging").Info("creating confirmation panel")
 	currentView := g.CurrentView()
 	colorFunction := color.New(color.FgRed).SprintFunc()
 	coloredMessage := colorFunction(strings.TrimSpace(message))

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -57,10 +57,13 @@ func (gui *Gui) handleSwitchToStagingPanel(g *gocui.Gui, v *gocui.View) error {
 		}
 		return nil
 	}
-	if !file.Tracked || !file.HasUnstagedChanges {
+	if !file.HasUnstagedChanges {
+		gui.Log.WithField("staging", "staging").Info("making error panel")
 		return gui.createErrorPanel(g, gui.Tr.SLocalize("FileStagingRequirements"))
 	}
-	gui.switchFocus(g, v, stagingView)
+	if err := gui.switchFocus(g, v, stagingView); err != nil {
+		return err
+	}
 	return gui.refreshStagingPanel()
 }
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -72,6 +72,13 @@ type Gui struct {
 	statusManager *statusManager
 }
 
+type stagingState struct {
+	StageableLines   []int
+	HunkStarts       []int
+	CurrentLineIndex int
+	Diff             string
+}
+
 type guiState struct {
 	Files             []*commands.File
 	Branches          []*commands.Branch
@@ -85,6 +92,7 @@ type guiState struct {
 	EditHistory       *stack.Stack
 	Platform          commands.Platform
 	Updating          bool
+	StagingState      *stagingState
 }
 
 // NewGui builds a new gui handler
@@ -206,6 +214,20 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		v.Title = gui.Tr.SLocalize("DiffTitle")
 		v.Wrap = true
 		v.FgColor = gocui.ColorWhite
+	}
+
+	v, err = g.SetView("staging", leftSideWidth+panelSpacing, 0, width-1, optionsTop, gocui.LEFT)
+	if err != nil {
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+		v.Title = gui.Tr.SLocalize("StagingTitle")
+		v.Wrap = true
+		v.Highlight = true
+		v.FgColor = gocui.ColorWhite
+		if _, err := g.SetViewOnBottom("staging"); err != nil {
+			return err
+		}
 	}
 
 	if v, err := g.SetView("status", 0, 0, leftSideWidth, statusFilesBoundary, gocui.BOTTOM|gocui.RIGHT); err != nil {

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -222,7 +222,6 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			return err
 		}
 		v.Title = gui.Tr.SLocalize("StagingTitle")
-		v.Wrap = true
 		v.Highlight = true
 		v.FgColor = gocui.ColorWhite
 		if _, err := g.SetViewOnBottom("staging"); err != nil {

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -213,6 +213,13 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Handler:     gui.handleResetHard,
 			Description: gui.Tr.SLocalize("resetHard"),
 		}, {
+			ViewName:    "files",
+			Key:         gocui.KeyEnter,
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleSwitchToStagingPanel,
+			Description: gui.Tr.SLocalize("StageLines"),
+			KeyReadable: "enter",
+		}, {
 			ViewName: "main",
 			Key:      gocui.KeyEsc,
 			Modifier: gocui.ModNone,
@@ -384,6 +391,26 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Key:      'q',
 			Modifier: gocui.ModNone,
 			Handler:  gui.handleMenuClose,
+		}, {
+			ViewName: "staging",
+			Key:      gocui.KeyEsc,
+			Modifier: gocui.ModNone,
+			Handler:  gui.handleStagingEscape,
+		}, {
+			ViewName: "staging",
+			Key:      gocui.KeyArrowUp,
+			Modifier: gocui.ModNone,
+			Handler:  gui.handleStagingKeyUp,
+		}, {
+			ViewName: "staging",
+			Key:      gocui.KeyArrowDown,
+			Modifier: gocui.ModNone,
+			Handler:  gui.handleStagingKeyDown,
+		}, {
+			ViewName: "staging",
+			Key:      gocui.KeySpace,
+			Modifier: gocui.ModNone,
+			Handler:  gui.handleStageLine,
 		},
 	}
 

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -392,25 +392,64 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Modifier: gocui.ModNone,
 			Handler:  gui.handleMenuClose,
 		}, {
-			ViewName: "staging",
-			Key:      gocui.KeyEsc,
-			Modifier: gocui.ModNone,
-			Handler:  gui.handleStagingEscape,
+			ViewName:    "staging",
+			Key:         gocui.KeyEsc,
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleStagingEscape,
+			KeyReadable: "esc",
+			Description: gui.Tr.SLocalize("EscapeStaging"),
 		}, {
 			ViewName: "staging",
 			Key:      gocui.KeyArrowUp,
 			Modifier: gocui.ModNone,
-			Handler:  gui.handleStagingKeyUp,
+			Handler:  gui.handleStagingPrevLine,
 		}, {
 			ViewName: "staging",
 			Key:      gocui.KeyArrowDown,
 			Modifier: gocui.ModNone,
-			Handler:  gui.handleStagingKeyDown,
+			Handler:  gui.handleStagingNextLine,
 		}, {
 			ViewName: "staging",
-			Key:      gocui.KeySpace,
+			Key:      'k',
 			Modifier: gocui.ModNone,
-			Handler:  gui.handleStageLine,
+			Handler:  gui.handleStagingPrevLine,
+		}, {
+			ViewName: "staging",
+			Key:      'j',
+			Modifier: gocui.ModNone,
+			Handler:  gui.handleStagingNextLine,
+		}, {
+			ViewName: "staging",
+			Key:      gocui.KeyArrowLeft,
+			Modifier: gocui.ModNone,
+			Handler:  gui.handleStagingPrevHunk,
+		}, {
+			ViewName: "staging",
+			Key:      gocui.KeyArrowRight,
+			Modifier: gocui.ModNone,
+			Handler:  gui.handleStagingNextHunk,
+		}, {
+			ViewName: "staging",
+			Key:      'h',
+			Modifier: gocui.ModNone,
+			Handler:  gui.handleStagingPrevHunk,
+		}, {
+			ViewName: "staging",
+			Key:      'l',
+			Modifier: gocui.ModNone,
+			Handler:  gui.handleStagingNextHunk,
+		}, {
+			ViewName:    "staging",
+			Key:         gocui.KeySpace,
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleStageLine,
+			Description: gui.Tr.SLocalize("StageLine"),
+		}, {
+			ViewName:    "staging",
+			Key:         'a',
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleStageHunk,
+			Description: gui.Tr.SLocalize("StageHunk"),
 		},
 	}
 

--- a/pkg/gui/staging_panel.go
+++ b/pkg/gui/staging_panel.go
@@ -1,0 +1,163 @@
+package gui
+
+import (
+	"errors"
+	"io/ioutil"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazygit/pkg/git"
+)
+
+func (gui *Gui) refreshStagingPanel() error {
+	// get the currently selected file. Get the diff of that file directly, not
+	// using any custom diff tools.
+	// parse the file to find out where the chunks and unstaged changes are
+
+	file, err := gui.getSelectedFile(gui.g)
+	if err != nil {
+		if err != gui.Errors.ErrNoFiles {
+			return err
+		}
+		return gui.handleStagingEscape(gui.g, nil)
+	}
+
+	if !file.HasUnstagedChanges {
+		return gui.handleStagingEscape(gui.g, nil)
+	}
+
+	// note for custom diffs, we'll need to send a flag here saying not to use the custom diff
+	diff := gui.GitCommand.Diff(file, true)
+	colorDiff := gui.GitCommand.Diff(file, false)
+
+	gui.Log.WithField("staging", "staging").Info("DIFF IS:")
+	gui.Log.WithField("staging", "staging").Info(spew.Sdump(diff))
+	gui.Log.WithField("staging", "staging").Info("hello")
+
+	if len(diff) < 2 {
+		return gui.handleStagingEscape(gui.g, nil)
+	}
+
+	// parse the diff and store the line numbers of hunks and stageable lines
+	// TODO: maybe instantiate this at application start
+	p, err := git.NewPatchParser(gui.Log)
+	if err != nil {
+		return nil
+	}
+	hunkStarts, stageableLines, err := p.ParsePatch(diff)
+	if err != nil {
+		return nil
+	}
+
+	var currentLineIndex int
+	if gui.State.StagingState != nil {
+		end := len(stageableLines) - 1
+		if end < gui.State.StagingState.CurrentLineIndex {
+			currentLineIndex = end
+		} else {
+			currentLineIndex = gui.State.StagingState.CurrentLineIndex
+		}
+	} else {
+		currentLineIndex = 0
+	}
+
+	gui.State.StagingState = &stagingState{
+		StageableLines:   stageableLines,
+		HunkStarts:       hunkStarts,
+		CurrentLineIndex: currentLineIndex,
+		Diff:             diff,
+	}
+
+	if len(stageableLines) == 0 {
+		return errors.New("No lines to stage")
+	}
+
+	stagingView := gui.getStagingView(gui.g)
+	stagingView.SetCursor(0, stageableLines[currentLineIndex])
+	stagingView.SetOrigin(0, 0)
+	return gui.renderString(gui.g, "staging", colorDiff)
+}
+
+func (gui *Gui) handleStagingEscape(g *gocui.Gui, v *gocui.View) error {
+	if _, err := gui.g.SetViewOnBottom("staging"); err != nil {
+		return err
+	}
+
+	return gui.switchFocus(gui.g, nil, gui.getFilesView(gui.g))
+}
+
+// nextNumber returns the next index, cycling if we reach the end
+func nextIndex(numbers []int, currentNumber int) int {
+	for index, number := range numbers {
+		if number > currentNumber {
+			return index
+		}
+	}
+	return 0
+}
+
+// prevNumber returns the next number, cycling if we reach the end
+func prevIndex(numbers []int, currentNumber int) int {
+	end := len(numbers) - 1
+	for i := end; i >= 0; i -= 1 {
+		if numbers[i] < currentNumber {
+			return i
+		}
+	}
+	return end
+}
+
+func (gui *Gui) handleStagingKeyUp(g *gocui.Gui, v *gocui.View) error {
+	return gui.handleCycleLine(true)
+}
+
+func (gui *Gui) handleStagingKeyDown(g *gocui.Gui, v *gocui.View) error {
+	return gui.handleCycleLine(false)
+}
+
+func (gui *Gui) handleCycleLine(up bool) error {
+	state := gui.State.StagingState
+	lineNumbers := state.StageableLines
+	currentLine := lineNumbers[state.CurrentLineIndex]
+	var newIndex int
+	if up {
+		newIndex = prevIndex(lineNumbers, currentLine)
+	} else {
+		newIndex = nextIndex(lineNumbers, currentLine)
+	}
+
+	state.CurrentLineIndex = newIndex
+	stagingView := gui.getStagingView(gui.g)
+	stagingView.SetCursor(0, lineNumbers[newIndex])
+	stagingView.SetOrigin(0, 0)
+	return nil
+}
+
+func (gui *Gui) handleStageLine(g *gocui.Gui, v *gocui.View) error {
+	state := gui.State.StagingState
+	p, err := git.NewPatchModifier(gui.Log)
+	if err != nil {
+		return err
+	}
+
+	currentLine := state.StageableLines[state.CurrentLineIndex]
+	patch, err := p.ModifyPatch(state.Diff, currentLine)
+	if err != nil {
+		return err
+	}
+
+	// for logging purposes
+	ioutil.WriteFile("patch.diff", []byte(patch), 0600)
+
+	// apply the patch then refresh this panel
+	// create a new temp file with the patch, then call git apply with that patch
+	_, err = gui.GitCommand.ApplyPatch(patch)
+	if err != nil {
+		panic(err)
+	}
+
+	gui.refreshStagingPanel()
+	gui.refreshFiles(gui.g)
+	return nil
+}

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -103,6 +103,9 @@ func (gui *Gui) newLineFocused(g *gocui.Gui, v *gocui.View) error {
 		return gui.handleCommitSelect(g, v)
 	case "stash":
 		return gui.handleStashEntrySelect(g, v)
+	case "staging":
+		return nil
+		// return gui.handleStagingSelect(g, v)
 	default:
 		panic(gui.Tr.SLocalize("NoViewMachingNewLineFocusedSwitchStatement"))
 	}
@@ -153,6 +156,10 @@ func (gui *Gui) switchFocus(g *gocui.Gui, oldView, newView *gocui.View) error {
 	if _, err := g.SetCurrentView(newView.Name()); err != nil {
 		return err
 	}
+	if _, err := g.SetViewOnTop(newView.Name()); err != nil {
+		return err
+	}
+
 	g.Cursor = newView.Editable
 
 	return gui.newLineFocused(g, newView)
@@ -290,6 +297,11 @@ func (gui *Gui) getCommitMessageView(g *gocui.Gui) *gocui.View {
 
 func (gui *Gui) getBranchesView(g *gocui.Gui) *gocui.View {
 	v, _ := g.View("branches")
+	return v
+}
+
+func (gui *Gui) getStagingView(g *gocui.Gui) *gocui.View {
+	v, _ := g.View("staging")
 	return v
 }
 

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -259,7 +259,6 @@ func (gui *Gui) renderString(g *gocui.Gui, viewName, s string) error {
 		output := string(bom.Clean([]byte(s)))
 		output = utils.NormalizeLinefeeds(output)
 		fmt.Fprint(v, output)
-		v.Wrap = true
 		return nil
 	})
 	return nil

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -406,6 +406,27 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "StageLines",
 			Other: `stage individual hunks/lines`,
+		}, &i18n.Message{
+			ID:    "FileStagingRequirements",
+			Other: `Can only stage individual lines for tracked files with unstaged changes`,
+		}, &i18n.Message{
+			ID:    "StagingTitle",
+			Other: `Staging`,
+		}, &i18n.Message{
+			ID:    "StageHunk",
+			Other: `stage hunk`,
+		}, &i18n.Message{
+			ID:    "StageLine",
+			Other: `stage line`,
+		}, &i18n.Message{
+			ID:    "EscapeStaging",
+			Other: `return to files panel`,
+		}, &i18n.Message{
+			ID:    "CantFindHunks",
+			Other: `Could not find any hunks in this patch`,
+		}, &i18n.Message{
+			ID:    "CantFindHunk",
+			Other: `Could not find hunk`,
 		},
 	)
 }

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -403,6 +403,9 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "NoBranchOnRemote",
 			Other: `Deze branch bestaat niet op de remote. U moet het eerst naar de remote pushen.`,
+		}, &i18n.Message{
+			ID:    "StageLines",
+			Other: `stage individual hunks/lines`,
 		},
 	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -420,6 +420,21 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "StagingTitle",
 			Other: `Staging`,
+		}, &i18n.Message{
+			ID:    "StageHunk",
+			Other: `stage hunk`,
+		}, &i18n.Message{
+			ID:    "StageLine",
+			Other: `stage line`,
+		}, &i18n.Message{
+			ID:    "EscapeStaging",
+			Other: `return to files panel`,
+		}, &i18n.Message{
+			ID:    "CantFindHunks",
+			Other: `Could not find any hunks in this patch`,
+		}, &i18n.Message{
+			ID:    "CantFindHunk",
+			Other: `Could not find hunk`,
 		},
 	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -411,6 +411,15 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "NoBranchOnRemote",
 			Other: `This branch doesn't exist on remote. You need to push it to remote first.`,
+		}, &i18n.Message{
+			ID:    "StageLines",
+			Other: `stage individual hunks/lines`,
+		}, &i18n.Message{
+			ID:    "FileStagingRequirements",
+			Other: `Can only stage individual lines for tracked files with unstaged changes`,
+		}, &i18n.Message{
+			ID:    "StagingTitle",
+			Other: `Staging`,
 		},
 	)
 }

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -386,6 +386,9 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "NoBranchOnRemote",
 			Other: `Ta gałąź nie istnieje na zdalnym. Najpierw musisz go odepchnąć na odległość.`,
+		}, &i18n.Message{
+			ID:    "StageLines",
+			Other: `stage individual hunks/lines`,
 		},
 	)
 }

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -389,6 +389,27 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "StageLines",
 			Other: `stage individual hunks/lines`,
+		}, &i18n.Message{
+			ID:    "FileStagingRequirements",
+			Other: `Can only stage individual lines for tracked files with unstaged changes`,
+		}, &i18n.Message{
+			ID:    "StagingTitle",
+			Other: `Staging`,
+		}, &i18n.Message{
+			ID:    "StageHunk",
+			Other: `stage hunk`,
+		}, &i18n.Message{
+			ID:    "StageLine",
+			Other: `stage line`,
+		}, &i18n.Message{
+			ID:    "EscapeStaging",
+			Other: `return to files panel`,
+		}, &i18n.Message{
+			ID:    "CantFindHunks",
+			Other: `Could not find any hunks in this patch`,
+		}, &i18n.Message{
+			ID:    "CantFindHunk",
+			Other: `Could not find hunk`,
 		},
 	)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -214,3 +214,24 @@ func IncludesString(list []string, a string) bool {
 	}
 	return false
 }
+
+// NextIndex returns the index of the element that comes after the given number
+func NextIndex(numbers []int, currentNumber int) int {
+	for index, number := range numbers {
+		if number > currentNumber {
+			return index
+		}
+	}
+	return 0
+}
+
+// PrevIndex returns the index that comes before the given number, cycling if we reach the end
+func PrevIndex(numbers []int, currentNumber int) int {
+	end := len(numbers) - 1
+	for i := end; i >= 0; i -= 1 {
+		if numbers[i] < currentNumber {
+			return i
+		}
+	}
+	return end
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -425,3 +425,95 @@ func TestIncludesString(t *testing.T) {
 		assert.EqualValues(t, s.expected, IncludesString(s.list, s.element))
 	}
 }
+
+func TestNextIndex(t *testing.T) {
+	type scenario struct {
+		testName string
+		list     []int
+		element  int
+		expected int
+	}
+
+	scenarios := []scenario{
+		{
+			// I'm not really fussed about how it behaves here
+			"no elements",
+			[]int{},
+			1,
+			0,
+		},
+		{
+			"one element",
+			[]int{1},
+			1,
+			0,
+		},
+		{
+			"two elements",
+			[]int{1, 2},
+			1,
+			1,
+		},
+		{
+			"two elements, giving second one",
+			[]int{1, 2},
+			2,
+			0,
+		},
+		{
+			"three elements, giving second one",
+			[]int{1, 2, 3},
+			2,
+			2,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			assert.EqualValues(t, s.expected, NextIndex(s.list, s.element))
+		})
+	}
+}
+
+func TestPrevIndex(t *testing.T) {
+	type scenario struct {
+		testName string
+		list     []int
+		element  int
+		expected int
+	}
+
+	scenarios := []scenario{
+		{
+			// I'm not really fussed about how it behaves here
+			"no elements",
+			[]int{},
+			1,
+			-1,
+		},
+		{
+			"one element",
+			[]int{1},
+			1,
+			0,
+		},
+		{
+			"two elements",
+			[]int{1, 2},
+			1,
+			1,
+		},
+		{
+			"three elements, giving second one",
+			[]int{1, 2, 3},
+			2,
+			0,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			assert.EqualValues(t, s.expected, PrevIndex(s.list, s.element))
+		})
+	}
+}


### PR DESCRIPTION
Feels GOOD to put this PR up.

It's a WIP right now but basically works. Press enter in the files panel on a tracked file with unstaged changes, and you'll be able to use the up/down keys to cycle through unstaged lines, and left/right to cycle through hunks. Pressing space on a line will stage that line, and pressing 'a' will stage the hunk of the currently focused line.

Before I merge this I want to add some more unit tests and ensure that I've got my strings all i18n'd, and that I'm logging the right stuff where I should be. I might make another PR down the line to support reverting lines.