### PR TITLE
Add homebrew bump formula workflow

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,20 @@
+name: Bump Homebrew formula
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get tag
+        id: tag
+        run: echo "::set-output name=tag::${GITHUB_REF##*/}"
+      - name: Bump Homebrew formula
+        uses: dawidd6/action-homebrew-bump-formula@v1.1.0
+        with:
+          token: ${{secrets.GITHUB_API_TOKEN}}
+          formula: lazygit
+          url: "https://github.com/${{github.repository}}/archive/${{steps.tag.outputs.tag}}.tar.gz"


### PR DESCRIPTION
This PR introduces a new Github Actions workflow that runs on new tag creation event and bumps the `lazygit` formula one can find in `homebrew-core` tap.

@jesseduffield if you are interested in this, there would be a need to add a Personal Access Token with `public_repo` scope to the `Secrets` in settings of the repository. The secret should be named `GITHUB_API_TOKEN`.

It's a new Action, that I wrote recently: https://github.com/dawidd6/action-homebrew-bump-formula.