### PR TITLE
Improve directory check for .git

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -27,8 +27,11 @@ func navigateToRepoRootDirectory(stat func(string) (os.FileInfo, error), chdir f
 	for {
 		f, err := stat(".git")
 
-		if err == nil && f.IsDir() {
-			return nil
+		if err == nil {
+			if f.IsDir() {
+				return nil
+			}
+			return errors.New("expected .git to be a directory")
 		}
 
 		if !os.IsNotExist(err) {


### PR DESCRIPTION
Return error if the .git exists but is not a directory. This provides a
slightly better failure message for git repo with submodules in case
the '.git' is a file which provides the reference to the parent's .git
folder with the submodule inside.

Related to #421, see https://github.com/jesseduffield/lazygit/issues/421#issuecomment-483129288 