### PR TITLE
more compatible commands

### DIFF
--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -1907,7 +1907,7 @@ func TestGitCommandGetCommitFiles(t *testing.T) {
 			"123456",
 			test.CreateMockCommand(t, []*test.CommandSwapper{
 				{
-					Expect:  "git show --pretty= --name-only --no-renames 123456",
+					Expect:  "git diff-tree --no-commit-id --name-only -r --no-renames 123456",
 					Replace: "echo 'hello\nworld'",
 				},
 			}),


### PR DESCRIPTION
I should probably look further into this but for now here's some fixes to problematic commands using git 2.0.5. I'm thinking that I might restrict versions to git v2+ but we'll see what we can do with plumbing commands.