### PR TITLE
Always include atleast 2 commits when doing squash and fixup

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -863,7 +863,7 @@ func (c *GitCommand) DiscardOldFileChanges(commits []*Commit, commitIndex int, f
 		return err
 	}
 
-	cmd, err := c.PrepareInteractiveRebaseCommand(sha+"^", todo, true)
+	cmd, err := c.PrepareInteractiveRebaseCommand(sha, todo, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -613,12 +613,12 @@ func (c *GitCommand) GenericMerge(commandType string, command string) error {
 }
 
 func (c *GitCommand) RewordCommit(commits []*Commit, index int) (*exec.Cmd, error) {
-	todo, err := c.GenerateGenericRebaseTodo(commits, index, "reword")
+	todo, sha, err := c.GenerateGenericRebaseTodo(commits, index, "reword")
 	if err != nil {
 		return nil, err
 	}
 
-	return c.PrepareInteractiveRebaseCommand(commits[index+1].Sha, todo, false)
+	return c.PrepareInteractiveRebaseCommand(sha, todo, false)
 }
 
 func (c *GitCommand) MoveCommitDown(commits []*Commit, index int) error {
@@ -643,12 +643,12 @@ func (c *GitCommand) MoveCommitDown(commits []*Commit, index int) error {
 }
 
 func (c *GitCommand) InteractiveRebase(commits []*Commit, index int, action string) error {
-	todo, err := c.GenerateGenericRebaseTodo(commits, index, action)
+	todo, sha, err := c.GenerateGenericRebaseTodo(commits, index, action)
 	if err != nil {
 		return err
 	}
 
-	cmd, err := c.PrepareInteractiveRebaseCommand(commits[index+1].Sha, todo, true)
+	cmd, err := c.PrepareInteractiveRebaseCommand(sha, todo, true)
 	if err != nil {
 		return err
 	}
@@ -702,21 +702,31 @@ func (c *GitCommand) SoftReset(baseSha string) error {
 	return c.OSCommand.RunCommand("git reset --soft " + baseSha)
 }
 
-func (c *GitCommand) GenerateGenericRebaseTodo(commits []*Commit, index int, action string) (string, error) {
-	if len(commits) <= index+1 {
-		// assuming they aren't picking the bottom commit
-		return "", errors.New(c.Tr.SLocalize("CannotRebaseOntoFirstCommit"))
+func (c *GitCommand) GenerateGenericRebaseTodo(commits []*Commit, actionIndex int, action string) (string, string, error) {
+	baseIndex := actionIndex + 1
+
+	if len(commits) <= baseIndex {
+		return "", "", errors.New(c.Tr.SLocalize("CannotRebaseOntoFirstCommit"))
+	}
+
+	if action == "squash" || action == "fixup" {
+		baseIndex++
+
+		if len(commits) <= baseIndex {
+			return "", "", errors.New(c.Tr.SLocalize("CannotSquashOntoSecondCommit"))
+		}
 	}
 
 	todo := ""
-	for i, commit := range commits[0 : index+1] {
+	for i, commit := range commits[0:baseIndex] {
 		a := "pick"
-		if i == index {
+		if i == actionIndex {
 			a = action
 		}
 		todo = a + " " + commit.Sha + " " + commit.Name + "\n" + todo
 	}
-	return todo, nil
+
+	return todo, commits[baseIndex].Sha, nil
 }
 
 // AmendTo amends the given commit with whatever files are staged
@@ -848,14 +858,12 @@ func (c *GitCommand) DiscardOldFileChanges(commits []*Commit, commitIndex int, f
 		return errors.New(c.Tr.SLocalize("DisabledForGPG"))
 	}
 
-	commitSha := commits[commitIndex].Sha
-
-	todo, err := c.GenerateGenericRebaseTodo(commits, commitIndex, "edit")
+	todo, sha, err := c.GenerateGenericRebaseTodo(commits, commitIndex, "edit")
 	if err != nil {
 		return err
 	}
 
-	cmd, err := c.PrepareInteractiveRebaseCommand(commitSha+"^", todo, true)
+	cmd, err := c.PrepareInteractiveRebaseCommand(sha+"^", todo, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -1817,7 +1817,7 @@ func TestGitCommandDiscardOldFileChanges(t *testing.T) {
 			"test999.txt",
 			test.CreateMockCommand(t, []*test.CommandSwapper{
 				{
-					Expect:  "git rebase --interactive --autostash 123456^",
+					Expect:  "git rebase --interactive --autostash abcdef",
 					Replace: "echo",
 				},
 				{

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -566,6 +566,9 @@ func addDutch(i18nObject *i18n.Bundle) error {
 			ID:    "CannotRebaseOntoFirstCommit",
 			Other: "You cannot interactive rebase onto the first commit",
 		}, &i18n.Message{
+			ID:    "CannotSquashOntoSecondCommit",
+			Other: "You cannot squash/fixup onto the second commit",
+		}, &i18n.Message{
 			ID:    "Donate",
 			Other: "Donate",
 		}, &i18n.Message{

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -589,6 +589,9 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			ID:    "CannotRebaseOntoFirstCommit",
 			Other: "You cannot interactive rebase onto the first commit",
 		}, &i18n.Message{
+			ID:    "CannotSquashOntoSecondCommit",
+			Other: "You cannot squash/fixup onto the second commit",
+		}, &i18n.Message{
 			ID:    "Donate",
 			Other: "Donate",
 		}, &i18n.Message{

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -549,6 +549,9 @@ func addPolish(i18nObject *i18n.Bundle) error {
 			ID:    "CannotRebaseOntoFirstCommit",
 			Other: "You cannot interactive rebase onto the first commit",
 		}, &i18n.Message{
+			ID:    "CannotSquashOntoSecondCommit",
+			Other: "You cannot squash/fixup onto the second commit",
+		}, &i18n.Message{
 			ID:    "Donate",
 			Other: "Donate",
 		}, &i18n.Message{


### PR DESCRIPTION
I had issues using squash, this is because the interactive rebase is only including one commit and the rebase don't understand what todo.

This is the issue that I have fixed: https://github.com/jesseduffield/lazygit/issues/415

The fix is quite simple. When doing an interactive rebasing we do always include one extra commit to make sure that the squash command works.