### PR TITLE
switch custom command keybinding to ':'

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -67,7 +67,7 @@ Default path for the config file:
       scrollDownMain-alt1: 'J' # main panel scrool down
       scrollUpMain-alt2: '<c-u>' # main panel scrool up
       scrollDownMain-alt2: '<c-d>' # main panel scrool down
-      executeCustomCommand: 'X'
+      executeCustomCommand: ':'
       createRebaseOptionsMenu: 'm'
       pushFiles: 'P'
       pullFiles: 'p'

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -297,7 +297,7 @@ keybinding:
     scrollDownMain-alt1: 'J'
     scrollUpMain-alt2: '<c-u>'
     scrollDownMain-alt2: '<c-d>'
-    executeCustomCommand: 'X'
+    executeCustomCommand: ':'
     createRebaseOptionsMenu: 'm'
     pushFiles: 'P'
     pullFiles: 'p'

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -451,7 +451,7 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Description: gui.Tr.SLocalize("fetch"),
 		},
 		{
-			ViewName:    "files",
+			ViewName:    "",
 			Key:         gui.getKey("universal.executeCustomCommand"),
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleCustomCommand,


### PR DESCRIPTION
currently it's 'shift+X' and only supported in the files panel. Using ':' globally makes more sense (and if we want to change it to be a more general thing for issuing commands of any kind inside lazygit we can do that later).

For those who were used to using shift+X, I apologise, but I'm too lazy to maintain support for the old keybinding