### PR TITLE
allow fastforwarding the current branch

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -408,6 +408,11 @@ func (c *GitCommand) Pull(args string, ask func(string) string) error {
 	return c.OSCommand.DetectUnamePass("git pull --no-edit "+args, ask)
 }
 
+// PullWithoutPasswordCheck assumes that the pull will not prompt the user for a password
+func (c *GitCommand) PullWithoutPasswordCheck(args string) error {
+	return c.OSCommand.RunCommand("git pull --no-edit " + args)
+}
+
 // Push pushes to a branch
 func (c *GitCommand) Push(branchName string, force bool, upstream string, args string, ask func(string) string) error {
 	forceFlag := ""

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -372,12 +372,19 @@ func (gui *Gui) handleFastForward(g *gocui.Gui, v *gocui.View) error {
 	go func() {
 		_ = gui.createLoaderPanel(gui.g, v, message)
 
-		if err := gui.GitCommand.FastForward(branch.Name, remoteName, remoteBranchName); err != nil {
-			_ = gui.createErrorPanel(gui.g, err.Error())
+		if gui.State.Panels.Branches.SelectedLine == 0 {
+			if err := gui.GitCommand.PullWithoutPasswordCheck("--ff-only"); err != nil {
+				_ = gui.createErrorPanel(gui.g, err.Error())
+			}
+			_ = gui.refreshSidePanels(gui.g)
 		} else {
-			_ = gui.closeConfirmationPrompt(gui.g, true)
+			if err := gui.GitCommand.FastForward(branch.Name, remoteName, remoteBranchName); err != nil {
+				_ = gui.createErrorPanel(gui.g, err.Error())
+			}
 			_ = gui.RenderSelectedBranchUpstreamDifferences()
 		}
+
+		_ = gui.closeConfirmationPrompt(gui.g, true)
 	}()
 	return nil
 }


### PR DESCRIPTION
fixes https://github.com/jesseduffield/lazygit/issues/647

To support fast-forwarding the current branch, it turns out it's best to just do a `git pull --ff-only` because if you try and do a regular fetch you'll get the opposite of what the new commits contain in your working tree which is probably not what you want.

I haven't included support for password checks in this case because it would make it more complicated and I have a grand plan for how to solve that problem properly in the future