### PR TITLE
Discard rename

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,4 @@
 # These are supported funding model platforms
 
 github: [jesseduffield]
-ko_fi: jesseduffield
 custom: ['https://donorbox.org/lazygit']

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,5 +61,3 @@ brews:
     # conflicts:
     #   - svn
     #   - bash
-
-  # test comment to see if goreleaser only releases on new commits

--- a/pkg/commands/file.go
+++ b/pkg/commands/file.go
@@ -1,5 +1,7 @@
 package commands
 
+import "strings"
+
 // File : A file from git status
 // duplicating this for now
 type File struct {
@@ -13,4 +15,8 @@ type File struct {
 	DisplayString           string
 	Type                    string // one of 'file', 'directory', and 'other'
 	ShortStatus             string // e.g. 'AD', ' A', 'M ', '??'
+}
+
+func (f *File) IsRename() bool {
+	return strings.Contains(f.Name, " -> ")
 }

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -420,7 +420,7 @@ func TestGitCommandGetStatusFiles(t *testing.T) {
 			gitCmd := NewDummyGitCommand()
 			gitCmd.OSCommand.command = s.command
 
-			s.test(gitCmd.GetStatusFiles())
+			s.test(gitCmd.GetStatusFiles(GetStatusFileOptions{}))
 		})
 	}
 }

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -411,7 +411,7 @@ func (gui *Gui) handleRefreshFiles(g *gocui.Gui, v *gocui.View) error {
 
 func (gui *Gui) refreshStateFiles() error {
 	// get files to stage
-	files := gui.GitCommand.GetStatusFiles()
+	files := gui.GitCommand.GetStatusFiles(commands.GetStatusFileOptions{})
 	gui.State.Files = gui.GitCommand.MergeStatusFiles(gui.State.Files, files)
 
 	if err := gui.fileWatcher.addFilesToFileWatcher(files); err != nil {


### PR DESCRIPTION
Admittedly our File abstraction is not perfect: given that we allow one of these to represent a file rename, perhaps we should call it a StatusLine which contains one or two files. At any rate for now I think it suffices to just check based on the file 'name' whether it describes a rename and if so, refetch the files with the --no-renames flag and obtain the before and after files that way.