### PR TITLE
Add script generating keybindings cheatsheet

### DIFF
--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -12,7 +12,6 @@ type Binding struct {
 	Handler     func(*gocui.Gui, *gocui.View) error
 	Key         interface{} // FIXME: find out how to get `gocui.Key | rune`
 	Modifier    gocui.Modifier
-	KeyReadable string
 	Description string
 }
 
@@ -23,16 +22,26 @@ func (b *Binding) GetDisplayStrings() []string {
 
 // GetKey is a function.
 func (b *Binding) GetKey() string {
-	r, ok := b.Key.(rune)
-	key := ""
+	key := 0
 
-	if ok {
-		key = string(r)
-	} else if b.KeyReadable != "" {
-		key = b.KeyReadable
+	switch b.Key.(type) {
+	case rune:
+		key = int(b.Key.(rune))
+	case gocui.Key:
+		key = int(b.Key.(gocui.Key))
 	}
 
-	return key
+	// special keys
+	switch key {
+	case 27:
+		return "esc"
+	case 13:
+		return "enter"
+	case 32:
+		return "space"
+	}
+
+	return string(key)
 }
 
 // GetKeybindings is a function.
@@ -144,7 +153,6 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Key:         gocui.KeySpace,
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleFilePress,
-			KeyReadable: "space",
 			Description: gui.Tr.SLocalize("toggleStaged"),
 		}, {
 			ViewName:    "files",
@@ -218,7 +226,6 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleSwitchToStagingPanel,
 			Description: gui.Tr.SLocalize("StageLines"),
-			KeyReadable: "enter",
 		}, {
 			ViewName:    "files",
 			Key:         'f',
@@ -290,7 +297,6 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Key:         gocui.KeySpace,
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleBranchPress,
-			KeyReadable: "space",
 			Description: gui.Tr.SLocalize("checkout"),
 		}, {
 			ViewName:    "branches",
@@ -369,7 +375,6 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Key:         gocui.KeySpace,
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleStashApply,
-			KeyReadable: "space",
 			Description: gui.Tr.SLocalize("apply"),
 		}, {
 			ViewName:    "stash",
@@ -418,7 +423,6 @@ func (gui *Gui) GetKeybindings() []*Binding {
 			Key:         gocui.KeyEsc,
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleStagingEscape,
-			KeyReadable: "esc",
 			Description: gui.Tr.SLocalize("EscapeStaging"),
 		}, {
 			ViewName: "staging",

--- a/scripts/generate_cheatsheet.go
+++ b/scripts/generate_cheatsheet.go
@@ -9,55 +9,55 @@
 package main
 
 import (
-    "fmt"
-    "github.com/jesseduffield/lazygit/pkg/app"
-    "github.com/jesseduffield/lazygit/pkg/config"
-    "log"
-    "os"
-    "strings"
+	"fmt"
+	"github.com/jesseduffield/lazygit/pkg/app"
+	"github.com/jesseduffield/lazygit/pkg/config"
+	"log"
+	"os"
+	"strings"
 )
 
 func writeString(file *os.File, str string) {
-    _, err := file.WriteString(str)
-    if err != nil {
-        log.Fatal(err)
-    }
+	_, err := file.WriteString(str)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
-func getTitle(mApp *app.App ,viewName string) string {
-    viewTitle := strings.Title(viewName) + "Title"
-    translatedTitle := mApp.Tr.SLocalize(viewTitle)
-    formattedTitle := fmt.Sprintf("\n## %s\n\n", translatedTitle)
-    return formattedTitle
+func getTitle(mApp *app.App, viewName string) string {
+	viewTitle := strings.Title(viewName) + "Title"
+	translatedTitle := mApp.Tr.SLocalize(viewTitle)
+	formattedTitle := fmt.Sprintf("\n## %s\n\n", translatedTitle)
+	return formattedTitle
 }
 
 func main() {
-    mConfig, _ := config.NewAppConfig("", "", "", "", "", new(bool))
-    mApp, _ := app.Setup(mConfig)
-    lang := mApp.Tr.GetLanguage()
-    file, _ := os.Create("Keybindings_" + lang + ".md")
-    current := ""
+	mConfig, _ := config.NewAppConfig("", "", "", "", "", new(bool))
+	mApp, _ := app.Setup(mConfig)
+	lang := mApp.Tr.GetLanguage()
+	file, _ := os.Create("Keybindings_" + lang + ".md")
+	current := ""
 
-    writeString(file, fmt.Sprintf("# Lazygit %s\n", mApp.Tr.SLocalize("menu")))
-    writeString(file, getTitle(mApp, "global"))
+	writeString(file, fmt.Sprintf("# Lazygit %s\n", mApp.Tr.SLocalize("menu")))
+	writeString(file, getTitle(mApp, "global"))
 
-    writeString(file, "<pre>\n")
+	writeString(file, "<pre>\n")
 
-    for _, binding := range mApp.Gui.GetKeybindings() {
-        if binding.Description == "" {
-            continue
-        }
+	for _, binding := range mApp.Gui.GetKeybindings() {
+		if binding.Description == "" {
+			continue
+		}
 
-        if binding.ViewName != current {
-            current = binding.ViewName
-            writeString(file, "</pre>\n")
-            writeString(file, getTitle(mApp, current))
-            writeString(file, "<pre>\n")
-        }
+		if binding.ViewName != current {
+			current = binding.ViewName
+			writeString(file, "</pre>\n")
+			writeString(file, getTitle(mApp, current))
+			writeString(file, "<pre>\n")
+		}
 
-        info := fmt.Sprintf("  <kbd>%s</kbd>: %s\n", binding.GetKey(), binding.Description)
-        writeString(file, info)
-    }
+		info := fmt.Sprintf("  <kbd>%s</kbd>: %s\n", binding.GetKey(), binding.Description)
+		writeString(file, info)
+	}
 
-    writeString(file, "</pre>\n")
+	writeString(file, "</pre>\n")
 }

--- a/scripts/generate_cheatsheet.go
+++ b/scripts/generate_cheatsheet.go
@@ -1,0 +1,63 @@
+// This "script" generates a file called Keybindings_{{.LANG}}.md
+// in current working directory.
+//
+// The content of this generated file is a keybindings cheatsheet.
+//
+// To generate cheatsheet in english run:
+//   LANG=en go run scripts/generate_cheatsheet.go
+
+package main
+
+import (
+    "fmt"
+    "github.com/jesseduffield/lazygit/pkg/app"
+    "github.com/jesseduffield/lazygit/pkg/config"
+    "log"
+    "os"
+    "strings"
+)
+
+func writeString(file *os.File, str string) {
+    _, err := file.WriteString(str)
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+
+func getTitle(mApp *app.App ,viewName string) string {
+    viewTitle := strings.Title(viewName) + "Title"
+    translatedTitle := mApp.Tr.SLocalize(viewTitle)
+    formattedTitle := fmt.Sprintf("\n## %s\n\n", translatedTitle)
+    return formattedTitle
+}
+
+func main() {
+    mConfig, _ := config.NewAppConfig("", "", "", "", "", new(bool))
+    mApp, _ := app.Setup(mConfig)
+    lang := mApp.Tr.GetLanguage()
+    file, _ := os.Create("Keybindings_" + lang + ".md")
+    current := ""
+
+    writeString(file, fmt.Sprintf("# Lazygit %s\n", mApp.Tr.SLocalize("menu")))
+    writeString(file, getTitle(mApp, "global"))
+
+    writeString(file, "<pre>\n")
+
+    for _, binding := range mApp.Gui.GetKeybindings() {
+        if binding.Description == "" {
+            continue
+        }
+
+        if binding.ViewName != current {
+            current = binding.ViewName
+            writeString(file, "</pre>\n")
+            writeString(file, getTitle(mApp, current))
+            writeString(file, "<pre>\n")
+        }
+
+        info := fmt.Sprintf("  <kbd>%s</kbd>: %s\n", binding.GetKey(), binding.Description)
+        writeString(file, info)
+    }
+
+    writeString(file, "</pre>\n")
+}


### PR DESCRIPTION
Closes: #334.

There are still some keybindings without description though. I'll try to successively add them.

Currently generated markdown file looks like this:

# Lazygit menu

## Global

<pre>
  <kbd>P</kbd>: push
  <kbd>p</kbd>: pull
  <kbd>R</kbd>: refresh
</pre>

## Status

<pre>
  <kbd>e</kbd>: edit config file
  <kbd>o</kbd>: open config file
  <kbd>u</kbd>: check for update
  <kbd>s</kbd>: switch to a recent repo
</pre>

## Files

<pre>
  <kbd>c</kbd>: commit changes
  <kbd>A</kbd>: amend last commit
  <kbd>C</kbd>: commit changes using git editor
  <kbd>space</kbd>: toggle staged
  <kbd>d</kbd>: delete if untracked / checkout if tracked
  <kbd>m</kbd>: resolve merge conflicts
  <kbd>e</kbd>: edit file
  <kbd>o</kbd>: open file
  <kbd>i</kbd>: add to .gitignore
  <kbd>r</kbd>: refresh files
  <kbd>S</kbd>: stash files
  <kbd>M</kbd>: abort merge
  <kbd>a</kbd>: stage/unstage all
  <kbd>t</kbd>: add patch
  <kbd>D</kbd>: reset hard and remove untracked files
  <kbd>enter</kbd>: stage individual hunks/lines
  <kbd>f</kbd>: fetch
</pre>

## Branches

<pre>
  <kbd>space</kbd>: checkout
  <kbd>o</kbd>: create pull request
  <kbd>c</kbd>: checkout by name
  <kbd>F</kbd>: force checkout
  <kbd>n</kbd>: new branch
  <kbd>d</kbd>: delete branch
  <kbd>m</kbd>: merge into currently checked out branch
  <kbd>f</kbd>: fast-forward this branch from its upstream
</pre>

## Commits

<pre>
  <kbd>s</kbd>: squash down
  <kbd>r</kbd>: rename commit
  <kbd>R</kbd>: rename commit with editor
  <kbd>g</kbd>: reset to this commit
  <kbd>f</kbd>: fixup commit
</pre>

## Stash

<pre>
  <kbd>space</kbd>: apply
  <kbd>g</kbd>: pop
  <kbd>d</kbd>: drop
</pre>

## Staging

<pre>
  <kbd>esc</kbd>: return to files panel
  <kbd>space</kbd>: stage line
  <kbd>a</kbd>: stage hunk
</pre>
