### PR TITLE
prompt to create new branch if branch not found

### DIFF
--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -769,6 +769,12 @@ func addDutch(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "NoFilesStagedPrompt",
 			Other: "You have not staged any files. Commit all files?",
+		}, &i18n.Message{
+			ID:    "BranchNotFoundTitle",
+			Other: "Branch not found",
+		}, &i18n.Message{
+			ID:    "BranchNotFoundPrompt",
+			Other: "Branch not found. Create a new branch named",
 		},
 	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1155,6 +1155,12 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "NoFilesStagedPrompt",
 			Other: "You have not staged any files. Commit all files?",
+		}, &i18n.Message{
+			ID:    "BranchNotFoundTitle",
+			Other: "Branch not found",
+		}, &i18n.Message{
+			ID:    "BranchNotFoundPrompt",
+			Other: "Branch not found. Create a new branch named",
 		},
 	)
 }

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -752,6 +752,12 @@ func addPolish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "NoFilesStagedPrompt",
 			Other: "You have not staged any files. Commit all files?",
+		}, &i18n.Message{
+			ID:    "BranchNotFoundTitle",
+			Other: "Branch not found",
+		}, &i18n.Message{
+			ID:    "BranchNotFoundPrompt",
+			Other: "Branch not found. Create a new branch named",
 		},
 	)
 }


### PR DESCRIPTION
Often I'll accidentally go to checkout a branch when I mean checkout a new branch. We should just prompt the user whether they want to create a new one in this case if the branch isn't found.