### PR TITLE
fix naming of remote branches

### DIFF
--- a/pkg/commands/branch_list_builder.go
+++ b/pkg/commands/branch_list_builder.go
@@ -52,7 +52,7 @@ func (b *BranchListBuilder) obtainBranches() []*Branch {
 
 		split := strings.Split(line, SEPARATION_CHAR)
 
-		name := split[1]
+		name := strings.TrimPrefix(split[1], "heads/")
 		branch := &Branch{
 			Name:      name,
 			Pullables: "?",

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1290,6 +1290,14 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		{
 			ViewName:    "branches",
 			Contexts:    []string{"remote-branches"},
+			Key:         gui.getKey("universal.new"),
+			Handler:     gui.handleNewBranchOffRemote,
+			Description: gui.Tr.SLocalize("newBranch"),
+		},
+
+		{
+			ViewName:    "branches",
+			Contexts:    []string{"remote-branches"},
 			Key:         gui.getKey("branches.mergeIntoCurrentBranch"),
 			Handler:     gui.handleMergeRemoteBranch,
 			Description: gui.Tr.SLocalize("mergeIntoCurrentBranch"),

--- a/pkg/gui/remote_branches_panel.go
+++ b/pkg/gui/remote_branches_panel.go
@@ -139,3 +139,26 @@ func (gui *Gui) handleCreateResetToRemoteBranchMenu(g *gocui.Gui, v *gocui.View)
 
 	return gui.createResetMenu(fmt.Sprintf("%s/%s", selectedBranch.RemoteName, selectedBranch.Name))
 }
+
+func (gui *Gui) handleNewBranchOffRemote(g *gocui.Gui, v *gocui.View) error {
+	branch := gui.getSelectedRemoteBranch()
+	if branch == nil {
+		return nil
+	}
+	message := gui.Tr.TemplateLocalize(
+		"NewBranchNameBranchOff",
+		Teml{
+			"branchName": branch.FullName(),
+		},
+	)
+	return gui.createPromptPanel(g, v, message, branch.FullName(), func(g *gocui.Gui, v *gocui.View) error {
+		if err := gui.GitCommand.NewBranch(gui.trimmedContent(v), branch.FullName()); err != nil {
+			return gui.surfaceError(err)
+		}
+		gui.State.Panels.Branches.SelectedLine = 0
+		if err := gui.switchBranchesPanelContext("local-branches"); err != nil {
+			return err
+		}
+		return gui.refreshSidePanels(refreshOptions{mode: ASYNC})
+	})
+}


### PR DESCRIPTION
fixes https://github.com/jesseduffield/lazygit/issues/848

When you want to create a local copy of a branch from a remote branch, lazygit shows its name prefixed with 'heads/' which causes issues. It's using the `for-each-ref` command under the hood, and it seems this command, unlike the `git branch` command, includes that prefix.

So I'm just gonna remove the prefix. From local testing it seems to work fine