### PR TITLE
lazyload commits

### DIFF
--- a/pkg/commands/commit_list_builder_test.go
+++ b/pkg/commands/commit_list_builder_test.go
@@ -188,7 +188,7 @@ func TestCommitListBuilderGetLog(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			c := NewDummyCommitListBuilder()
 			c.OSCommand.SetCommand(s.command)
-			s.test(c.getLog())
+			s.test(c.getLog(true))
 		})
 	}
 }
@@ -312,7 +312,7 @@ func TestCommitListBuilderGetCommits(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			c := NewDummyCommitListBuilder()
 			c.OSCommand.SetCommand(s.command)
-			s.test(c.GetCommits())
+			s.test(c.GetCommits(true))
 		})
 	}
 }

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -128,6 +128,7 @@ type tagsPanelState struct {
 type commitPanelState struct {
 	SelectedLine     int
 	SpecificDiffMode bool
+	LimitCommits     bool
 }
 
 type reflogCommitPanelState struct {
@@ -212,7 +213,7 @@ func NewGui(log *logrus.Entry, gitCommand *commands.GitCommand, oSCommand *comma
 			Remotes:        &remotePanelState{SelectedLine: 0},
 			RemoteBranches: &remoteBranchesState{SelectedLine: -1},
 			Tags:           &tagsPanelState{SelectedLine: -1},
-			Commits:        &commitPanelState{SelectedLine: -1},
+			Commits:        &commitPanelState{SelectedLine: -1, LimitCommits: true},
 			ReflogCommits:  &reflogCommitPanelState{SelectedLine: 0}, // TODO: might need to make -1
 			CommitFiles:    &commitFilesPanelState{SelectedLine: -1},
 			Stash:          &stashPanelState{SelectedLine: -1},


### PR DESCRIPTION
We start off with thirty commits but if you scroll down past 20 we'll load the remaining commits in the background