### PR TITLE
follow cursor when staging and unstaging a file rename

### DIFF
--- a/pkg/commands/file.go
+++ b/pkg/commands/file.go
@@ -1,6 +1,10 @@
 package commands
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/jesseduffield/lazygit/pkg/utils"
+)
 
 // File : A file from git status
 // duplicating this for now
@@ -17,6 +21,18 @@ type File struct {
 	ShortStatus             string // e.g. 'AD', ' A', 'M ', '??'
 }
 
+const RENAME_SEPARATOR = " -> "
+
 func (f *File) IsRename() bool {
-	return strings.Contains(f.Name, " -> ")
+	return strings.Contains(f.Name, RENAME_SEPARATOR)
+}
+
+// Names returns an array containing just the filename, or in the case of a rename, the after filename and the before filename
+func (f *File) Names() []string {
+	return strings.Split(f.Name, RENAME_SEPARATOR)
+}
+
+// returns true if the file names are the same or if a a file rename includes the filename of the other
+func (f *File) Matches(f2 *File) bool {
+	return utils.StringArraysOverlap(f.Names(), f2.Names())
 }

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -541,7 +541,7 @@ func TestGitCommandMergeStatusFiles(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			gitCmd := NewDummyGitCommand()
 
-			s.test(gitCmd.MergeStatusFiles(s.oldFiles, s.newFiles))
+			s.test(gitCmd.MergeStatusFiles(s.oldFiles, s.newFiles, nil))
 		})
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -322,3 +322,15 @@ func FindStringSubmatch(str string, regexpStr string) (bool, []string) {
 	match := re.FindStringSubmatch(str)
 	return len(match) > 0, match
 }
+
+func StringArraysOverlap(strArrA []string, strArrB []string) bool {
+	for _, first := range strArrA {
+		for _, second := range strArrB {
+			if first == second {
+				return true
+			}
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
fixes https://github.com/jesseduffield/lazygit/issues/494

This logic is slightly complicated. When we have two files involved in a rename and we have staged one then the other, we take away two rows (for the before and after files) and add the new row (for the rename). We need to ensure that the rename is positioned where our cursor is. When unstaging, we need to ensure that the two rows for each file are positioned where the cursor is. Likewise we need to ensure that the cursor moves up in the event that one of the files involved in the rename is removed from the list and is above the cursor.