### PR TITLE
better upstream tracking and allow renaming a branch

### DIFF
--- a/pkg/commands/branch.go
+++ b/pkg/commands/branch.go
@@ -3,8 +3,9 @@ package commands
 // Branch : A git branch
 // duplicating this for now
 type Branch struct {
-	Name      string
-	Recency   string
-	Pushables string
-	Pullables string
+	Name         string
+	Recency      string
+	Pushables    string
+	Pullables    string
+	UpstreamName string
 }

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -343,7 +343,7 @@ func (c *GitCommand) CurrentBranchName() (string, error) {
 		match := re.FindStringSubmatch(output)
 		branchName = match[1]
 	}
-	return utils.TrimTrailingNewline(branchName), nil
+	return strings.TrimSpace(branchName), nil
 }
 
 // DeleteBranch delete branch
@@ -1162,4 +1162,8 @@ func (c *GitCommand) GetPager(width int) string {
 
 func (c *GitCommand) colorArg() string {
 	return c.Config.GetUserConfig().GetString("git.paging.colorArg")
+}
+
+func (c *GitCommand) RenameBranch(oldName string, newName string) error {
+	return c.OSCommand.RunCommand("git branch --move %s %s", oldName, newName)
 }

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -334,6 +334,7 @@ keybinding:
     checkoutBranchByName: 'c'
     forceCheckoutBranch: 'F'
     rebaseBranch: 'r'
+    renameBranch: 'R'
     mergeIntoCurrentBranch: 'M'
     viewGitFlowOptions: 'i'
     fastForward: 'f'

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -24,7 +24,6 @@ import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands"
 	"github.com/jesseduffield/lazygit/pkg/config"
-	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/i18n"
 	"github.com/jesseduffield/lazygit/pkg/tasks"
 	"github.com/jesseduffield/lazygit/pkg/theme"
@@ -278,6 +277,10 @@ func (gui *Gui) nextScreenMode(g *gocui.Gui, v *gocui.View) error {
 	if err := gui.refreshCommitsViewWithSelection(); err != nil {
 		return err
 	}
+	// same with branches
+	if err := gui.refreshBranchesViewWithSelection(); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -286,6 +289,10 @@ func (gui *Gui) prevScreenMode(g *gocui.Gui, v *gocui.View) error {
 	gui.State.ScreenMode = utils.PrevIntInCycle([]int{SCREEN_NORMAL, SCREEN_HALF, SCREEN_FULL}, gui.State.ScreenMode)
 	// commits render differently depending on whether we're in fullscreen more or not
 	if err := gui.refreshCommitsViewWithSelection(); err != nil {
+		return err
+	}
+	// same with branches
+	if err := gui.refreshBranchesViewWithSelection(); err != nil {
 		return err
 	}
 
@@ -386,12 +393,6 @@ func (gui *Gui) onFocusLost(v *gocui.View, newView *gocui.View) error {
 		}
 	}
 	switch v.Name() {
-	case "branches":
-		if v.Context == "local-branches" {
-			// This stops the branches panel from showing the upstream/downstream changes to the selected branch, when it loses focus
-			displayStrings := presentation.GetBranchListDisplayStrings(gui.State.Branches, false, -1)
-			gui.renderDisplayStrings(gui.getBranchesView(), displayStrings)
-		}
 	case "main":
 		// if we have lost focus to a first-class panel, we need to do some cleanup
 		gui.changeMainViewsContext("normal")

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -577,6 +577,14 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		},
 		{
 			ViewName:    "branches",
+			Contexts:    []string{"local-branches"},
+			Key:         gui.getKey("branches.renameBranch"),
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleRenameBranch,
+			Description: gui.Tr.SLocalize("viewResetOptions"),
+		},
+		{
+			ViewName:    "branches",
 			Contexts:    []string{"tags"},
 			Key:         gui.getKey("universal.select"),
 			Modifier:    gocui.ModNone,

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -10,25 +10,38 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
-func GetBranchListDisplayStrings(branches []*commands.Branch, isFocused bool, selectedLine int) [][]string {
+func GetBranchListDisplayStrings(branches []*commands.Branch, fullDescription bool) [][]string {
 	lines := make([][]string, len(branches))
 
 	for i := range branches {
-		showUpstreamDifferences := isFocused && i == selectedLine
-		lines[i] = getBranchDisplayStrings(branches[i], showUpstreamDifferences)
+		lines[i] = getBranchDisplayStrings(branches[i], fullDescription)
 	}
 
 	return lines
 }
 
 // getBranchDisplayStrings returns the display string of branch
-func getBranchDisplayStrings(b *commands.Branch, showUpstreamDifferences bool) []string {
+func getBranchDisplayStrings(b *commands.Branch, fullDescription bool) []string {
 	displayName := utils.ColoredString(b.Name, GetBranchColor(b.Name))
-	if showUpstreamDifferences && b.Pushables != "" && b.Pullables != "" {
-		displayName = fmt.Sprintf("%s ↑%s↓%s", displayName, b.Pushables, b.Pullables)
+	if b.Pushables != "" && b.Pullables != "" && b.Pushables != "?" && b.Pullables != "?" {
+		trackColor := color.FgYellow
+		if b.Pushables == "0" && b.Pullables == "0" {
+			trackColor = color.FgGreen
+		}
+		track := utils.ColoredString(fmt.Sprintf("↑%s↓%s", b.Pushables, b.Pullables), trackColor)
+		displayName = fmt.Sprintf("%s %s", displayName, track)
 	}
 
-	return []string{b.Recency, displayName}
+	recencyColor := color.FgCyan
+	if b.Recency == "  *" {
+		recencyColor = color.FgGreen
+	}
+
+	if fullDescription {
+		return []string{utils.ColoredString(b.Recency, recencyColor), displayName, utils.ColoredString(b.UpstreamName, color.FgYellow)}
+	}
+
+	return []string{utils.ColoredString(b.Recency, recencyColor), displayName}
 }
 
 // GetBranchColor branch color

--- a/pkg/gui/reset_menu_panel.go
+++ b/pkg/gui/reset_menu_panel.go
@@ -36,6 +36,9 @@ func (gui *Gui) createResetMenu(ref string) error {
 				if err := gui.refreshFiles(); err != nil {
 					return err
 				}
+				if err := gui.refreshBranches(gui.g); err != nil {
+					return err
+				}
 				if err := gui.resetOrigin(gui.getCommitsView()); err != nil {
 					return err
 				}

--- a/pkg/gui/status_panel.go
+++ b/pkg/gui/status_panel.go
@@ -22,11 +22,20 @@ func (gui *Gui) refreshStatus(g *gocui.Gui) error {
 	// contents end up cleared
 	g.Update(func(*gocui.Gui) error {
 		v.Clear()
+		// TODO: base this off of the current branch
 		state.pushables, state.pullables = gui.GitCommand.GetCurrentBranchUpstreamDifferenceCount()
 		if err := gui.updateWorkTreeState(); err != nil {
 			return err
 		}
-		status := fmt.Sprintf("↑%s↓%s", state.pushables, state.pullables)
+
+		trackColor := color.FgYellow
+		if state.pushables == "0" && state.pullables == "0" {
+			trackColor = color.FgGreen
+		} else if state.pushables == "?" && state.pullables == "?" {
+			trackColor = color.FgRed
+		}
+
+		status := utils.ColoredString(fmt.Sprintf("↑%s↓%s", state.pushables, state.pullables), trackColor)
 		branches := gui.State.Branches
 
 		if gui.State.WorkingTreeState != "normal" {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1017,6 +1017,15 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "Keybindings",
 			Other: "Keybindings",
+		}, &i18n.Message{
+			ID:    "renameBranch",
+			Other: "rename branch",
+		}, &i18n.Message{
+			ID:    "NewBranchNamePrompt",
+			Other: "Enter new branch name for branch",
+		}, &i18n.Message{
+			ID:    "RenameBranchWarning",
+			Other: "This branch is tracking a remote. This action will only rename the local branch name, not the name of the remote branch. Continue?",
 		},
 	)
 }


### PR DESCRIPTION
I accidentally combined these two things into the one commit so I'm putting them in the one PR!

Two things this PR does:
1) Adds the ability to rename a branch with shift+R
2) shows upstream/downstream differences against each branch, and shows the branch's upstream when in half or fullscreen mode in the branches panel.

![image](https://user-images.githubusercontent.com/8456633/76857613-ec36d680-68a9-11ea-8101-f31365e22054.png)

![image](https://user-images.githubusercontent.com/8456633/76857628-f48f1180-68a9-11ea-84be-85c3f9198561.png)
