### PR TITLE
get whole commit SHA from rebase commits

### DIFF
--- a/pkg/commands/commit_list_builder.go
+++ b/pkg/commands/commit_list_builder.go
@@ -190,7 +190,7 @@ func (c *CommitListBuilder) getInteractiveRebasingCommits() ([]*Commit, error) {
 		}
 		splitLine := strings.Split(line, " ")
 		commits = append([]*Commit{{
-			Sha:    splitLine[1][0:7],
+			Sha:    splitLine[1],
 			Name:   strings.Join(splitLine[2:], " "),
 			Status: "rebasing",
 			Action: splitLine[0],
@@ -207,7 +207,7 @@ func (c *CommitListBuilder) getInteractiveRebasingCommits() ([]*Commit, error) {
 // Subject: second commit on master
 func (c *CommitListBuilder) commitFromPatch(content string) (*Commit, error) {
 	lines := strings.Split(content, "\n")
-	sha := strings.Split(lines[0], " ")[1][0:7]
+	sha := strings.Split(lines[0], " ")[1]
 	name := strings.TrimPrefix(lines[3], "Subject: ")
 	return &Commit{
 		Sha:    sha,


### PR DESCRIPTION
this was causing an out of bounds exception when doing an interactive rebase.