### PR TITLE
keybinding doc for nextMatch/prevMatch in Config.md (#659)

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -53,6 +53,8 @@ Default path for the config file:
       nextBlock: '<right>' # goto the next block / panel
       prevBlock-alt: 'h' # goto the previous block / panel
       nextBlock-alt: 'l' # goto the next block / panel
+      nextMatch: 'n'
+      prevMatch: 'N'
       optionMenu: 'x' # show help menu
       optionMenu-alt1: '?' # show help menu
       select: '<space>'
@@ -217,6 +219,8 @@ For all possible keybinding options, check [Custom_Keybinding.md](https://github
       nextItem-alt: 'e'
       prevBlock-alt: 'n'
       nextBlock-alt: 'i'
+      nextMatch: '='
+      prevMatch: '-'
       new: 'k'
       edit: 'o'
       openFile: 'O'


### PR DESCRIPTION
Hey @jesseduffield , thank you so much for bringing the search feature to lazygit! This feature is very helpful. I realized that the documentation for keybinding wasn't there in `Config.md`, so I added that, along with updates to example keyboard config for Colemak users.

P.S. It would be extra nice to have the ability to set `smartcase` or `ignorecase`.