### PR TITLE
Better interface for discarding file changes

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -905,3 +905,8 @@ func (c *GitCommand) RemoveUntrackedFiles() error {
 func (c *GitCommand) ResetHardHead() error {
 	return c.OSCommand.RunCommand("git reset --hard HEAD")
 }
+
+// ResetSoftHead runs `git reset --soft HEAD`
+func (c *GitCommand) ResetSoftHead() error {
+	return c.OSCommand.RunCommand("git reset --soft HEAD")
+}

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -217,11 +217,11 @@ func includesInt(list []int, a int) bool {
 
 // ResetAndClean removes all unstaged changes and removes all untracked files
 func (c *GitCommand) ResetAndClean() error {
-	if err := c.OSCommand.RunCommand("git reset --hard HEAD"); err != nil {
+	if err := c.ResetHardHead(); err != nil {
 		return err
 	}
 
-	return c.OSCommand.RunCommand("git clean -fd")
+	return c.RemoveUntrackedFiles()
 }
 
 func (c *GitCommand) GetCurrentBranchUpstreamDifferenceCount() (string, string) {
@@ -889,4 +889,19 @@ func (c *GitCommand) DiscardOldFileChanges(commits []*Commit, commitIndex int, f
 
 	// continue
 	return c.GenericMerge("rebase", "continue")
+}
+
+// DiscardAnyUnstagedFileChanges discards any unstages file changes via `git checkout -- .`
+func (c *GitCommand) DiscardAnyUnstagedFileChanges() error {
+	return c.OSCommand.RunCommand("git checkout -- .")
+}
+
+// RemoveUntrackedFiles runs `git clean -fd`
+func (c *GitCommand) RemoveUntrackedFiles() error {
+	return c.OSCommand.RunCommand("git clean -fd")
+}
+
+// ResetHardHead runs `git reset --hard HEAD`
+func (c *GitCommand) ResetHardHead() error {
+	return c.OSCommand.RunCommand("git reset --hard HEAD")
 }

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -1933,8 +1933,8 @@ func TestGitCommandGetCommitFiles(t *testing.T) {
 	}
 }
 
-// TestGitCommandDiscardUnstagedChanges is a function.
-func TestGitCommandDiscardUnstagedChanges(t *testing.T) {
+// TestGitCommandDiscardUnstagedFileChanges is a function.
+func TestGitCommandDiscardUnstagedFileChanges(t *testing.T) {
 	type scenario struct {
 		testName string
 		file     *File
@@ -1964,6 +1964,105 @@ func TestGitCommandDiscardUnstagedChanges(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			gitCmd.OSCommand.command = s.command
 			s.test(gitCmd.DiscardUnstagedFileChanges(s.file))
+		})
+	}
+}
+
+// TestGitCommandDiscardAnyUnstagedFileChanges is a function.
+func TestGitCommandDiscardAnyUnstagedFileChanges(t *testing.T) {
+	type scenario struct {
+		testName string
+		command  func(string, ...string) *exec.Cmd
+		test     func(error)
+	}
+
+	scenarios := []scenario{
+		{
+			"valid case",
+			test.CreateMockCommand(t, []*test.CommandSwapper{
+				{
+					Expect:  `git checkout -- .`,
+					Replace: "echo",
+				},
+			}),
+			func(err error) {
+				assert.NoError(t, err)
+			},
+		},
+	}
+
+	gitCmd := NewDummyGitCommand()
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			gitCmd.OSCommand.command = s.command
+			s.test(gitCmd.DiscardAnyUnstagedFileChanges())
+		})
+	}
+}
+
+// TestGitCommandRemoveUntrackedFiles is a function.
+func TestGitCommandRemoveUntrackedFiles(t *testing.T) {
+	type scenario struct {
+		testName string
+		command  func(string, ...string) *exec.Cmd
+		test     func(error)
+	}
+
+	scenarios := []scenario{
+		{
+			"valid case",
+			test.CreateMockCommand(t, []*test.CommandSwapper{
+				{
+					Expect:  `git clean -fd`,
+					Replace: "echo",
+				},
+			}),
+			func(err error) {
+				assert.NoError(t, err)
+			},
+		},
+	}
+
+	gitCmd := NewDummyGitCommand()
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			gitCmd.OSCommand.command = s.command
+			s.test(gitCmd.RemoveUntrackedFiles())
+		})
+	}
+}
+
+// TestGitCommandResetHardHead is a function.
+func TestGitCommandResetHardHead(t *testing.T) {
+	type scenario struct {
+		testName string
+		command  func(string, ...string) *exec.Cmd
+		test     func(error)
+	}
+
+	scenarios := []scenario{
+		{
+			"valid case",
+			test.CreateMockCommand(t, []*test.CommandSwapper{
+				{
+					Expect:  `git reset --hard HEAD`,
+					Replace: "echo",
+				},
+			}),
+			func(err error) {
+				assert.NoError(t, err)
+			},
+		},
+	}
+
+	gitCmd := NewDummyGitCommand()
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			gitCmd.OSCommand.command = s.command
+			s.test(gitCmd.ResetHardHead())
 		})
 	}
 }

--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -255,9 +255,9 @@ func (c *OSCommand) CreateTempFile(filename, content string) (string, error) {
 	return tmpfile.Name(), nil
 }
 
-// RemoveFile removes a file at the specified path
-func (c *OSCommand) RemoveFile(filename string) error {
-	err := os.Remove(filename)
+// Remove removes a file or directory at the specified path
+func (c *OSCommand) Remove(filename string) error {
+	err := os.RemoveAll(filename)
 	return WrapError(err)
 }
 

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -529,6 +529,11 @@ func (gui *Gui) handleCreateDiscardMenu(g *gocui.Gui, v *gocui.View) error {
 	}
 
 	handleMenuPress := func(index int) error {
+		file, err := gui.getSelectedFile(g)
+		if err != nil {
+			return err
+		}
+
 		if err := options[index].handler(file); err != nil {
 			return err
 		}

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -541,7 +541,7 @@ func (gui *Gui) handleCreateDiscardMenu(g *gocui.Gui, v *gocui.View) error {
 		return gui.refreshFiles()
 	}
 
-	return gui.createMenu(file.Name, options, handleMenuPress)
+	return gui.createMenu(file.Name, options, len(options), handleMenuPress)
 }
 
 func (gui *Gui) handleCreateResetMenu(g *gocui.Gui, v *gocui.View) error {
@@ -597,5 +597,5 @@ func (gui *Gui) handleCreateResetMenu(g *gocui.Gui, v *gocui.View) error {
 		return gui.refreshFiles()
 	}
 
-	return gui.createMenu("", options, handleMenuPress)
+	return gui.createMenu("", options, len(options), handleMenuPress)
 }

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -472,19 +472,6 @@ func (gui *Gui) anyFilesWithMergeConflicts() bool {
 	return false
 }
 
-func (gui *Gui) handleSoftReset(g *gocui.Gui, v *gocui.View) error {
-	return gui.createConfirmationPanel(g, v, gui.Tr.SLocalize("SoftReset"), gui.Tr.SLocalize("ConfirmSoftReset"), func(g *gocui.Gui, v *gocui.View) error {
-		if err := gui.GitCommand.SoftReset("HEAD^"); err != nil {
-			return gui.createErrorPanel(g, err.Error())
-		}
-
-		if err := gui.refreshCommits(gui.g); err != nil {
-			return err
-		}
-		return gui.refreshFiles()
-	}, nil)
-}
-
 type discardOption struct {
 	handler     func(fileName *commands.File) error
 	description string
@@ -552,7 +539,7 @@ func (gui *Gui) handleCreateDiscardMenu(g *gocui.Gui, v *gocui.View) error {
 	return gui.createMenu(file.Name, options, handleMenuPress)
 }
 
-func (gui *Gui) handleResetAndClean(g *gocui.Gui, v *gocui.View) error {
+func (gui *Gui) handleCreateResetMenu(g *gocui.Gui, v *gocui.View) error {
 	options := []*discardAllOption{
 		{
 			description: gui.Tr.SLocalize("discardAllChangesToAllFiles"),
@@ -573,6 +560,13 @@ func (gui *Gui) handleResetAndClean(g *gocui.Gui, v *gocui.View) error {
 			command:     "git clean -fd",
 			handler: func() error {
 				return gui.GitCommand.RemoveUntrackedFiles()
+			},
+		},
+		{
+			description: gui.Tr.SLocalize("softReset"),
+			command:     "git reset --soft HEAD",
+			handler: func() error {
+				return gui.GitCommand.ResetSoftHead()
 			},
 		},
 		{

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -176,8 +176,8 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			ViewName:    "files",
 			Key:         'd',
 			Modifier:    gocui.ModNone,
-			Handler:     gui.handleFileRemove,
-			Description: gui.Tr.SLocalize("removeFile"),
+			Handler:     gui.handleCreateDiscardMenu,
+			Description: gui.Tr.SLocalize("viewDiscardOptions"),
 		}, {
 			ViewName:    "files",
 			Key:         'e',

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -210,12 +210,6 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Description: gui.Tr.SLocalize("stashFiles"),
 		}, {
 			ViewName:    "files",
-			Key:         's',
-			Modifier:    gocui.ModNone,
-			Handler:     gui.handleSoftReset,
-			Description: gui.Tr.SLocalize("softReset"),
-		}, {
-			ViewName:    "files",
 			Key:         'a',
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleStageAll,
@@ -230,8 +224,8 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			ViewName:    "files",
 			Key:         'D',
 			Modifier:    gocui.ModNone,
-			Handler:     gui.handleResetAndClean,
-			Description: gui.Tr.SLocalize("resetHard"),
+			Handler:     gui.handleCreateResetMenu,
+			Description: gui.Tr.SLocalize("viewResetOptions"),
 		}, {
 			ViewName:    "files",
 			Key:         gocui.KeyEnter,

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -82,6 +82,8 @@ func (gui *Gui) createMenu(title string, items interface{}, itemCount int, handl
 	}
 
 	for _, key := range []gocui.Key{gocui.KeySpace, gocui.KeyEnter} {
+		_ = gui.g.DeleteKeybinding("menu", key, gocui.ModNone)
+
 		if err := gui.g.SetKeybinding("menu", key, gocui.ModNone, wrappedHandlePress); err != nil {
 			return err
 		}

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -389,9 +389,6 @@ func addDutch(i18nObject *i18n.Bundle) error {
 			ID:    "refreshFiles",
 			Other: `refresh bestanden`,
 		}, &i18n.Message{
-			ID:    "resetHard",
-			Other: `harde reset and verwijderen ongevolgde bestanden`,
-		}, &i18n.Message{
 			ID:    "mergeIntoCurrentBranch",
 			Other: `merge in met huidige checked out branch`,
 		}, &i18n.Message{
@@ -471,13 +468,7 @@ func addDutch(i18nObject *i18n.Bundle) error {
 			Other: "Normal",
 		}, &i18n.Message{
 			ID:    "softReset",
-			Other: "soft reset to last commit",
-		}, &i18n.Message{
-			ID:    "SoftReset",
-			Other: "Soft reset",
-		}, &i18n.Message{
-			ID:    "ConfirmSoftReset",
-			Other: "Are you sure you want to `reset --soft HEAD^`? The changes in your topmost commit will be placed in your working tree",
+			Other: "soft reset",
 		}, &i18n.Message{
 			ID:    "CantRebaseOntoSelf",
 			Other: "You cannot rebase a branch onto itself",
@@ -697,6 +688,9 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "discardUntrackedFiles",
 			Other: "discard untracked files",
+		}, &i18n.Message{
+			ID:    "viewResetOptions",
+			Other: `view reset options`,
 		}, &i18n.Message{
 			ID:    "hardReset",
 			Other: "hard reset",

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -158,9 +158,6 @@ func addDutch(i18nObject *i18n.Bundle) error {
 			ID:    "FileNoMergeCons",
 			Other: "Dit bestand heeft geen merge conflicten",
 		}, &i18n.Message{
-			ID:    "SureResetHardHead",
-			Other: "Weet je het zeker dat je `reset --hard HEAD` en `clean -fd` wil uitvoeren? Het kan dat je hierdoor bestanden verliest",
-		}, &i18n.Message{
 			ID:    "SureTo",
 			Other: "Weet je het zeker dat je {{.fileName}} wilt {{.deleteVerb}} (je veranderingen zullen worden verwijderd)",
 		}, &i18n.Message{
@@ -340,9 +337,6 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "CantCloseConfirmationPrompt",
 			Other: "Kon de bevestiging prompt niet sluiten: {{.error}}",
-		}, &i18n.Message{
-			ID:    "ClearFilePanel",
-			Other: "maak bestandsvenster leeg",
 		}, &i18n.Message{
 			ID:    "MergeAborted",
 			Other: "Merge afgebroken",
@@ -694,6 +688,18 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "discardUnstagedChanges",
 			Other: "discard unstaged changes",
+		}, &i18n.Message{
+			ID:    "discardAllChangesToAllFiles",
+			Other: "nuke working tree",
+		}, &i18n.Message{
+			ID:    "discardAnyUnstagedChanges",
+			Other: "discard unstaged changes",
+		}, &i18n.Message{
+			ID:    "discardUntrackedFiles",
+			Other: "discard untracked files",
+		}, &i18n.Message{
+			ID:    "hardReset",
+			Other: "hard reset",
 		},
 	)
 }

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -383,9 +383,6 @@ func addDutch(i18nObject *i18n.Bundle) error {
 			ID:    "GitconfigParseErr",
 			Other: `Gogit kon je gitconfig bestand niet goed parsen door de aanwezigheid van losstaande '\' tekens. Het weghalen van deze tekens zou het probleem moeten oplossen. `,
 		}, &i18n.Message{
-			ID:    "removeFile",
-			Other: `Verwijder als untracked / uitchecken wordt gevolgd (ga weg)`,
-		}, &i18n.Message{
 			ID:    "editFile",
 			Other: `verander bestand`,
 		}, &i18n.Message{
@@ -685,6 +682,18 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "StashPrefix",
 			Other: "Auto-stashing changes for ",
+		}, &i18n.Message{
+			ID:    "viewDiscardOptions",
+			Other: "view 'discard changes' options",
+		}, &i18n.Message{
+			ID:    "cancel",
+			Other: "cancel",
+		}, &i18n.Message{
+			ID:    "discardAllChanges",
+			Other: "discard all changes",
+		}, &i18n.Message{
+			ID:    "discardUnstagedChanges",
+			Other: "discard unstaged changes",
 		},
 	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -181,9 +181,6 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			ID:    "FileNoMergeCons",
 			Other: "This file has no inline merge conflicts",
 		}, &i18n.Message{
-			ID:    "SureResetHardHead",
-			Other: "Are you sure you want to `reset --hard HEAD` and `clean -fd`? You may lose changes",
-		}, &i18n.Message{
 			ID:    "SoftReset",
 			Other: "Soft reset",
 		}, &i18n.Message{
@@ -405,9 +402,6 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "NoChangedFiles",
 			Other: "No changed files",
-		}, &i18n.Message{
-			ID:    "ClearFilePanel",
-			Other: "Clear file panel",
 		}, &i18n.Message{
 			ID:    "MergeAborted",
 			Other: "Merge aborted",
@@ -717,6 +711,18 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "discardUnstagedChanges",
 			Other: "discard unstaged changes",
+		}, &i18n.Message{
+			ID:    "discardAllChangesToAllFiles",
+			Other: "nuke working tree",
+		}, &i18n.Message{
+			ID:    "discardAnyUnstagedChanges",
+			Other: "discard unstaged changes",
+		}, &i18n.Message{
+			ID:    "discardUntrackedFiles",
+			Other: "discard untracked files",
+		}, &i18n.Message{
+			ID:    "hardReset",
+			Other: "hard reset",
 		},
 	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -448,9 +448,6 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			ID:    "GitconfigParseErr",
 			Other: `Gogit failed to parse your gitconfig file due to the presence of unquoted '\' characters. Removing these should fix the issue.`,
 		}, &i18n.Message{
-			ID:    "removeFile",
-			Other: `delete if untracked / checkout if tracked`,
-		}, &i18n.Message{
 			ID:    "editFile",
 			Other: `edit file`,
 		}, &i18n.Message{
@@ -708,6 +705,18 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "StashPrefix",
 			Other: "Auto-stashing changes for ",
+		}, &i18n.Message{
+			ID:    "viewDiscardOptions",
+			Other: "view 'discard changes' options",
+		}, &i18n.Message{
+			ID:    "cancel",
+			Other: "cancel",
+		}, &i18n.Message{
+			ID:    "discardAllChanges",
+			Other: "discard all changes",
+		}, &i18n.Message{
+			ID:    "discardUnstagedChanges",
+			Other: "discard unstaged changes",
 		},
 	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -103,9 +103,6 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			ID:    "stashFiles",
 			Other: "stash files",
 		}, &i18n.Message{
-			ID:    "softReset",
-			Other: "soft reset to last commit",
-		}, &i18n.Message{
 			ID:    "open",
 			Other: "open",
 		}, &i18n.Message{
@@ -181,11 +178,8 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			ID:    "FileNoMergeCons",
 			Other: "This file has no inline merge conflicts",
 		}, &i18n.Message{
-			ID:    "SoftReset",
-			Other: "Soft reset",
-		}, &i18n.Message{
-			ID:    "ConfirmSoftReset",
-			Other: "Are you sure you want to `reset --soft HEAD^`? The changes in your topmost commit will be placed in your working tree",
+			ID:    "softReset",
+			Other: "soft reset",
 		}, &i18n.Message{
 			ID:    "SureTo",
 			Other: "Are you sure you want to {{.deleteVerb}} {{.fileName}} (you will lose your changes)?",
@@ -454,9 +448,6 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			ID:    "refreshFiles",
 			Other: `refresh files`,
 		}, &i18n.Message{
-			ID:    "resetHard",
-			Other: `reset hard and remove untracked files`,
-		}, &i18n.Message{
 			ID:    "mergeIntoCurrentBranch",
 			Other: `merge into currently checked out branch`,
 		}, &i18n.Message{
@@ -723,6 +714,9 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "hardReset",
 			Other: "hard reset",
+		}, &i18n.Message{
+			ID:    "viewResetOptions",
+			Other: `view reset options`,
 		},
 	)
 }

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -147,9 +147,6 @@ func addPolish(i18nObject *i18n.Bundle) error {
 			ID:    "FileNoMergeCons",
 			Other: "Ten plik nie powoduje konfliktów scalania",
 		}, &i18n.Message{
-			ID:    "SureResetHardHead",
-			Other: "Jesteś pewny, że chcesz wykonać `reset --hard HEAD` i `clean -fd`? Możesz stracić wprowadzone zmiany",
-		}, &i18n.Message{
 			ID:    "SureTo",
 			Other: "Jesteś pewny, że chcesz {{.deleteVerb}} {{.fileName}} (stracisz swoje wprowadzone zmiany)?",
 		}, &i18n.Message{
@@ -332,9 +329,6 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "CantCloseConfirmationPrompt",
 			Other: "Nie można zamknąć monitu potwierdzenia: {{.error}}",
-		}, &i18n.Message{
-			ID:    "ClearFilePanel",
-			Other: "Wyczyść panel plików",
 		}, &i18n.Message{
 			ID:    "MergeAborted",
 			Other: "Scalanie anulowane",
@@ -677,6 +671,18 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "discardUnstagedChanges",
 			Other: "discard unstaged changes",
+		}, &i18n.Message{
+			ID:    "discardAllChangesToAllFiles",
+			Other: "nuke working tree",
+		}, &i18n.Message{
+			ID:    "discardAnyUnstagedChanges",
+			Other: "discard unstaged changes",
+		}, &i18n.Message{
+			ID:    "discardUntrackedFiles",
+			Other: "discard untracked files",
+		}, &i18n.Message{
+			ID:    "hardReset",
+			Other: "hard reset",
 		},
 	)
 }

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -372,9 +372,6 @@ func addPolish(i18nObject *i18n.Bundle) error {
 			ID:    "AnonymousReportingPrompt",
 			Other: "Włączyć anonimowe raportowanie błędów w celu pomocy w usprawnianiu lazygita (enter/esc)?",
 		}, &i18n.Message{
-			ID:    "removeFile",
-			Other: `usuń jeśli nie śledzony / przełącz jeśli śledzony`,
-		}, &i18n.Message{
 			ID:    "editFile",
 			Other: `edytuj plik`,
 		}, &i18n.Message{
@@ -668,6 +665,18 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "StashPrefix",
 			Other: "Auto-stashing changes for ",
+		}, &i18n.Message{
+			ID:    "viewDiscardOptions",
+			Other: "view 'discard changes' options",
+		}, &i18n.Message{
+			ID:    "cancel",
+			Other: "cancel",
+		}, &i18n.Message{
+			ID:    "discardAllChanges",
+			Other: "discard all changes",
+		}, &i18n.Message{
+			ID:    "discardUnstagedChanges",
+			Other: "discard unstaged changes",
 		},
 	)
 }

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -378,9 +378,6 @@ func addPolish(i18nObject *i18n.Bundle) error {
 			ID:    "refreshFiles",
 			Other: `odśwież pliki`,
 		}, &i18n.Message{
-			ID:    "resetHard",
-			Other: `zresetuj twardo i usuń niepotwierdzone pliki`,
-		}, &i18n.Message{
 			ID:    "mergeIntoCurrentBranch",
 			Other: `scal do obecnej gałęzi`,
 		}, &i18n.Message{
@@ -457,13 +454,7 @@ func addPolish(i18nObject *i18n.Bundle) error {
 			Other: "Normal",
 		}, &i18n.Message{
 			ID:    "softReset",
-			Other: "soft reset to last commit",
-		}, &i18n.Message{
-			ID:    "SoftReset",
-			Other: "Soft reset",
-		}, &i18n.Message{
-			ID:    "ConfirmSoftReset",
-			Other: "Are you sure you want to `reset --soft HEAD^`? The changes in your topmost commit will be placed in your working tree",
+			Other: "soft reset",
 		}, &i18n.Message{
 			ID:    "SureSquashThisCommit",
 			Other: "Are you sure you want to squash this commit into the commit below?",
@@ -683,6 +674,9 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "hardReset",
 			Other: "hard reset",
+		}, &i18n.Message{
+			ID:    "viewResetOptions",
+			Other: `view reset options`,
 		},
 	)
 }


### PR DESCRIPTION
fixes #390 

This adds some more options for discarding changes to files. On individual files you now have the option to discard all changes or just the unstaged changes (`git checkout -- filename`).

when hitting shift+D you can now choose from some more options as well, including the ability to discard unstaged changes with `git checkout -- .`

This also removes the 's' keybinding for 'git reset --soft HEAD' and adds that as an option to the reset menu