### PR TITLE
428: WIP commits

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -21,6 +21,7 @@
     merging:
       # only applicable to unix users
       manualCommit: false
+    skipHookPrefix: WIP
   update:
     method: prompt # can be: prompt | background | never
     days: 14 # how often an update is checked for

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -334,8 +334,8 @@ func (c *GitCommand) usingGpg() bool {
 }
 
 // Commit commits to git
-func (c *GitCommand) Commit(message string) (*exec.Cmd, error) {
-	command := fmt.Sprintf("git commit -m %s", c.OSCommand.Quote(message))
+func (c *GitCommand) Commit(message string, flags string) (*exec.Cmd, error) {
+	command := fmt.Sprintf("git commit %s -m %s", flags, c.OSCommand.Quote(message))
 	if c.usingGpg() {
 		return c.OSCommand.PrepareSubProcess(c.OSCommand.Platform.shell, c.OSCommand.Platform.shellArg, command), nil
 	}

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -801,6 +801,7 @@ func TestGitCommandCommit(t *testing.T) {
 		command            func(string, ...string) *exec.Cmd
 		getGlobalGitConfig func(string) (string, error)
 		test               func(*exec.Cmd, error)
+		flags              string
 	}
 
 	scenarios := []scenario{
@@ -808,7 +809,7 @@ func TestGitCommandCommit(t *testing.T) {
 			"Commit using gpg",
 			func(cmd string, args ...string) *exec.Cmd {
 				assert.EqualValues(t, "bash", cmd)
-				assert.EqualValues(t, []string{"-c", `git commit -m 'test'`}, args)
+				assert.EqualValues(t, []string{"-c", `git commit  -m 'test'`}, args)
 
 				return exec.Command("echo")
 			},
@@ -819,6 +820,7 @@ func TestGitCommandCommit(t *testing.T) {
 				assert.NotNil(t, cmd)
 				assert.Nil(t, err)
 			},
+			"",
 		},
 		{
 			"Commit without using gpg",
@@ -835,6 +837,24 @@ func TestGitCommandCommit(t *testing.T) {
 				assert.Nil(t, cmd)
 				assert.Nil(t, err)
 			},
+			"",
+		},
+		{
+			"Commit with --no-verify flag",
+			func(cmd string, args ...string) *exec.Cmd {
+				assert.EqualValues(t, "git", cmd)
+				assert.EqualValues(t, []string{"commit", "--no-verify", "-m", "test"}, args)
+
+				return exec.Command("echo")
+			},
+			func(string) (string, error) {
+				return "false", nil
+			},
+			func(cmd *exec.Cmd, err error) {
+				assert.Nil(t, cmd)
+				assert.Nil(t, err)
+			},
+			"--no-verify",
 		},
 		{
 			"Commit without using gpg with an error",
@@ -851,6 +871,7 @@ func TestGitCommandCommit(t *testing.T) {
 				assert.Nil(t, cmd)
 				assert.Error(t, err)
 			},
+			"",
 		},
 	}
 
@@ -859,7 +880,7 @@ func TestGitCommandCommit(t *testing.T) {
 			gitCmd := NewDummyGitCommand()
 			gitCmd.getGlobalGitConfig = s.getGlobalGitConfig
 			gitCmd.OSCommand.command = s.command
-			s.test(gitCmd.Commit("test"))
+			s.test(gitCmd.Commit("test", s.flags))
 		})
 	}
 }

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -248,6 +248,7 @@ func GetDefaultConfig() []byte {
   git:
     merging:
       manualCommit: false
+    skipHookPrefix: 'WIP'
 update:
   method: prompt # can be: prompt | background | never
   days: 14 # how often a update is checked for

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -30,7 +30,12 @@ func (gui *Gui) handleCommitConfirm(g *gocui.Gui, v *gocui.View) error {
 	if message == "" {
 		return gui.createErrorPanel(g, gui.Tr.SLocalize("CommitWithoutMessageErr"))
 	}
-	ok, err := gui.runSyncOrAsyncCommand(gui.GitCommand.Commit(message))
+	flags := ""
+	skipHookPrefix := gui.Config.GetUserConfig().GetString("git.skipHookPrefix")
+	if skipHookPrefix != "" && strings.HasPrefix(message, skipHookPrefix) {
+		flags = "--no-verify"
+	}
+	ok, err := gui.runSyncOrAsyncCommand(gui.GitCommand.Commit(message, flags))
 	if err != nil {
 		return err
 	}

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -274,6 +274,22 @@ func (gui *Gui) handleIgnoreFile(g *gocui.Gui, v *gocui.View) error {
 	return gui.refreshFiles()
 }
 
+func (gui *Gui) handleWIPCommitPress(g *gocui.Gui, filesView *gocui.View) error {
+	skipHookPreifx := gui.Config.GetUserConfig().GetString("git.skipHookPrefix")
+	if skipHookPreifx == "" {
+		return gui.createErrorPanel(gui.g, gui.Tr.SLocalize("SkipHookPrefixNotConfigured"))
+	}
+
+	if err := gui.renderString(g, "commitMessage", skipHookPreifx); err != nil {
+		return err
+	}
+	if err := gui.getCommitMessageView().SetCursor(len(skipHookPreifx), 0); err != nil {
+		return err
+	}
+
+	return gui.handleCommitPress(g, filesView)
+}
+
 func (gui *Gui) handleCommitPress(g *gocui.Gui, filesView *gocui.View) error {
 	if len(gui.stagedFiles()) == 0 && gui.State.WorkingTreeState == "normal" {
 		return gui.createErrorPanel(g, gui.Tr.SLocalize("NoStagedFilesToCommit"))

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -408,7 +408,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 
 	if gui.getCommitMessageView() == nil {
 		// doesn't matter where this view starts because it will be hidden
-		if commitMessageView, err := g.SetView("commitMessage", 0, 0, width/2, height/2, 0); err != nil {
+		if commitMessageView, err := g.SetView("commitMessage", width, height, width*2, height*2, 0); err != nil {
 			if err.Error() != "unknown view" {
 				return err
 			}
@@ -422,7 +422,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 
 	if check, _ := g.View("credentials"); check == nil {
 		// doesn't matter where this view starts because it will be hidden
-		if credentialsView, err := g.SetView("credentials", 0, 0, width/2, height/2, 0); err != nil {
+		if credentialsView, err := g.SetView("credentials", width, height, width*2, height*2, 0); err != nil {
 			if err.Error() != "unknown view" {
 				return err
 			}

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -154,6 +154,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleCommitPress,
 			Description: gui.Tr.SLocalize("CommitChanges"),
+		},
+		{
+			ViewName:    "files",
+			Key:         'w',
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleWIPCommitPress,
+			Description: gui.Tr.SLocalize("commitChangesWithoutHook"),
 		}, {
 			ViewName:    "files",
 			Key:         'A',

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -750,6 +750,12 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "CustomCommand",
 			Other: "Custom Command:",
+		}, &i18n.Message{
+			ID:    "commitChangesWithoutHook",
+			Other: "commit changes without pre-commit hook",
+		}, &i18n.Message{
+			ID:    "SkipHookPrefixNotConfigured",
+			Other: "You have not configured a commit message prefix for skipping hooks. Set `git.skipHookPrefix = 'WIP'` in your config",
 		},
 	)
 }


### PR DESCRIPTION
Now you can hit 'w' and get a commit message panel open with 'WIP' preloaded for you. If you hit enter you'll commit with the --no-verify flag, meaning you'll skip pre-commit hooks.

If you type 'WIP' as the prefix to a commit message via the 'c' keybinding, the same effect happens.

You can change 'WIP' to whichever prefix you like in the config, under the `git.skipHookPrefix`.

Although the key is set in the default config, I've just realised that viper has issues loading in yaml due to differences in case sensitivity https://github.com/spf13/viper/pull/635 meaning users may need to manually configure this themselves for now