### PR TITLE
allow for changing the current directory on exit

### DIFF
--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -72,17 +72,22 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			ViewName: "",
 			Key:      'q',
 			Modifier: gocui.ModNone,
-			Handler:  gui.quit,
+			Handler:  gui.handleQuit,
+		}, {
+			ViewName: "",
+			Key:      'Q',
+			Modifier: gocui.ModNone,
+			Handler:  gui.handleQuitWithoutChangingDirectory,
 		}, {
 			ViewName: "",
 			Key:      gocui.KeyCtrlC,
 			Modifier: gocui.ModNone,
-			Handler:  gui.quit,
+			Handler:  gui.handleQuit,
 		}, {
 			ViewName: "",
 			Key:      gocui.KeyEsc,
 			Modifier: gocui.ModNone,
-			Handler:  gui.quit,
+			Handler:  gui.handleQuit,
 		}, {
 			ViewName:    "",
 			Key:         gocui.KeyPgup,

--- a/pkg/gui/quitting.go
+++ b/pkg/gui/quitting.go
@@ -1,0 +1,48 @@
+package gui
+
+import (
+	"os"
+
+	"github.com/jesseduffield/gocui"
+)
+
+// when a user runs lazygit with the LAZYGIT_NEW_DIR_FILE env variable defined
+// we will write the current directory to that file on exit so that their
+// shell can then change to that directory. That means you don't get kicked
+// back to the directory that you started with.
+func (gui *Gui) recordCurrentDirectory() error {
+	if os.Getenv("LAZYGIT_NEW_DIR_FILE") == "" {
+		return nil
+	}
+
+	// determine current directory, set it in LAZYGIT_NEW_DIR_FILE
+	dirName, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	return gui.OSCommand.CreateFileWithContent(os.Getenv("LAZYGIT_NEW_DIR_FILE"), dirName)
+}
+
+func (gui *Gui) handleQuitWithoutChangingDirectory(g *gocui.Gui, v *gocui.View) error {
+	gui.State.RetainOriginalDir = true
+	return gui.quit(v)
+}
+
+func (gui *Gui) handleQuit(g *gocui.Gui, v *gocui.View) error {
+	gui.State.RetainOriginalDir = false
+	return gui.quit(v)
+}
+
+func (gui *Gui) quit(v *gocui.View) error {
+	if gui.State.Updating {
+		return gui.createUpdateQuitConfirmation(gui.g, v)
+	}
+	if gui.Config.GetUserConfig().GetBool("confirmOnQuit") {
+		return gui.createConfirmationPanel(gui.g, v, true, "", gui.Tr.SLocalize("ConfirmQuit"), func(g *gocui.Gui, v *gocui.View) error {
+			return gocui.ErrQuit
+		}, nil)
+	}
+
+	return gocui.ErrQuit
+}


### PR DESCRIPTION
For this to work you'll need to put this in your ~/.zshrc (or equivalent rc file):
```
lg()
{
    export LAZYGIT_NEW_DIR_FILE=~/.lazygit/newdir

    lazygit "$@"

    if [ -f $LAZYGIT_NEW_DIR_FILE ]; then
            cd "$(cat $LAZYGIT_NEW_DIR_FILE)"
            rm -f $LAZYGIT_NEW_DIR_FILE > /dev/null
    fi
}
```