### PR TITLE
Allow editing merge conflict files in editor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.13
 
 require (
 	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21
-	github.com/creack/pty v1.1.9 // indirect
 	github.com/fatih/color v1.7.0
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-errors/errors v1.0.1
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/golang/protobuf v1.3.2 // indirect
@@ -31,11 +31,8 @@ require (
 	github.com/tcnksm/go-gitconfig v0.1.2
 	golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708 // indirect
 	golang.org/x/net v0.0.0-20191112182307-2180aed22343 // indirect
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea // indirect
 	golang.org/x/text v0.3.2
-	golang.org/x/tools v0.0.0-20191113055240-e33b02e76616 // indirect
-	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.2.5

--- a/go.sum
+++ b/go.sum
@@ -24,7 +24,6 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -78,8 +77,6 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jesseduffield/gocui v0.3.1-0.20191110053728-01cdcccd0508 h1:8CPQLUe+0QXxnbnUfaMxh1UGxg3rYCqCvbxecC9rrIY=
 github.com/jesseduffield/gocui v0.3.1-0.20191110053728-01cdcccd0508/go.mod h1:2RtZznzYKt8RLRwvFiSkXjU0Ei8WwHdubgnlaYH47dw=
-github.com/jesseduffield/pty v1.1.3 h1:JTPQ/bbGH3IBwQhxKZiFxfD4wv7cYrY7LNTwbucsZ64=
-github.com/jesseduffield/pty v1.1.3/go.mod h1:7jlS40+UhOqkZJDIG1B/H21xnuET/+fvbbnHCa8wSIo=
 github.com/jesseduffield/pty v1.2.1 h1:7xYBiwNH0PpWqC8JmvrPq1a/ksNqyCavzWu9pbBGYWI=
 github.com/jesseduffield/pty v1.2.1/go.mod h1:7jlS40+UhOqkZJDIG1B/H21xnuET/+fvbbnHCa8wSIo=
 github.com/jesseduffield/roll v0.0.0-20190629104057-695be2e62b00 h1:+JaOkfBNYQYlGD7dgru8mCwYNEc5tRRI8mThlVANhSM=
@@ -222,7 +219,6 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -250,9 +246,6 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
-golang.org/x/tools v0.0.0-20191113055240-e33b02e76616/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -261,6 +254,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/pkg/gui/file_watching.go
+++ b/pkg/gui/file_watching.go
@@ -1,0 +1,64 @@
+package gui
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/jesseduffield/lazygit/pkg/commands"
+)
+
+// NOTE: given that we often edit files ourselves, this may make us end up refreshing files too often
+// TODO: consider watching the whole directory recursively (could be more expensive)
+func (gui *Gui) watchFilesForChanges() {
+	var err error
+	gui.fileWatcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		gui.Log.Error(err)
+		return
+	}
+	go func() {
+		for {
+			select {
+			// watch for events
+			case event := <-gui.fileWatcher.Events:
+				if event.Op == fsnotify.Chmod {
+					// for some reason we pick up chmod events when they don't actually happen
+					continue
+				}
+				// only refresh if we're not already
+				if !gui.State.IsRefreshingFiles {
+					if err := gui.refreshFiles(); err != nil {
+						err = gui.createErrorPanel(gui.g, err.Error())
+						if err != nil {
+							gui.Log.Error(err)
+						}
+					}
+				}
+
+			// watch for errors
+			case err := <-gui.fileWatcher.Errors:
+				if err != nil {
+					gui.Log.Warn(err)
+				}
+			}
+		}
+	}()
+}
+
+func (gui *Gui) addFilesToFileWatcher(files []*commands.File) error {
+	// watch the files for changes
+	dirName, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		if err := gui.fileWatcher.Add(filepath.Join(dirName, file.Name)); err != nil {
+			// swallowing errors here because it doesn't really matter if we can't watch a file
+			gui.Log.Warn(err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -66,6 +66,8 @@ func (gui *Gui) handleFileSelect(g *gocui.Gui, v *gocui.View, alreadySelected bo
 	}
 
 	if file.HasInlineMergeConflicts {
+		gui.getMainView().Title = gui.Tr.SLocalize("MergeConflictsTitle")
+		gui.State.SplitMainPanel = false
 		return gui.refreshMergePanel()
 	}
 

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -906,16 +906,14 @@ func (gui *Gui) GetContextMap() map[string][]*Binding {
 				Handler:     gui.handleSelectPrevConflict,
 				Description: gui.Tr.SLocalize("PrevConflict"),
 			}, {
-				ViewName: "main",
-				Key:      gocui.KeyArrowRight,
-				Modifier: gocui.ModNone,
-				Handler:  gui.handleSelectNextConflict,
-
+				ViewName:    "main",
+				Key:         gocui.KeyArrowRight,
+				Modifier:    gocui.ModNone,
+				Handler:     gui.handleSelectNextConflict,
 				Description: gui.Tr.SLocalize("NextConflict"),
 			}, {
-				ViewName: "main",
-				Key:      gocui.KeyArrowUp,
-
+				ViewName:    "main",
+				Key:         gocui.KeyArrowUp,
 				Modifier:    gocui.ModNone,
 				Handler:     gui.handleSelectTop,
 				Description: gui.Tr.SLocalize("SelectTop"),
@@ -961,6 +959,18 @@ func (gui *Gui) GetContextMap() map[string][]*Binding {
 				Modifier:    gocui.ModNone,
 				Handler:     gui.handlePopFileSnapshot,
 				Description: gui.Tr.SLocalize("Undo"),
+			}, {
+				ViewName:    "main",
+				Key:         'e',
+				Modifier:    gocui.ModNone,
+				Handler:     gui.handleFileEdit,
+				Description: gui.Tr.SLocalize("editFile"),
+			}, {
+				ViewName:    "main",
+				Key:         'o',
+				Modifier:    gocui.ModNone,
+				Handler:     gui.handleFileOpen,
+				Description: gui.Tr.SLocalize("openFile"),
 			},
 		},
 	}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -148,6 +148,9 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			ID:    "resolveMergeConflicts",
 			Other: "resolve merge conflicts",
 		}, &i18n.Message{
+			ID:    "MergeConflictsTitle",
+			Other: "Merge Conflicts",
+		}, &i18n.Message{
 			ID:    "checkout",
 			Other: "checkout",
 		}, &i18n.Message{


### PR DESCRIPTION
adds the 'e' (for edit with e.g. vim) and 'o' (for open in editor) keybindings to the merge conflict context, and adds file watching for all modified files so that we can refresh the files whenever something changes (and prompt the user when all merge conflicts are resolved).

This effectively means that the recurring calls of refreshFiles are only there for when new files show up. I considered recursively watching the whole directory but I have a feeling that could cause issues when there are a lot of files so I think this is a good starting point.