### PR TITLE
go v1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     environment:
       GO111MODULE: "on"
     working_directory: /go/src/github.com/jesseduffield/lazygit
@@ -38,7 +38,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     working_directory: /go/src/github.com/jesseduffield/lazygit
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@
 # docker build -t lazygit .
 # docker run -it lazygit:latest /bin/sh -l
 
-FROM golang:alpine
+FROM golang:1.13-alpine3.10
 WORKDIR /go/src/github.com/jesseduffield/lazygit/
 COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build
 
-FROM alpine:latest
+FROM alpine:3.10
 RUN apk add -U git xdg-utils
 WORKDIR /go/src/github.com/jesseduffield/lazygit/
 COPY --from=0 /go/src/github.com/jesseduffield/lazygit /go/src/github.com/jesseduffield/lazygit

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jesseduffield/lazygit
 
-go 1.12
+go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect


### PR DESCRIPTION
Upgrade the repo to use go v1.13

We already shipped the formula with go v1.13, https://github.com/Homebrew/homebrew-core/pull/44288