### PR TITLE
allow editing commit files

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -104,6 +104,7 @@
   <kbd>c</kbd>: checkout file
   <kbd>d</kbd>: discard this commit's changes to this file
   <kbd>o</kbd>: open file
+  <kbd>e</kbd>: edit file
   <kbd>space</kbd>: toggle file included in patch
   <kbd>enter</kbd>: enter file to add selected lines to the patch
   <kbd>,</kbd>: previous page

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -104,6 +104,7 @@
   <kbd>c</kbd>: bestand uitchecken
   <kbd>d</kbd>: uitsluit deze commit zijn veranderingen aan dit bestand
   <kbd>o</kbd>: open bestand
+  <kbd>e</kbd>: verander bestand
   <kbd>space</kbd>: toggle file included in patch
   <kbd>enter</kbd>: enter file to add selected lines to the patch
   <kbd>,</kbd>: previous page

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -104,6 +104,7 @@
   <kbd>c</kbd>: checkout file
   <kbd>d</kbd>: discard this commit's changes to this file
   <kbd>o</kbd>: otwórz plik
+  <kbd>e</kbd>: edytuj plik
   <kbd>space</kbd>: toggle file included in patch
   <kbd>enter</kbd>: enter file to add selected lines to the patch
   <kbd>,</kbd>: previous page

--- a/pkg/gui/commit_files_panel.go
+++ b/pkg/gui/commit_files_panel.go
@@ -121,7 +121,20 @@ func (gui *Gui) refreshCommitFilesView() error {
 
 func (gui *Gui) handleOpenOldCommitFile(g *gocui.Gui, v *gocui.View) error {
 	file := gui.getSelectedCommitFile()
+	if file == nil {
+		return nil
+	}
+
 	return gui.openFile(file.Name)
+}
+
+func (gui *Gui) handleEditCommitFile(g *gocui.Gui, v *gocui.View) error {
+	file := gui.getSelectedCommitFile()
+	if file == nil {
+		return nil
+	}
+
+	return gui.editFile(file.Name)
 }
 
 func (gui *Gui) handleToggleFileForPatch(g *gocui.Gui, v *gocui.View) error {

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -880,6 +880,12 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		},
 		{
 			ViewName:    "commitFiles",
+			Key:         gui.getKey("universal.edit"),
+			Handler:     gui.handleEditCommitFile,
+			Description: gui.Tr.SLocalize("editFile"),
+		},
+		{
+			ViewName:    "commitFiles",
 			Key:         gui.getKey("universal.select"),
 			Handler:     gui.handleToggleFileForPatch,
 			Description: gui.Tr.SLocalize("toggleAddToPatch"),


### PR DESCRIPTION
This gets us halfway there, though we really need a way of going straight back to the previous state when switching to a subprocess, because right now it's taking us back to the files panel after.