### PR TITLE
request explicit return from subprocess

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -1,8 +1,8 @@
 package gui
 
 import (
-	"bytes"
-	"io"
+	"fmt"
+	"io/ioutil"
 	"math"
 	"os"
 	"sync"
@@ -10,7 +10,6 @@ import (
 	// "io"
 	// "io/ioutil"
 
-	"io/ioutil"
 	"os/exec"
 	"strings"
 	"time"
@@ -147,7 +146,6 @@ type guiState struct {
 	WorkingTreeState    string // one of "merging", "rebasing", "normal"
 	Contexts            map[string]string
 	CherryPickedCommits []*commands.Commit
-	SubProcessOutput    string
 }
 
 // NewGui builds a new gui handler
@@ -519,16 +517,6 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		}
 	}
 
-	if gui.State.SubProcessOutput != "" {
-		output := gui.State.SubProcessOutput
-		gui.State.SubProcessOutput = ""
-		x, y := gui.g.Size()
-		// if we just came back from vim, we don't want vim's output to show up in our popup
-		if float64(len(output))*1.5 < float64(x*y) {
-			return gui.createMessagePanel(gui.g, nil, "Output", output)
-		}
-	}
-
 	type listViewState struct {
 		selectedLine int
 		lineCount    int
@@ -697,15 +685,9 @@ func (gui *Gui) RunWithSubprocesses() error {
 			} else if err == gui.Errors.ErrSwitchRepo {
 				continue
 			} else if err == gui.Errors.ErrSubProcess {
-				output, err := gui.runCommand(gui.SubProcess)
-				if err != nil {
+				if err := gui.runCommand(); err != nil {
 					return err
 				}
-				gui.State.SubProcessOutput = output
-				gui.SubProcess.Stdout = ioutil.Discard
-				gui.SubProcess.Stderr = ioutil.Discard
-				gui.SubProcess.Stdin = nil
-				gui.SubProcess = nil
 			} else {
 				return err
 			}
@@ -714,20 +696,28 @@ func (gui *Gui) RunWithSubprocesses() error {
 	return nil
 }
 
-func (gui *Gui) runCommand(cmd *exec.Cmd) (string, error) {
-	var stdoutBuf bytes.Buffer
-	cmd.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stdoutBuf)
-	cmd.Stdin = os.Stdin
+func (gui *Gui) runCommand() error {
+	gui.SubProcess.Stdout = os.Stdout
+	gui.SubProcess.Stderr = os.Stdout
+	gui.SubProcess.Stdin = os.Stdin
 
-	if err := cmd.Run(); err != nil {
+	fmt.Fprintf(os.Stdout, "\n%s\n\n", utils.ColoredString("+ "+strings.Join(gui.SubProcess.Args, " "), color.FgBlue))
+
+	if err := gui.SubProcess.Run(); err != nil {
 		// not handling the error explicitly because usually we're going to see it
 		// in the output anyway
 		gui.Log.Error(err)
 	}
 
-	outStr := stdoutBuf.String()
-	return outStr, nil
+	gui.SubProcess.Stdout = ioutil.Discard
+	gui.SubProcess.Stderr = ioutil.Discard
+	gui.SubProcess.Stdin = nil
+	gui.SubProcess = nil
+
+	fmt.Fprintf(os.Stdout, "\n%s", utils.ColoredString(gui.Tr.SLocalize("pressEnterToReturn"), color.FgGreen))
+	fmt.Scanln() // wait for enter press
+
+	return nil
 }
 
 func (gui *Gui) quit(g *gocui.Gui, v *gocui.View) error {

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -736,6 +736,9 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "resetTo",
 			Other: `reset to`,
+		}, &i18n.Message{
+			ID:    "pressEnterToReturn",
+			Other: "Press enter to return to lazygit",
 		},
 	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -759,6 +759,9 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "resetTo",
 			Other: `reset to`,
+		}, &i18n.Message{
+			ID:    "pressEnterToReturn",
+			Other: "Press enter to return to lazygit",
 		},
 	)
 }

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -719,6 +719,9 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "resetTo",
 			Other: `reset to`,
+		}, &i18n.Message{
+			ID:    "pressEnterToReturn",
+			Other: "Press enter to return to lazygit",
 		},
 	)
 }


### PR DESCRIPTION
Previously we were recording output from subprocesses using a multiwriter
and hooking that up to the cmd's stdout to write to both os.Stdout and
a buffer. We would then display the output after the program finished.

This worked well for commands like 'ls' but not for commands like 'vi'
which expect you to be in a tty, and when you've got the cmd's stdout
pointing at a multiwriter, the subprogram thinks we're not in a tty
and then things like terminal corruption can happen. This was the case
with neovim, and even in vim a warning was given with a pause before
starting the program.

Now we're chucking out the multiwriter and instead making it that you
need to press enter after the program has finished to return to lazygit.
This allows you to view the output of the program (e.g. if it's ls) and
then decide that you want to return. It's one level of unnecessary
redirection for editors like vim, but even they could potentially have
output to stderr/stdout that you want to look at before returning.