### PR TITLE
Support resetting to a commit in either soft, hard, or mixed mode

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -277,8 +277,8 @@ func (c *GitCommand) Fetch(unamePassQuestion func(string) string, canAskForCrede
 }
 
 // ResetToCommit reset to commit
-func (c *GitCommand) ResetToCommit(sha string) error {
-	return c.OSCommand.RunCommand(fmt.Sprintf("git reset %s", sha))
+func (c *GitCommand) ResetToCommit(sha string, strength string) error {
+	return c.OSCommand.RunCommand(fmt.Sprintf("git reset --%s %s", strength, sha))
 }
 
 // NewBranch create new branch

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -616,12 +616,12 @@ func TestGitCommandResetToCommit(t *testing.T) {
 	gitCmd := NewDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
 		assert.EqualValues(t, "git", cmd)
-		assert.EqualValues(t, []string{"reset", "78976bc"}, args)
+		assert.EqualValues(t, []string{"reset", "--hard", "78976bc"}, args)
 
 		return exec.Command("echo")
 	}
 
-	assert.NoError(t, gitCmd.ResetToCommit("78976bc"))
+	assert.NoError(t, gitCmd.ResetToCommit("78976bc", "hard"))
 }
 
 // TestGitCommandNewBranch is a function.

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/fatih/color"
 	"github.com/go-errors/errors"
 
 	"github.com/jesseduffield/gocui"
@@ -124,7 +125,8 @@ func (gui *Gui) handleResetToCommit(g *gocui.Gui, commitView *gocui.View) error 
 		if commit == nil {
 			panic(errors.New(gui.Tr.SLocalize("NoCommitsThisBranch")))
 		}
-		if err := gui.GitCommand.ResetToCommit(commit.Sha); err != nil {
+
+		if err := gui.GitCommand.ResetToCommit(commit.Sha, "mixed"); err != nil {
 			return gui.createErrorPanel(g, err.Error())
 		}
 		if err := gui.refreshCommits(g); err != nil {
@@ -553,4 +555,51 @@ func (gui *Gui) handleSquashAllAboveFixupCommits(g *gocui.Gui, v *gocui.View) er
 			return gui.handleGenericMergeCommandResult(err)
 		})
 	}, nil)
+}
+
+type resetOption struct {
+	description string
+	command     string
+}
+
+// GetDisplayStrings is a function.
+func (r *resetOption) GetDisplayStrings(isFocused bool) []string {
+	return []string{r.description, color.New(color.FgRed).Sprint(r.command)}
+}
+
+func (gui *Gui) handleCreateCommitResetMenu(g *gocui.Gui, v *gocui.View) error {
+	commit := gui.getSelectedCommit(g)
+	if commit == nil {
+		return gui.createErrorPanel(gui.g, gui.Tr.SLocalize("NoCommitsThisBranch"))
+	}
+
+	strengths := []string{"soft", "mixed", "hard"}
+	options := make([]*resetOption, len(strengths))
+	for i, strength := range strengths {
+		options[i] = &resetOption{
+			description: fmt.Sprintf("%s reset", strength),
+			command:     fmt.Sprintf("reset --%s %s", strength, commit.Sha),
+		}
+	}
+
+	handleMenuPress := func(index int) error {
+		if err := gui.GitCommand.ResetToCommit(commit.Sha, strengths[index]); err != nil {
+			return err
+		}
+
+		if err := gui.refreshCommits(g); err != nil {
+			return err
+		}
+		if err := gui.refreshFiles(); err != nil {
+			return err
+		}
+		if err := gui.resetOrigin(gui.getCommitsView()); err != nil {
+			return err
+		}
+
+		gui.State.Panels.Commits.SelectedLine = 0
+		return gui.handleCommitSelect(g, gui.getCommitsView())
+	}
+
+	return gui.createMenu(fmt.Sprintf("%s %s", gui.Tr.SLocalize("resetTo"), commit.Sha), options, len(options), handleMenuPress)
 }

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -327,7 +327,7 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			ViewName:    "commits",
 			Key:         'g',
 			Modifier:    gocui.ModNone,
-			Handler:     gui.handleResetToCommit,
+			Handler:     gui.handleCreateCommitResetMenu,
 			Description: gui.Tr.SLocalize("resetToThisCommit"),
 		}, {
 			ViewName:    "commits",

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -733,6 +733,9 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "SkipHookPrefixNotConfigured",
 			Other: "Je hebt nog niet een commit bericht voorvoegsel ingesteld voor het overslaan van hooks. Set `git.skipHookPrefix = 'WIP'` in je config",
+		}, &i18n.Message{
+			ID:    "resetTo",
+			Other: `reset to`,
 		},
 	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -756,6 +756,9 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "SkipHookPrefixNotConfigured",
 			Other: "You have not configured a commit message prefix for skipping hooks. Set `git.skipHookPrefix = 'WIP'` in your config",
+		}, &i18n.Message{
+			ID:    "resetTo",
+			Other: `reset to`,
 		},
 	)
 }

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -716,6 +716,9 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "SkipHookPrefixNotConfigured",
 			Other: "You have not configured a commit message prefix for skipping hooks. Set `git.skipHookPrefix = 'WIP'` in your config",
+		}, &i18n.Message{
+			ID:    "resetTo",
+			Other: `reset to`,
 		},
 	)
 }


### PR DESCRIPTION
Now when you hit 'g' on a commit, you can choose between three options for resetting: soft, mixed and hard.

Worth noting that the structure of the code differs slightly to what I had with resetting in the files panel because it seemed when I created handler functions against the menu items themselves, they were keeping track of the 'strength' variable from the array rather than just grabbing it's value, meaning every menu item did a hard reset because 'hard' was the last value given to the variable.

So that's kind of weird. But either way based on my testing it seems to all work fine.