### PR TITLE
Prevent crash when opening in small window

### DIFF
--- a/pkg/gui/context.go
+++ b/pkg/gui/context.go
@@ -21,7 +21,11 @@ func (gui *Gui) contextTitleMap() map[string]map[string]string {
 }
 
 func (gui *Gui) setMainTitle() error {
-	currentViewName := gui.g.CurrentView().Name()
+	currentView := gui.g.CurrentView()
+	if currentView == nil {
+		return nil
+	}
+	currentViewName := currentView.Name()
 	var newTitle string
 	if context, ok := gui.State.Contexts[currentViewName]; ok {
 		newTitle = gui.contextTitleMap()[currentViewName][context]

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -86,6 +86,10 @@ func (gui *Gui) refreshFiles() error {
 	selectedFile, _ := gui.getSelectedFile(gui.g)
 
 	filesView := gui.getFilesView()
+	if filesView == nil {
+		// if the filesView hasn't been instantiated yet we just return
+		return nil
+	}
 	if err := gui.refreshStateFiles(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #426 We were crashing when opening lazygit in a small window because the limit view
was the only view that got created, and there were two functions that referenced
either the 'current' view or the files view, neither of which existed.

Now those functions just return nil if the view does not exist