### PR TITLE
correctly compare new main height to previous

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -489,7 +489,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 	prevMainView, err := gui.g.View("main")
 	if err == nil {
 		_, prevMainHeight := prevMainView.Size()
-		heightDiff := mainPanelBottom - prevMainHeight
+		heightDiff := mainPanelBottom - prevMainHeight - 1
 		if heightDiff > 0 {
 			if manager, ok := gui.viewBufferManagerMap["main"]; ok {
 				manager.ReadLines(heightDiff)


### PR DESCRIPTION
when determining whether we need to feed more of a command's output into the main view, we compare its current height to its previous height. We were incorrectly believing there to always be a height difference of 1, meaning that when we re-rendered anything in the screen and triggered the comparison, we would end up feeding through a heap more from the command output, and end up with a high CPU