### PR TITLE
Readme: add MacPorts install source

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Core:
 brew install lazygit
 ```
 
+### MacPorts
+Latest version built from github releases.
+Tap:
+```
+sudo port install lazygit
+```
+
 ### Ubuntu
 
 Packages for Ubuntu 16.04, 18.04 and 18.10 are available via [Launchpad PPA](https://launchpad.net/~lazygit-team).


### PR DESCRIPTION
MacPorts has a lazygit port since last summer, too. Kept up to date, based on github releases. See:

https://ports.macports.org/port/lazygit/summary
https://github.com/macports/macports-ports/blob/master/devel/lazygit/Portfile