### PR TITLE
Better staging keybindings

### DIFF
--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1137,16 +1137,8 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Contexts:    []string{"patch-building"},
 			Key:         gui.getKey("universal.select"),
 			Modifier:    gocui.ModNone,
-			Handler:     gui.handleAddSelectionToPatch,
-			Description: gui.Tr.SLocalize("StageSelection"),
-		},
-		{
-			ViewName:    "main",
-			Contexts:    []string{"patch-building"},
-			Key:         gui.getKey("universal.remove"),
-			Modifier:    gocui.ModNone,
-			Handler:     gui.handleRemoveSelectionFromPatch,
-			Description: gui.Tr.SLocalize("ResetSelection"),
+			Handler:     gui.handleToggleSelectionForPatch,
+			Description: gui.Tr.SLocalize("ToggleSelectionForPatch"),
 		},
 		{
 			ViewName:    "main",

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1015,7 +1015,7 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Contexts:    []string{"staging"},
 			Key:         gui.getKey("universal.select"),
 			Modifier:    gocui.ModNone,
-			Handler:     gui.handleStageSelection,
+			Handler:     gui.handleToggleStagedSelection,
 			Description: gui.Tr.SLocalize("StageSelection"),
 		},
 		{

--- a/pkg/gui/line_by_line_panel.go
+++ b/pkg/gui/line_by_line_panel.go
@@ -220,6 +220,10 @@ func (gui *Gui) handleMouseScrollDown(g *gocui.Gui, v *gocui.View) error {
 	return gui.handleCycleLine(1)
 }
 
+func (gui *Gui) getSelectedCommitFileName() string {
+	return gui.State.CommitFiles[gui.State.Panels.CommitFiles.SelectedLine].Name
+}
+
 func (gui *Gui) refreshMainView() error {
 	state := gui.State.Panels.LineByLine
 
@@ -227,7 +231,7 @@ func (gui *Gui) refreshMainView() error {
 	// I'd prefer not to have knowledge of contexts using this file but I'm not sure
 	// how to get around this
 	if gui.State.MainContext == "patch-building" {
-		filename := gui.State.CommitFiles[gui.State.Panels.CommitFiles.SelectedLine].Name
+		filename := gui.getSelectedCommitFileName()
 		includedLineIndices = gui.GitCommand.PatchManager.GetFileIncLineIndices(filename)
 	}
 	colorDiff := state.PatchParser.Render(state.FirstLineIdx, state.LastLineIdx, includedLineIndices)

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -501,10 +501,10 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			Other: `select hunk`,
 		}, &i18n.Message{
 			ID:    "StageSelection",
-			Other: `stage selection`,
+			Other: `toggle line staged / unstaged`,
 		}, &i18n.Message{
 			ID:    "ResetSelection",
-			Other: `reset selection`,
+			Other: `delete change (git reset)`,
 		}, &i18n.Message{
 			ID:    "ToggleDragSelect",
 			Other: `toggle drag select`,

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -511,6 +511,9 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "ToggleSelectHunk",
 			Other: `toggle select hunk`,
+		}, &i18n.Message{
+			ID:    "ToggleSelectionForPatch",
+			Other: `add/remove line(s) to patch`,
 		},
 		&i18n.Message{
 			ID:    "TogglePanel",


### PR DESCRIPTION
Now, the space key will toggle staged/unstaged depending on whether you've selected staged changes or not. The 'd' key will continue to work as before but I think I'll remove it down the line. One thing I'll need to get around to is having second-tier context-specific keybindings, for the sake of different descriptions. In this case the context for the main panel is 'staging' but depending on whether we're dealing with staged lines or not, the 'd' keybinding doesn't apply. We need a way to have knowledge about stuff like that when generating keybindings, which I predict will be challenging.