### PR TITLE
WIP: Running custom commands

### DIFF
--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -296,3 +296,8 @@ func (c *OSCommand) GetLazygitPath() string {
 	}
 	return filepath.ToSlash(ex)
 }
+
+// RunCustomCommand returns the pointer to a custom command
+func (c *OSCommand) RunCustomCommand(command string) *exec.Cmd {
+	return c.PrepareSubProcess(c.Platform.shell, c.Platform.shellArg, command)
+}

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -599,3 +599,15 @@ func (gui *Gui) handleCreateResetMenu(g *gocui.Gui, v *gocui.View) error {
 
 	return gui.createMenu("", options, len(options), handleMenuPress)
 }
+
+func (gui *Gui) handleCustomCommand(g *gocui.Gui, v *gocui.View) error {
+	// gui.subProcessChan <- gui.OSCommand.RunCustomCommand(`read -p "Name: " name; echo $name; read -p "Okay: " okay; echo $okay`)
+
+	// return nil
+
+	return gui.createPromptPanel(g, v, gui.Tr.SLocalize("CustomCommand"), func(g *gocui.Gui, v *gocui.View) error {
+		command := gui.trimmedContent(v)
+		gui.SubProcess = gui.OSCommand.RunCustomCommand(command)
+		return gui.Errors.ErrSubProcess
+	})
+}

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -601,10 +601,6 @@ func (gui *Gui) handleCreateResetMenu(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (gui *Gui) handleCustomCommand(g *gocui.Gui, v *gocui.View) error {
-	// gui.subProcessChan <- gui.OSCommand.RunCustomCommand(`read -p "Name: " name; echo $name; read -p "Okay: " okay; echo $okay`)
-
-	// return nil
-
 	return gui.createPromptPanel(g, v, gui.Tr.SLocalize("CustomCommand"), func(g *gocui.Gui, v *gocui.View) error {
 		command := gui.trimmedContent(v)
 		gui.SubProcess = gui.OSCommand.RunCustomCommand(command)

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -239,6 +239,12 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Handler:     gui.handleGitFetch,
 			Description: gui.Tr.SLocalize("fetch"),
 		}, {
+			ViewName:    "files",
+			Key:         'X',
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleCustomCommand,
+			Description: gui.Tr.SLocalize("executeCustomCommand"),
+		}, {
 			ViewName:    "branches",
 			Key:         gocui.KeySpace,
 			Modifier:    gocui.ModNone,

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -718,6 +718,12 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "SureCreateFixupCommit",
 			Other: `Are you sure you want to create a fixup! commit for commit {{.commit}}?`,
+		}, &i18n.Message{
+			ID:    "executeCustomCommand",
+			Other: "execute custom command",
+		}, &i18n.Message{
+			ID:    "CustomCommand",
+			Other: "Custom Command:",
 		},
 	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -741,6 +741,12 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "SureCreateFixupCommit",
 			Other: `Are you sure you want to create a fixup! commit for commit {{.commit}}?`,
+		}, &i18n.Message{
+			ID:    "executeCustomCommand",
+			Other: "execute custom command",
+		}, &i18n.Message{
+			ID:    "CustomCommand",
+			Other: "Custom Command:",
 		},
 	)
 }

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -701,6 +701,12 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "SureCreateFixupCommit",
 			Other: `Are you sure you want to create a fixup! commit for commit {{.commit}}?`,
+		}, &i18n.Message{
+			ID:    "executeCustomCommand",
+			Other: "execute custom command",
+		}, &i18n.Message{
+			ID:    "CustomCommand",
+			Other: "Custom Command:",
 		},
 	)
 }


### PR DESCRIPTION
fixes https://github.com/jesseduffield/lazygit/issues/389

This feature is not for storing custom commands in a config to then access in lazygit via a hotkey (although I still do want to do that)

![image](https://user-images.githubusercontent.com/8456633/54199795-e7647780-451d-11e9-88b3-090b70617ca2.png)


This is for directly typing a command in lazygit to run in a shell.
The keybinding is 'X' on the files panel, and I might make it global.
Currently in order to switch to a subprocess we need to close and re-open the gui which in itself doesn't take too long but it does cause a flash which is a bit jarring for commands that run instantly.

I also want to refresh the side panels after you run the command given how likely it will be that your command changes something in those panels. This brings to the foreground the need to speed up the various refresh-panel functions, given that right now a lot of it could be parallelised and taken out of the UI thread.

I've tested with the following commands:
1) `read -p "Name: "  name; echo $name; read -p "Number: "  number; echo $number`
2) `vim`
3) `ls`

Each is a different use case: in 1, we need to give input so I think it makes sense to be swapping out to a full subprocess so that you can enter stuff. In 2 we definitely need to switch to that subprocess, and in 3 we don't, so it's the one that currently seems the most off.

In each case when we get back to lazygit I show the command's output (both stdout and stderr) in a popup panel, unless for example we've just come back from vim and the output is huge because it was rendering a whole screen's worth of characters.

Let me know what you think of this first-cut approach :)