### PR TITLE
Fix applying patch on Windows machines

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -628,7 +628,7 @@ func (c *GitCommand) Diff(file *File, plain bool, cached bool) string {
 
 func (c *GitCommand) ApplyPatch(patch string, flags ...string) error {
 	c.Log.Warn(patch)
-	filepath := filepath.Join(c.Config.GetUserConfigDir(), utils.GetCurrentRepoName(), time.Now().Format(time.StampNano)+".patch")
+	filepath := filepath.Join(c.Config.GetUserConfigDir(), utils.GetCurrentRepoName(), time.Now().Format("Jan _2 15.04.05.000000000")+".patch")
 	if err := c.OSCommand.CreateFileWithContent(filepath, patch); err != nil {
 		return err
 	}


### PR DESCRIPTION
I encountered a bug where I would be unable to stage a hunk of a diff, this would manifest with an error like:

```
{
  "buildDate": "",
  "commit": "",
  "debug": true,
  "level": "error",
  "msg": "open C:\\Users\\Jamie Brynes\\AppData\\Roaming\\jesseduffield\\lazygit\\advent-of-code-2019\\Jan  5 19:31:17.633511000.patch: The filename, directory name, or volume label syntax is incorrect.",
  "time": "2020-01-05T19:31:17Z",
  "version": "unversioned"
}
```

This bug is caused by how the timestamp was formatted for the patch file. On Windows machines, `:` is an invalid character for a filename, but the `stampNano` format for time contains `:`.

This fix just swaps out the `stampNano` format for one which is almost identical except for the `:` characters are swapped out for `.` characters. You can see the original format [here](https://github.com/golang/go/blob/8adc1e00aa1a92a85b9d6f3526419d49dd7859dd/src/time/format.go#L89)