### PR TITLE
allow a LOG_LEVEL env var to be set

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -35,6 +35,7 @@ type App struct {
 func newProductionLogger(config config.AppConfigurer) *logrus.Logger {
 	log := logrus.New()
 	log.Out = ioutil.Discard
+	log.SetLevel(logrus.ErrorLevel)
 	return log
 }
 
@@ -44,8 +45,18 @@ func globalConfigDir() string {
 	return configDir.Path
 }
 
+func getLogLevel() logrus.Level {
+	strLevel := os.Getenv("LOG_LEVEL")
+	level, err := logrus.ParseLevel(strLevel)
+	if err != nil {
+		return logrus.DebugLevel
+	}
+	return level
+}
+
 func newDevelopmentLogger(config config.AppConfigurer) *logrus.Logger {
 	log := logrus.New()
+	log.SetLevel(getLogLevel())
 	file, err := os.OpenFile(filepath.Join(globalConfigDir(), "development.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		panic("unable to log to file") // TODO: don't panic (also, remove this call to the `panic` function)


### PR DESCRIPTION
now you can say `LOG_LEVEL=warn lazygit -debug` to have only have logs on the warn level. This is useful for when you want to add some specific logging for something you're testing and don't want to be distracted by the clutter of command outputs.