### PR TITLE
Unidirectional data binding and Fast-forwarding branches without checking them out

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -52,6 +52,9 @@ func newLogger(config config.AppConfigurer) *logrus.Entry {
 	} else {
 		log = newProductionLogger(config)
 	}
+
+	// highly recommended: tail -f development.log | humanlog
+	// https://github.com/aybabtme/humanlog
 	log.Formatter = &logrus.JSONFormatter{}
 
 	if config.GetUserConfig().GetString("reporting") == "on" {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -52,6 +52,8 @@ func newLogger(config config.AppConfigurer) *logrus.Entry {
 	} else {
 		log = newProductionLogger(config)
 	}
+	log.Formatter = &logrus.JSONFormatter{}
+
 	if config.GetUserConfig().GetString("reporting") == "on" {
 		// this isn't really a secret token: it only has permission to push new rollbar items
 		hook := rollrus.NewHook("23432119147a4367abf7c0de2aa99a2d", environment)

--- a/pkg/commands/branch.go
+++ b/pkg/commands/branch.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/fatih/color"
@@ -10,13 +11,21 @@ import (
 // Branch : A git branch
 // duplicating this for now
 type Branch struct {
-	Name    string
-	Recency string
+	Name      string
+	Recency   string
+	Pushables string
+	Pullables string
+	Selected  bool
 }
 
 // GetDisplayStrings returns the dispaly string of branch
 func (b *Branch) GetDisplayStrings() []string {
-	return []string{b.Recency, utils.ColoredString(b.Name, b.GetColor())}
+	displayName := utils.ColoredString(b.Name, b.GetColor())
+	if b.Selected && b.Pushables != "" && b.Pullables != "" {
+		displayName = fmt.Sprintf("↑%s↓%s %s", b.Pushables, b.Pullables, displayName)
+	}
+
+	return []string{b.Recency, displayName}
 }
 
 // GetColor branch color

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -130,6 +130,17 @@ func (c *GitCommand) GetStashEntryDiff(index int) (string, error) {
 
 // GetStatusFiles git status files
 func (c *GitCommand) GetStatusFiles() []*File {
+
+	// files := []*File{}
+	// for i := 0; i < 100; i++ {
+	// 	files = append(files, &File{
+	// 		Name:          strconv.Itoa(i),
+	// 		DisplayString: strconv.Itoa(i),
+	// 		Type:          "file",
+	// 	})
+	// }
+	// return files
+
 	statusOutput, _ := c.GitStatus()
 	statusStrings := utils.SplitLines(statusOutput)
 	files := []*File{}

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -557,8 +557,8 @@ func TestGitCommandMergeStatusFiles(t *testing.T) {
 	}
 }
 
-// TestGitCommandUpstreamDifferentCount is a function.
-func TestGitCommandUpstreamDifferentCount(t *testing.T) {
+// TestGitCommandGetCommitDifferences is a function.
+func TestGitCommandGetCommitDifferences(t *testing.T) {
 	type scenario struct {
 		testName string
 		command  func(string, ...string) *exec.Cmd
@@ -610,7 +610,7 @@ func TestGitCommandUpstreamDifferentCount(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			gitCmd := newDummyGitCommand()
 			gitCmd.OSCommand.command = s.command
-			s.test(gitCmd.UpstreamDifferenceCount())
+			s.test(gitCmd.GetCommitDifferences("HEAD", "@{u}"))
 		})
 	}
 }

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -24,10 +24,10 @@ func (gui *Gui) handleCommitConfirm(g *gocui.Gui, v *gocui.View) error {
 		return gui.Errors.ErrSubProcess
 	}
 	v.Clear()
-	v.SetCursor(0, 0)
-	v.SetOrigin(0, 0)
-	g.SetViewOnBottom("commitMessage")
-	gui.switchFocus(g, v, gui.getFilesView(g))
+	_ = v.SetCursor(0, 0)
+	_ = v.SetOrigin(0, 0)
+	_, _ = g.SetViewOnBottom("commitMessage")
+	_ = gui.switchFocus(g, v, gui.getFilesView(g))
 	return gui.refreshSidePanels(g)
 }
 

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -23,12 +23,12 @@ func (gui *Gui) handleCommitConfirm(g *gocui.Gui, v *gocui.View) error {
 		gui.SubProcess = sub
 		return gui.Errors.ErrSubProcess
 	}
-	gui.refreshFiles(g)
 	v.Clear()
 	v.SetCursor(0, 0)
+	v.SetOrigin(0, 0)
 	g.SetViewOnBottom("commitMessage")
 	gui.switchFocus(g, v, gui.getFilesView(g))
-	return gui.refreshCommits(g)
+	return gui.refreshSidePanels(g)
 }
 
 func (gui *Gui) handleCommitClose(g *gocui.Gui, v *gocui.View) error {

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -96,7 +96,8 @@ func (gui *Gui) handleResetToCommit(g *gocui.Gui, commitView *gocui.View) error 
 			panic(err)
 		}
 		gui.resetOrigin(commitView)
-		return gui.handleCommitSelect(g, nil)
+		gui.State.Panels.Commits.SelectedLine = 0
+		return gui.handleCommitSelect(g, commitView)
 	}, nil)
 }
 

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -9,37 +9,76 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
+// list panel functions
+
+func (gui *Gui) getSelectedCommit(g *gocui.Gui) *commands.Commit {
+	selectedLine := gui.State.Panels.Commits.SelectedLine
+	if selectedLine == -1 {
+		return nil
+	}
+
+	return gui.State.Commits[selectedLine]
+}
+
+func (gui *Gui) handleCommitSelect(g *gocui.Gui, v *gocui.View) error {
+	commit := gui.getSelectedCommit(g)
+	if commit == nil {
+		return gui.renderString(g, "main", gui.Tr.SLocalize("NoCommitsThisBranch"))
+	}
+
+	if err := gui.focusPoint(0, gui.State.Panels.Commits.SelectedLine, v); err != nil {
+		return err
+	}
+	commitText, err := gui.GitCommand.Show(commit.Sha)
+	if err != nil {
+		return err
+	}
+	return gui.renderString(g, "main", commitText)
+}
+
 func (gui *Gui) refreshCommits(g *gocui.Gui) error {
 	g.Update(func(*gocui.Gui) error {
 		commits, err := gui.GitCommand.GetCommits()
 		if err != nil {
 			return err
 		}
-
 		gui.State.Commits = commits
-		v, err := g.View("commits")
-		if err != nil {
-			return err
-		}
 
 		gui.refreshSelectedLine(&gui.State.Panels.Commits.SelectedLine, len(gui.State.Commits))
-
-		v.Clear()
 
 		list, err := utils.RenderList(gui.State.Commits)
 		if err != nil {
 			return err
 		}
+
+		v := gui.getCommitsView(gui.g)
+		v.Clear()
 		fmt.Fprint(v, list)
 
 		gui.refreshStatus(g)
-		if g.CurrentView().Name() == "commits" {
+		if v == g.CurrentView() {
 			gui.handleCommitSelect(g, v)
 		}
 		return nil
 	})
 	return nil
 }
+
+func (gui *Gui) handleCommitsNextLine(g *gocui.Gui, v *gocui.View) error {
+	panelState := gui.State.Panels.Commits
+	gui.changeSelectedLine(&panelState.SelectedLine, len(gui.State.Commits), false)
+
+	return gui.handleCommitSelect(gui.g, v)
+}
+
+func (gui *Gui) handleCommitsPrevLine(g *gocui.Gui, v *gocui.View) error {
+	panelState := gui.State.Panels.Commits
+	gui.changeSelectedLine(&panelState.SelectedLine, len(gui.State.Commits), true)
+
+	return gui.handleCommitSelect(gui.g, v)
+}
+
+// specific functions
 
 func (gui *Gui) handleResetToCommit(g *gocui.Gui, commitView *gocui.View) error {
 	return gui.createConfirmationPanel(g, commitView, gui.Tr.SLocalize("ResetToCommit"), gui.Tr.SLocalize("SureResetThisCommit"), func(g *gocui.Gui, v *gocui.View) error {
@@ -61,24 +100,8 @@ func (gui *Gui) handleResetToCommit(g *gocui.Gui, commitView *gocui.View) error 
 	}, nil)
 }
 
-func (gui *Gui) handleCommitSelect(g *gocui.Gui, v *gocui.View) error {
-	commit := gui.getSelectedCommit(g)
-	if commit == nil {
-		return gui.renderString(g, "main", gui.Tr.SLocalize("NoCommitsThisBranch"))
-	}
-
-	if err := gui.focusPoint(0, gui.State.Panels.Commits.SelectedLine, v); err != nil {
-		return err
-	}
-	commitText, err := gui.GitCommand.Show(commit.Sha)
-	if err != nil {
-		return err
-	}
-	return gui.renderString(g, "main", commitText)
-}
-
 func (gui *Gui) handleCommitSquashDown(g *gocui.Gui, v *gocui.View) error {
-	if gui.getItemPosition(v) != 0 {
+	if gui.State.Panels.Commits.SelectedLine != 0 {
 		return gui.createErrorPanel(g, gui.Tr.SLocalize("OnlySquashTopmostCommit"))
 	}
 	if len(gui.State.Commits) <= 1 {
@@ -134,7 +157,7 @@ func (gui *Gui) handleCommitFixup(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (gui *Gui) handleRenameCommit(g *gocui.Gui, v *gocui.View) error {
-	if gui.getItemPosition(gui.getCommitsView(g)) != 0 {
+	if gui.State.Panels.Commits.SelectedLine != 0 {
 		return gui.createErrorPanel(g, gui.Tr.SLocalize("OnlyRenameTopCommit"))
 	}
 	return gui.createPromptPanel(g, v, gui.Tr.SLocalize("renameCommit"), func(g *gocui.Gui, v *gocui.View) error {
@@ -149,7 +172,7 @@ func (gui *Gui) handleRenameCommit(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (gui *Gui) handleRenameCommitEditor(g *gocui.Gui, v *gocui.View) error {
-	if gui.getItemPosition(gui.getCommitsView(g)) != 0 {
+	if gui.State.Panels.Commits.SelectedLine != 0 {
 		return gui.createErrorPanel(g, gui.Tr.SLocalize("OnlyRenameTopCommit"))
 	}
 
@@ -159,29 +182,4 @@ func (gui *Gui) handleRenameCommitEditor(g *gocui.Gui, v *gocui.View) error {
 	})
 
 	return nil
-}
-
-func (gui *Gui) getSelectedCommit(g *gocui.Gui) *commands.Commit {
-	selectedLine := gui.State.Panels.Commits.SelectedLine
-	if selectedLine == -1 {
-		return nil
-	}
-
-	return gui.State.Commits[selectedLine]
-}
-
-func (gui *Gui) handleCommitsNextLine(g *gocui.Gui, v *gocui.View) error {
-	gui.Log.Info(utils.AsJson(gui.State.Panels))
-	panelState := gui.State.Panels.Commits
-	gui.changeSelectedLine(&panelState.SelectedLine, len(gui.State.Commits), false)
-
-	return gui.handleCommitSelect(gui.g, v)
-}
-
-func (gui *Gui) handleCommitsPrevLine(g *gocui.Gui, v *gocui.View) error {
-	gui.Log.Info(utils.AsJson(gui.State.Panels))
-	panelState := gui.State.Panels.Commits
-	gui.changeSelectedLine(&panelState.SelectedLine, len(gui.State.Commits), true)
-
-	return gui.handleCommitSelect(gui.g, v)
 }

--- a/pkg/gui/confirmation_panel.go
+++ b/pkg/gui/confirmation_panel.go
@@ -28,7 +28,7 @@ func (gui *Gui) wrappedConfirmationFunction(function func(*gocui.Gui, *gocui.Vie
 func (gui *Gui) closeConfirmationPrompt(g *gocui.Gui) error {
 	view, err := g.View("confirmation")
 	if err != nil {
-		panic(err)
+		return nil // if it's already been closed we can just return
 	}
 	if err := gui.returnFocus(g, view); err != nil {
 		panic(err)
@@ -77,11 +77,10 @@ func (gui *Gui) prepareConfirmationPanel(currentView *gocui.View, title, prompt 
 		confirmationView.Wrap = true
 		confirmationView.FgColor = gocui.ColorWhite
 	}
-	confirmationView.Clear()
-
-	if err := gui.switchFocus(gui.g, currentView, confirmationView); err != nil {
-		return nil, err
-	}
+	gui.g.Update(func(g *gocui.Gui) error {
+		confirmationView.Clear()
+		return gui.switchFocus(gui.g, currentView, confirmationView)
+	})
 	return confirmationView, nil
 }
 

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -64,7 +64,7 @@ func (gui *Gui) refreshFiles(g *gocui.Gui) error {
 		fmt.Fprint(filesView, list)
 
 		if filesView == g.CurrentView() {
-			gui.handleFileSelect(g, filesView)
+			return gui.handleFileSelect(g, filesView)
 		}
 		return nil
 	})
@@ -411,7 +411,7 @@ func (gui *Gui) pushWithForceFlag(currentView *gocui.View, force bool) error {
 
 func (gui *Gui) pushFiles(g *gocui.Gui, v *gocui.View) error {
 	// if we have pullables we'll ask if the user wants to force push
-	_, pullables := gui.GitCommand.UpstreamDifferenceCount()
+	_, pullables := gui.GitCommand.GetCurrentBranchUpstreamDifferenceCount()
 	if pullables == "?" || pullables == "0" {
 		return gui.pushWithForceFlag(v, false)
 	}

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -15,6 +15,79 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
+// list panel functions
+
+func (gui *Gui) getSelectedFile(g *gocui.Gui) (*commands.File, error) {
+	selectedLine := gui.State.Panels.Files.SelectedLine
+	if selectedLine == -1 {
+		return &commands.File{}, gui.Errors.ErrNoFiles
+	}
+
+	return gui.State.Files[selectedLine], nil
+}
+
+func (gui *Gui) handleFileSelect(g *gocui.Gui, v *gocui.View) error {
+	file, err := gui.getSelectedFile(g)
+	if err != nil {
+		if err != gui.Errors.ErrNoFiles {
+			return err
+		}
+		return gui.renderString(g, "main", gui.Tr.SLocalize("NoChangedFiles"))
+	}
+
+	if file.HasMergeConflicts {
+		return gui.refreshMergePanel(g)
+	}
+
+	if err := gui.focusPoint(0, gui.State.Panels.Files.SelectedLine, v); err != nil {
+		return err
+	}
+
+	content := gui.GitCommand.Diff(file, false)
+	return gui.renderString(g, "main", content)
+}
+
+func (gui *Gui) refreshFiles(g *gocui.Gui) error {
+	filesView, err := g.View("files")
+	if err != nil {
+		return err
+	}
+	gui.refreshStateFiles()
+
+	gui.g.Update(func(g *gocui.Gui) error {
+
+		filesView.Clear()
+		list, err := utils.RenderList(gui.State.Files)
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(filesView, list)
+
+		if filesView == g.CurrentView() {
+			gui.handleFileSelect(g, filesView)
+		}
+		return nil
+	})
+
+	return nil
+}
+
+func (gui *Gui) handleFilesNextLine(g *gocui.Gui, v *gocui.View) error {
+	panelState := gui.State.Panels.Files
+	gui.changeSelectedLine(&panelState.SelectedLine, len(gui.State.Files), false)
+
+	return gui.handleFileSelect(gui.g, v)
+}
+
+func (gui *Gui) handleFilesPrevLine(g *gocui.Gui, v *gocui.View) error {
+	panelState := gui.State.Panels.Files
+	gui.changeSelectedLine(&panelState.SelectedLine, len(gui.State.Files), true)
+
+	return gui.handleFileSelect(gui.g, v)
+}
+
+// specific functions
+
 func (gui *Gui) stagedFiles() []*commands.File {
 	files := gui.State.Files
 	result := make([]*commands.File, 0)
@@ -139,15 +212,6 @@ func (gui *Gui) handleAddPatch(g *gocui.Gui, v *gocui.View) error {
 	return gui.Errors.ErrSubProcess
 }
 
-func (gui *Gui) getSelectedFile(g *gocui.Gui) (*commands.File, error) {
-	selectedLine := gui.State.Panels.Files.SelectedLine
-	if selectedLine == -1 {
-		return &commands.File{}, gui.Errors.ErrNoFiles
-	}
-
-	return gui.State.Files[selectedLine], nil
-}
-
 func (gui *Gui) handleFileRemove(g *gocui.Gui, v *gocui.View) error {
 	file, err := gui.getSelectedFile(g)
 	if err != nil {
@@ -189,27 +253,6 @@ func (gui *Gui) handleIgnoreFile(g *gocui.Gui, v *gocui.View) error {
 		return gui.createErrorPanel(g, err.Error())
 	}
 	return gui.refreshFiles(g)
-}
-
-func (gui *Gui) handleFileSelect(g *gocui.Gui, v *gocui.View) error {
-	file, err := gui.getSelectedFile(g)
-	if err != nil {
-		if err != gui.Errors.ErrNoFiles {
-			return err
-		}
-		return gui.renderString(g, "main", gui.Tr.SLocalize("NoChangedFiles"))
-	}
-
-	if file.HasMergeConflicts {
-		return gui.refreshMergePanel(g)
-	}
-
-	if err := gui.focusPoint(0, gui.State.Panels.Files.SelectedLine, v); err != nil {
-		return err
-	}
-
-	content := gui.GitCommand.Diff(file, false)
-	return gui.renderString(g, "main", content)
 }
 
 func (gui *Gui) handleCommitPress(g *gocui.Gui, filesView *gocui.View) error {
@@ -335,45 +378,6 @@ func (gui *Gui) catSelectedFile(g *gocui.Gui) (string, error) {
 	return cat, nil
 }
 
-func (gui *Gui) handleFilesNextLine(g *gocui.Gui, v *gocui.View) error {
-	panelState := gui.State.Panels.Files
-	gui.changeSelectedLine(&panelState.SelectedLine, len(gui.State.Files), false)
-
-	return gui.handleFileSelect(gui.g, v)
-}
-
-func (gui *Gui) handleFilesPrevLine(g *gocui.Gui, v *gocui.View) error {
-	panelState := gui.State.Panels.Files
-	gui.changeSelectedLine(&panelState.SelectedLine, len(gui.State.Files), true)
-
-	return gui.handleFileSelect(gui.g, v)
-}
-
-func (gui *Gui) refreshFiles(g *gocui.Gui) error {
-	filesView, err := g.View("files")
-	if err != nil {
-		return err
-	}
-	gui.refreshStateFiles()
-
-	gui.g.Update(func(g *gocui.Gui) error {
-
-		filesView.Clear()
-		list, err := utils.RenderList(gui.State.Files)
-		if err != nil {
-			return err
-		}
-		fmt.Fprint(filesView, list)
-
-		if filesView == g.CurrentView() {
-			gui.handleFileSelect(g, filesView)
-		}
-		return nil
-	})
-
-	return nil
-}
-
 func (gui *Gui) pullFiles(g *gocui.Gui, v *gocui.View) error {
 	gui.createMessagePanel(g, v, "", gui.Tr.SLocalize("PullWait"))
 	go func() {
@@ -399,8 +403,7 @@ func (gui *Gui) pushWithForceFlag(currentView *gocui.View, force bool) error {
 			_ = gui.createErrorPanel(gui.g, err.Error())
 		} else {
 			_ = gui.closeConfirmationPrompt(gui.g)
-			_ = gui.refreshCommits(gui.g)
-			_ = gui.refreshStatus(gui.g)
+			_ = gui.refreshSidePanels(gui.g)
 		}
 	}()
 	return nil

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -95,12 +95,17 @@ type stashPanelState struct {
 	SelectedLine int
 }
 
+type menuPanelState struct {
+	SelectedLine int
+}
+
 type panelStates struct {
 	Files    *filePanelState
 	Staging  *stagingPanelState
 	Branches *branchPanelState
 	Commits  *commitPanelState
 	Stash    *stashPanelState
+	Menu     *menuPanelState
 }
 
 type guiState struct {
@@ -137,6 +142,7 @@ func NewGui(log *logrus.Entry, gitCommand *commands.GitCommand, oSCommand *comma
 			Branches: &branchPanelState{SelectedLine: 0},
 			Commits:  &commitPanelState{SelectedLine: -1},
 			Stash:    &stashPanelState{SelectedLine: -1},
+			Menu:     &menuPanelState{SelectedLine: 0},
 		},
 	}
 
@@ -359,12 +365,12 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		}
 
 		gui.g.SetCurrentView(filesView.Name())
-		gui.refreshFiles(g)
-		gui.refreshBranches(g)
-		gui.refreshCommits(g)
-		gui.refreshStashEntries(g)
-		if err := gui.renderGlobalOptions(g); err != nil {
-			return err
+
+		gui.refreshSidePanels(gui.g)
+		if gui.g.CurrentView().Name() != "menu" {
+			if err := gui.renderGlobalOptions(g); err != nil {
+				return err
+			}
 		}
 		if err := gui.switchFocus(g, nil, filesView); err != nil {
 			return err
@@ -387,6 +393,9 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			return err
 		}
 	}
+
+	// TODO: comment-out
+	gui.Log.Info(utils.AsJson(gui.State))
 
 	return gui.resizeCurrentPopupPanel(g)
 }

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -386,7 +386,12 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleStashDrop,
 			Description: gui.Tr.SLocalize("drop"),
-		}, {
+		},
+		{ViewName: "stash", Key: 'k', Modifier: gocui.ModNone, Handler: gui.handleStashPrevLine},
+		{ViewName: "stash", Key: gocui.KeyArrowUp, Modifier: gocui.ModNone, Handler: gui.handleStashPrevLine},
+		{ViewName: "stash", Key: 'j', Modifier: gocui.ModNone, Handler: gui.handleStashNextLine},
+		{ViewName: "stash", Key: gocui.KeyArrowDown, Modifier: gocui.ModNone, Handler: gui.handleStashNextLine},
+		{
 			ViewName: "commitMessage",
 			Key:      gocui.KeyEnter,
 			Modifier: gocui.ModNone,
@@ -406,7 +411,11 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Key:      'q',
 			Modifier: gocui.ModNone,
 			Handler:  gui.handleMenuClose,
-		}, {
+		},
+		{ViewName: "menu", Key: 'k', Modifier: gocui.ModNone, Handler: gui.handleMenuPrevLine},
+		{ViewName: "menu", Key: gocui.KeyArrowUp, Modifier: gocui.ModNone, Handler: gui.handleMenuPrevLine},
+		{ViewName: "menu", Key: 'j', Modifier: gocui.ModNone, Handler: gui.handleMenuNextLine},
+		{ViewName: "menu", Key: gocui.KeyArrowDown, Modifier: gocui.ModNone, Handler: gui.handleMenuNextLine}, {
 			ViewName:    "staging",
 			Key:         gocui.KeyEsc,
 			Modifier:    gocui.ModNone,
@@ -466,17 +475,6 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Handler:     gui.handleStageHunk,
 			Description: gui.Tr.SLocalize("StageHunk"),
 		},
-	}
-
-	// Would make these keybindings global but that interferes with editing
-	// input in the confirmation panel
-	for _, viewName := range []string{"status", "commits", "stash", "menu"} {
-		bindings = append(bindings, []*Binding{
-			{ViewName: viewName, Key: gocui.KeyArrowUp, Modifier: gocui.ModNone, Handler: gui.cursorUp},
-			{ViewName: viewName, Key: gocui.KeyArrowDown, Modifier: gocui.ModNone, Handler: gui.cursorDown},
-			{ViewName: viewName, Key: 'k', Modifier: gocui.ModNone, Handler: gui.cursorUp},
-			{ViewName: viewName, Key: 'j', Modifier: gocui.ModNone, Handler: gui.cursorDown},
-		}...)
 	}
 
 	for _, viewName := range []string{"status", "branches", "files", "commits", "stash", "menu"} {

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -219,7 +219,12 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Handler:     gui.handleSwitchToStagingPanel,
 			Description: gui.Tr.SLocalize("StageLines"),
 			KeyReadable: "enter",
-		}, {
+		},
+		{ViewName: "files", Key: 'k', Modifier: gocui.ModNone, Handler: gui.handleFilesPrevLine},
+		{ViewName: "files", Key: gocui.KeyArrowUp, Modifier: gocui.ModNone, Handler: gui.handleFilesPrevLine},
+		{ViewName: "files", Key: 'j', Modifier: gocui.ModNone, Handler: gui.handleFilesNextLine},
+		{ViewName: "files", Key: gocui.KeyArrowDown, Modifier: gocui.ModNone, Handler: gui.handleFilesNextLine},
+		{
 			ViewName: "main",
 			Key:      gocui.KeyEsc,
 			Modifier: gocui.ModNone,
@@ -322,7 +327,12 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleMerge,
 			Description: gui.Tr.SLocalize("mergeIntoCurrentBranch"),
-		}, {
+		},
+		{ViewName: "branches", Key: 'k', Modifier: gocui.ModNone, Handler: gui.handleBranchesPrevLine},
+		{ViewName: "branches", Key: gocui.KeyArrowUp, Modifier: gocui.ModNone, Handler: gui.handleBranchesPrevLine},
+		{ViewName: "branches", Key: 'j', Modifier: gocui.ModNone, Handler: gui.handleBranchesNextLine},
+		{ViewName: "branches", Key: gocui.KeyArrowDown, Modifier: gocui.ModNone, Handler: gui.handleBranchesNextLine},
+		{
 			ViewName:    "commits",
 			Key:         's',
 			Modifier:    gocui.ModNone,
@@ -352,7 +362,12 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleCommitFixup,
 			Description: gui.Tr.SLocalize("fixupCommit"),
-		}, {
+		},
+		{ViewName: "commits", Key: 'k', Modifier: gocui.ModNone, Handler: gui.handleCommitsPrevLine},
+		{ViewName: "commits", Key: gocui.KeyArrowUp, Modifier: gocui.ModNone, Handler: gui.handleCommitsPrevLine},
+		{ViewName: "commits", Key: 'j', Modifier: gocui.ModNone, Handler: gui.handleCommitsNextLine},
+		{ViewName: "commits", Key: gocui.KeyArrowDown, Modifier: gocui.ModNone, Handler: gui.handleCommitsNextLine},
+		{
 			ViewName:    "stash",
 			Key:         gocui.KeySpace,
 			Modifier:    gocui.ModNone,
@@ -455,17 +470,22 @@ func (gui *Gui) GetKeybindings() []*Binding {
 
 	// Would make these keybindings global but that interferes with editing
 	// input in the confirmation panel
-	for _, viewName := range []string{"status", "files", "branches", "commits", "stash", "menu"} {
+	for _, viewName := range []string{"status", "commits", "stash", "menu"} {
+		bindings = append(bindings, []*Binding{
+			{ViewName: viewName, Key: gocui.KeyArrowUp, Modifier: gocui.ModNone, Handler: gui.cursorUp},
+			{ViewName: viewName, Key: gocui.KeyArrowDown, Modifier: gocui.ModNone, Handler: gui.cursorDown},
+			{ViewName: viewName, Key: 'k', Modifier: gocui.ModNone, Handler: gui.cursorUp},
+			{ViewName: viewName, Key: 'j', Modifier: gocui.ModNone, Handler: gui.cursorDown},
+		}...)
+	}
+
+	for _, viewName := range []string{"status", "branches", "files", "commits", "stash", "menu"} {
 		bindings = append(bindings, []*Binding{
 			{ViewName: viewName, Key: gocui.KeyTab, Modifier: gocui.ModNone, Handler: gui.nextView},
 			{ViewName: viewName, Key: gocui.KeyArrowLeft, Modifier: gocui.ModNone, Handler: gui.previousView},
 			{ViewName: viewName, Key: gocui.KeyArrowRight, Modifier: gocui.ModNone, Handler: gui.nextView},
-			{ViewName: viewName, Key: gocui.KeyArrowUp, Modifier: gocui.ModNone, Handler: gui.cursorUp},
-			{ViewName: viewName, Key: gocui.KeyArrowDown, Modifier: gocui.ModNone, Handler: gui.cursorDown},
 			{ViewName: viewName, Key: 'h', Modifier: gocui.ModNone, Handler: gui.previousView},
 			{ViewName: viewName, Key: 'l', Modifier: gocui.ModNone, Handler: gui.nextView},
-			{ViewName: viewName, Key: 'k', Modifier: gocui.ModNone, Handler: gui.cursorUp},
-			{ViewName: viewName, Key: 'j', Modifier: gocui.ModNone, Handler: gui.cursorDown},
 		}...)
 	}
 

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -25,22 +25,18 @@ func (gui *Gui) handleMenuPrevLine(g *gocui.Gui, v *gocui.View) error {
 	panelState := gui.State.Panels.Menu
 	gui.changeSelectedLine(&panelState.SelectedLine, v.LinesHeight(), true)
 
-	if err := gui.focusPoint(0, gui.State.Panels.Commits.SelectedLine, v); err != nil {
-		return err
-	}
-
 	return gui.handleMenuSelect(g, v)
 }
 
 // specific functions
 
-func (gui *Gui) renderMenuOptions(g *gocui.Gui) error {
+func (gui *Gui) renderMenuOptions() error {
 	optionsMap := map[string]string{
 		"esc/q": gui.Tr.SLocalize("close"),
 		"↑ ↓":   gui.Tr.SLocalize("navigate"),
 		"space": gui.Tr.SLocalize("execute"),
 	}
-	return gui.renderOptionsMap(g, optionsMap)
+	return gui.renderOptionsMap(optionsMap)
 }
 
 func (gui *Gui) handleMenuClose(g *gocui.Gui, v *gocui.View) error {
@@ -67,10 +63,6 @@ func (gui *Gui) createMenu(items interface{}, handlePress func(int) error) error
 	menuView.Clear()
 	fmt.Fprint(menuView, list)
 	gui.State.Panels.Menu.SelectedLine = 0
-
-	if err := gui.renderMenuOptions(gui.g); err != nil {
-		return err
-	}
 
 	wrappedHandlePress := func(g *gocui.Gui, v *gocui.View) error {
 		selectedLine := gui.State.Panels.Menu.SelectedLine

--- a/pkg/gui/merge_panel.go
+++ b/pkg/gui/merge_panel.go
@@ -194,9 +194,6 @@ func (gui *Gui) refreshMergePanel(g *gocui.Gui) error {
 		gui.State.ConflictIndex = len(gui.State.Conflicts) - 1
 	}
 	hasFocus := gui.currentViewName(g) == "main"
-	if hasFocus {
-		gui.renderMergeOptions(g)
-	}
 	content, err := gui.coloredConflictFile(cat, gui.State.Conflicts, gui.State.ConflictIndex, gui.State.ConflictTop, hasFocus)
 	if err != nil {
 		return err
@@ -233,8 +230,8 @@ func (gui *Gui) switchToMerging(g *gocui.Gui) error {
 	return gui.refreshMergePanel(g)
 }
 
-func (gui *Gui) renderMergeOptions(g *gocui.Gui) error {
-	return gui.renderOptionsMap(g, map[string]string{
+func (gui *Gui) renderMergeOptions() error {
+	return gui.renderOptionsMap(map[string]string{
 		"↑ ↓":   gui.Tr.SLocalize("selectHunk"),
 		"← →":   gui.Tr.SLocalize("navigateConflicts"),
 		"space": gui.Tr.SLocalize("pickHunk"),

--- a/pkg/gui/stash_panel.go
+++ b/pkg/gui/stash_panel.go
@@ -37,14 +37,7 @@ func (gui *Gui) getSelectedStashEntry(v *gocui.View) *commands.StashEntry {
 	return gui.State.StashEntries[lineNumber]
 }
 
-func (gui *Gui) renderStashOptions(g *gocui.Gui) error {
-	return gui.renderGlobalOptions(g)
-}
-
 func (gui *Gui) handleStashEntrySelect(g *gocui.Gui, v *gocui.View) error {
-	if err := gui.renderStashOptions(g); err != nil {
-		return err
-	}
 	go func() {
 		stashEntry := gui.getSelectedStashEntry(v)
 		if stashEntry == nil {

--- a/pkg/gui/stash_panel.go
+++ b/pkg/gui/stash_panel.go
@@ -30,7 +30,7 @@ func (gui *Gui) handleStashEntrySelect(g *gocui.Gui, v *gocui.View) error {
 	go func() {
 		// doing this asynchronously cos it can take time
 		diff, _ := gui.GitCommand.GetStashEntryDiff(stashEntry.Index)
-		gui.renderString(g, "main", diff)
+		_ = gui.renderString(g, "main", diff)
 	}()
 	return nil
 }

--- a/pkg/gui/stash_panel.go
+++ b/pkg/gui/stash_panel.go
@@ -8,19 +8,46 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
+// list panel functions
+
+func (gui *Gui) getSelectedStashEntry(v *gocui.View) *commands.StashEntry {
+	selectedLine := gui.State.Panels.Stash.SelectedLine
+	if selectedLine == -1 {
+		return nil
+	}
+
+	return gui.State.StashEntries[selectedLine]
+}
+
+func (gui *Gui) handleStashEntrySelect(g *gocui.Gui, v *gocui.View) error {
+	stashEntry := gui.getSelectedStashEntry(v)
+	if stashEntry == nil {
+		return gui.renderString(g, "main", gui.Tr.SLocalize("NoStashEntries"))
+	}
+	if err := gui.focusPoint(0, gui.State.Panels.Stash.SelectedLine, v); err != nil {
+		return err
+	}
+	go func() {
+		// doing this asynchronously cos it can take time
+		diff, _ := gui.GitCommand.GetStashEntryDiff(stashEntry.Index)
+		gui.renderString(g, "main", diff)
+	}()
+	return nil
+}
+
 func (gui *Gui) refreshStashEntries(g *gocui.Gui) error {
 	g.Update(func(g *gocui.Gui) error {
-		v, err := g.View("stash")
-		if err != nil {
-			panic(err)
-		}
 		gui.State.StashEntries = gui.GitCommand.GetStashEntries()
 
-		v.Clear()
+		gui.refreshSelectedLine(&gui.State.Panels.Stash.SelectedLine, len(gui.State.StashEntries))
+
 		list, err := utils.RenderList(gui.State.StashEntries)
 		if err != nil {
 			return err
 		}
+
+		v := gui.getStashView(gui.g)
+		v.Clear()
 		fmt.Fprint(v, list)
 
 		return gui.resetOrigin(v)
@@ -28,27 +55,21 @@ func (gui *Gui) refreshStashEntries(g *gocui.Gui) error {
 	return nil
 }
 
-func (gui *Gui) getSelectedStashEntry(v *gocui.View) *commands.StashEntry {
-	if len(gui.State.StashEntries) == 0 {
-		return nil
-	}
-	stashView, _ := gui.g.View("stash")
-	lineNumber := gui.getItemPosition(stashView)
-	return gui.State.StashEntries[lineNumber]
+func (gui *Gui) handleStashNextLine(g *gocui.Gui, v *gocui.View) error {
+	panelState := gui.State.Panels.Stash
+	gui.changeSelectedLine(&panelState.SelectedLine, len(gui.State.StashEntries), false)
+
+	return gui.handleStashEntrySelect(gui.g, v)
 }
 
-func (gui *Gui) handleStashEntrySelect(g *gocui.Gui, v *gocui.View) error {
-	go func() {
-		stashEntry := gui.getSelectedStashEntry(v)
-		if stashEntry == nil {
-			gui.renderString(g, "main", gui.Tr.SLocalize("NoStashEntries"))
-			return
-		}
-		diff, _ := gui.GitCommand.GetStashEntryDiff(stashEntry.Index)
-		gui.renderString(g, "main", diff)
-	}()
-	return nil
+func (gui *Gui) handleStashPrevLine(g *gocui.Gui, v *gocui.View) error {
+	panelState := gui.State.Panels.Stash
+	gui.changeSelectedLine(&panelState.SelectedLine, len(gui.State.StashEntries), true)
+
+	return gui.handleStashEntrySelect(gui.g, v)
 }
+
+// specific functions
 
 func (gui *Gui) handleStashApply(g *gocui.Gui, v *gocui.View) error {
 	return gui.stashDo(g, v, "apply")

--- a/pkg/gui/status_panel.go
+++ b/pkg/gui/status_panel.go
@@ -19,7 +19,7 @@ func (gui *Gui) refreshStatus(g *gocui.Gui) error {
 	// contents end up cleared
 	g.Update(func(*gocui.Gui) error {
 		v.Clear()
-		pushables, pullables := gui.GitCommand.UpstreamDifferenceCount()
+		pushables, pullables := gui.GitCommand.GetCurrentBranchUpstreamDifferenceCount()
 		fmt.Fprint(v, "↑"+pushables+"↓"+pullables)
 		branches := gui.State.Branches
 		if err := gui.updateHasMergeConflictStatus(); err != nil {
@@ -48,6 +48,8 @@ func (gui *Gui) handleCheckForUpdate(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (gui *Gui) handleStatusSelect(g *gocui.Gui, v *gocui.View) error {
+	blue := color.New(color.FgBlue)
+
 	dashboardString := strings.Join(
 		[]string{
 			lazygitTitle(),
@@ -56,7 +58,7 @@ func (gui *Gui) handleStatusSelect(g *gocui.Gui, v *gocui.View) error {
 			"Config Options: https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md",
 			"Tutorial: https://youtu.be/VDXvbHZYeKY",
 			"Raise an Issue: https://github.com/jesseduffield/lazygit/issues",
-			"Buy Jesse a coffee: https://donorbox.org/lazygit",
+			blue.Sprint("Buy Jesse a coffee: https://donorbox.org/lazygit"), // caffeine ain't free
 		}, "\n\n")
 
 	return gui.renderString(g, "main", dashboardString)

--- a/pkg/gui/status_panel.go
+++ b/pkg/gui/status_panel.go
@@ -42,10 +42,6 @@ func (gui *Gui) refreshStatus(g *gocui.Gui) error {
 	return nil
 }
 
-func (gui *Gui) renderStatusOptions(g *gocui.Gui) error {
-	return gui.renderGlobalOptions(g)
-}
-
 func (gui *Gui) handleCheckForUpdate(g *gocui.Gui, v *gocui.View) error {
 	gui.Updater.CheckForNewUpdate(gui.onUserUpdateCheckFinish, true)
 	return gui.createMessagePanel(gui.g, v, "", gui.Tr.SLocalize("CheckingForUpdates"))
@@ -63,10 +59,7 @@ func (gui *Gui) handleStatusSelect(g *gocui.Gui, v *gocui.View) error {
 			"Buy Jesse a coffee: https://donorbox.org/lazygit",
 		}, "\n\n")
 
-	if err := gui.renderString(g, "main", dashboardString); err != nil {
-		return err
-	}
-	return gui.renderStatusOptions(g)
+	return gui.renderString(g, "main", dashboardString)
 }
 
 func (gui *Gui) handleOpenConfig(g *gocui.Gui, v *gocui.View) error {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -435,6 +435,12 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "CantFindHunk",
 			Other: `Could not find hunk`,
+		}, &i18n.Message{
+			ID:    "FastForward",
+			Other: `fast-forward this branch from its upstream`,
+		}, &i18n.Message{
+			ID:    "Fetching",
+			Other: "fetching and fast-forwarding {{.from}} -> {{.to}} ...",
 		},
 	)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -234,4 +235,9 @@ func PrevIndex(numbers []int, currentNumber int) int {
 		}
 	}
 	return end
+}
+
+func AsJson(i interface{}) string {
+	bytes, _ := json.MarshalIndent(i, "", "    ")
+	return string(bytes)
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -517,3 +517,14 @@ func TestPrevIndex(t *testing.T) {
 		})
 	}
 }
+
+func TestAsJson(t *testing.T) {
+	type myStruct struct {
+		a string
+	}
+
+	output := AsJson(&myStruct{a: "foo"})
+
+	// no idea why this is returning empty hashes but it's works in the app ¯\_(ツ)_/¯
+	assert.EqualValues(t, "{}", output)
+}


### PR DESCRIPTION
This was originally intended to just be a PR about allowing you to fast-forward branches, but to do so I needed to rework how navigating list panels work. Previously, you would obtain the 'selected line' in a list panel by just looking at the view's cursor/origin position. That causes issues because often the underlying data can be changed before the view is updated, leading to out-of-bounds panics.

So now I'm storing the selected line of each panel in the gui's state and updating that value whenever you move the cursor or the panel is refreshed, so we're not relying on the view layer for any data layer information. This should hopefully reduce the number of crashes we've been seeing particularly in the files panel. There's no doubt a way to factor out some of this code because there's currently a bit of duplication, but I couldn't find an easy way of dealing with the different types that each panel's list has, and I want to minimise use of the interface{} type to utilise linting.

Along the way I found out that we're doing some updates to views (e.g. clearing views) outside of a g.Update() call, meaning we weren't being concurrent-safe and crashes were happening as a result. I'm not sure the extent to which this will fix some of the issues that we have in the issues board with some panics, because I can't say for sure what caused the original crashes, but we can just wait for a bit and see if any more crop up.

As for what this PR adds: The pushable/pullable count on a branch is now shown when you select it, and if you hit 'f' on a selected branch, it will fast-forward fetch from that branch's remote. The obvious use case is that if you're about to merge/rebase your branch onto master or develop, you'd first want to ensure that those branches are up to date with their upstream branches. Now you can do that without checking out, which will hopefully make the process of rebasing, with a rebasing PR coming soon, much easier.