### PR TITLE
Remove &t=1 from Bitbucket PR URL

### DIFF
--- a/pkg/commands/pull_request.go
+++ b/pkg/commands/pull_request.go
@@ -34,7 +34,7 @@ func getServices() []*Service {
 		},
 		{
 			Name:           "bitbucket.org",
-			PullRequestURL: "https://bitbucket.org/%s/%s/pull-requests/new?source=%s&t=1",
+			PullRequestURL: "https://bitbucket.org/%s/%s/pull-requests/new?source=%s",
 		},
 		{
 			Name:           "gitlab.com",

--- a/pkg/commands/pull_request_test.go
+++ b/pkg/commands/pull_request_test.go
@@ -64,7 +64,7 @@ func TestCreatePullRequest(t *testing.T) {
 				}
 
 				assert.Equal(t, cmd, "open")
-				assert.Equal(t, args, []string{"https://bitbucket.org/johndoe/social_network/pull-requests/new?source=feature/profile-page&t=1"})
+				assert.Equal(t, args, []string{"https://bitbucket.org/johndoe/social_network/pull-requests/new?source=feature/profile-page"})
 				return exec.Command("echo")
 			},
 			func(err error) {
@@ -83,7 +83,7 @@ func TestCreatePullRequest(t *testing.T) {
 				}
 
 				assert.Equal(t, cmd, "open")
-				assert.Equal(t, args, []string{"https://bitbucket.org/johndoe/social_network/pull-requests/new?source=feature/events&t=1"})
+				assert.Equal(t, args, []string{"https://bitbucket.org/johndoe/social_network/pull-requests/new?source=feature/events"})
 				return exec.Command("echo")
 			},
 			func(err error) {


### PR DESCRIPTION
This part of the query string caused a problem on Windows
because the & character was being treated as an escape
character. The URL works without the &t=1 so this seemed
the easiest fix.
Issue #470