### PR TITLE
prompt to commit all files if committing with no staged files

### DIFF
--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -137,9 +137,6 @@ func addDutch(i18nObject *i18n.Bundle) error {
 			ID:    "CannotGitAdd",
 			Other: "Kan commando niet uitvoeren git add --path untracked files",
 		}, &i18n.Message{
-			ID:    "NoStagedFilesToCommit",
-			Other: "Er zijn geen staged bestanden om te commiten",
-		}, &i18n.Message{
 			ID:    "NoFilesDisplay",
 			Other: "Geen bestanden om te laten zien",
 		}, &i18n.Message{
@@ -766,6 +763,12 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "commitPrefixPatternError",
 			Other: "Error in commitPrefix pattern",
+		}, &i18n.Message{
+			ID:    "NoFilesStagedTitle",
+			Other: "No files staged",
+		}, &i18n.Message{
+			ID:    "NoFilesStagedPrompt",
+			Other: "You have not staged any files. Commit all files?",
 		},
 	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -157,9 +157,6 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			ID:    "CannotGitAdd",
 			Other: "Cannot git add --patch untracked files",
 		}, &i18n.Message{
-			ID:    "NoStagedFilesToCommit",
-			Other: "There are no staged files to commit",
-		}, &i18n.Message{
 			ID:    "NoFilesDisplay",
 			Other: "No file to display",
 		}, &i18n.Message{
@@ -1152,6 +1149,12 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "commitPrefixPatternError",
 			Other: "Error in commitPrefix pattern",
+		}, &i18n.Message{
+			ID:    "NoFilesStagedTitle",
+			Other: "No files staged",
+		}, &i18n.Message{
+			ID:    "NoFilesStagedPrompt",
+			Other: "You have not staged any files. Commit all files?",
 		},
 	)
 }

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -129,9 +129,6 @@ func addPolish(i18nObject *i18n.Bundle) error {
 			ID:    "CannotGitAdd",
 			Other: "Nie można git add --patch nieśledzonych plików",
 		}, &i18n.Message{
-			ID:    "NoStagedFilesToCommit",
-			Other: "Brak zatwierdzonych plików do commita",
-		}, &i18n.Message{
 			ID:    "NoFilesDisplay",
 			Other: "Brak pliku do wyświetlenia",
 		}, &i18n.Message{
@@ -749,6 +746,12 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "commitPrefixPatternError",
 			Other: "Error in commitPrefix pattern",
+		}, &i18n.Message{
+			ID:    "NoFilesStagedTitle",
+			Other: "No files staged",
+		}, &i18n.Message{
+			ID:    "NoFilesStagedPrompt",
+			Other: "You have not staged any files. Commit all files?",
 		},
 	)
 }


### PR DESCRIPTION
This is a UI quirk that's been annoying. You really shouldn't have to press 'a' to stage all files before committing: it should just prompt you whether you want to do that upon pressing 'c'