### PR TITLE
Fix rebase errors on Windows when there are spaces in the path

### DIFF
--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -326,7 +326,7 @@ func (c *OSCommand) GetLazygitPath() string {
 	if err != nil {
 		ex = os.Args[0] // fallback to the first call argument if needed
 	}
-	return filepath.ToSlash(ex)
+	return `"` + filepath.ToSlash(ex) + `"`
 }
 
 // RunCustomCommand returns the pointer to a custom command


### PR DESCRIPTION
I encountered a bug where squashing a commit down would fail with an error like: 

```
C:/Users/Jamie Brynes/go/bin/lazygit.exe: C:/Users/Jamie: No such file or directory
error: There was a problem with the editor 'C:/Users/Jamie Brynes/go/bin/lazygit.exe'. 
```

This is due to the `GIT_SEQUENCE_EDITOR` variable being set to `C:/Users/Jamie Brynes/go/bin/lazygit.exe` (https://github.com/jesseduffield/lazygit/blob/master/pkg/commands/git.go#L758) which Git would try to invoke (and fail due to the spaces in the path). Interestingly, using the `Quote` method on the `OSCommand` struct did not fix the issue, instead it would fail to find `\"C:/Users/Jamie Brynes/go/bin/lazygit.exe\"`.

Would recommend that someone on a Unix system test out this change before merging. 