### PR TITLE
fix segfault on line by line panel

### DIFF
--- a/pkg/gui/commit_files_panel.go
+++ b/pkg/gui/commit_files_panel.go
@@ -29,7 +29,9 @@ func (gui *Gui) handleCommitFileSelect(g *gocui.Gui, v *gocui.View) error {
 	}
 
 	gui.getMainView().Title = "Patch"
-	gui.State.Panels.LineByLine = nil
+	if gui.currentViewName() == "commitFiles" {
+		gui.handleEscapeLineByLinePanel()
+	}
 
 	commitFile := gui.getSelectedCommitFile(g)
 	if commitFile == nil {
@@ -194,9 +196,7 @@ func (gui *Gui) enterCommitFile(selectedLineIdx int) error {
 			}
 		}
 
-		if err := gui.changeMainViewsContext("patch-building"); err != nil {
-			return err
-		}
+		gui.changeMainViewsContext("patch-building")
 		if err := gui.switchFocus(gui.g, gui.getCommitFilesView(), gui.getMainView()); err != nil {
 			return err
 		}

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -49,7 +49,7 @@ func (gui *Gui) handleCommitSelect(g *gocui.Gui, v *gocui.View) error {
 
 	gui.getMainView().Title = "Patch"
 	gui.getSecondaryView().Title = "Custom Patch"
-	gui.State.Panels.LineByLine = nil
+	gui.handleEscapeLineByLinePanel()
 
 	commit := gui.getSelectedCommit(g)
 	if commit == nil {

--- a/pkg/gui/context.go
+++ b/pkg/gui/context.go
@@ -4,9 +4,9 @@ package gui
 // which currently just means a context that affects both the main and secondary views
 // other views can have their context changed directly but this function helps
 // keep the main and secondary views in sync
-func (gui *Gui) changeMainViewsContext(context string) error {
+func (gui *Gui) changeMainViewsContext(context string) {
 	if gui.State.MainContext == context {
-		return nil
+		return
 	}
 
 	switch context {
@@ -16,5 +16,5 @@ func (gui *Gui) changeMainViewsContext(context string) error {
 	}
 
 	gui.State.MainContext = context
-	return nil
+	return
 }

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -173,9 +173,7 @@ func (gui *Gui) enterFile(forceSecondaryFocused bool, selectedLineIdx int) error
 	if file.HasMergeConflicts {
 		return gui.createErrorPanel(gui.g, gui.Tr.SLocalize("FileStagingRequirements"))
 	}
-	if err := gui.changeMainViewsContext("staging"); err != nil {
-		return err
-	}
+	gui.changeMainViewsContext("staging")
 	if err := gui.switchFocus(gui.g, gui.getFilesView(), gui.getMainView()); err != nil {
 		return err
 	}
@@ -497,9 +495,7 @@ func (gui *Gui) handleSwitchToMerge(g *gocui.Gui, v *gocui.View) error {
 	if !file.HasInlineMergeConflicts {
 		return gui.createErrorPanel(g, gui.Tr.SLocalize("FileNoMergeCons"))
 	}
-	if err := gui.changeMainViewsContext("merging"); err != nil {
-		return err
-	}
+	gui.changeMainViewsContext("merging")
 	if err := gui.switchFocus(g, v, gui.getMainView()); err != nil {
 		return err
 	}

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -348,9 +348,7 @@ func (gui *Gui) onFocusLost(v *gocui.View, newView *gocui.View) error {
 		}
 	case "main":
 		// if we have lost focus to a first-class panel, we need to do some cleanup
-		if err := gui.changeMainViewsContext("normal"); err != nil {
-			return err
-		}
+		gui.changeMainViewsContext("normal")
 	case "commitFiles":
 		if gui.State.MainContext != "patch-building" {
 			if _, err := gui.g.SetViewOnBottom(v.Name()); err != nil {
@@ -698,9 +696,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 }
 
 func (gui *Gui) onInitialViewsCreation() error {
-	if err := gui.changeMainViewsContext("normal"); err != nil {
-		return err
-	}
+	gui.changeMainViewsContext("normal")
 
 	gui.getBranchesView().Context = "local-branches"
 	gui.getCommitsView().Context = "branch-commits"

--- a/pkg/gui/line_by_line_panel.go
+++ b/pkg/gui/line_by_line_panel.go
@@ -314,3 +314,8 @@ func (gui *Gui) handleToggleSelectHunk(g *gocui.Gui, v *gocui.View) error {
 
 	return gui.focusSelection(state.SelectMode == HUNK)
 }
+
+func (gui *Gui) handleEscapeLineByLinePanel() {
+	gui.changeMainViewsContext("normal")
+	gui.State.Panels.LineByLine = nil
+}

--- a/pkg/gui/patch_building_panel.go
+++ b/pkg/gui/patch_building_panel.go
@@ -87,8 +87,7 @@ func (gui *Gui) handleRemoveSelectionFromPatch(g *gocui.Gui, v *gocui.View) erro
 }
 
 func (gui *Gui) handleEscapePatchBuildingPanel(g *gocui.Gui, v *gocui.View) error {
-	gui.State.Panels.LineByLine = nil
-	gui.changeMainViewsContext("normal")
+	gui.handleEscapeLineByLinePanel()
 
 	if gui.GitCommand.PatchManager.IsEmpty() {
 		gui.GitCommand.PatchManager.Reset()

--- a/pkg/gui/staging_panel.go
+++ b/pkg/gui/staging_panel.go
@@ -94,7 +94,7 @@ func (gui *Gui) handleTogglePanel(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (gui *Gui) handleStagingEscape(g *gocui.Gui, v *gocui.View) error {
-	gui.State.Panels.LineByLine = nil
+	gui.handleEscapeLineByLinePanel()
 
 	return gui.switchFocus(gui.g, nil, gui.getFilesView())
 }


### PR DESCRIPTION
The state object is sometimes undefined in the onclick method of the
line by line panel. Because we set it to nil in a bunch of places,
I've decided to just change the main context to 'normal' before setting
it to nil anywhere. That way the keybindings for the line by line panel
won't get executed and we won't get a segfault.