### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # run with:
 # docker build -t lazygit .
-# docker run -it lazygit:latest
+# docker run -it lazygit:latest /bin/sh -l
 
 FROM golang:alpine
 WORKDIR /go/src/github.com/jesseduffield/lazygit/
@@ -11,3 +11,4 @@ FROM alpine:latest
 RUN apk add -U git xdg-utils
 WORKDIR /go/src/github.com/jesseduffield/lazygit/
 COPY --from=0 /go/src/github.com/jesseduffield/lazygit/lazygit /bin/
+RUN echo "alias gg=lazygit" >> ~/.profile

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,9 @@
 FROM golang:alpine
 WORKDIR /go/src/github.com/jesseduffield/lazygit/
 COPY ./ .
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o lazygit .
+RUN CGO_ENABLED=0 GOOS=linux go build -o lazygit .
 
 FROM alpine:latest
 RUN apk add -U git xdg-utils
-WORKDIR /root/
-COPY --from=0 /go/src/github.com/jesseduffield/lazygit/lazygit .
-CMD ["./lazygit"]
+WORKDIR /go/src/github.com/jesseduffield/lazygit/
+COPY --from=0 /go/src/github.com/jesseduffield/lazygit/lazygit /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@
 # docker run -it lazygit:latest
 
 FROM golang:alpine
+WORKDIR /go/src/github.com/jesseduffield/lazygit/
+COPY ./ .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o lazygit .
 
+FROM alpine:latest
 RUN apk add -U git xdg-utils
-
-ADD . /go/src/github.com/jesseduffield/lazygit
-
-RUN go install github.com/jesseduffield/lazygit
-
-WORKDIR /go/src/github.com/jesseduffield/lazygit
+WORKDIR /root/
+COPY --from=0 /go/src/github.com/jesseduffield/lazygit/lazygit .
+CMD ["./lazygit"]


### PR DESCRIPTION
This simply modifies the Dockerfile to use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/). Also, it's recommended in the docs to use `COPY` not `ADD` unless necessary. This significantly shrinks the size of the final image, observe:

```
# Before
lazygit             latest              92a15a264af0        26 seconds ago      458MB
golang              alpine              57915f96905a        4 weeks ago         310MB
 
# After
lazygit             latest              7a50dc45d103        4 seconds ago       49.1MB
<none>              <none>              a6c1a4447760        12 seconds ago      466MB
golang              alpine              57915f96905a        4 weeks ago         310MB
alpine              latest              196d12cf6ab1        2 months ago        4.41MB
```

The size of the lazygit image went from 458MB to 49.1MB.

**N.B.**: I don't copy over the entire repository, only the final binary. You will need to mount a volume. The user will need to do this anyway if they want to use a different repository.