### PR TITLE
Faster reset --hard head and clean as well

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -208,9 +208,13 @@ func includesInt(list []int, a int) bool {
 	return false
 }
 
-// ResetHard clears the working tree to match HEAD
-func (c *GitCommand) ResetHard() error {
-	return c.OSCommand.RunCommand("git reset --hard HEAD")
+// ResetAndClean removes all unstaged changes and removes all untracked files
+func (c *GitCommand) ResetAndClean() error {
+	if err := c.OSCommand.RunCommand("git reset --hard HEAD"); err != nil {
+		return err
+	}
+
+	return c.OSCommand.RunCommand("git clean -fd")
 }
 
 // UpstreamDifferenceCount checks how many pushables/pullables there are for the

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -208,9 +208,9 @@ func includesInt(list []int, a int) bool {
 	return false
 }
 
-// ResetHard does the equivalent of `git reset --hard HEAD`
+// ResetHard clears the working tree to match HEAD
 func (c *GitCommand) ResetHard() error {
-	return c.Worktree.Reset(&gogit.ResetOptions{Mode: gogit.HardReset})
+	return c.OSCommand.RunCommand("git reset --hard HEAD")
 }
 
 // UpstreamDifferenceCount checks how many pushables/pullables there are for the

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -433,9 +433,9 @@ func (gui *Gui) handleAbortMerge(g *gocui.Gui, v *gocui.View) error {
 	return gui.refreshFiles(g)
 }
 
-func (gui *Gui) handleResetHard(g *gocui.Gui, v *gocui.View) error {
+func (gui *Gui) handleResetAndClean(g *gocui.Gui, v *gocui.View) error {
 	return gui.createConfirmationPanel(g, v, gui.Tr.SLocalize("ClearFilePanel"), gui.Tr.SLocalize("SureResetHardHead"), func(g *gocui.Gui, v *gocui.View) error {
-		if err := gui.GitCommand.ResetHard(); err != nil {
+		if err := gui.GitCommand.ResetAndClean(); err != nil {
 			gui.createErrorPanel(g, err.Error())
 		}
 		return gui.refreshFiles(g)

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -210,7 +210,7 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			ViewName:    "files",
 			Key:         'D',
 			Modifier:    gocui.ModNone,
-			Handler:     gui.handleResetHard,
+			Handler:     gui.handleResetAndClean,
 			Description: gui.Tr.SLocalize("resetHard"),
 		}, {
 			ViewName:    "files",

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -138,7 +138,7 @@ func addDutch(i18nObject *i18n.Bundle) error {
 			Other: "Dit bestand heeft geen merge conflicten",
 		}, &i18n.Message{
 			ID:    "SureResetHardHead",
-			Other: "Weet je het zeker dat je `reset --hard HEAD` wil uitvoeren? Het kan dat je hierdoor bestanden verliest",
+			Other: "Weet je het zeker dat je `reset --hard HEAD` en `clean -fd` wil uitvoeren? Het kan dat je hierdoor bestanden verliest",
 		}, &i18n.Message{
 			ID:    "SureTo",
 			Other: "Weet je het zeker dat je {{.fileName}} wilt {{.deleteVerb}} (je veranderingen zullen worden verwijderd)",
@@ -384,7 +384,7 @@ func addDutch(i18nObject *i18n.Bundle) error {
 			Other: `refresh bestanden`,
 		}, &i18n.Message{
 			ID:    "resetHard",
-			Other: `harde reset`,
+			Other: `harde reset and verwijderen ongevolgde bestanden`,
 		}, &i18n.Message{
 			ID:    "mergeIntoCurrentBranch",
 			Other: `merge in met huidige checked out branch`,

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -146,7 +146,7 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			Other: "This file has no merge conflicts",
 		}, &i18n.Message{
 			ID:    "SureResetHardHead",
-			Other: "Are you sure you want `reset --hard HEAD`? You may lose changes",
+			Other: "Are you sure you want `reset --hard HEAD` and `clean -fd`? You may lose changes",
 		}, &i18n.Message{
 			ID:    "SureTo",
 			Other: "Are you sure you want to {{.deleteVerb}} {{.fileName}} (you will lose your changes)?",
@@ -392,7 +392,7 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			Other: `refresh files`,
 		}, &i18n.Message{
 			ID:    "resetHard",
-			Other: `reset hard`,
+			Other: `reset hard and remove untracked files`,
 		}, &i18n.Message{
 			ID:    "mergeIntoCurrentBranch",
 			Other: `merge into currently checked out branch`,

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -127,7 +127,7 @@ func addPolish(i18nObject *i18n.Bundle) error {
 			Other: "Ten plik nie powoduje konfliktów scalania",
 		}, &i18n.Message{
 			ID:    "SureResetHardHead",
-			Other: "Jesteś pewny, że chcesz wykonać `reset --hard HEAD`? Możesz stracić wprowadzone zmiany",
+			Other: "Jesteś pewny, że chcesz wykonać `reset --hard HEAD` i `clean -fd`? Możesz stracić wprowadzone zmiany",
 		}, &i18n.Message{
 			ID:    "SureTo",
 			Other: "Jesteś pewny, że chcesz {{.deleteVerb}} {{.fileName}} (stracisz swoje wprowadzone zmiany)?",
@@ -370,7 +370,7 @@ func addPolish(i18nObject *i18n.Bundle) error {
 			Other: `odśwież pliki`,
 		}, &i18n.Message{
 			ID:    "resetHard",
-			Other: `zresetuj twardo`,
+			Other: `zresetuj twardo i usuń niepotwierdzone pliki`,
 		}, &i18n.Message{
 			ID:    "mergeIntoCurrentBranch",
 			Other: `scal do obecnej gałęzi`,


### PR DESCRIPTION
This PR 
1) reverts to using porcelain git for resetting --hard, as go-git was taking over 5 seconds
2) adds a `git clean -fd` to the command, to remove untracked files and folders. Warnings have been updated to tell users that's what they'll be doing.

using go-git for hard resetting used to remove untracked files anyway, and I think it makes sense that the shift+'D' keybinding should be to just blow away anything that's not 1:1 with HEAD. However I'll keep this PR up here for a bit if people have objections.