### PR TITLE
Feature: configurable pull request services/URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,61 +158,7 @@ Then `source ~/.zshrc` and from now on when you call `lg` and exit you'll switch
 
 ## Configuration
 
-All Lazygit configurations are stored on `<userConfigDir>/jesseduffield/lazygit/config.yml`, where
-`userConfigDir` is your OS-dependent user configurations folder, namely:
-
-- Windows: `%APPDATA%` (`C:\Users\<User>\AppData\Roaming`)
-- Linux/BSDs: `${XDG_CONFIG_HOME}` (`${HOME}/.config`)
-- MacOSX: `${HOME}/Library/Application Support`
-
-This file is auto-generated on first run.
-
-You can also get the default values with `lazygit -c`, which returns something like:
-
-```
-gui:
-  ## stuff relating to the UI
-  scrollHeight: 2
-  scrollPastBottom: true
-  mouseEvents: false # will default to true when the feature is complete
-  theme:
-    activeBorderColor:
-      - white
-      - bold
-    inactiveBorderColor:
-      - white
-    optionsTextColor:
-      - blue
-  commitLength:
-    show: true
-git:
-  merging:
-    manualCommit: false
-  skipHookPrefix: 'WIP'
-  autoFetch: true
-update:
-  method: prompt # can be: prompt | background | never
-  days: 14 # how often a update is checked for
-reporting: 'undetermined' # one of: 'on' | 'off' | 'undetermined'
-confirmOnQuit: false
-```
-
-### Custom pull request URLs
-
-Some git provider setups (e.g. on-premises GitLab) can have distinct URLs for git-related calls and
-the web interface/API itself. To work with those, Lazygit needs to know where it needs to create
-the pull request. You can do so on your `config.yml` file using the following syntax:
-
-```yaml
-services:
-  "<gitDomain>": "<provider>:<webDomain>"
-```
-
-Where:
-
-- `gitDomain` stands for the domain used by git itself (i.e. the one present on clone URLs), e.g. `git.work.com`
-- `provider` is one of `github`, `bitbucket` or `gitlab`
-- `webDomain` is the URL where your git service exposes a web interface and APIs, e.g. `gitservice.work.com`
+Check the [configuration docs](docs/Config.md).
 
 ## Cool features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple terminal UI for git commands, written in Go with the [gocui](https://github.com/jroimartin/gocui 'gocui') library.
 
-Rant time: You've heard it before, git is _powerful_, but what good is that power when everything is so damn hard to do? Interactive rebasing requires you to edit a goddamn TODO file in your editor? *Are you kidding me?* To stage part of a file you need to use a command line program stepping through each hunk and if a hunk can't be split down any further but contains code you don't want to stage, bad luck? *Are you KIDDING me?!* Sometimes you get asked to stash your changes when switching branches only to realise that after you switch and unstash that there weren't even any conflicts and it would have been fine to just checkout the branch directly? *YOU HAVE GOT TO BE KIDDING ME!* 
+Rant time: You've heard it before, git is _powerful_, but what good is that power when everything is so damn hard to do? Interactive rebasing requires you to edit a goddamn TODO file in your editor? *Are you kidding me?* To stage part of a file you need to use a command line program stepping through each hunk and if a hunk can't be split down any further but contains code you don't want to stage, bad luck? *Are you KIDDING me?!* Sometimes you get asked to stash your changes when switching branches only to realise that after you switch and unstash that there weren't even any conflicts and it would have been fine to just checkout the branch directly? *YOU HAVE GOT TO BE KIDDING ME!*
 
 If you're a mere mortal like me and you're tired of hearing how powerful git is when in your daily life it's a powerful pain in your ass, lazygit might be for you.
 
@@ -24,9 +24,11 @@ Github Sponsors is matching all donations dollar-for-dollar for 12 months so if 
 ## Installation
 
 ### Homebrew
+
 Normally the lazygit formula can be found in the Homebrew core but we suggest you tap our formula to get the frequently updated one. It works with Linux, too.
 
 Tap:
+
 ```
 brew install jesseduffield/lazygit/lazygit
 ```
@@ -38,8 +40,10 @@ brew install lazygit
 ```
 
 ### MacPorts
+
 Latest version built from github releases.
 Tap:
+
 ```
 sudo port install lazygit
 ```
@@ -82,11 +86,11 @@ Packages for Arch Linux are available via AUR (Arch User Repository).
 There are two packages. The stable one which is built with the latest release
 and the git version which builds from the most recent commit.
 
-- Stable: https://aur.archlinux.org/packages/lazygit/
-- Development: https://aur.archlinux.org/packages/lazygit-git/
+- Stable: <https://aur.archlinux.org/packages/lazygit/>
+- Development: <https://aur.archlinux.org/packages/lazygit-git/>
 
 Instruction of how to install AUR content can be found here:
-https://wiki.archlinux.org/index.php/Arch_User_Repository
+<https://wiki.archlinux.org/index.php/Arch_User_Repository>
 
 ### Fedora and CentOS 7
 
@@ -99,7 +103,7 @@ sudo dnf install lazygit
 
 ### Conda
 
-Released versions are available for different platforms, see https://anaconda.org/conda-forge/lazygit
+Released versions are available for different platforms, see <https://anaconda.org/conda-forge/lazygit>
 
 ```sh
 conda install -c conda-forge lazygit
@@ -131,10 +135,11 @@ whichever rc file you're using).
 - Rebase Magic tutorial [here](https://youtu.be/4XaToVut_hs)
 - List of keybindings
   [here](/docs/keybindings).
-  
+
 ## Changing Directory On Exit
 
 If you change repos in lazygit and want your shell to change directory into that repo on exiting lazygit, add this to your `~/.zshrc` (or other rc file):
+
 ```
 lg()
 {
@@ -148,7 +153,66 @@ lg()
     fi
 }
 ```
+
 Then `source ~/.zshrc` and from now on when you call `lg` and exit you'll switch directories to whatever you were in inside lazyigt. To override this behaviour you can exit using `shift+Q` rather than just `q`.
+
+## Configuration
+
+All Lazygit configurations are stored on `<userConfigDir>/jesseduffield/lazygit/config.yml`, where
+`userConfigDir` is your OS-dependent user configurations folder, namely:
+
+- Windows: `%APPDATA%` (`C:\Users\<User>\AppData\Roaming`)
+- Linux/BSDs: `${XDG_CONFIG_HOME}` (`${HOME}/.config`)
+- MacOSX: `${HOME}/Library/Application Support`
+
+This file is auto-generated on first run.
+
+You can also get the default values with `lazygit -c`, which returns something like:
+
+```
+gui:
+  ## stuff relating to the UI
+  scrollHeight: 2
+  scrollPastBottom: true
+  mouseEvents: false # will default to true when the feature is complete
+  theme:
+    activeBorderColor:
+      - white
+      - bold
+    inactiveBorderColor:
+      - white
+    optionsTextColor:
+      - blue
+  commitLength:
+    show: true
+git:
+  merging:
+    manualCommit: false
+  skipHookPrefix: 'WIP'
+  autoFetch: true
+update:
+  method: prompt # can be: prompt | background | never
+  days: 14 # how often a update is checked for
+reporting: 'undetermined' # one of: 'on' | 'off' | 'undetermined'
+confirmOnQuit: false
+```
+
+### Custom pull request URLs
+
+Some git provider setups (e.g. on-premises GitLab) can have distinct URLs for git-related calls and
+the web interface/API itself. To work with those, Lazygit needs to know where it needs to create
+the pull request. You can do so on your `config.yml` file using the following syntax:
+
+```yaml
+services:
+  "<gitDomain>": "<provider>:<webDomain>"
+```
+
+Where:
+
+- `gitDomain` stands for the domain used by git itself (i.e. the one present on clone URLs), e.g. `git.work.com`
+- `provider` is one of `github`, `bitbucket` or `gitlab`
+- `webDomain` is the URL where your git service exposes a web interface and APIs, e.g. `gitservice.work.com`
 
 ## Cool features
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -1,11 +1,11 @@
-# User Config:
+# User Config
 
 Default path for the config file:
 
 * Linux: `~/.config/jesseduffield/lazygit/config.yml`
 * MacOS: `~/Library/Application Support/jesseduffield/lazygit/config.yml`
 
-## Default:
+## Default
 
 ```yaml
   gui:
@@ -136,30 +136,30 @@ Default path for the config file:
       undo: 'z'
 ```
 
-## Platform Defaults:
+## Platform Defaults
 
-### Windows:
+### Windows
 
 ```yaml
   os:
     openCommand: 'cmd /c "start "" {{filename}}"'
 ```
 
-### Linux:
+### Linux
 
 ```yaml
   os:
     openCommand: 'sh -c "xdg-open {{filename}} >/dev/null"'
 ```
 
-### OSX:
+### OSX
 
 ```yaml
   os:
     openCommand: 'open {{filename}}'
 ```
 
-### Recommended Config Values:
+### Recommended Config Values
 
 for users of VSCode
 
@@ -168,7 +168,7 @@ for users of VSCode
     openCommand: 'code -r {{filename}}'
 ```
 
-## Color Attributes:
+## Color Attributes
 
 For color attributes you can choose an array of attributes (with max one color attribute)
 The available attributes are:
@@ -186,7 +186,7 @@ The available attributes are:
 - reverse # useful for high-contrast
 - underline
 
-## Light terminal theme:
+## Light terminal theme
 
 If you have issues with a light terminal theme where you can't read / see the text add these settings
 
@@ -203,15 +203,16 @@ If you have issues with a light terminal theme where you can't read / see the te
         - blue
 ```
 
-## Example Coloring:
+## Example Coloring
 
 ![border example](/docs/resources/colored-border-example.png)
 
-## Keybindings:
+## Keybindings
+
 For all possible keybinding options, check [Custom_Keybinding.md](https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Custom_Keybinding.md)
 
+### Example Keybindings For Colemak Users
 
-#### Example Keybindings For Colemak Users:
 ```yaml
   keybinding:
     universal:
@@ -238,3 +239,19 @@ For all possible keybinding options, check [Custom_Keybinding.md](https://github
       viewGitFlowOptions: 'I'
 ```
 
+## Custom pull request URLs
+
+Some git provider setups (e.g. on-premises GitLab) can have distinct URLs for git-related calls and
+the web interface/API itself. To work with those, Lazygit needs to know where it needs to create
+the pull request. You can do so on your `config.yml` file using the following syntax:
+
+```yaml
+services:
+  "<gitDomain>": "<provider>:<webDomain>"
+```
+
+Where:
+
+- `gitDomain` stands for the domain used by git itself (i.e. the one present on clone URLs), e.g. `git.work.com`
+- `provider` is one of `github`, `bitbucket` or `gitlab`
+- `webDomain` is the URL where your git service exposes a web interface and APIs, e.g. `gitservice.work.com`

--- a/pkg/commands/pull_request.go
+++ b/pkg/commands/pull_request.go
@@ -33,7 +33,7 @@ func NewService(typeName string, repositoryDomain string, siteDomain string) *Se
 	case "github":
 		return &Service{
 			Name:           repositoryDomain,
-			PullRequestURL: fmt.Sprintf("https://%s%s", siteDomain, "/%s/%s/compare/%%s?expand=1"),
+			PullRequestURL: fmt.Sprintf("https://%s%s", siteDomain, "/%s/%s/compare/%s?expand=1"),
 		}
 	case "bitbucket":
 		return &Service{

--- a/pkg/commands/pull_request.go
+++ b/pkg/commands/pull_request.go
@@ -111,7 +111,7 @@ func getRepoInfoFromURL(url string) *RepoInformation {
 
 	if isHTTP {
 		splits := strings.Split(url, "/")
-		owner := splits[len(splits)-2]
+		owner := strings.Join(splits[3:len(splits)-1], "/")
 		repo := strings.TrimSuffix(splits[len(splits)-1], ".git")
 
 		return &RepoInformation{
@@ -122,8 +122,8 @@ func getRepoInfoFromURL(url string) *RepoInformation {
 
 	tmpSplit := strings.Split(url, ":")
 	splits := strings.Split(tmpSplit[1], "/")
-	owner := splits[0]
-	repo := strings.TrimSuffix(splits[1], ".git")
+	owner := strings.Join(splits[0:len(splits)-1], "/")
+	repo := strings.TrimSuffix(splits[len(splits)-1], ".git")
 
 	return &RepoInformation{
 		Owner:      owner,

--- a/pkg/commands/pull_request_test.go
+++ b/pkg/commands/pull_request_test.go
@@ -147,6 +147,13 @@ func TestCreatePullRequest(t *testing.T) {
 			gitCommand := NewDummyGitCommand()
 			gitCommand.OSCommand.command = s.command
 			gitCommand.OSCommand.Config.GetUserConfig().Set("os.openLinkCommand", "open {{link}}")
+			gitCommand.Config.GetUserConfig().Set("services", map[string]string{
+				// valid configuration for a custom service URL
+				"git.work.com": "gitlab:code.work.com",
+				// invalid configurations for a custom service URL
+				"invalid.work.com":   "noservice:invalid.work.com",
+				"noservice.work.com": "noservice.work.com",
+			})
 			dummyPullRequest := NewPullRequest(gitCommand)
 			s.test(dummyPullRequest.Create(s.branch))
 		})


### PR DESCRIPTION
Configuration that makes possible to setup custom URLs for service providers, for cases where the git URL and the web UI/API URLs are distinct. The configuration has two parts:

- known providers and their PR/MR URL pattern
  - hard-coded on the `NewService` function
- default providers
  - github.com
  - bitbucket.org
  - gitlab.com
- user-defined services URLs on `config.yml`

The config.yml services should be set like this:
```yaml
services:
  "<gitDomain>": "<provider>:<webDomain>"
```

Where:

- `gitDomain` stands for the domain used by git itself (i.e. the one present on clone URLs), e.g. `git.work.com`
- `provider` is one of `github`, `bitbucket` or `gitlab`
- `webDomain` is the URL where your git service exposes a web interface and APIs, e.g. `gitservice.work.com`

This info is also added on the `README.md`.

Closes #322.