### PR TITLE
Swallow errors entirely, instead of assigning and ignoring them

### DIFF
--- a/pkg/git/commit_list_builder.go
+++ b/pkg/git/commit_list_builder.go
@@ -261,10 +261,8 @@ func (c *CommitListBuilder) getMergeBase() (string, error) {
 		baseBranch = "develop"
 	}
 
-	output, err := c.OSCommand.RunCommandWithOutput(fmt.Sprintf("git merge-base HEAD %s", baseBranch))
-	if err != nil {
-		// swallowing error because it's not a big deal; probably because there are no commits yet
-	}
+	// swallowing error because it's not a big deal; probably because there are no commits yet
+	output, _ := c.OSCommand.RunCommandWithOutput(fmt.Sprintf("git merge-base HEAD %s", baseBranch))
 	return output, nil
 }
 

--- a/scripts/push_new_patch/main.go
+++ b/scripts/push_new_patch/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	splitVersion := strings.Split(stringVersion, ".")
 	patch := splitVersion[len(splitVersion)-1]
-	newPatch, err := strconv.Atoi(patch)
+	newPatch, _ := strconv.Atoi(patch)
 	splitVersion[len(splitVersion)-1] = strconv.FormatInt(int64(newPatch)+1, 10)
 	newVersion := strings.Join(splitVersion, ".")
 


### PR DESCRIPTION
Ignoring those returned errors looks fine, let's not assign them to err.