### PR TITLE
Add option to split patch into a new commit

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -441,6 +441,12 @@ func (c *GitCommand) Commit(message string, flags string) (*exec.Cmd, error) {
 	return nil, c.OSCommand.RunCommand(command)
 }
 
+// Get the subject of the HEAD commit
+func (c *GitCommand) GetHeadCommitMessage() (string, error) {
+	message, err := c.OSCommand.RunCommandWithOutput("git log -1 --pretty=%s")
+	return strings.TrimSpace(message), err
+}
+
 // AmendHead amends HEAD with whatever is staged in your working tree
 func (c *GitCommand) AmendHead() (*exec.Cmd, error) {
 	command := "git commit --amend --no-edit --allow-empty"

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -443,7 +443,7 @@ func (c *GitCommand) Commit(message string, flags string) (*exec.Cmd, error) {
 
 // Get the subject of the HEAD commit
 func (c *GitCommand) GetHeadCommitMessage() (string, error) {
-	message, err := c.OSCommand.RunCommandWithOutput("git log -1 --pretty=%s")
+	message, err := c.OSCommand.RunCommandWithOutput("git log -1 --pretty=%s", "%s")
 	return strings.TrimSpace(message), err
 }
 

--- a/pkg/gui/patch_options_panel.go
+++ b/pkg/gui/patch_options_panel.go
@@ -21,6 +21,10 @@ func (gui *Gui) handleCreatePatchOptionsMenu(g *gocui.Gui, v *gocui.View) error 
 			onPress:       gui.handlePullPatchIntoWorkingTree,
 		},
 		{
+			displayString: "pull patch into new commit",
+			onPress:       gui.handlePullPatchIntoNewCommit,
+		},
+		{
 			displayString: "apply patch",
 			onPress:       func() error { return gui.handleApplyPatch(false) },
 		},
@@ -135,6 +139,22 @@ func (gui *Gui) handlePullPatchIntoWorkingTree() error {
 	} else {
 		return pull(false)
 	}
+}
+
+func (gui *Gui) handlePullPatchIntoNewCommit() error {
+	if ok, err := gui.validateNormalWorkingTreeState(); !ok {
+		return err
+	}
+
+	if err := gui.returnFocusFromLineByLinePanelIfNecessary(); err != nil {
+		return err
+	}
+
+	return gui.WithWaitingStatus(gui.Tr.SLocalize("RebasingStatus"), func() error {
+		commitIndex := gui.getPatchCommitIndex()
+		err := gui.GitCommand.PullPatchIntoNewCommit(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager)
+		return gui.handleGenericMergeCommandResult(err)
+	})
 }
 
 func (gui *Gui) handleApplyPatch(reverse bool) error {


### PR DESCRIPTION
Add GetHeadCommitMessage to read the subject of the HEAD commit
Create PullPatchIntoNewCommit based heavily on PullPatchIntoIndex to
  split the current patch from its commit and apply it in a separate
  commit immediately after.