### PR TITLE
Autostash checkout

### DIFF
--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -121,15 +121,7 @@ func (gui *Gui) handleBranchPress(g *gocui.Gui, v *gocui.View) error {
 		return gui.createErrorPanel(g, gui.Tr.SLocalize("AlreadyCheckedOutBranch"))
 	}
 	branch := gui.getSelectedBranch()
-	if err := gui.GitCommand.Checkout(branch.Name, false); err != nil {
-		if err := gui.createErrorPanel(g, err.Error()); err != nil {
-			return err
-		}
-	} else {
-		gui.State.Panels.Branches.SelectedLine = 0
-	}
-
-	return gui.refreshSidePanels(g)
+	return gui.handleCheckoutBranch(branch.Name)
 }
 
 func (gui *Gui) handleCreatePullRequestPress(g *gocui.Gui, v *gocui.View) error {
@@ -166,12 +158,44 @@ func (gui *Gui) handleForceCheckout(g *gocui.Gui, v *gocui.View) error {
 	}, nil)
 }
 
+func (gui *Gui) handleCheckoutBranch(branchName string) error {
+	if err := gui.GitCommand.Checkout(branchName, false); err != nil {
+		// note, this will only work for english-language git commands. If we force git to use english, and the error isn't this one, then the user will receive an english command they may not understand. I'm not sure what the best solution to this is. Running the command once in english and a second time in the native language is one option
+		if !strings.Contains(err.Error(), "Please commit your changes or stash them before you switch branch") {
+			if err := gui.createErrorPanel(gui.g, err.Error()); err != nil {
+				return err
+			}
+		}
+
+		// offer to autostash changes
+		return gui.createConfirmationPanel(gui.g, gui.getBranchesView(), gui.Tr.SLocalize("AutoStashTitle"), gui.Tr.SLocalize("AutoStashPrompt"), func(g *gocui.Gui, v *gocui.View) error {
+			if err := gui.GitCommand.StashSave(gui.Tr.SLocalize("StashPrefix") + branchName); err != nil {
+				return gui.createErrorPanel(g, err.Error())
+			}
+			if err := gui.GitCommand.Checkout(branchName, false); err != nil {
+				return gui.createErrorPanel(g, err.Error())
+			}
+
+			// checkout successful so we select the new branch
+			gui.State.Panels.Branches.SelectedLine = 0
+
+			if err := gui.GitCommand.StashDo(0, "pop"); err != nil {
+				if err := gui.refreshSidePanels(g); err != nil {
+					return err
+				}
+				return gui.createErrorPanel(g, err.Error())
+			}
+			return gui.refreshSidePanels(g)
+		}, nil)
+	}
+
+	gui.State.Panels.Branches.SelectedLine = 0
+	return gui.refreshSidePanels(gui.g)
+}
+
 func (gui *Gui) handleCheckoutByName(g *gocui.Gui, v *gocui.View) error {
 	gui.createPromptPanel(g, v, gui.Tr.SLocalize("BranchName")+":", func(g *gocui.Gui, v *gocui.View) error {
-		if err := gui.GitCommand.Checkout(gui.trimmedContent(v), false); err != nil {
-			return gui.createErrorPanel(g, err.Error())
-		}
-		return gui.refreshSidePanels(g)
+		return gui.handleCheckoutBranch(gui.trimmedContent(v))
 	})
 	return nil
 }

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -361,7 +361,7 @@ func (gui *Gui) editFile(filename string) error {
 func (gui *Gui) handleFileEdit(g *gocui.Gui, v *gocui.View) error {
 	file, err := gui.getSelectedFile(g)
 	if err != nil {
-		return err
+		return gui.createErrorPanel(gui.g, err.Error())
 	}
 
 	return gui.editFile(file.Name)
@@ -370,7 +370,7 @@ func (gui *Gui) handleFileEdit(g *gocui.Gui, v *gocui.View) error {
 func (gui *Gui) handleFileOpen(g *gocui.Gui, v *gocui.View) error {
 	file, err := gui.getSelectedFile(g)
 	if err != nil {
-		return err
+		return gui.createErrorPanel(gui.g, err.Error())
 	}
 	return gui.openFile(file.Name)
 }
@@ -454,7 +454,7 @@ func (gui *Gui) handleSwitchToMerge(g *gocui.Gui, v *gocui.View) error {
 	file, err := gui.getSelectedFile(g)
 	if err != nil {
 		if err != gui.Errors.ErrNoFiles {
-			return err
+			return gui.createErrorPanel(gui.g, err.Error())
 		}
 		return nil
 	}

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -282,7 +282,7 @@ func (gui *Gui) handleFileRemove(g *gocui.Gui, v *gocui.View) error {
 	)
 	return gui.createConfirmationPanel(g, v, strings.Title(deleteVerb)+" file", message, func(g *gocui.Gui, v *gocui.View) error {
 		if err := gui.GitCommand.RemoveFile(file); err != nil {
-			return err
+			return gui.createErrorPanel(gui.g, err.Error())
 		}
 		return gui.refreshFiles()
 	}, nil)

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -673,6 +673,15 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "CreateRepo",
 			Other: "Not in a git repository. Create a new git repository? (y/n): ",
+		}, &i18n.Message{
+			ID:    "AutoStashTitle",
+			Other: "Autostash?",
+		}, &i18n.Message{
+			ID:    "AutoStashPrompt",
+			Other: "You must stash and pop your changes to bring them across. Do this automatically? (enter/esc)",
+		}, &i18n.Message{
+			ID:    "StashPrefix",
+			Other: "Auto-stashing changes for ",
 		},
 	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -696,6 +696,15 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "CreateRepo",
 			Other: "Not in a git repository. Create a new git repository? (y/n): ",
+		}, &i18n.Message{
+			ID:    "AutoStashTitle",
+			Other: "Autostash?",
+		}, &i18n.Message{
+			ID:    "AutoStashPrompt",
+			Other: "You must stash and pop your changes to bring them across. Do this automatically? (enter/esc)",
+		}, &i18n.Message{
+			ID:    "StashPrefix",
+			Other: "Auto-stashing changes for ",
 		},
 	)
 }

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -656,6 +656,15 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "CreateRepo",
 			Other: "Not in a git repository. Create a new git repository? (y/n): ",
+		}, &i18n.Message{
+			ID:    "AutoStashTitle",
+			Other: "Autostash?",
+		}, &i18n.Message{
+			ID:    "AutoStashPrompt",
+			Other: "You must stash and pop your changes to bring them across. Do this automatically? (enter/esc)",
+		}, &i18n.Message{
+			ID:    "StashPrefix",
+			Other: "Auto-stashing changes for ",
 		},
 	)
 }

--- a/test/repos/merge_conflict.sh
+++ b/test/repos/merge_conflict.sh
@@ -133,4 +133,23 @@ echo "once upon a time there was a horse" >> file5
 git add file5
 git commit -m "fourth commit on master"
 
-# git merge develop # should have a merge conflict here
+
+# this is for the autostash feature
+
+git checkout -b base_branch
+
+echo "original1\noriginal2\noriginal3" > file
+git add file
+git commit -m "file"
+
+git checkout -b other_branch
+
+git checkout base_branch
+
+echo "new1\noriginal2\noriginal3" > file
+git add file
+git commit -m "file changed"
+
+git checkout other_branch
+
+echo "new2\noriginal2\noriginal3" > file


### PR DESCRIPTION
If you need to stash your changes in order to checkout a branch, lazygit will no offer to stash and pop your changes for you. Worst case scenario, you get a merge conflict after popping the changes, in which case the stash entry will still be there if you want to apply it back to the original branch.

![image](https://user-images.githubusercontent.com/8456633/54469269-fbdc9480-47e9-11e9-9f46-1fe1504d07e2.png)
