### PR TITLE
Rely on model rather than view to focus a point

### DIFF
--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -34,7 +34,7 @@ func (gui *Gui) handleBranchSelect(g *gocui.Gui, v *gocui.View) error {
 		return gui.renderString(g, "main", gui.Tr.SLocalize("NoBranchesThisRepo"))
 	}
 	branch := gui.getSelectedBranch()
-	if err := gui.focusPoint(0, gui.State.Panels.Branches.SelectedLine, v); err != nil {
+	if err := gui.focusPoint(0, gui.State.Panels.Branches.SelectedLine, len(gui.State.Branches), v); err != nil {
 		return err
 	}
 	go func() {

--- a/pkg/gui/commit_files_panel.go
+++ b/pkg/gui/commit_files_panel.go
@@ -20,7 +20,7 @@ func (gui *Gui) handleCommitFileSelect(g *gocui.Gui, v *gocui.View) error {
 		return gui.renderString(g, "commitFiles", gui.Tr.SLocalize("NoCommiteFiles"))
 	}
 
-	if err := gui.focusPoint(0, gui.State.Panels.CommitFiles.SelectedLine, v); err != nil {
+	if err := gui.focusPoint(0, gui.State.Panels.CommitFiles.SelectedLine, len(gui.State.CommitFiles), v); err != nil {
 		return err
 	}
 	commitText, err := gui.GitCommand.ShowCommitFile(commitFile.Sha, commitFile.Name)

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -36,7 +36,7 @@ func (gui *Gui) handleCommitSelect(g *gocui.Gui, v *gocui.View) error {
 		return gui.renderString(g, "main", gui.Tr.SLocalize("NoCommitsThisBranch"))
 	}
 
-	if err := gui.focusPoint(0, gui.State.Panels.Commits.SelectedLine, v); err != nil {
+	if err := gui.focusPoint(0, gui.State.Panels.Commits.SelectedLine, len(gui.State.Commits), v); err != nil {
 		return err
 	}
 	commitText, err := gui.GitCommand.Show(commit.Sha)

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -63,7 +63,7 @@ func (gui *Gui) handleFileSelect(g *gocui.Gui, v *gocui.View, alreadySelected bo
 		return gui.renderString(g, "main", gui.Tr.SLocalize("NoChangedFiles"))
 	}
 
-	if err := gui.focusPoint(0, gui.State.Panels.Files.SelectedLine, v); err != nil {
+	if err := gui.focusPoint(0, gui.State.Panels.Files.SelectedLine, len(gui.State.Files), v); err != nil {
 		return err
 	}
 

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -10,7 +10,7 @@ import (
 // list panel functions
 
 func (gui *Gui) handleMenuSelect(g *gocui.Gui, v *gocui.View) error {
-	return gui.focusPoint(0, gui.State.Panels.Menu.SelectedLine, v)
+	return gui.focusPoint(0, gui.State.Panels.Menu.SelectedLine, gui.State.MenuItemCount, v)
 }
 
 func (gui *Gui) handleMenuNextLine(g *gocui.Gui, v *gocui.View) error {
@@ -51,8 +51,9 @@ func (gui *Gui) handleMenuClose(g *gocui.Gui, v *gocui.View) error {
 	return gui.returnFocus(g, v)
 }
 
-func (gui *Gui) createMenu(title string, items interface{}, handlePress func(int) error) error {
+func (gui *Gui) createMenu(title string, items interface{}, itemCount int, handlePress func(int) error) error {
 	isFocused := gui.g.CurrentView().Name() == "menu"
+	gui.State.MenuItemCount = itemCount
 	list, err := utils.RenderList(items, isFocused)
 	if err != nil {
 		return err

--- a/pkg/gui/options_menu_panel.go
+++ b/pkg/gui/options_menu_panel.go
@@ -49,5 +49,5 @@ func (gui *Gui) handleCreateOptionsMenu(g *gocui.Gui, v *gocui.View) error {
 		return bindings[index].Handler(g, v)
 	}
 
-	return gui.createMenu(strings.Title(gui.Tr.SLocalize("menu")), bindings, handleMenuPress)
+	return gui.createMenu(strings.Title(gui.Tr.SLocalize("menu")), bindings, len(bindings), handleMenuPress)
 }

--- a/pkg/gui/rebase_options_panel.go
+++ b/pkg/gui/rebase_options_panel.go
@@ -38,7 +38,7 @@ func (gui *Gui) handleCreateRebaseOptionsMenu(g *gocui.Gui, v *gocui.View) error
 		title = gui.Tr.SLocalize("RebaseOptionsTitle")
 	}
 
-	return gui.createMenu(title, options, handleMenuPress)
+	return gui.createMenu(title, options, len(options), handleMenuPress)
 }
 
 func (gui *Gui) genericMergeCommand(command string) error {

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -44,7 +44,7 @@ func (gui *Gui) handleCreateRecentReposMenu(g *gocui.Gui, v *gocui.View) error {
 		return gui.Errors.ErrSwitchRepo
 	}
 
-	return gui.createMenu(gui.Tr.SLocalize("RecentRepos"), recentRepos, handleMenuPress)
+	return gui.createMenu(gui.Tr.SLocalize("RecentRepos"), recentRepos, len(recentRepos), handleMenuPress)
 }
 
 // updateRecentRepoList registers the fact that we opened lazygit in this repo,

--- a/pkg/gui/stash_panel.go
+++ b/pkg/gui/stash_panel.go
@@ -31,7 +31,7 @@ func (gui *Gui) handleStashEntrySelect(g *gocui.Gui, v *gocui.View) error {
 	if stashEntry == nil {
 		return gui.renderString(g, "main", gui.Tr.SLocalize("NoStashEntries"))
 	}
-	if err := gui.focusPoint(0, gui.State.Panels.Stash.SelectedLine, v); err != nil {
+	if err := gui.focusPoint(0, gui.State.Panels.Stash.SelectedLine, len(gui.State.StashEntries), v); err != nil {
 		return err
 	}
 	go func() {

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -180,8 +180,8 @@ func (gui *Gui) resetOrigin(v *gocui.View) error {
 }
 
 // if the cursor down past the last item, move it to the last line
-func (gui *Gui) focusPoint(cx int, cy int, v *gocui.View) error {
-	if cy < 0 {
+func (gui *Gui) focusPoint(cx int, cy int, lineCount int, v *gocui.View) error {
+	if cy < 0 || cy > lineCount {
 		return nil
 	}
 	ox, oy := v.Origin()
@@ -191,7 +191,7 @@ func (gui *Gui) focusPoint(cx int, cy int, v *gocui.View) error {
 	// if line is above origin, move origin and set cursor to zero
 	// if line is below origin + height, move origin and set cursor to max
 	// otherwise set cursor to value - origin
-	if ly > v.LinesHeight() {
+	if ly > lineCount {
 		if err := v.SetCursor(cx, cy); err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently when we want to focus a point on a view (i.e. highlight a
line and ensure it's within the bounds of a view's box, we use the
LinesHeight method on the view to work out how many lines in total
there are.

This is bad because for example if we come back from editing a file,
the view will have no contents so LinesHeight == 0, but we might
be trying to select line 10 because there are actual ten things we
expect to be rendered already. This causes a crash when e.g. 10 is
greater than the height of the view.

So we need to pass in to our FocusPoint method the actual number of
items we want to render, rather than having the method rely on the
LinesHeight, so that the method knows to scroll a bit before setting
the cursor's y position.

Unfortunately this makes for some awkward code with our current setup.
We don't have a good interface type on these state objects so we now
need to explicitly obtain the len() of whatever array we're rendering.

In the case of the menu panel this is even more awkward because the items
list is just an interface{} and it's not easy to get the list of that, so
now when we instantiate a menu we need to pass in the count of items
as well.

The better solution would be to define an interface with a getItems
and getLength method and have all these item arrays become structs
implementing the interface, but I am too lazy to do this right now :)