### PR TITLE
add catCmd and OS-specific values

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -479,7 +479,7 @@ func (c *GitCommand) Push(branchName string, force bool, upstream string, args s
 
 // CatFile obtains the content of a file
 func (c *GitCommand) CatFile(fileName string) (string, error) {
-	return c.OSCommand.RunCommandWithOutput("cat %s", c.OSCommand.Quote(fileName))
+	return c.OSCommand.RunCommandWithOutput("%s %s", c.OSCommand.Platform.catCmd, c.OSCommand.Quote(fileName))
 }
 
 // StageFile stages a file

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"testing"
 	"time"
 
@@ -1022,11 +1023,18 @@ func TestGitCommandPush(t *testing.T) {
 	}
 }
 
-// TestGitCommandCatFile is a function.
+// TestGitCommandCatFile tests emitting a file using commands, where commands vary by OS.
 func TestGitCommandCatFile(t *testing.T) {
+	var osCmd string
+	switch os := runtime.GOOS; os {
+	case "windows":
+		osCmd = "type"
+	default:
+		osCmd = "cat"
+	}
 	gitCmd := NewDummyGitCommand()
 	gitCmd.OSCommand.command = func(cmd string, args ...string) *exec.Cmd {
-		assert.EqualValues(t, "cat", cmd)
+		assert.EqualValues(t, osCmd, cmd)
 		assert.EqualValues(t, []string{"test.txt"}, args)
 
 		return exec.Command("echo", "-n", "test")

--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -23,6 +23,7 @@ import (
 // Platform stores the os state
 type Platform struct {
 	os                   string
+	catCmd               string
 	shell                string
 	shellArg             string
 	escapedQuote         string

--- a/pkg/commands/os_default_platform.go
+++ b/pkg/commands/os_default_platform.go
@@ -9,6 +9,7 @@ import (
 func getPlatform() *Platform {
 	return &Platform{
 		os:                   runtime.GOOS,
+		catCmd:               "cat",
 		shell:                "bash",
 		shellArg:             "-c",
 		escapedQuote:         "'",

--- a/pkg/commands/os_windows.go
+++ b/pkg/commands/os_windows.go
@@ -3,6 +3,7 @@ package commands
 func getPlatform() *Platform {
 	return &Platform{
 		os:                   "windows",
+		catCmd:               "type",
 		shell:                "cmd",
 		shellArg:             "/c",
 		escapedQuote:         `\"`,


### PR DESCRIPTION
Add a catCmd to the Platform struct and set the value to "cat" for
non-windows builds and "type" for windows builds.