### PR TITLE
Fix crash on exit

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -880,7 +880,9 @@ func (gui *Gui) RunWithSubprocesses() error {
 					}
 				}
 
-				gui.fileWatcher.Watcher.Close()
+				if !gui.fileWatcher.Disabled {
+					gui.fileWatcher.Watcher.Close()
+				}
 
 				break
 			} else if err == gui.Errors.ErrSwitchRepo {


### PR DESCRIPTION
This PR fixes a bug related to #588 and #594 wherein you would experience a panic on exit due to a nil pointer deference. 

Now on exit, we check if the file watcher is enabled before attempting to close it.