### PR TITLE
add filter argument for filter logs by path

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,9 @@ func main() {
 	repoPath := "."
 	flaggy.String(&repoPath, "p", "path", "Path of git repo")
 
+	filterLogFlag := false
+	flaggy.Bool(&filterLogFlag, "f", "filter", "Filter current path logs of git repo")
+
 	dump := ""
 	flaggy.AddPositionalValue(&dump, "gitargs", 1, false, "Todo file")
 	flaggy.DefaultParser.PositionalFlags[0].Hidden = true
@@ -62,7 +65,16 @@ func main() {
 		}
 	}
 
-	appConfig, err := config.NewAppConfig("lazygit", version, commit, date, buildSource, debuggingFlag)
+	filterLogPath := ""
+	if filterLogFlag {
+		dir, err := os.Getwd()
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		filterLogPath = dir
+	}
+
+	appConfig, err := config.NewAppConfig("lazygit", version, commit, date, buildSource, debuggingFlag, filterLogPath)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/pkg/commands/commit_list_builder.go
+++ b/pkg/commands/commit_list_builder.go
@@ -286,7 +286,12 @@ func (c *CommitListBuilder) getUnpushedCommits() map[string]bool {
 func (c *CommitListBuilder) getLog() string {
 	// currently limiting to 30 for performance reasons
 	// TODO: add lazyloading when you scroll down
-	result, err := c.OSCommand.RunCommandWithOutput("git log --oneline -30")
+	filterPath := c.GitCommand.Config.GetFilterLogPath()
+	command := "git log --oneline -30"
+	if filterPath != "" {
+		command = command + " " + filterPath
+	}
+	result, err := c.OSCommand.RunCommandWithOutput(command)
 	if err != nil {
 		// assume if there is an error there are no commits yet for this branch
 		return ""

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -14,6 +14,7 @@ import (
 // AppConfig contains the base configuration fields required for lazygit.
 type AppConfig struct {
 	Debug         bool   `long:"debug" env:"DEBUG" default:"false"`
+	FilterLogPath string `long:"filterLogPath"`
 	Version       string `long:"version" env:"VERSION" default:"unversioned"`
 	Commit        string `long:"commit" env:"COMMIT"`
 	BuildDate     string `long:"build-date" env:"BUILD_DATE"`
@@ -29,6 +30,7 @@ type AppConfig struct {
 // from AppConfig and still be used by lazygit.
 type AppConfigurer interface {
 	GetDebug() bool
+	GetFilterLogPath() string
 	GetVersion() string
 	GetCommit() string
 	GetBuildDate() string
@@ -45,7 +47,7 @@ type AppConfigurer interface {
 }
 
 // NewAppConfig makes a new app config
-func NewAppConfig(name, version, commit, date string, buildSource string, debuggingFlag bool) (*AppConfig, error) {
+func NewAppConfig(name, version, commit, date string, buildSource string, debuggingFlag bool, filterLogPath string) (*AppConfig, error) {
 	userConfig, userConfigPath, err := LoadConfig("config", true)
 	if err != nil {
 		return nil, err
@@ -61,6 +63,7 @@ func NewAppConfig(name, version, commit, date string, buildSource string, debugg
 		Commit:        commit,
 		BuildDate:     date,
 		Debug:         debuggingFlag,
+		FilterLogPath: filterLogPath,
 		BuildSource:   buildSource,
 		UserConfig:    userConfig,
 		UserConfigDir: filepath.Dir(userConfigPath),
@@ -88,6 +91,11 @@ func (c *AppConfig) SetIsNewRepo(toSet bool) {
 // GetDebug returns debug flag
 func (c *AppConfig) GetDebug() bool {
 	return c.Debug
+}
+
+// getFilterLogPath returns filter path
+func (c *AppConfig) GetFilterLogPath() string {
+	return c.FilterLogPath
 }
 
 // GetVersion returns debug flag


### PR DESCRIPTION
hi @jesseduffield ,

thanks your great tool . and now i have a feature request about git log :

how to show filtered logs like `git log . ` ?

i had message about it in that [issue](https://github.com/jesseduffield/lazygit/issues/413#issuecomment-560263234) , 

and i have a try in this [fork](https://github.com/houfeng0923/lazygit/commit/67a3afffa793a902e898e41b7b7362996c857ec2) .

now just chdir to repo sub path and : `lazygit -f`
