### PR TITLE
Add option to set predefined commit message prefix. Fixes #760.

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -267,3 +267,19 @@ Where:
 - `gitDomain` stands for the domain used by git itself (i.e. the one present on clone URLs), e.g. `git.work.com`
 - `provider` is one of `github`, `bitbucket` or `gitlab`
 - `webDomain` is the URL where your git service exposes a web interface and APIs, e.g. `gitservice.work.com`
+
+## Predefined commit message prefix
+In situations where certain naming pattern is used for branches and commits, pattern can be used to populate
+commit message with prefix that is parsed from the branch name.
+
+Example:
+* Branch name: feature/AB-123
+* Commit message: [AB-123] Adding feature
+
+```yaml
+  git:
+    commitPrefixes:
+      my_project: # This is repository folder name
+        pattern: "^\\w+\\/(\\w+-\\w+)"
+        replace: "[$1] "
+```

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -291,7 +291,10 @@ func (gui *Gui) handleCommitPress(g *gocui.Gui, filesView *gocui.View) error {
 	prefixPattern := gui.Config.GetUserConfig().GetString("git.commitPrefixes." + utils.GetCurrentRepoName() + ".pattern")
 	prefixReplace := gui.Config.GetUserConfig().GetString("git.commitPrefixes." + utils.GetCurrentRepoName() + ".replace")
 	if len(prefixPattern) > 0 && len(prefixReplace) > 0 {
-		rgx := regexp.MustCompile(prefixPattern)
+		rgx, err := regexp.Compile(prefixPattern)
+		if err != nil {
+			return gui.createErrorPanel(fmt.Sprintf("%s: %s", gui.Tr.SLocalize("commitPrefixPatternError"), err.Error()))
+		}
 		prefix := rgx.ReplaceAllString(gui.getCheckedOutBranch().Name, prefixReplace)
 		gui.renderString(g, "commitMessage", prefix)
 		if err := commitMessageView.SetCursor(len(prefix), 0); err != nil {

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -763,6 +763,9 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "IgnoreTrackedPrompt",
 			Other: "Are you sure you want to ignore a tracked file?",
+		}, &i18n.Message{
+			ID:    "commitPrefixPatternError",
+			Other: "Error in commitPrefix pattern",
 		},
 	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1137,6 +1137,9 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "copyBranchNameToClipboard",
 			Other: "copy branch name to clipboard",
+		}, &i18n.Message{
+			ID:    "commitPrefixPatternError",
+			Other: "Error in commitPrefix pattern",
 		},
 	)
 }

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -746,6 +746,9 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "IgnoreTrackedPrompt",
 			Other: "Are you sure you want to ignore a tracked file?",
+		}, &i18n.Message{
+			ID:    "commitPrefixPatternError",
+			Other: "Error in commitPrefix pattern",
 		},
 	)
 }


### PR DESCRIPTION
Here's my attempt to introduce predefined commit messages that I opened issue for. 
Only issue I have is that the cursor doesn't move to the end, but I noticed same thing also happens for WIP commit, so I assume it's some underline issue.