### PR TITLE
make use of branch config when pushing/pulling

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -404,12 +404,12 @@ func (c *GitCommand) AmendHead() (*exec.Cmd, error) {
 }
 
 // Pull pulls from repo
-func (c *GitCommand) Pull(ask func(string) string) error {
-	return c.OSCommand.DetectUnamePass("git pull --no-edit", ask)
+func (c *GitCommand) Pull(args string, ask func(string) string) error {
+	return c.OSCommand.DetectUnamePass("git pull --no-edit "+args, ask)
 }
 
 // Push pushes to a branch
-func (c *GitCommand) Push(branchName string, force bool, upstream string, ask func(string) string) error {
+func (c *GitCommand) Push(branchName string, force bool, upstream string, args string, ask func(string) string) error {
 	forceFlag := ""
 	if force {
 		forceFlag = "--force-with-lease"
@@ -420,7 +420,7 @@ func (c *GitCommand) Push(branchName string, force bool, upstream string, ask fu
 		setUpstreamArg = "--set-upstream " + upstream
 	}
 
-	cmd := fmt.Sprintf("git push --follow-tags %s %s", forceFlag, setUpstreamArg)
+	cmd := fmt.Sprintf("git push --follow-tags %s %s %s", forceFlag, setUpstreamArg, args)
 	return c.OSCommand.DetectUnamePass(cmd, ask)
 }
 

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -1015,7 +1015,7 @@ func TestGitCommandPush(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			gitCmd := NewDummyGitCommand()
 			gitCmd.OSCommand.command = s.command
-			err := gitCmd.Push("test", s.forcePush, "", func(passOrUname string) string {
+			err := gitCmd.Push("test", s.forcePush, "", "", func(passOrUname string) string {
 				return "\n"
 			})
 			s.test(err)


### PR DESCRIPTION
fixes https://github.com/jesseduffield/lazygit/issues/598

Now when pushing/pulling, if we don't have any upstream changes to compare with, but we _do_ have the branch listed in our git config, we'll make use of its remote to push/pull.

Worth noting that I didn't get quite the same behaviour when I used `hub pr checkout`. I tested on this PR https://github.com/jesseduffield/lazygit/pull/560 but that chucked the following into my config:
```
[branch "tim77-patch-1"]
	remote = origin
	merge = refs/pull/560/head

```

Maybe that was the case because I already had that branch in origin. At any rate, to mirror the excerpt from the original issue I switched that to
```
[branch "tim77-patch-1"]
	remote = https://github.com/tim77/lazygit.git
	merge = refs/pull/560/head
```

And tested the PR with that setup.

I am a little ashamed at how many args are being tacked onto my push/pull methods but I think I want to do a proper overhaul at how I handle args in these helper functions down the line.

I also bumped into https://github.com/jesseduffield/lazygit/issues/501 while working on this feature. I'll need to tackle that next