### PR TITLE
handle files with escape character(s)

### DIFF
--- a/pkg/commands/file.go
+++ b/pkg/commands/file.go
@@ -28,9 +28,9 @@ func (f *File) GetDisplayStrings() []string {
 	output := green.Sprint(f.DisplayString[0:1])
 	output += red.Sprint(f.DisplayString[1:3])
 	if f.HasUnstagedChanges {
-		output += red.Sprint(f.Name)
+		output += red.Sprint(f.DisplayString[3:])
 	} else {
-		output += green.Sprint(f.Name)
+		output += green.Sprint(f.DisplayString[3:])
 	}
 	return []string{output}
 }

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -138,13 +138,14 @@ func (c *GitCommand) GetStatusFiles() []*File {
 		change := statusString[0:2]
 		stagedChange := change[0:1]
 		unstagedChange := statusString[1:2]
-		filename := c.OSCommand.Unquote(statusString[3:])
+		filename := statusString[3:]
+		displayString := statusString[0:3] + c.OSCommand.Unquote(filename)
 		_, untracked := map[string]bool{"??": true, "A ": true, "AM": true}[change]
 		_, hasNoStagedChanges := map[string]bool{" ": true, "U": true, "?": true}[stagedChange]
 
 		file := &File{
 			Name:               filename,
-			DisplayString:      statusString,
+			DisplayString:      displayString,
 			HasStagedChanges:   !hasNoStagedChanges,
 			HasUnstagedChanges: unstagedChange != " ",
 			Tracked:            !untracked,
@@ -402,12 +403,12 @@ func (c *GitCommand) SquashFixupCommit(branchName string, shaValue string) error
 
 // CatFile obtains the content of a file
 func (c *GitCommand) CatFile(fileName string) (string, error) {
-	return c.OSCommand.RunCommandWithOutput(fmt.Sprintf("cat %s", c.OSCommand.Quote(fileName)))
+	return c.OSCommand.RunCommandWithOutput(fmt.Sprintf("cat %s", fileName))
 }
 
 // StageFile stages a file
 func (c *GitCommand) StageFile(fileName string) error {
-	return c.OSCommand.RunCommand(fmt.Sprintf("git add %s", c.OSCommand.Quote(fileName)))
+	return c.OSCommand.RunCommand(fmt.Sprintf("git add %s", fileName))
 }
 
 // StageAll stages all files
@@ -426,7 +427,7 @@ func (c *GitCommand) UnStageFile(fileName string, tracked bool) error {
 	if tracked {
 		command = "git reset HEAD %s"
 	}
-	return c.OSCommand.RunCommand(fmt.Sprintf(command, c.OSCommand.Quote(fileName)))
+	return c.OSCommand.RunCommand(fmt.Sprintf(command, fileName))
 }
 
 // GitStatus returns the plaintext short status of the repo
@@ -593,7 +594,7 @@ func (c *GitCommand) Diff(file *File, plain bool) string {
 	cachedArg := ""
 	trackedArg := "--"
 	colorArg := "--color"
-	fileName := c.OSCommand.Quote(file.Name)
+	fileName := file.Name
 	if file.HasStagedChanges && !file.HasUnstagedChanges {
 		cachedArg = "--cached"
 	}

--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -134,7 +134,7 @@ func sanitisedCommandOutput(output []byte, err error) (string, error) {
 func (c *OSCommand) OpenFile(filename string) error {
 	commandTemplate := c.Config.GetUserConfig().GetString("os.openCommand")
 	templateValues := map[string]string{
-		"filename": c.Quote(filename),
+		"filename": filename,
 	}
 
 	command := utils.ResolvePlaceholderString(commandTemplate, templateValues)

--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/jesseduffield/lazygit/pkg/config"
@@ -192,9 +193,12 @@ func (c *OSCommand) Quote(message string) string {
 }
 
 // Unquote removes wrapping quotations marks if they are present
-// this is needed for removing quotes from staged filenames with spaces
+// this is needed for removing quotes from staged filenames with escape character(s)
 func (c *OSCommand) Unquote(message string) string {
-	return strings.Replace(message, `"`, "", -1)
+	if unquoted, err := strconv.Unquote(message); err == nil {
+		return unquoted
+	}
+	return message
 }
 
 // AppendLineToFile adds a new line in file


### PR DESCRIPTION
`git status --untracked-files=all --short` prints file **with wrapping
quotation marks when escape character(s) exists in its name**, we need
to use strconv.Unquote() to unquote their name properly

But we still need quoted version of filename for git commands, 
so just **substitute display string only**

Now lazygit prints filename with escape character(s) properly as we can see
in this screenshot, and **does not panic when file with quotation mark in its name
is selected**

![lazygit](https://user-images.githubusercontent.com/18724352/52009803-24008480-2517-11e9-9005-6310b7f344a0.gif)