### PR TITLE
477 discard unmerged conflict

### DIFF
--- a/pkg/commands/file.go
+++ b/pkg/commands/file.go
@@ -12,7 +12,6 @@ type File struct {
 	Deleted                 bool
 	HasMergeConflicts       bool
 	HasInlineMergeConflicts bool
-	NeedReset               bool
 	DisplayString           string
 	Type                    string // one of 'file', 'directory', and 'other'
 	ShortStatus             string // e.g. 'AD', ' A', 'M ', '??'

--- a/pkg/commands/file.go
+++ b/pkg/commands/file.go
@@ -12,6 +12,7 @@ type File struct {
 	Deleted                 bool
 	HasMergeConflicts       bool
 	HasInlineMergeConflicts bool
+	NeedReset               bool
 	DisplayString           string
 	Type                    string // one of 'file', 'directory', and 'other'
 	ShortStatus             string // e.g. 'AD', ' A', 'M ', '??'

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -476,11 +476,6 @@ func (c *GitCommand) DiscardAllFileChanges(file *File) error {
 			return err
 		}
 	}
-	if file.HasMergeConflicts || file.HasInlineMergeConflicts {
-		if err := c.OSCommand.RunCommand(fmt.Sprintf("git checkout -- %s", quotedFileName)); err != nil {
-			return err
-		}
-	}
 
 	if !file.Tracked {
 		return c.removeFile(file.Name)

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -188,7 +188,6 @@ func (c *GitCommand) GetStatusFiles() []*File {
 			Deleted:                 unstagedChange == "D" || stagedChange == "D",
 			HasMergeConflicts:       hasMergeConflicts,
 			HasInlineMergeConflicts: hasInlineMergeConflicts,
-			NeedReset:               !hasNoStagedChanges || hasMergeConflicts || hasInlineMergeConflicts,
 			Type:                    c.OSCommand.FileType(filename),
 			ShortStatus:             change,
 		}
@@ -474,7 +473,7 @@ func (c *GitCommand) RebaseMode() (string, error) {
 func (c *GitCommand) DiscardAllFileChanges(file *File) error {
 	// if the file isn't tracked, we assume you want to delete it
 	quotedFileName := c.OSCommand.Quote(file.Name)
-	if file.NeedReset {
+	if file.HasStagedChanges || file.HasMergeConflicts || file.HasInlineMergeConflicts {
 		if err := c.OSCommand.RunCommand(fmt.Sprintf("git reset -- %s", quotedFileName)); err != nil {
 			return err
 		}

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -176,6 +176,8 @@ func (c *GitCommand) GetStatusFiles() []*File {
 		filename := c.OSCommand.Unquote(statusString[3:])
 		_, untracked := map[string]bool{"??": true, "A ": true, "AM": true}[change]
 		_, hasNoStagedChanges := map[string]bool{" ": true, "U": true, "?": true}[stagedChange]
+		hasMergeConflicts := change == "UU" || change == "AA" || change == "DU"
+		hasInlineMergeConflicts := change == "UU" || change == "AA"
 
 		file := &File{
 			Name:                    filename,
@@ -184,8 +186,9 @@ func (c *GitCommand) GetStatusFiles() []*File {
 			HasUnstagedChanges:      unstagedChange != " ",
 			Tracked:                 !untracked,
 			Deleted:                 unstagedChange == "D" || stagedChange == "D",
-			HasMergeConflicts:       change == "UU" || change == "AA" || change == "DU",
-			HasInlineMergeConflicts: change == "UU" || change == "AA",
+			HasMergeConflicts:       hasMergeConflicts,
+			HasInlineMergeConflicts: hasInlineMergeConflicts,
+			NeedReset:               !hasNoStagedChanges || hasMergeConflicts || hasInlineMergeConflicts,
 			Type:                    c.OSCommand.FileType(filename),
 			ShortStatus:             change,
 		}
@@ -471,7 +474,7 @@ func (c *GitCommand) RebaseMode() (string, error) {
 func (c *GitCommand) DiscardAllFileChanges(file *File) error {
 	// if the file isn't tracked, we assume you want to delete it
 	quotedFileName := c.OSCommand.Quote(file.Name)
-	if file.HasStagedChanges || file.HasMergeConflicts || file.HasInlineMergeConflicts {
+	if file.NeedReset {
 		if err := c.OSCommand.RunCommand(fmt.Sprintf("git reset -- %s", quotedFileName)); err != nil {
 			return err
 		}

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -471,11 +471,17 @@ func (c *GitCommand) RebaseMode() (string, error) {
 func (c *GitCommand) DiscardAllFileChanges(file *File) error {
 	// if the file isn't tracked, we assume you want to delete it
 	quotedFileName := c.OSCommand.Quote(file.Name)
-	if file.HasStagedChanges {
+	if file.HasStagedChanges || file.HasMergeConflicts || file.HasInlineMergeConflicts {
 		if err := c.OSCommand.RunCommand(fmt.Sprintf("git reset -- %s", quotedFileName)); err != nil {
 			return err
 		}
 	}
+	if file.HasMergeConflicts || file.HasInlineMergeConflicts {
+		if err := c.OSCommand.RunCommand(fmt.Sprintf("git checkout -- %s", quotedFileName)); err != nil {
+			return err
+		}
+	}
+
 	if !file.Tracked {
 		return c.removeFile(file.Name)
 	}

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -473,7 +473,7 @@ func (c *GitCommand) RebaseMode() (string, error) {
 func (c *GitCommand) DiscardAllFileChanges(file *File) error {
 	// if the file isn't tracked, we assume you want to delete it
 	quotedFileName := c.OSCommand.Quote(file.Name)
-	if file.HasStagedChanges || file.HasMergeConflicts || file.HasInlineMergeConflicts {
+	if file.HasStagedChanges || file.HasMergeConflicts {
 		if err := c.OSCommand.RunCommand(fmt.Sprintf("git reset -- %s", quotedFileName)); err != nil {
 			return err
 		}

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -1348,33 +1348,6 @@ func TestGitCommandDiscardAllFileChanges(t *testing.T) {
 			},
 		},
 		{
-			"Reset and checkout inline merge conflicts",
-			func() (func(string, ...string) *exec.Cmd, *[][]string) {
-				cmdsCalled := [][]string{}
-				return func(cmd string, args ...string) *exec.Cmd {
-					cmdsCalled = append(cmdsCalled, args)
-
-					return exec.Command("echo")
-				}, &cmdsCalled
-			},
-			func(cmdsCalled *[][]string, err error) {
-				assert.NoError(t, err)
-				assert.Len(t, *cmdsCalled, 2)
-				assert.EqualValues(t, *cmdsCalled, [][]string{
-					{"reset", "--", "test"},
-					{"checkout", "--", "test"},
-				})
-			},
-			&File{
-				Name:                    "test",
-				Tracked:                 true,
-				HasInlineMergeConflicts: true,
-			},
-			func(string) error {
-				return nil
-			},
-		},
-		{
 			"Reset and remove",
 			func() (func(string, ...string) *exec.Cmd, *[][]string) {
 				cmdsCalled := [][]string{}

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -356,56 +356,77 @@ func TestGitCommandGetStatusFiles(t *testing.T) {
 			func(cmd string, args ...string) *exec.Cmd {
 				return exec.Command(
 					"echo",
-					"MM file1.txt\nA  file3.txt\nAM file2.txt\n?? file4.txt",
+					"MM file1.txt\nA  file3.txt\nAM file2.txt\n?? file4.txt\nUU file5.txt",
 				)
 			},
 			func(files []*File) {
-				assert.Len(t, files, 4)
+				assert.Len(t, files, 5)
 
 				expected := []*File{
 					{
-						Name:               "file1.txt",
-						HasStagedChanges:   true,
-						HasUnstagedChanges: true,
-						Tracked:            true,
-						Deleted:            false,
-						HasMergeConflicts:  false,
-						DisplayString:      "MM file1.txt",
-						Type:               "other",
-						ShortStatus:        "MM",
+						Name:                    "file1.txt",
+						HasStagedChanges:        true,
+						HasUnstagedChanges:      true,
+						Tracked:                 true,
+						Deleted:                 false,
+						HasMergeConflicts:       false,
+						HasInlineMergeConflicts: false,
+						NeedReset:               true,
+						DisplayString:           "MM file1.txt",
+						Type:                    "other",
+						ShortStatus:             "MM",
 					},
 					{
-						Name:               "file3.txt",
-						HasStagedChanges:   true,
-						HasUnstagedChanges: false,
-						Tracked:            false,
-						Deleted:            false,
-						HasMergeConflicts:  false,
-						DisplayString:      "A  file3.txt",
-						Type:               "other",
-						ShortStatus:        "A ",
+						Name:                    "file3.txt",
+						HasStagedChanges:        true,
+						HasUnstagedChanges:      false,
+						Tracked:                 false,
+						Deleted:                 false,
+						HasMergeConflicts:       false,
+						HasInlineMergeConflicts: false,
+						NeedReset:               true,
+						DisplayString:           "A  file3.txt",
+						Type:                    "other",
+						ShortStatus:             "A ",
 					},
 					{
-						Name:               "file2.txt",
-						HasStagedChanges:   true,
-						HasUnstagedChanges: true,
-						Tracked:            false,
-						Deleted:            false,
-						HasMergeConflicts:  false,
-						DisplayString:      "AM file2.txt",
-						Type:               "other",
-						ShortStatus:        "AM",
+						Name:                    "file2.txt",
+						HasStagedChanges:        true,
+						HasUnstagedChanges:      true,
+						Tracked:                 false,
+						Deleted:                 false,
+						HasMergeConflicts:       false,
+						HasInlineMergeConflicts: false,
+						NeedReset:               true,
+						DisplayString:           "AM file2.txt",
+						Type:                    "other",
+						ShortStatus:             "AM",
 					},
 					{
-						Name:               "file4.txt",
-						HasStagedChanges:   false,
-						HasUnstagedChanges: true,
-						Tracked:            false,
-						Deleted:            false,
-						HasMergeConflicts:  false,
-						DisplayString:      "?? file4.txt",
-						Type:               "other",
-						ShortStatus:        "??",
+						Name:                    "file4.txt",
+						HasStagedChanges:        false,
+						HasUnstagedChanges:      true,
+						Tracked:                 false,
+						Deleted:                 false,
+						HasMergeConflicts:       false,
+						HasInlineMergeConflicts: false,
+						NeedReset:               false,
+						DisplayString:           "?? file4.txt",
+						Type:                    "other",
+						ShortStatus:             "??",
+					},
+					{
+						Name:                    "file5.txt",
+						HasStagedChanges:        false,
+						HasUnstagedChanges:      true,
+						Tracked:                 true,
+						Deleted:                 false,
+						HasMergeConflicts:       true,
+						HasInlineMergeConflicts: true,
+						NeedReset:               true,
+						DisplayString:           "UU file5.txt",
+						Type:                    "other",
+						ShortStatus:             "UU",
 					},
 				}
 
@@ -1195,8 +1216,8 @@ func TestGitCommandDiscardAllFileChanges(t *testing.T) {
 				})
 			},
 			&File{
-				Name:             "test",
-				HasStagedChanges: true,
+				Name:      "test",
+				NeedReset: true,
 			},
 			func(string) error {
 				return nil
@@ -1296,9 +1317,9 @@ func TestGitCommandDiscardAllFileChanges(t *testing.T) {
 				})
 			},
 			&File{
-				Name:             "test",
-				Tracked:          true,
-				HasStagedChanges: true,
+				Name:      "test",
+				Tracked:   true,
+				NeedReset: true,
 			},
 			func(string) error {
 				return nil
@@ -1322,9 +1343,9 @@ func TestGitCommandDiscardAllFileChanges(t *testing.T) {
 				})
 			},
 			&File{
-				Name:             "test",
-				Tracked:          false,
-				HasStagedChanges: true,
+				Name:      "test",
+				Tracked:   false,
+				NeedReset: true,
 			},
 			func(filename string) error {
 				assert.Equal(t, "test", filename)


### PR DESCRIPTION
Use a boolean to determine when we need to reset a file, which is true when the file: `!hasNoStagedChanges || hasMergeConflicts || hasInlineMergeConflicts`.
This is required because, if there is a conflict, we need to do `git reset -- $FILENAME` before doing a `git checkout -- $FILENAME`.

Tests have been updated and a new case added for a file with `UU` status.