### PR TITLE
Fix typo in README `.zhsrc` -> `.zshrc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ whichever rc file you're using).
   
 ## Changing Directory On Exit
 
-If you change repos in lazygit and want your shell to change directory into that repo on exiting lazygit, add this to your `~./zhsrc` (or other rc file):
+If you change repos in lazygit and want your shell to change directory into that repo on exiting lazygit, add this to your `~./zshrc` (or other rc file):
 ```
 lg()
 {


### PR DESCRIPTION
Fix typo in `Changing Directory On Exit` section.

It should be `.zshrc` instead of `.zhsrc`