### PR TITLE
Missed a spot with this new string task thing

### DIFF
--- a/pkg/gui/merge_panel.go
+++ b/pkg/gui/merge_panel.go
@@ -212,15 +212,16 @@ func (gui *Gui) refreshMergePanel() error {
 	if err != nil {
 		return err
 	}
-	if err := gui.newStringTask("main", content); err != nil {
-		return err
-	}
-	if err := gui.scrollToConflict(gui.g); err != nil {
-		return err
-	}
 
 	mainView := gui.getMainView()
 	mainView.Wrap = false
+	if err := gui.setViewContent(gui.g, mainView, content); err != nil {
+		return err
+	}
+	gui.Log.Warn("scrolling to conflict")
+	if err := gui.scrollToConflict(gui.g); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
The issue here was that we were using a string task
but expecting to be able to set the origin straight after
to point at the conflict, but because it's async it was
actually resetting the origin to 0 after a little bit.

The proper solution here is maybe to add a flag to that thing
asking whether you want to reset main's origin. But I'm
too lazy to do that right now so instead I'm just using
setViewContent. That will probably cause issues in the future.