### PR TITLE
fix: fixed gpg breaking terminal

### DIFF
--- a/pkg/commands/commit_list_builder.go
+++ b/pkg/commands/commit_list_builder.go
@@ -109,11 +109,12 @@ func (c *CommitListBuilder) GetCommits(options GetCommitsOptions) ([]*Commit, er
 	cmd := c.getLogCmd(options)
 
 	err = RunLineOutputCmd(cmd, func(line string) (bool, error) {
-		commit := c.extractCommitFromLine(line)
-		_, unpushed := unpushedCommits[commit.ShortSha()]
-		commit.Status = map[bool]string{true: "unpushed", false: "pushed"}[unpushed]
-		commits = append(commits, commit)
-
+		if strings.Split(line, " ")[0] != "gpg:" {
+			commit := c.extractCommitFromLine(line)
+			_, unpushed := unpushedCommits[commit.ShortSha()]
+			commit.Status = map[bool]string{true: "unpushed", false: "pushed"}[unpushed]
+			commits = append(commits, commit)
+		}
 		return false, nil
 	})
 	if err != nil {


### PR DESCRIPTION
reported in #756
Unsure if this fixes all the issues reported in this issue.

All it does is ignore the line if it starts with the gpg message

Signed-off-by: Glenn Vriesman <glenn.vriesman@gmail.com>