### PR TITLE
allow commits to be checked out

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -515,7 +515,7 @@ func (c *GitCommand) DiscardUnstagedFileChanges(file *File) error {
 	return c.OSCommand.RunCommand("git checkout -- %s", quotedFileName)
 }
 
-// Checkout checks out a branch, with --force if you set the force arg to true
+// Checkout checks out a branch (or commit), with --force if you set the force arg to true
 func (c *GitCommand) Checkout(branch string, force bool) error {
 	forceArg := ""
 	if force {

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -611,3 +611,14 @@ func (gui *Gui) handleCreateLightweightTag(commitSha string) error {
 		return gui.handleCommitSelect(g, v)
 	})
 }
+
+func (gui *Gui) handleCheckoutCommit(g *gocui.Gui, v *gocui.View) error {
+	commit := gui.getSelectedCommit(g)
+	if commit == nil {
+		return gui.renderString(g, "main", gui.Tr.SLocalize("NoCommitsThisBranch"))
+	}
+
+	return gui.createConfirmationPanel(g, gui.getCommitsView(), true, gui.Tr.SLocalize("checkoutCommit"), gui.Tr.SLocalize("SureCheckoutThisCommit"), func(g *gocui.Gui, v *gocui.View) error {
+		return gui.handleCheckoutRef(commit.Sha)
+	}, nil)
+}

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -596,6 +596,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			ViewName:    "commits",
 			Key:         gocui.KeySpace,
 			Modifier:    gocui.ModNone,
+			Handler:     gui.handleCheckoutCommit,
+			Description: gui.Tr.SLocalize("checkoutCommit"),
+		},
+		{
+			ViewName:    "commits",
+			Key:         'h',
+			Modifier:    gocui.ModNone,
 			Handler:     gui.handleToggleDiffCommit,
 			Description: gui.Tr.SLocalize("CommitsDiff"),
 		},

--- a/pkg/gui/remote_branches_panel.go
+++ b/pkg/gui/remote_branches_panel.go
@@ -79,7 +79,7 @@ func (gui *Gui) handleCheckoutRemoteBranch(g *gocui.Gui, v *gocui.View) error {
 	if remoteBranch == nil {
 		return nil
 	}
-	if err := gui.handleCheckoutBranch(remoteBranch.RemoteName + "/" + remoteBranch.Name); err != nil {
+	if err := gui.handleCheckoutRef(remoteBranch.RemoteName + "/" + remoteBranch.Name); err != nil {
 		return err
 	}
 	return gui.switchBranchesPanelContext("local-branches")

--- a/pkg/gui/tags_panel.go
+++ b/pkg/gui/tags_panel.go
@@ -90,7 +90,7 @@ func (gui *Gui) handleCheckoutTag(g *gocui.Gui, v *gocui.View) error {
 	if tag == nil {
 		return nil
 	}
-	if err := gui.handleCheckoutBranch(tag.Name); err != nil {
+	if err := gui.handleCheckoutRef(tag.Name); err != nil {
 		return err
 	}
 	return gui.switchBranchesPanelContext("local-branches")

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -924,6 +924,12 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "FetchingRemoteStatus",
 			Other: "fetching remote",
+		}, &i18n.Message{
+			ID:    "checkoutCommit",
+			Other: "checkout commit",
+		}, &i18n.Message{
+			ID:    "SureCheckoutThisCommit",
+			Other: "Are you sure you want to checkout this commit?",
 		},
 	)
 }


### PR DESCRIPTION
I've made this now possible, with the 'space' keybinding. Unfortunately 'space' was previously reserved for diffing two commits, and now that's been moved to 'h'. I'm open to suggestions on a better keybinding for that but I feel space makes sense with commits given that it's the same keybinding used for checking out branches.