### PR TITLE
Add 'overrideGpg' switch to config

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -44,6 +44,7 @@ Default path for the config file:
     skipHookPrefix: WIP
     autoFetch: true
     branchLogCmd: "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --"
+    overrideGpg: false # prevents lazygit from spawning a separate process when using GPG
   update:
     method: prompt # can be: prompt | background | never
     days: 14 # how often an update is checked for

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -435,6 +435,11 @@ func (c *GitCommand) AbortMerge() error {
 // usingGpg tells us whether the user has gpg enabled so that we can know
 // whether we need to run a subprocess to allow them to enter their password
 func (c *GitCommand) usingGpg() bool {
+	overrideGpg := c.Config.GetUserConfig().GetBool("git.overrideGpg")
+	if overrideGpg {
+		return false
+	}
+
 	gpgsign, _ := c.getLocalGitConfig("commit.gpgsign")
 	if gpgsign == "" {
 		gpgsign, _ = c.getGlobalGitConfig("commit.gpgsign")

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -270,6 +270,7 @@ git:
     args: ""
   skipHookPrefix: 'WIP'
   autoFetch: true
+  overrideGpg: false # prevents lazygit from spawning a separate process when using GPG
 update:
   method: prompt # can be: prompt | background | never
   days: 14 # how often a update is checked for


### PR DESCRIPTION
My reasoning behind adding this switch is, to give the user a way to prevent lazygit from spawning a separate process (`cmd /c` in the case of Windows) when committing, amending, or rebasing. This is useful when you either don't need to enter a password when using GPG, or when your GPG setup doesn't need a separate shell for the password prompt (e.g. when using a gui password prompt).