### PR TITLE
ignore carriage returns

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -508,6 +508,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		v.Title = gui.Tr.SLocalize("DiffTitle")
 		v.Wrap = true
 		v.FgColor = textColor
+		v.IgnoreCarriageReturns = true
 	}
 
 	hiddenViewOffset := 0
@@ -522,6 +523,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		secondaryView.Title = gui.Tr.SLocalize("DiffTitle")
 		secondaryView.Wrap = true
 		secondaryView.FgColor = gocui.ColorWhite
+		secondaryView.IgnoreCarriageReturns = true
 	}
 
 	if v, err := g.SetView("status", 0, 0, leftSideWidth, vHeights["status"]-1, gocui.BOTTOM|gocui.RIGHT); err != nil {


### PR DESCRIPTION
when we were coming across a carriage return in the output of a git diff, we were clearing the line rather than repositioning the cursor to the beginning of the line. We actually can't get the expected functionality without a bit of a rewrite of how the views are drawn (which I'm working on in another top secret repo) so instead I'm just going to ignore carriage returns: a feature already available in the gocui library.