### PR TITLE
workflows: git fetch --unshallow before goreleaser step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - name: Unshallow repo
+        run: git fetch --prune --unshallow
       - name: Setup Go
         uses: actions/setup-go@v1
         with:


### PR DESCRIPTION
Should fix the changelog issue.

Reference: https://github.com/goreleaser/goreleaser-action