### PR TITLE
Update bitbucket pull request url.

### DIFF
--- a/pkg/commands/pull_request.go
+++ b/pkg/commands/pull_request.go
@@ -34,7 +34,7 @@ func getServices() []*Service {
 		},
 		{
 			Name:           "bitbucket.org",
-			PullRequestURL: "https://bitbucket.org/%s/%s/pull-requests/new?t=%s",
+			PullRequestURL: "https://bitbucket.org/%s/%s/pull-requests/new?source=%s&t=1",
 		},
 		{
 			Name:           "gitlab.com",

--- a/pkg/commands/pull_request_test.go
+++ b/pkg/commands/pull_request_test.go
@@ -64,7 +64,7 @@ func TestCreatePullRequest(t *testing.T) {
 				}
 
 				assert.Equal(t, cmd, "open")
-				assert.Equal(t, args, []string{"https://bitbucket.org/johndoe/social_network/pull-requests/new?t=feature/profile-page"})
+				assert.Equal(t, args, []string{"https://bitbucket.org/johndoe/social_network/pull-requests/new?source=feature/profile-page&t=1"})
 				return exec.Command("echo")
 			},
 			func(err error) {
@@ -83,7 +83,7 @@ func TestCreatePullRequest(t *testing.T) {
 				}
 
 				assert.Equal(t, cmd, "open")
-				assert.Equal(t, args, []string{"https://bitbucket.org/johndoe/social_network/pull-requests/new?t=feature/events"})
+				assert.Equal(t, args, []string{"https://bitbucket.org/johndoe/social_network/pull-requests/new?source=feature/events&t=1"})
 				return exec.Command("echo")
 			},
 			func(err error) {


### PR DESCRIPTION
Today i noticed that opening PR from lazygit stopped working, it preselected the wrong branch. It turns out they changed the format of url. This should fix it.