### PR TITLE
Remove custom Homebrew tap from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Jira? This is the app for you!
 ### Homebrew
 
 ```sh
-brew tap jesseduffield/lazygit
 brew install lazygit
 ```
 


### PR DESCRIPTION
Now that lazygit [has been added to the Homebrew core repository](https://github.com/Homebrew/homebrew-core/pull/37614), Homebrew users no longer need to tap into `jesseduffield/lazygit` to install it.

See also #256.
