### PR TITLE
prevent flicker from bolding background of selected line

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -24,7 +24,9 @@ Default path for the config file:
       optionsTextColor:
         - blue
       selectedLineBgColor:
-        - bold
+        - default
+      selectedRangeBgColor:
+        - blue
     commitLength:
       show: true
     mouseEvents: true
@@ -216,7 +218,7 @@ If you have issues with a light terminal theme where you can't read / see the te
       inactiveBorderColor:
         - black
       selectedLineBgColor:
-        - bold
+        - default
 ```
 
 ## Struggling to see selected line
@@ -227,6 +229,8 @@ If you struggle to see the selected line I recomment using the reverse attribute
   gui:
     theme:
       selectedLineBgColor:
+        - reverse
+      selectedRangeBgColor:
         - reverse
 ```
 

--- a/pkg/commands/patch_parser.go
+++ b/pkg/commands/patch_parser.go
@@ -120,7 +120,7 @@ func coloredString(colorAttr color.Attribute, str string, selected bool, include
 	var cl *color.Color
 	attributes := []color.Attribute{colorAttr}
 	if selected {
-		attributes = append(attributes, theme.SelectedLineBgColor)
+		attributes = append(attributes, theme.SelectedRangeBgColor)
 	}
 	cl = color.New(attributes...)
 	var clIncluded *color.Color

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -256,7 +256,9 @@ func GetDefaultConfig() []byte {
     optionsTextColor:
       - blue
     selectedLineBgColor:
-      - bold
+      - default
+    selectedRangeBgColor:
+      - blue
   commitLength:
     show: true
 git:

--- a/pkg/gui/merge_panel.go
+++ b/pkg/gui/merge_panel.go
@@ -59,7 +59,7 @@ func (gui *Gui) coloredConflictFile(content string, conflicts []commands.Conflic
 		colour := color.New(colourAttr)
 		if hasFocus && conflictIndex < len(conflicts) && conflicts[conflictIndex] == conflict && gui.shouldHighlightLine(i, conflict, conflictTop) {
 			colour.Add(color.Bold)
-			colour.Add(theme.SelectedLineBgColor)
+			colour.Add(theme.SelectedRangeBgColor)
 		}
 		if i == conflict.End && len(remainingConflicts) > 0 {
 			conflict, remainingConflicts = gui.shiftConflict(remainingConflicts)

--- a/pkg/theme/theme.go
+++ b/pkg/theme/theme.go
@@ -24,6 +24,9 @@ var (
 	// SelectedLineBgColor is the background color for the selected line
 	SelectedLineBgColor color.Attribute
 
+	// SelectedRangeBgColor is the background color of the selected range of lines
+	SelectedRangeBgColor color.Attribute
+
 	// GocuiSelectedLineBgColor is the background color for the selected line in gocui
 	GocuiSelectedLineBgColor gocui.Attribute
 
@@ -39,6 +42,7 @@ func UpdateTheme(userConfig *viper.Viper) {
 	ActiveBorderColor = GetGocuiColor(userConfig.GetStringSlice("gui.theme.activeBorderColor"))
 	InactiveBorderColor = GetGocuiColor(userConfig.GetStringSlice("gui.theme.inactiveBorderColor"))
 	SelectedLineBgColor = GetBgColor(userConfig.GetStringSlice("gui.theme.selectedLineBgColor"))
+	SelectedRangeBgColor = GetBgColor(userConfig.GetStringSlice("gui.theme.selectedRangeBgColor"))
 	GocuiSelectedLineBgColor = GetGocuiColor(userConfig.GetStringSlice("gui.theme.selectedLineBgColor"))
 	OptionsColor = GetGocuiColor(userConfig.GetStringSlice("gui.theme.optionsTextColor"))
 	OptionsFgColor = GetFgColor(userConfig.GetStringSlice("gui.theme.optionsTextColor"))


### PR DESCRIPTION
We're going with a default of bold for regular selected lines and blue background for ranges. Those who struggle to see will need to change both to 'reverse'.