### PR TITLE
better handling of current branch name

### DIFF
--- a/pkg/commands/branch.go
+++ b/pkg/commands/branch.go
@@ -3,7 +3,9 @@ package commands
 // Branch : A git branch
 // duplicating this for now
 type Branch struct {
-	Name         string
+	Name string
+	// the displayname is something like '(HEAD detached at 123asdf)', whereas in that case the name would be '123asdf'
+	DisplayName  string
 	Recency      string
 	Pushables    string
 	Pullables    string

--- a/pkg/commands/commit_list_builder.go
+++ b/pkg/commands/commit_list_builder.go
@@ -279,7 +279,7 @@ func (c *CommitListBuilder) setCommitCherryPickStatuses(commits []*Commit) ([]*C
 }
 
 func (c *CommitListBuilder) getMergeBase() (string, error) {
-	currentBranch, err := c.GitCommand.CurrentBranchName()
+	currentBranch, _, err := c.GitCommand.CurrentBranchName()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -331,19 +331,29 @@ func (c *GitCommand) NewBranch(name string, baseBranch string) error {
 	return c.OSCommand.RunCommand("git checkout -b %s %s", name, baseBranch)
 }
 
-// CurrentBranchName is a function.
-func (c *GitCommand) CurrentBranchName() (string, error) {
+// CurrentBranchName get the current branch name and displayname.
+// the first returned string is the name and the second is the displayname
+// e.g. name is 123asdf and displayname is '(HEAD detached at 123asdf)'
+func (c *GitCommand) CurrentBranchName() (string, string, error) {
 	branchName, err := c.OSCommand.RunCommandWithOutput("git symbolic-ref --short HEAD")
-	if err != nil || branchName == "HEAD\n" {
-		output, err := c.OSCommand.RunCommandWithOutput("git branch --contains")
-		if err != nil {
-			return "", err
-		}
-		re := regexp.MustCompile(CurrentBranchNameRegex)
-		match := re.FindStringSubmatch(output)
-		branchName = match[1]
+	if err == nil && branchName != "HEAD\n" {
+		trimmedBranchName := strings.TrimSpace(branchName)
+		return trimmedBranchName, trimmedBranchName, nil
 	}
-	return strings.TrimSpace(branchName), nil
+	output, err := c.OSCommand.RunCommandWithOutput("git branch --contains")
+	if err != nil {
+		return "", "", err
+	}
+	for _, line := range utils.SplitLines(output) {
+		re := regexp.MustCompile(CurrentBranchNameRegex)
+		match := re.FindStringSubmatch(line)
+		if len(match) > 0 {
+			branchName = match[1]
+			displayBranchName := match[0][2:]
+			return branchName, displayBranchName, nil
+		}
+	}
+	return "HEAD", "HEAD", nil
 }
 
 // DeleteBranch delete branch

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -22,14 +22,18 @@ func GetBranchListDisplayStrings(branches []*commands.Branch, fullDescription bo
 
 // getBranchDisplayStrings returns the display string of branch
 func getBranchDisplayStrings(b *commands.Branch, fullDescription bool) []string {
-	displayName := utils.ColoredString(b.Name, GetBranchColor(b.Name))
+	displayName := b.Name
+	if b.DisplayName != "" {
+		displayName = b.DisplayName
+	}
+	coloredName := utils.ColoredString(displayName, GetBranchColor(b.Name))
 	if b.Pushables != "" && b.Pullables != "" && b.Pushables != "?" && b.Pullables != "?" {
 		trackColor := color.FgYellow
 		if b.Pushables == "0" && b.Pullables == "0" {
 			trackColor = color.FgGreen
 		}
 		track := utils.ColoredString(fmt.Sprintf("↑%s↓%s", b.Pushables, b.Pullables), trackColor)
-		displayName = fmt.Sprintf("%s %s", displayName, track)
+		coloredName = fmt.Sprintf("%s %s", coloredName, track)
 	}
 
 	recencyColor := color.FgCyan
@@ -38,10 +42,10 @@ func getBranchDisplayStrings(b *commands.Branch, fullDescription bool) []string 
 	}
 
 	if fullDescription {
-		return []string{utils.ColoredString(b.Recency, recencyColor), displayName, utils.ColoredString(b.UpstreamName, color.FgYellow)}
+		return []string{utils.ColoredString(b.Recency, recencyColor), coloredName, utils.ColoredString(b.UpstreamName, color.FgYellow)}
 	}
 
-	return []string{utils.ColoredString(b.Recency, recencyColor), displayName}
+	return []string{utils.ColoredString(b.Recency, recencyColor), coloredName}
 }
 
 // GetBranchColor branch color


### PR DESCRIPTION
When we have a detached HEAD on a commit or we're mid-rebase, as far as git is concerned there _is_ no 'current branch'. But we still need to display something in the local branches panel for the current branch. So I've added a 'displayName' which could be something like '(HEAD detached at 12353f)' which sits alongside the name (which would be 12345f). This gives us a little more context about what state we're actually in.

![image](https://user-images.githubusercontent.com/8456633/77631866-49fda980-6fa1-11ea-9991-a5f99b1ad58f.png)
