### PR TITLE
Add keybinding for editing files from commit files panel.

### DIFF
--- a/pkg/gui/commit_files_panel.go
+++ b/pkg/gui/commit_files_panel.go
@@ -124,6 +124,12 @@ func (gui *Gui) handleOpenOldCommitFile(g *gocui.Gui, v *gocui.View) error {
 	return gui.openFile(file.Name)
 }
 
+func (gui *Gui) handleEditOldCommitFile(g *gocui.Gui, v *gocui.View) error {
+	file := gui.getSelectedCommitFile()
+	_, err := gui.runSyncOrAsyncCommand(gui.OSCommand.EditFile(file.Name))
+	return err
+}
+
 func (gui *Gui) handleToggleFileForPatch(g *gocui.Gui, v *gocui.View) error {
 	if ok, err := gui.validateNormalWorkingTreeState(); !ok {
 		return err

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -880,6 +880,12 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		},
 		{
 			ViewName:    "commitFiles",
+			Key:         gui.getKey("universal.edit"),
+			Handler:     gui.handleEditOldCommitFile,
+			Description: gui.Tr.SLocalize("editFile"),
+		},
+		{
+			ViewName:    "commitFiles",
 			Key:         gui.getKey("universal.select"),
 			Handler:     gui.handleToggleFileForPatch,
 			Description: gui.Tr.SLocalize("toggleAddToPatch"),


### PR DESCRIPTION
I think it is neat to have the edit file shortcut here, so you can continue where you left of in cases where something is committed as WIP.