### PR TITLE
add git flow support

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -90,6 +90,7 @@ Default path for the config file: `~/.config/jesseduffield/lazygit/config.yml`
       forceCheckoutBranch: 'F'
       rebaseBranch: 'r'
       mergeIntoCurrentBranch: 'M'
+      viewGitFlowOptions: 'i'
       fastForward: 'f' # fast-forward this branch from its upstream
       pushTag: 'P'
       setUpstream: 'u' # set as upstream of checked-out branch

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -323,6 +323,7 @@ keybinding:
     forceCheckoutBranch: 'F'
     rebaseBranch: 'r'
     mergeIntoCurrentBranch: 'M'
+    viewGitFlowOptions: 'i'
     fastForward: 'f'
     pushTag: 'P'
     setUpstream: 'u'

--- a/pkg/gui/git_flow.go
+++ b/pkg/gui/git_flow.go
@@ -1,0 +1,106 @@
+package gui
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/jesseduffield/gocui"
+)
+
+type gitFlowOption struct {
+	handler     func() error
+	description string
+}
+
+func (gui *Gui) gitFlowFinishBranch(gitFlowConfig string, branchName string) error {
+	// need to find out what kind of branch this is
+	prefix := strings.SplitAfterN(branchName, "/", 2)[0]
+	suffix := strings.Replace(branchName, prefix, "", 1)
+
+	branchType := ""
+	for _, line := range strings.Split(strings.TrimSpace(gitFlowConfig), "\n") {
+		if strings.HasPrefix(line, "gitflow.prefix.") && strings.HasSuffix(line, prefix) {
+			// now I just need to how do you say
+			regex := regexp.MustCompile("gitflow.prefix.([^ ]*) .*")
+			matches := regex.FindAllStringSubmatch(line, 1)
+
+			if len(matches) > 0 && len(matches[0]) > 1 {
+				branchType = matches[0][1]
+				break
+			}
+		}
+	}
+
+	if branchType == "" {
+		return gui.createErrorPanel(gui.g, gui.Tr.SLocalize("NotAGitFlowBranch"))
+	}
+
+	subProcess := gui.OSCommand.PrepareSubProcess("git", "flow", branchType, "finish", suffix)
+	gui.SubProcess = subProcess
+	return gui.Errors.ErrSubProcess
+}
+
+// GetDisplayStrings is a function.
+func (r *gitFlowOption) GetDisplayStrings(isFocused bool) []string {
+	return []string{r.description}
+}
+
+func (gui *Gui) handleCreateGitFlowMenu(g *gocui.Gui, v *gocui.View) error {
+	branch := gui.getSelectedBranch()
+	if branch == nil {
+		return nil
+	}
+
+	// get config
+	gitFlowConfig, err := gui.OSCommand.RunCommandWithOutput("git config --local --get-regexp gitflow")
+	if err != nil {
+		return gui.createErrorPanel(gui.g, "You need to install git-flow and enable it in this repo to use git-flow features")
+	}
+
+	startHandler := func(branchType string) func() error {
+		return func() error {
+			title := gui.Tr.TemplateLocalize("NewBranchNamePrompt", map[string]interface{}{"branchType": branchType})
+			return gui.createPromptPanel(gui.g, gui.getMenuView(), title, "", func(g *gocui.Gui, v *gocui.View) error {
+				name := gui.trimmedContent(v)
+				subProcess := gui.OSCommand.PrepareSubProcess("git", "flow", branchType, "start", name)
+				gui.SubProcess = subProcess
+				return gui.Errors.ErrSubProcess
+			})
+		}
+	}
+
+	options := []*gitFlowOption{
+		{
+			// not localising here because it's one to one with the actual git flow commands
+			description: fmt.Sprintf("finish branch '%s'", branch.Name),
+			handler: func() error {
+				return gui.gitFlowFinishBranch(gitFlowConfig, branch.Name)
+			},
+		},
+		{
+			description: "start feature",
+			handler:     startHandler("feature"),
+		},
+		{
+			description: "start hotfix",
+			handler:     startHandler("hotfix"),
+		},
+		{
+			description: "start release",
+			handler:     startHandler("release"),
+		},
+		{
+			description: gui.Tr.SLocalize("cancel"),
+			handler: func() error {
+				return nil
+			},
+		},
+	}
+
+	handleMenuPress := func(index int) error {
+		return options[index].handler()
+	}
+
+	return gui.createMenu("git flow", options, len(options), handleMenuPress)
+}

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1,9 +1,10 @@
 package gui
 
 import (
-	"github.com/jesseduffield/gocui"
 	"log"
 	"strings"
+
+	"github.com/jesseduffield/gocui"
 )
 
 // Binding - a keybinding mapping a key and modifier to a handler. The keypress
@@ -519,6 +520,14 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleMerge,
 			Description: gui.Tr.SLocalize("mergeIntoCurrentBranch"),
+		},
+		{
+			ViewName:    "branches",
+			Contexts:    []string{"local-branches"},
+			Key:         gui.getKey("branches.viewGitFlowOptions"),
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleCreateGitFlowMenu,
+			Description: gui.Tr.SLocalize("gitFlowOptions"),
 		},
 		{
 			ViewName:    "branches",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -930,6 +930,15 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "SureCheckoutThisCommit",
 			Other: "Are you sure you want to checkout this commit?",
+		}, &i18n.Message{
+			ID:    "gitFlowOptions",
+			Other: "show git-flow options",
+		}, &i18n.Message{
+			ID:    "NotAGitFlowBranch",
+			Other: "This does not seem to be a git flow branch",
+		}, &i18n.Message{
+			ID:    "NewBranchNamePrompt",
+			Other: "new {{.branchType}} name:",
 		},
 	)
 }


### PR DESCRIPTION
now if you press 'i' (unfortunate keybinding I know but we're running out) in the branches view you can view git flow options. This is currently limited to starting or finishing feature/hotfix/release branches. 

Custom prefixes are supported, and we basically just send commands to the underlying `git-flow` program in a subprocess (so this requires that to be installed).