### PR TITLE
make Ctrl+P visible

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -4,6 +4,7 @@
 
 <pre>
   <kbd>m</kbd>: view merge/rebase options
+  <kbd>ctrl+p</kbd>: view custom patch options
   <kbd>P</kbd>: push
   <kbd>p</kbd>: pull
   <kbd>R</kbd>: refresh

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -36,6 +36,9 @@ func (b *Binding) GetKey() string {
 		if b.Key.(gocui.Key) == gocui.KeyCtrlK {
 			return "ctrl+k"
 		}
+		if b.Key.(gocui.Key) == gocui.KeyCtrlP {
+			return "ctrl+p"
+		}
 		key = int(b.Key.(gocui.Key))
 	}
 
@@ -140,6 +143,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		},
 		{
 			ViewName:    "",
+			Key:         gocui.KeyCtrlP,
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleCreatePatchOptionsMenu,
+			Description: gui.Tr.SLocalize("ViewPatchOptions"),
+		},
+		{
+			ViewName:    "",
 			Key:         'P',
 			Modifier:    gocui.ModNone,
 			Handler:     gui.pushFiles,
@@ -176,12 +186,6 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Key:      gocui.MouseMiddle,
 			Modifier: gocui.ModNone,
 			Handler:  gui.handleCreateOptionsMenu,
-		},
-		{
-			ViewName: "",
-			Key:      gocui.KeyCtrlP,
-			Modifier: gocui.ModNone,
-			Handler:  gui.handleCreatePatchOptionsMenu,
 		},
 		{
 			ViewName:    "status",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -823,6 +823,9 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			ID:    "toggleAddToPatch",
 			Other: "toggle file included in patch",
 		}, &i18n.Message{
+			ID:    "ViewPatchOptions",
+			Other: "view custom patch options",
+		}, &i18n.Message{
 			ID:    "PatchOptionsTitle",
 			Other: "Patch Options",
 		}, &i18n.Message{


### PR DESCRIPTION
today I had to refer to the "15 features in 15 minutes" video for the third time in order to find the feature i JUST KNOW is there, but don't remember how to access.

This PR hopefully resolves my problem, by exposing "patch options" and the Ctrl+P shortcut in menus and documentation.