### PR TITLE
Decouple escaping from quitting

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -50,6 +50,8 @@ Default path for the config file:
     days: 14 # how often an update is checked for
   reporting: 'undetermined' # one of: 'on' | 'off' | 'undetermined'
   confirmOnQuit: false
+  # determines whether hitting 'esc' will quit the application when there is nothing to cancel/close
+  quitOnTopLevelReturn: true
   keybinding:
     universal:
       quit: 'q'

--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -16,6 +16,8 @@
   <kbd>+</kbd>: next screen mode (normal/half/fullscreen)
   <kbd>_</kbd>: prev screen mode
   <kbd>:</kbd>: execute custom command
+  <kbd>|</kbd>: view scoping options
+  <kbd>ctrl+e</kbd>: open diff menu
 </pre>
 
 ## Branches Panel
@@ -40,6 +42,7 @@
   <kbd>f</kbd>: fast-forward this branch from its upstream
   <kbd>g</kbd>: view reset options
   <kbd>R</kbd>: rename branch
+  <kbd>ctrl+o</kbd>: copy branch name to clipboard
   <kbd>,</kbd>: previous page
   <kbd>.</kbd>: next page
   <kbd><</kbd>: scroll to top
@@ -53,6 +56,7 @@
   <kbd>esc</kbd>: return to remotes list
   <kbd>g</kbd>: view reset options
   <kbd>space</kbd>: checkout
+  <kbd>n</kbd>: new branch
   <kbd>M</kbd>: merge into currently checked out branch
   <kbd>d</kbd>: delete branch
   <kbd>r</kbd>: rebase checked-out branch onto this branch
@@ -134,11 +138,11 @@
   <kbd>p</kbd>: pick commit (when mid-rebase)
   <kbd>t</kbd>: revert commit
   <kbd>c</kbd>: copy commit (cherry-pick)
+  <kbd>ctrl+o</kbd>: copy commit SHA to clipboard
   <kbd>C</kbd>: copy commit range (cherry-pick)
   <kbd>v</kbd>: paste commits (cherry-pick)
   <kbd>enter</kbd>: view commit's files
   <kbd>space</kbd>: checkout commit
-  <kbd>i</kbd>: select commit to diff with another commit
   <kbd>T</kbd>: tag commit
   <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
   <kbd>,</kbd>: previous page
@@ -246,7 +250,6 @@
 
 <pre>
   <kbd>esc</kbd>: close menu
-  <kbd>q</kbd>: close menu
   <kbd>,</kbd>: previous page
   <kbd>.</kbd>: next page
   <kbd><</kbd>: scroll to top

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -16,6 +16,8 @@
   <kbd>+</kbd>: next screen mode (normal/half/fullscreen)
   <kbd>_</kbd>: prev screen mode
   <kbd>:</kbd>: voor aangepast commando uit
+  <kbd>|</kbd>: view scoping options
+  <kbd>ctrl+e</kbd>: open diff menu
 </pre>
 
 ## Branches Panel
@@ -40,6 +42,7 @@
   <kbd>f</kbd>: fast-forward this branch from its upstream
   <kbd>g</kbd>: bekijk reset opties
   <kbd>R</kbd>: rename branch
+  <kbd>ctrl+o</kbd>: copy branch name to clipboard
   <kbd>,</kbd>: previous page
   <kbd>.</kbd>: next page
   <kbd><</kbd>: scroll to top
@@ -53,6 +56,7 @@
   <kbd>esc</kbd>: return to remotes list
   <kbd>g</kbd>: bekijk reset opties
   <kbd>space</kbd>: uitchecken
+  <kbd>n</kbd>: nieuwe branch
   <kbd>M</kbd>: merge in met huidige checked out branch
   <kbd>d</kbd>: verwijder branch
   <kbd>r</kbd>: rebase branch
@@ -134,11 +138,11 @@
   <kbd>p</kbd>: pick commit (when mid-rebase)
   <kbd>t</kbd>: commit omgedaan maken
   <kbd>c</kbd>: kopiëer commit (cherry-pick)
+  <kbd>ctrl+o</kbd>: copy commit SHA to clipboard
   <kbd>C</kbd>: kopiëer commit reeks (cherry-pick)
   <kbd>v</kbd>: plak commits (cherry-pick)
   <kbd>enter</kbd>: bekijk gecommite bestanden
   <kbd>space</kbd>: checkout commit
-  <kbd>i</kbd>: select commit to diff with another commit
   <kbd>T</kbd>: tag commit
   <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
   <kbd>,</kbd>: previous page
@@ -246,7 +250,6 @@
 
 <pre>
   <kbd>esc</kbd>: close menu
-  <kbd>q</kbd>: close menu
   <kbd>,</kbd>: previous page
   <kbd>.</kbd>: next page
   <kbd><</kbd>: scroll to top

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -16,6 +16,8 @@
   <kbd>+</kbd>: next screen mode (normal/half/fullscreen)
   <kbd>_</kbd>: prev screen mode
   <kbd>:</kbd>: execute custom command
+  <kbd>|</kbd>: view scoping options
+  <kbd>ctrl+e</kbd>: open diff menu
 </pre>
 
 ## Gałęzie Panel
@@ -40,6 +42,7 @@
   <kbd>f</kbd>: fast-forward this branch from its upstream
   <kbd>g</kbd>: view reset options
   <kbd>R</kbd>: rename branch
+  <kbd>ctrl+o</kbd>: copy branch name to clipboard
   <kbd>,</kbd>: previous page
   <kbd>.</kbd>: next page
   <kbd><</kbd>: scroll to top
@@ -53,6 +56,7 @@
   <kbd>esc</kbd>: return to remotes list
   <kbd>g</kbd>: view reset options
   <kbd>space</kbd>: przełącz
+  <kbd>n</kbd>: nowa gałąź
   <kbd>M</kbd>: scal do obecnej gałęzi
   <kbd>d</kbd>: usuń gałąź
   <kbd>r</kbd>: rebase branch
@@ -134,11 +138,11 @@
   <kbd>p</kbd>: pick commit (when mid-rebase)
   <kbd>t</kbd>: revert commit
   <kbd>c</kbd>: copy commit (cherry-pick)
+  <kbd>ctrl+o</kbd>: copy commit SHA to clipboard
   <kbd>C</kbd>: copy commit range (cherry-pick)
   <kbd>v</kbd>: paste commits (cherry-pick)
   <kbd>enter</kbd>: view commit's files
   <kbd>space</kbd>: checkout commit
-  <kbd>i</kbd>: select commit to diff with another commit
   <kbd>T</kbd>: tag commit
   <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
   <kbd>,</kbd>: previous page
@@ -246,7 +250,6 @@
 
 <pre>
   <kbd>esc</kbd>: close menu
-  <kbd>q</kbd>: close menu
   <kbd>,</kbd>: previous page
   <kbd>.</kbd>: next page
   <kbd><</kbd>: scroll to top

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -278,6 +278,7 @@ update:
 reporting: 'undetermined' # one of: 'on' | 'off' | 'undetermined'
 splashUpdatesIndex: 0
 confirmOnQuit: false
+quitOnTopLevelReturn: true
 keybinding:
   universal:
     quit: 'q'

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -217,7 +217,7 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			ViewName: "",
 			Key:      gui.getKey("universal.return"),
 			Modifier: gocui.ModNone,
-			Handler:  gui.handleQuit,
+			Handler:  gui.handleTopLevelReturn,
 		},
 		{
 			ViewName:    "",
@@ -845,12 +845,6 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		{
 			ViewName:    "menu",
 			Key:         gui.getKey("universal.return"),
-			Handler:     gui.handleMenuClose,
-			Description: gui.Tr.SLocalize("closeMenu"),
-		},
-		{
-			ViewName:    "menu",
-			Key:         gui.getKey("universal.quit"),
 			Handler:     gui.handleMenuClose,
 			Description: gui.Tr.SLocalize("closeMenu"),
 		},

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -25,7 +25,7 @@ func (gui *Gui) handleMenuSelect(g *gocui.Gui, v *gocui.View) error {
 
 func (gui *Gui) renderMenuOptions() error {
 	optionsMap := map[string]string{
-		fmt.Sprintf("%s/%s", gui.getKeyDisplay("universal.return"), gui.getKeyDisplay("universal.quit")):       gui.Tr.SLocalize("close"),
+		gui.getKeyDisplay("universal.return"): gui.Tr.SLocalize("close"),
 		fmt.Sprintf("%s %s", gui.getKeyDisplay("universal.prevItem"), gui.getKeyDisplay("universal.nextItem")): gui.Tr.SLocalize("navigate"),
 		gui.getKeyDisplay("universal.select"): gui.Tr.SLocalize("execute"),
 	}

--- a/pkg/gui/quitting.go
+++ b/pkg/gui/quitting.go
@@ -34,6 +34,14 @@ func (gui *Gui) handleQuit(g *gocui.Gui, v *gocui.View) error {
 	return gui.quit(v)
 }
 
+func (gui *Gui) handleTopLevelReturn(g *gocui.Gui, v *gocui.View) error {
+	if gui.Config.GetUserConfig().GetBool("quitOnTopLevelReturn") {
+		return gui.handleQuit(g, v)
+	}
+
+	return nil
+}
+
 func (gui *Gui) quit(v *gocui.View) error {
 	if gui.State.Updating {
 		return gui.createUpdateQuitConfirmation(gui.g, v)

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -513,7 +513,8 @@ func (gui *Gui) renderGlobalOptions() error {
 	return gui.renderOptionsMap(map[string]string{
 		fmt.Sprintf("%s/%s", gui.getKeyDisplay("universal.scrollUpMain"), gui.getKeyDisplay("universal.scrollDownMain")):                                                                                 gui.Tr.SLocalize("scroll"),
 		fmt.Sprintf("%s %s %s %s", gui.getKeyDisplay("universal.prevBlock"), gui.getKeyDisplay("universal.nextBlock"), gui.getKeyDisplay("universal.prevItem"), gui.getKeyDisplay("universal.nextItem")): gui.Tr.SLocalize("navigate"),
-		fmt.Sprintf("%s/%s", gui.getKeyDisplay("universal.return"), gui.getKeyDisplay("universal.quit")):                                                                                                 gui.Tr.SLocalize("close"),
+		gui.getKeyDisplay("universal.return"):     gui.Tr.SLocalize("cancel"),
+		gui.getKeyDisplay("universal.quit"):       gui.Tr.SLocalize("quit"),
 		gui.getKeyDisplay("universal.optionMenu"): gui.Tr.SLocalize("menu"),
 		"1-5": gui.Tr.SLocalize("jump"),
 	})

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -250,6 +250,9 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			ID:    "close",
 			Other: "close",
 		}, &i18n.Message{
+			ID:    "quit",
+			Other: "quit",
+		}, &i18n.Message{
 			ID:    "SureResetThisCommit",
 			Other: "Are you sure you want to reset to this commit?",
 		}, &i18n.Message{

--- a/scripts/generate_cheatsheet.go
+++ b/scripts/generate_cheatsheet.go
@@ -31,7 +31,7 @@ func main() {
 
 	for _, lang := range langs {
 		os.Setenv("LC_ALL", lang)
-		mApp, _ := app.NewApp(mConfig)
+		mApp, _ := app.NewApp(mConfig, "")
 		file, err := os.Create(getProjectRoot() + "/docs/keybindings/Keybindings_" + lang + ".md")
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
When a user is not entering text into a prompt, the 'q' key should immediately
quit the application. On the other hand, the 'esc' key should cancel/close/go-back
to the previous context.

If we're at the surface level (nothing to cancel/close) and the user hits the
escape key, the default behaviour is to close the app, however we now have a
`quitOnTopLevelReturn` config key to override this.

I actually think from the beginning we should have made this config option
default to false rather than true which is the default this PR gives it,
but I don't want to anger too many people familiar with the existing behaviour.