### PR TITLE
Add path to config file on Windows

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -4,6 +4,7 @@ Default path for the config file:
 
 * Linux: `~/.config/jesseduffield/lazygit/config.yml`
 * MacOS: `~/Library/Application Support/jesseduffield/lazygit/config.yml`
+* Windows: `%APPDATA%\jesseduffield\lazygit\config.yml`
 
 ## Default
 


### PR DESCRIPTION
Add the default config path on Windows to config documentation.