### PR TITLE
Add field Alternative to gui.Binding

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -22,6 +22,7 @@
 
 <pre>
   <kbd>c</kbd>: commit changes
+  <kbd>w</kbd>: commit changes without pre-commit hook
   <kbd>A</kbd>: amend last commit
   <kbd>C</kbd>: commit changes using git editor
   <kbd>space</kbd>: toggle staged
@@ -36,6 +37,7 @@
   <kbd>D</kbd>: view reset options
   <kbd>enter</kbd>: stage individual hunks/lines
   <kbd>f</kbd>: fetch
+  <kbd>X</kbd>: execute custom command
 </pre>
 
 ## Branches
@@ -60,6 +62,8 @@
   <kbd>R</kbd>: rename commit with editor
   <kbd>g</kbd>: reset to this commit
   <kbd>f</kbd>: fixup commit
+  <kbd>F</kbd>: create fixup commit for this commit
+  <kbd>S</kbd>: squash above commits
   <kbd>d</kbd>: delete commit
   <kbd>J</kbd>: move commit down one
   <kbd>K</kbd>: move commit up one
@@ -71,7 +75,7 @@
   <kbd>C</kbd>: copy commit range (cherry-pick)
   <kbd>v</kbd>: paste commits (cherry-pick)
   <kbd>enter</kbd>: view commit's files
-  <kbd>space</kbd>: diff specific commits
+  <kbd>space</kbd>: select commit to diff with another commit
 </pre>
 
 ## Stash

--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -98,8 +98,8 @@
 ## Main (Normal)
 
 <pre>
-  <kbd>PgDn</kbd>: scroll down
-  <kbd>PgUp</kbd>: scroll up
+  <kbd>PgDn</kbd>: scroll down (fn+up)
+  <kbd>PgUp</kbd>: scroll up (fn+down)
 </pre>
 
 ## Main (Staging)

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -98,8 +98,8 @@
 ## Hoofd (Normaal)
 
 <pre>
-  <kbd>PgDn</kbd>: scroll omlaag
-  <kbd>PgUp</kbd>: scroll omhoog
+  <kbd>PgDn</kbd>: scroll omlaag (fn+up)
+  <kbd>PgUp</kbd>: scroll omhoog (fn+down)
 </pre>
 
 ## Hoofd (Stage Lines/Hunks)

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -3,7 +3,7 @@
 ## Global
 
 <pre>
-  <kbd>m</kbd>: view merge/rebase options
+  <kbd>m</kbd>: bekijk merge/rebase opties
   <kbd>P</kbd>: push
   <kbd>p</kbd>: pull
   <kbd>R</kbd>: verversen
@@ -22,10 +22,11 @@
 
 <pre>
   <kbd>c</kbd>: Commit veranderingen
+  <kbd>w</kbd>: commit veranderingen zonder pre-commit hook
   <kbd>A</kbd>: wijzig laatste commit
   <kbd>C</kbd>: commit veranderingen met de git editor
   <kbd>space</kbd>: toggle staged
-  <kbd>d</kbd>: bekijk 'ongedaan maken' opties
+  <kbd>d</kbd>: bekijk 'veranderingen ongedaan maken' opties
   <kbd>e</kbd>: verander bestand
   <kbd>o</kbd>: open bestand
   <kbd>i</kbd>: voeg toe aan .gitignore
@@ -33,9 +34,10 @@
   <kbd>S</kbd>: stash-bestanden
   <kbd>a</kbd>: toggle staged alle
   <kbd>t</kbd>: bewerkingen toevoegen
-  <kbd>D</kbd>: view reset options
+  <kbd>D</kbd>: bekijk reset opties
   <kbd>enter</kbd>: stage individuele hunks/lijnen
   <kbd>f</kbd>: fetch
+  <kbd>X</kbd>: voor aangepast commando uit
 </pre>
 
 ## Branches
@@ -57,68 +59,70 @@
 <pre>
   <kbd>s</kbd>: squash beneden
   <kbd>r</kbd>: hernoem commit
-  <kbd>R</kbd>: hernoem commit met editor
+  <kbd>R</kbd>: rename commit with editor
   <kbd>g</kbd>: reset naar deze commit
   <kbd>f</kbd>: Fixup commit
+  <kbd>F</kbd>: creëer fixup commit voor deze commit
+  <kbd>S</kbd>: squash bovenstaande commits
   <kbd>d</kbd>: verwijder commit
   <kbd>J</kbd>: verplaats commit 1 omlaag
   <kbd>K</kbd>: verplaats commit 1 omhoog
-  <kbd>e</kbd>: wijzig commit
-  <kbd>A</kbd>: Wijzig commit met opgeslagen verandering
+  <kbd>e</kbd>: verander commit
+  <kbd>A</kbd>: wijzig commit met staged veranderingen
   <kbd>p</kbd>: pick commit (when mid-rebase)
-  <kbd>t</kbd>: Maak commit ongedaan
+  <kbd>t</kbd>: commit omgedaan maken
   <kbd>c</kbd>: kopiëer commit (cherry-pick)
-  <kbd>C</kbd>: kopiëer commit range (cherry-pick)
+  <kbd>C</kbd>: kopiëer commit reeks (cherry-pick)
   <kbd>v</kbd>: plak commits (cherry-pick)
   <kbd>enter</kbd>: bekijk gecommite bestanden
-  <kbd>space</kbd>: Bekijk verschillen tussen specifieke commits
+  <kbd>space</kbd>: select commit to diff with another commit
 </pre>
 
 ## Stash
 
 <pre>
   <kbd>space</kbd>: toepassen
-  <kbd>g</kbd>: poppen
+  <kbd>g</kbd>: pop
   <kbd>d</kbd>: drop
 </pre>
 
-## Commit files
+## Commit bestanden
 
 <pre>
   <kbd>esc</kbd>: ga terug
-  <kbd>c</kbd>: checkout bestand
-  <kbd>d</kbd>: Verwijder wijzigingen van dit bestand
+  <kbd>c</kbd>: bestand uitchecken
+  <kbd>d</kbd>: uitsluit deze commit zijn veranderingen aan dit bestand
   <kbd>o</kbd>: open bestand
 </pre>
 
-## Main (Normal)
+## Hoofd (Normaal)
 
 <pre>
   <kbd>PgDn</kbd>: scroll omlaag
   <kbd>PgUp</kbd>: scroll omhoog
 </pre>
 
-## Main (Stage Lines/Hunks)
+## Hoofd (Stage Lines/Hunks)
 
 <pre>
   <kbd>esc</kbd>: ga terug naar het bestanden paneel
-  <kbd>▲</kbd>: selecteer vorige line
-  <kbd>▼</kbd>: selecteer volgende line
-  <kbd>◄</kbd>: selecteer vorige hunk
-  <kbd>►</kbd>: selecteer volgende hunk
+  <kbd>▲</kbd>: selecteer de vorige lijn
+  <kbd>▼</kbd>: selecteer de volgende lijn
+  <kbd>◄</kbd>: selecteer de vorige hunk
+  <kbd>►</kbd>: selecteer de volgende hunk
   <kbd>space</kbd>: stage lijn
   <kbd>a</kbd>: stage hunk
 </pre>
 
-## Main (Merging)
+## Hoofd (Merging)
 
 <pre>
   <kbd>esc</kbd>: ga terug naar het bestanden paneel
   <kbd>space</kbd>: pick hunk
   <kbd>b</kbd>: pick beide hunks
-  <kbd>◄</kbd>: selecteer vorige conflict
+  <kbd>◄</kbd>: selecteer voorgaand conflict
   <kbd>►</kbd>: selecteer volgende conflict
   <kbd>▲</kbd>: selecteer bovenste hunk
-  <kbd>▼</kbd>: selecteer laatste hunk
+  <kbd>▼</kbd>: selecteer onderste hunk
   <kbd>z</kbd>: ongedaan maken
 </pre>

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -98,8 +98,8 @@
 ## Main (Normal)
 
 <pre>
-  <kbd>PgDn</kbd>: scroll down
-  <kbd>PgUp</kbd>: scroll up
+  <kbd>PgDn</kbd>: scroll down (fn+up)
+  <kbd>PgUp</kbd>: scroll up (fn+down)
 </pre>
 
 ## Main (Zatwierdzanie)

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -22,6 +22,7 @@
 
 <pre>
   <kbd>c</kbd>: commituj zmiany
+  <kbd>w</kbd>: commit changes without pre-commit hook
   <kbd>A</kbd>: zmień ostatnie zatwierdzenie
   <kbd>C</kbd>: commituj zmiany używając edytora z gita
   <kbd>space</kbd>: przełącz zatwierdzenie
@@ -36,6 +37,7 @@
   <kbd>D</kbd>: view reset options
   <kbd>enter</kbd>: zatwierdź pojedyncze linie
   <kbd>f</kbd>: fetch
+  <kbd>X</kbd>: execute custom command
 </pre>
 
 ## Gałęzie
@@ -60,6 +62,8 @@
   <kbd>R</kbd>: przemianuj commit w edytorze
   <kbd>g</kbd>: zresetuj do tego commita
   <kbd>f</kbd>: napraw commit
+  <kbd>F</kbd>: create fixup commit for this commit
+  <kbd>S</kbd>: squash above commits
   <kbd>d</kbd>: delete commit
   <kbd>J</kbd>: move commit down one
   <kbd>K</kbd>: move commit up one
@@ -71,7 +75,7 @@
   <kbd>C</kbd>: copy commit range (cherry-pick)
   <kbd>v</kbd>: paste commits (cherry-pick)
   <kbd>enter</kbd>: view commit's files
-  <kbd>space</kbd>: diff specific commits
+  <kbd>space</kbd>: select commit to diff with another commit
 </pre>
 
 ## Schowek

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -13,6 +13,7 @@ type Binding struct {
 	Key         interface{} // FIXME: find out how to get `gocui.Key | rune`
 	Modifier    gocui.Modifier
 	Description string
+	Alternative string
 }
 
 // GetDisplayStrings returns the display string of a file
@@ -75,15 +76,17 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Modifier: gocui.ModNone,
 			Handler:  gui.quit,
 		}, {
-			ViewName: "",
-			Key:      gocui.KeyPgup,
-			Modifier: gocui.ModNone,
-			Handler:  gui.scrollUpMain,
+			ViewName:    "",
+			Key:         gocui.KeyPgup,
+			Modifier:    gocui.ModNone,
+			Handler:     gui.scrollUpMain,
+			Alternative: "fn+up",
 		}, {
-			ViewName: "",
-			Key:      gocui.KeyPgdn,
-			Modifier: gocui.ModNone,
-			Handler:  gui.scrollDownMain,
+			ViewName:    "",
+			Key:         gocui.KeyPgdn,
+			Modifier:    gocui.ModNone,
+			Handler:     gui.scrollDownMain,
+			Alternative: "fn+down",
 		}, {
 			ViewName: "",
 			Key:      gocui.KeyCtrlU,

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -576,12 +576,14 @@ func (gui *Gui) GetContextMap() map[string]map[string][]*Binding {
 					Modifier:    gocui.ModNone,
 					Handler:     gui.scrollDownMain,
 					Description: gui.Tr.SLocalize("ScrollDown"),
+					Alternative: "fn+up",
 				}, {
 					ViewName:    "main",
 					Key:         gocui.MouseWheelUp,
 					Modifier:    gocui.ModNone,
 					Handler:     gui.scrollUpMain,
 					Description: gui.Tr.SLocalize("ScrollUp"),
+					Alternative: "fn+down",
 				},
 			},
 			"staging": {

--- a/scripts/generate_cheatsheet.go
+++ b/scripts/generate_cheatsheet.go
@@ -99,7 +99,7 @@ func getBindingSections(mApp *app.App) []*bindingSection {
 }
 
 func addBinding(title string, bindingSections []*bindingSection, binding *gui.Binding) []*bindingSection {
-	if binding.Description == "" {
+	if binding.Description == "" && binding.Alternative == "" {
 		return bindingSections
 	}
 

--- a/scripts/generate_cheatsheet.go
+++ b/scripts/generate_cheatsheet.go
@@ -59,6 +59,9 @@ func formatTitle(title string) string {
 }
 
 func formatBinding(binding *gui.Binding) string {
+	if binding.Alternative != "" {
+		return fmt.Sprintf("  <kbd>%s</kbd>: %s (%s)\n", binding.GetKey(), binding.Description, binding.Alternative)
+	}
 	return fmt.Sprintf("  <kbd>%s</kbd>: %s\n", binding.GetKey(), binding.Description)
 }
 


### PR DESCRIPTION
Document and use alternative keybinding for generating cheatsheet. Add
alt keybinding `fn+up/down` for scroll up/down actions.

Closes #423.