### PR TITLE
tasks: don't use a function that requires Go 1.12

### DIFF
--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -59,7 +59,7 @@ func (m *ViewBufferManager) NewCmdTask(cmd *exec.Cmd, linesToRead int) func(chan
 
 		go func() {
 			<-stop
-			if cmd.ProcessState.ExitCode() == -1 {
+			if cmd.ProcessState == nil {
 				if err := kill(cmd); err != nil {
 					m.Log.Warn(err)
 				}


### PR DESCRIPTION
The `ExitCode()` function was introduced in Go 1.12.

Here is how it looks:

```go
// ExitCode returns the exit code of the exited process, or -1
// if the process hasn't exited or was terminated by a signal.
func (p *ProcessState) ExitCode() int {
	// return -1 if the process hasn't started.
	if p == nil {
		return -1
	}
	return p.status.ExitStatus()
}
```

With this commit it should be possible to build `lazygit` with older Go.