### PR TITLE
Use ASCII on Windows with east asian locale

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.11 // indirect
-	github.com/mattn/go-runewidth v0.0.7 // indirect
+	github.com/mattn/go-runewidth v0.0.7
 	github.com/mgutz/str v1.2.0
 	github.com/nicksnyder/go-i18n/v2 v2.0.3
 	github.com/onsi/ginkgo v1.10.3 // indirect

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
+	"runtime"
 	"sync"
 
 	// "io"
@@ -28,6 +29,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/theme"
 	"github.com/jesseduffield/lazygit/pkg/updates"
 	"github.com/jesseduffield/lazygit/pkg/utils"
+	"github.com/mattn/go-runewidth"
 	"github.com/sirupsen/logrus"
 )
 
@@ -781,6 +783,8 @@ func (gui *Gui) Run() error {
 		return err
 	}
 	defer g.Close()
+
+	g.ASCII = runtime.GOOS == "windows" && runewidth.IsEastAsian()
 
 	if gui.Config.GetUserConfig().GetBool("gui.mouseEvents") {
 		g.Mouse = true


### PR DESCRIPTION
On Windows Console (including Windows10) with East Asian Locale, border characters are double widths.

![image](https://user-images.githubusercontent.com/10111/71865320-ba84ef00-3145-11ea-8f8a-2d8af1aecf17.png)

This change set gui.ASCII true when Windows and East Asian Locale.

![image](https://user-images.githubusercontent.com/10111/71865401-f5872280-3145-11ea-98e7-afa285841ba1.png)
