### PR TITLE
Make amend even more non-interactive

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -623,10 +623,12 @@ func (c *GitCommand) FastForward(branchName string, remoteName string, remoteBra
 
 func (c *GitCommand) RunSkipEditorCommand(command string) error {
 	cmd := c.OSCommand.ExecutableFromString(command)
+	lazyGitPath := c.OSCommand.GetLazygitPath()
 	cmd.Env = append(
 		cmd.Env,
 		"LAZYGIT_CLIENT_COMMAND=EXIT_IMMEDIATELY",
-		"EDITOR="+c.OSCommand.GetLazygitPath(),
+		"EDITOR="+lazyGitPath,
+		"VISUAL="+lazyGitPath,
 	)
 	return c.OSCommand.RunExecutable(cmd)
 }

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"regexp"
 	"testing"
 	"time"
 
@@ -2099,6 +2100,37 @@ func TestGitCommandCreateFixupCommit(t *testing.T) {
 			s.test(gitCmd.CreateFixupCommit(s.sha))
 		})
 	}
+}
+
+// TestGitCommandSkipEditorCommand confirms that SkipEditorCommand injects
+// environment variables that suppress an interactive editor
+func TestGitCommandSkipEditorCommand(t *testing.T) {
+	cmd := NewDummyGitCommand()
+
+	cmd.OSCommand.SetBeforeExecuteCmd(func(cmd *exec.Cmd) {
+		test.AssertContainsMatch(
+			t,
+			cmd.Env,
+			regexp.MustCompile("^VISUAL="),
+			"expected VISUAL to be set for a non-interactive external command",
+		)
+
+		test.AssertContainsMatch(
+			t,
+			cmd.Env,
+			regexp.MustCompile("^EDITOR="),
+			"expected EDITOR to be set for a non-interactive external command",
+		)
+
+		test.AssertContainsMatch(
+			t,
+			cmd.Env,
+			regexp.MustCompile("^LAZYGIT_CLIENT_COMMAND=EXIT_IMMEDIATELY$"),
+			"expected LAZYGIT_CLIENT_COMMAND to be set for a non-interactive external command",
+		)
+	})
+
+	cmd.RunSkipEditorCommand("true")
 }
 
 func TestFindDotGitDir(t *testing.T) {

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -42,4 +43,16 @@ func CreateMockCommand(t *testing.T, swappers []*CommandSwapper) func(cmd string
 		commandIndex++
 		return command
 	}
+}
+
+func AssertContainsMatch(t *testing.T, strs []string, pattern *regexp.Regexp, message string) {
+	t.Helper()
+
+	for _, str := range strs {
+		if pattern.Match([]byte(str)) {
+			return
+		}
+	}
+
+	assert.Fail(t, message)
 }


### PR DESCRIPTION
**What's the problem?**

tl;dr, although `lazygit` overrides `EDITOR` when running non-interactive git commands, it doesn't override `VISUAL`, which `git` seems to prioritize.

**How do I make it happen?**

- Set `VISUAL` and `EDITOR` environment variables to an editor, e.g. `nvim`
- Edit a file under source control
- Start `lazygit`
- Use `space` to select the changes, highlight the topmost commit and use `A` to amend
- Press `Enter` at the prompt to confirm
- **Issue**: A window pops up over the LazyGit UI which appears to contain the raw output of `nvim`

**How does this help?**

By setting the `VISUAL` environment variable in addition to the `EDITOR` environment variable in order to suppress `git`'s display of an interactive editor.

**How would a review help?**

It was pretty challenging holding back from completely refactoring `pkg/commands/git.go` in order to allow a mock of `OSCommand` to be injected.  Ideally, `GitCommand` would be working through an interface covering `OSCommand`.  This would make it easy to satisfy this interface with a mock during unit tests, however, since everything in `GitCommand` is tied to the concrete type, `OSCommand`, I fell back to the approach used to inject `command`.

Maybe if I have the time, I'll consider a more comprehensive refactor, but for the time being, this doesn't feel too inconsistent with the prevailing style.