### PR TITLE
fix #680: unpushed commits still appear to be green instead of red

### DIFF
--- a/pkg/commands/commit_list_builder.go
+++ b/pkg/commands/commit_list_builder.go
@@ -105,7 +105,7 @@ func (c *CommitListBuilder) GetCommits(limit bool) ([]*Commit, error) {
 	// now we can split it up and turn it into commits
 	for _, line := range utils.SplitLines(log) {
 		commit := c.extractCommitFromLine(line)
-		_, unpushed := unpushedCommits[commit.Sha[:7]]
+		_, unpushed := unpushedCommits[commit.Sha[:8]]
 		commit.Status = map[bool]string{true: "unpushed", false: "pushed"}[unpushed]
 		commits = append(commits, commit)
 	}
@@ -298,7 +298,7 @@ func (c *CommitListBuilder) getMergeBase() (string, error) {
 // to the remote branch of the current branch, a map is returned to ease look up
 func (c *CommitListBuilder) getUnpushedCommits() map[string]bool {
 	pushables := map[string]bool{}
-	o, err := c.OSCommand.RunCommandWithOutput("git rev-list @{u}..HEAD --abbrev-commit")
+	o, err := c.OSCommand.RunCommandWithOutput("git rev-list @{u}..HEAD --abbrev-commit --abbrev=8")
 	if err != nil {
 		return pushables
 	}

--- a/pkg/commands/commit_list_builder.go
+++ b/pkg/commands/commit_list_builder.go
@@ -105,7 +105,7 @@ func (c *CommitListBuilder) GetCommits(limit bool) ([]*Commit, error) {
 	// now we can split it up and turn it into commits
 	for _, line := range utils.SplitLines(log) {
 		commit := c.extractCommitFromLine(line)
-		_, unpushed := unpushedCommits[commit.Sha[:8]]
+		_, unpushed := unpushedCommits[commit.Sha[:7]]
 		commit.Status = map[bool]string{true: "unpushed", false: "pushed"}[unpushed]
 		commits = append(commits, commit)
 	}


### PR DESCRIPTION
This PR fixes the issue that unpushed (local) changes still appear to be green instead of red. The reason is that: the `git rev-list @{u}..HEAD --abbrev-commit` command returns hash strings that are 7 characters instead of 8. Therefore, the map `unpushedCommits` would never contain a hash string that is 8 characters long, so all commits still appeared to be green.

Edit: for my local machine (Arch Linux), the `--abbrev-commit` flag returns 7 digits. My git version is `2.25.0`. I have made `getUnpushedCommits()` to return 8 digits hash strings by setting `--abbrev=8`.
