### PR TITLE
color active frames green by default

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -18,7 +18,7 @@ Default path for the config file:
         - white
         - bold
       inactiveBorderColor:
-        - white
+        - green
       optionsTextColor:
         - blue
       selectedLineBgColor:

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -247,7 +247,7 @@ func GetDefaultConfig() []byte {
   theme:
     lightTheme: false
     activeBorderColor:
-      - white
+      - green
       - bold
     inactiveBorderColor:
       - white


### PR DESCRIPTION
I keep seeing screenshots where the only difference between active and inactive panels is the bold attribute and I don't know how anybody can tell the difference so I'm defaulting active panel frames to green which is what I use. I also use black for the inactive frames but my terminal renders that as a dark grey which is not the case for the typical terminal.

Hopefully nobody minds!