### PR TITLE
Add scoop install option to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ They follow upstream latest releases
 ```sh
 sudo xbps-install -S lazygit
 ```
+### Scoop (Windows)
+
+You can install `lazygit` using [scoop](https://scoop.sh/). It's in the `extras` bucket:
+
+```sh
+# Add the extras bucket
+scoop bucket add extras
+
+# Install lazygit
+scoop install lazygit
+```
 
 ### Arch Linux
 


### PR DESCRIPTION
Updates the README with the install option [scoop](https://scoop.sh/) on Windows.

It's listed in the [extras](https://github.com/lukesampson/scoop-extras/blob/master/bucket/lazygit.json) bucket.