### PR TITLE
Fix #890

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -453,15 +453,7 @@ func (c *GitCommand) usingGpg() bool {
 func (c *GitCommand) Commit(message string, flags string) (*exec.Cmd, error) {
 	command := fmt.Sprintf("git commit %s -m %s", flags, c.OSCommand.Quote(message))
 	if c.usingGpg() {
-		quotedCommand := ""
-		// Windows does not seem to like quotes around the command
-		if c.OSCommand.Platform.os == "windows" {
-			quotedCommand = command
-		} else {
-			quotedCommand = c.OSCommand.Quote(command)
-		}
-
-		return c.OSCommand.ExecutableFromString(fmt.Sprintf("%s %s %s", c.OSCommand.Platform.shell, c.OSCommand.Platform.shellArg, quotedCommand)), nil
+		return c.OSCommand.ShellCommandFromString(command), nil
 	}
 
 	return nil, c.OSCommand.RunCommand(command)
@@ -478,15 +470,7 @@ func (c *GitCommand) GetHeadCommitMessage() (string, error) {
 func (c *GitCommand) AmendHead() (*exec.Cmd, error) {
 	command := "git commit --amend --no-edit --allow-empty"
 	if c.usingGpg() {
-		quotedCommand := ""
-		// Windows does not seem to like quotes around the command
-		if c.OSCommand.Platform.os == "windows" {
-			quotedCommand = command
-		} else {
-			quotedCommand = c.OSCommand.Quote(command)
-		}
-
-		return c.OSCommand.ExecutableFromString(fmt.Sprintf("%s %s %s", c.OSCommand.Platform.shell, c.OSCommand.Platform.shellArg, quotedCommand)), nil
+		return c.OSCommand.ShellCommandFromString(command), nil
 	}
 
 	return nil, c.OSCommand.RunCommand(command)

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -453,7 +453,15 @@ func (c *GitCommand) usingGpg() bool {
 func (c *GitCommand) Commit(message string, flags string) (*exec.Cmd, error) {
 	command := fmt.Sprintf("git commit %s -m %s", flags, c.OSCommand.Quote(message))
 	if c.usingGpg() {
-		return c.OSCommand.ExecutableFromString(fmt.Sprintf("%s %s %s", c.OSCommand.Platform.shell, c.OSCommand.Platform.shellArg, command)), nil
+		quotedCommand := ""
+		// Windows does not seem to like quotes around the command
+		if c.OSCommand.Platform.os == "windows" {
+			quotedCommand = command
+		} else {
+			quotedCommand = c.OSCommand.Quote(command)
+		}
+
+		return c.OSCommand.ExecutableFromString(fmt.Sprintf("%s %s %s", c.OSCommand.Platform.shell, c.OSCommand.Platform.shellArg, quotedCommand)), nil
 	}
 
 	return nil, c.OSCommand.RunCommand(command)
@@ -470,7 +478,15 @@ func (c *GitCommand) GetHeadCommitMessage() (string, error) {
 func (c *GitCommand) AmendHead() (*exec.Cmd, error) {
 	command := "git commit --amend --no-edit --allow-empty"
 	if c.usingGpg() {
-		return c.OSCommand.ExecutableFromString(fmt.Sprintf("%s %s %s", c.OSCommand.Platform.shell, c.OSCommand.Platform.shellArg, command)), nil
+		quotedCommand := ""
+		// Windows does not seem to like quotes around the command
+		if c.OSCommand.Platform.os == "windows" {
+			quotedCommand = command
+		} else {
+			quotedCommand = c.OSCommand.Quote(command)
+		}
+
+		return c.OSCommand.ExecutableFromString(fmt.Sprintf("%s %s %s", c.OSCommand.Platform.shell, c.OSCommand.Platform.shellArg, quotedCommand)), nil
 	}
 
 	return nil, c.OSCommand.RunCommand(command)

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -815,7 +815,7 @@ func TestGitCommandCommit(t *testing.T) {
 			"Commit using gpg",
 			func(cmd string, args ...string) *exec.Cmd {
 				assert.EqualValues(t, "bash", cmd)
-				assert.EqualValues(t, []string{"-c", "git", "commit", "-m", "test"}, args)
+				assert.EqualValues(t, []string{"-c", "git commit  -m 'test'"}, args)
 
 				return exec.Command("echo")
 			},
@@ -905,7 +905,7 @@ func TestGitCommandAmendHead(t *testing.T) {
 			"Amend commit using gpg",
 			func(cmd string, args ...string) *exec.Cmd {
 				assert.EqualValues(t, "bash", cmd)
-				assert.EqualValues(t, []string{"-c", "git", "commit", "--amend", "--no-edit", "--allow-empty"}, args)
+				assert.EqualValues(t, []string{"-c", "git commit --amend --no-edit --allow-empty"}, args)
 
 				return exec.Command("echo")
 			},

--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -118,6 +118,19 @@ func (c *OSCommand) ExecutableFromString(commandStr string) *exec.Cmd {
 	return cmd
 }
 
+// ShellCommandFromString takes a string like `git commit` and returns an executable shell command for it
+func (c *OSCommand) ShellCommandFromString(commandStr string) *exec.Cmd {
+	quotedCommand := ""
+	// Windows does not seem to like quotes around the command
+	if c.Platform.os == "windows" {
+		quotedCommand = commandStr
+	} else {
+		quotedCommand = c.Quote(commandStr)
+	}
+
+	return c.ExecutableFromString(fmt.Sprintf("%s %s %s", c.Platform.shell, c.Platform.shellArg, quotedCommand))
+}
+
 // RunCommandWithOutputLive runs RunCommandWithOutputLiveWrapper
 func (c *OSCommand) RunCommandWithOutputLive(command string, output func(string) string) error {
 	return RunCommandWithOutputLiveWrapper(c, command, output)


### PR DESCRIPTION
This PR fixes #890 by adding quotes around **non-windows** systems.
For some reason, Windows (`cmd /c`) doesn't seem to like the escaped quotes, so the git command is only quoted on **non-windows** systems.