### PR TITLE
919 support multiple pull modes

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -41,6 +41,8 @@ Default path for the config file:
       manualCommit: false
       # extra args passed to `git merge`, e.g. --no-ff
       args: ""
+    pull:
+      mode: 'merge' # one of 'merge' | 'rebase' | 'ff-only'
     skipHookPrefix: WIP
     autoFetch: true
     branchLogCmd: "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --"

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -791,8 +791,9 @@ func (c *GitCommand) ApplyPatch(patch string, flags ...string) error {
 	return c.OSCommand.RunCommand("git apply %s %s", flagStr, c.OSCommand.Quote(filepath))
 }
 
-func (c *GitCommand) FastForward(branchName string, remoteName string, remoteBranchName string) error {
-	return c.OSCommand.RunCommand("git fetch %s %s:%s", remoteName, remoteBranchName, branchName)
+func (c *GitCommand) FastForward(branchName string, remoteName string, remoteBranchName string, promptUserForCredential func(string) string) error {
+	command := fmt.Sprintf("git fetch %s %s:%s", remoteName, remoteBranchName, branchName)
+	return c.OSCommand.DetectUnamePass(command, promptUserForCredential)
 }
 
 func (c *GitCommand) RunSkipEditorCommand(command string) error {

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -510,16 +510,6 @@ func (c *GitCommand) AmendHead() (*exec.Cmd, error) {
 	return nil, c.OSCommand.RunCommand(command)
 }
 
-// Pull pulls from repo
-func (c *GitCommand) Pull(args string, promptUserForCredential func(string) string) error {
-	return c.OSCommand.DetectUnamePass("git pull --no-edit --rebase ", promptUserForCredential)
-}
-
-// PullWithoutPasswordCheck assumes that the pull will not prompt the user for a password
-func (c *GitCommand) PullWithoutPasswordCheck(args string) error {
-	return c.OSCommand.RunCommand("git pull --no-edit " + args)
-}
-
 // Push pushes to a branch
 func (c *GitCommand) Push(branchName string, force bool, upstream string, args string, promptUserForCredential func(string) string) error {
 	forceFlag := ""

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -370,10 +370,10 @@ func (c *GitCommand) RebaseBranch(branchName string) error {
 }
 
 // Fetch fetch git repo
-func (c *GitCommand) Fetch(unamePassQuestion func(string) string, canAskForCredentials bool) error {
+func (c *GitCommand) Fetch(promptUserForCredential func(string) string, canPromptForCredential bool) error {
 	return c.OSCommand.DetectUnamePass("git fetch", func(question string) string {
-		if canAskForCredentials {
-			return unamePassQuestion(question)
+		if canPromptForCredential {
+			return promptUserForCredential(question)
 		}
 		return "\n"
 	})
@@ -486,8 +486,8 @@ func (c *GitCommand) AmendHead() (*exec.Cmd, error) {
 }
 
 // Pull pulls from repo
-func (c *GitCommand) Pull(args string, ask func(string) string) error {
-	return c.OSCommand.DetectUnamePass("git pull --no-edit "+args, ask)
+func (c *GitCommand) Pull(args string, promptUserForCredential func(string) string) error {
+	return c.OSCommand.DetectUnamePass("git pull --no-edit "+args, promptUserForCredential)
 }
 
 // PullWithoutPasswordCheck assumes that the pull will not prompt the user for a password
@@ -496,7 +496,7 @@ func (c *GitCommand) PullWithoutPasswordCheck(args string) error {
 }
 
 // Push pushes to a branch
-func (c *GitCommand) Push(branchName string, force bool, upstream string, args string, ask func(string) string) error {
+func (c *GitCommand) Push(branchName string, force bool, upstream string, args string, promptUserForCredential func(string) string) error {
 	forceFlag := ""
 	if force {
 		forceFlag = "--force-with-lease"
@@ -508,7 +508,7 @@ func (c *GitCommand) Push(branchName string, force bool, upstream string, args s
 	}
 
 	cmd := fmt.Sprintf("git push --follow-tags %s %s %s", forceFlag, setUpstreamArg, args)
-	return c.OSCommand.DetectUnamePass(cmd, ask)
+	return c.OSCommand.DetectUnamePass(cmd, promptUserForCredential)
 }
 
 // CatFile obtains the content of a file

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -703,7 +703,7 @@ func TestGitCommandMerge(t *testing.T) {
 		return exec.Command("echo")
 	}
 
-	assert.NoError(t, gitCmd.Merge("test"))
+	assert.NoError(t, gitCmd.Merge("test", MergeOpts{}))
 }
 
 // TestGitCommandUsingGpg is a function.

--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -139,9 +139,9 @@ func (c *OSCommand) RunCommandWithOutputLive(command string, output func(string)
 }
 
 // DetectUnamePass detect a username / password question in a command
-// ask is a function that gets executen when this function detect you need to fillin a password
-// The ask argument will be "username" or "password" and expects the user's password or username back
-func (c *OSCommand) DetectUnamePass(command string, ask func(string) string) error {
+// promptUserForCredential is a function that gets executed when this function detect you need to fillin a password
+// The promptUserForCredential argument will be "username" or "password" and expects the user's password or username back
+func (c *OSCommand) DetectUnamePass(command string, promptUserForCredential func(string) string) error {
 	ttyText := ""
 	errMessage := c.RunCommandWithOutputLive(command, func(word string) string {
 		ttyText = ttyText + " " + word
@@ -155,7 +155,7 @@ func (c *OSCommand) DetectUnamePass(command string, ask func(string) string) err
 		for pattern, askFor := range prompts {
 			if match, _ := regexp.MatchString(pattern, ttyText); match {
 				ttyText = ""
-				return ask(askFor)
+				return promptUserForCredential(askFor)
 			}
 		}
 

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -268,6 +268,8 @@ git:
   merging:
     manualCommit: false
     args: ""
+  pull:
+    mode: 'merge' # one of 'merge' | 'rebase' | 'ff-only'
   skipHookPrefix: 'WIP'
   autoFetch: true
   branchLogCmd: "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --"

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -129,8 +129,12 @@ func (gui *Gui) handleGitFetch(g *gocui.Gui, v *gocui.View) error {
 		return err
 	}
 	go func() {
-		err := gui.fetch(g, v, true)
-		gui.HandleCredentialsPopup(g, err)
+		err := gui.fetch(true)
+		gui.HandleCredentialsPopup(err)
+		if err == nil {
+			_ = gui.closeConfirmationPrompt(gui.g, true)
+			_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC})
+		}
 	}()
 	return nil
 }
@@ -321,7 +325,7 @@ func (gui *Gui) mergeBranchIntoCheckedOutBranch(branchName string) error {
 	return gui.createConfirmationPanel(gui.g, gui.getBranchesView(), true, gui.Tr.SLocalize("MergingTitle"), prompt,
 		func(g *gocui.Gui, v *gocui.View) error {
 
-			err := gui.GitCommand.Merge(branchName)
+			err := gui.GitCommand.Merge(branchName, commands.MergeOpts{})
 			return gui.handleGenericMergeCommandResult(err)
 		}, nil)
 }

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -399,11 +399,8 @@ func (gui *Gui) handleFastForward(g *gocui.Gui, v *gocui.View) error {
 		_ = gui.createLoaderPanel(gui.g, v, message)
 
 		if gui.State.Panels.Branches.SelectedLine == 0 {
-			if err := gui.GitCommand.PullWithoutPasswordCheck("--ff-only"); err != nil {
-				_ = gui.surfaceError(err)
-				return
-			}
-			_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC})
+			_ = gui.pullWithMode("ff-only", PullFilesOptions{})
+			return
 		} else {
 			if err := gui.GitCommand.FastForward(branch.Name, remoteName, remoteBranchName); err != nil {
 				_ = gui.surfaceError(err)

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -130,7 +130,7 @@ func (gui *Gui) handleGitFetch(g *gocui.Gui, v *gocui.View) error {
 	}
 	go func() {
 		err := gui.fetch(true)
-		gui.HandleCredentialsPopup(err)
+		gui.handleCredentialsPopup(err)
 		_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC})
 	}()
 	return nil

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -129,8 +129,8 @@ func (gui *Gui) handleGitFetch(g *gocui.Gui, v *gocui.View) error {
 		return err
 	}
 	go func() {
-		unamePassOpend, err := gui.fetch(g, v, true)
-		gui.HandleCredentialsPopup(g, unamePassOpend, err)
+		err := gui.fetch(g, v, true)
+		gui.HandleCredentialsPopup(g, err)
 	}()
 	return nil
 }

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -400,16 +400,11 @@ func (gui *Gui) handleFastForward(g *gocui.Gui, v *gocui.View) error {
 
 		if gui.State.Panels.Branches.SelectedLine == 0 {
 			_ = gui.pullWithMode("ff-only", PullFilesOptions{})
-			return
 		} else {
-			if err := gui.GitCommand.FastForward(branch.Name, remoteName, remoteBranchName); err != nil {
-				_ = gui.surfaceError(err)
-				return
-			}
+			err := gui.GitCommand.FastForward(branch.Name, remoteName, remoteBranchName, gui.promptUserForCredential)
+			gui.handleCredentialsPopup(err)
 			_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC, scope: []int{BRANCHES}})
 		}
-
-		_ = gui.closeConfirmationPrompt(gui.g, true)
 	}()
 	return nil
 }

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -131,10 +131,7 @@ func (gui *Gui) handleGitFetch(g *gocui.Gui, v *gocui.View) error {
 	go func() {
 		err := gui.fetch(true)
 		gui.HandleCredentialsPopup(err)
-		if err == nil {
-			_ = gui.closeConfirmationPrompt(gui.g, true)
-			_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC})
-		}
+		_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC})
 	}()
 	return nil
 }

--- a/pkg/gui/credentials_panel.go
+++ b/pkg/gui/credentials_panel.go
@@ -77,7 +77,7 @@ func (gui *Gui) handleCredentialsViewFocused(g *gocui.Gui, v *gocui.View) error 
 }
 
 // HandleCredentialsPopup handles the views after executing a command that might ask for credentials
-func (gui *Gui) HandleCredentialsPopup(g *gocui.Gui, cmdErr error) {
+func (gui *Gui) HandleCredentialsPopup(cmdErr error) {
 	_, _ = gui.g.SetViewOnBottom("credentials")
 	if cmdErr != nil {
 		errMessage := cmdErr.Error()
@@ -86,8 +86,5 @@ func (gui *Gui) HandleCredentialsPopup(g *gocui.Gui, cmdErr error) {
 		}
 		// we are not logging this error because it may contain a password
 		_ = gui.createSpecificErrorPanel(errMessage, gui.getFilesView(), false)
-	} else {
-		_ = gui.closeConfirmationPrompt(g, true)
-		_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC})
 	}
 }

--- a/pkg/gui/credentials_panel.go
+++ b/pkg/gui/credentials_panel.go
@@ -76,8 +76,8 @@ func (gui *Gui) handleCredentialsViewFocused(g *gocui.Gui, v *gocui.View) error 
 	return nil
 }
 
-// HandleCredentialsPopup handles the views after executing a command that might ask for credentials
-func (gui *Gui) HandleCredentialsPopup(cmdErr error) {
+// handleCredentialsPopup handles the views after executing a command that might ask for credentials
+func (gui *Gui) handleCredentialsPopup(cmdErr error) {
 	_, _ = gui.g.SetViewOnBottom("credentials")
 	if cmdErr != nil {
 		errMessage := cmdErr.Error()

--- a/pkg/gui/credentials_panel.go
+++ b/pkg/gui/credentials_panel.go
@@ -9,9 +9,9 @@ import (
 type credentials chan string
 
 // waitForPassUname wait for a username or password input from the credentials popup
-func (gui *Gui) waitForPassUname(g *gocui.Gui, currentView *gocui.View, passOrUname string) string {
+func (gui *Gui) waitForPassUname(passOrUname string) string {
 	gui.credentials = make(chan string)
-	g.Update(func(g *gocui.Gui) error {
+	gui.g.Update(func(g *gocui.Gui) error {
 		credentialsView, _ := g.View("credentials")
 		if passOrUname == "username" {
 			credentialsView.Title = gui.Tr.SLocalize("CredentialsUsername")
@@ -20,7 +20,7 @@ func (gui *Gui) waitForPassUname(g *gocui.Gui, currentView *gocui.View, passOrUn
 			credentialsView.Title = gui.Tr.SLocalize("CredentialsPassword")
 			credentialsView.Mask = '*'
 		}
-		err := gui.switchFocus(g, currentView, credentialsView)
+		err := gui.switchFocus(g, gui.g.CurrentView(), credentialsView)
 		if err != nil {
 			return err
 		}

--- a/pkg/gui/credentials_panel.go
+++ b/pkg/gui/credentials_panel.go
@@ -8,8 +8,8 @@ import (
 
 type credentials chan string
 
-// waitForPassUname wait for a username or password input from the credentials popup
-func (gui *Gui) waitForPassUname(passOrUname string) string {
+// promptUserForCredential wait for a username or password input from the credentials popup
+func (gui *Gui) promptUserForCredential(passOrUname string) string {
 	gui.credentials = make(chan string)
 	gui.g.Update(func(g *gocui.Gui) error {
 		credentialsView, _ := g.View("credentials")

--- a/pkg/gui/credentials_panel.go
+++ b/pkg/gui/credentials_panel.go
@@ -77,10 +77,8 @@ func (gui *Gui) handleCredentialsViewFocused(g *gocui.Gui, v *gocui.View) error 
 }
 
 // HandleCredentialsPopup handles the views after executing a command that might ask for credentials
-func (gui *Gui) HandleCredentialsPopup(g *gocui.Gui, popupOpened bool, cmdErr error) {
-	if popupOpened {
-		_, _ = gui.g.SetViewOnBottom("credentials")
-	}
+func (gui *Gui) HandleCredentialsPopup(g *gocui.Gui, cmdErr error) {
+	_, _ = gui.g.SetViewOnBottom("credentials")
 	if cmdErr != nil {
 		errMessage := cmdErr.Error()
 		if strings.Contains(errMessage, "Invalid username or password") {

--- a/pkg/gui/credentials_panel.go
+++ b/pkg/gui/credentials_panel.go
@@ -86,5 +86,7 @@ func (gui *Gui) HandleCredentialsPopup(cmdErr error) {
 		}
 		// we are not logging this error because it may contain a password
 		_ = gui.createSpecificErrorPanel(errMessage, gui.getFilesView(), false)
+	} else {
+		_ = gui.closeConfirmationPrompt(gui.g, true)
 	}
 }

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -487,20 +487,23 @@ func (gui *Gui) pullFiles(opts PullFilesOptions) error {
 			},
 		)
 		gui.HandleCredentialsPopup(err)
-		if err == nil {
-			switch strategy {
-			case "rebase":
-				err := gui.GitCommand.RebaseBranch("FETCH_HEAD")
-				_ = gui.handleGenericMergeCommandResult(err)
-			case "merge":
-				err := gui.GitCommand.Merge("FETCH_HEAD", commands.MergeOpts{})
-				_ = gui.handleGenericMergeCommandResult(err)
-			case "ff-only":
-				err := gui.GitCommand.Merge("FETCH_HEAD", commands.MergeOpts{FastForwardOnly: true})
-				_ = gui.handleGenericMergeCommandResult(err)
-			default:
-				_ = gui.createErrorPanel(fmt.Sprintf("git pull strategy '%s' unrecognised", strategy))
-			}
+		if err != nil {
+			_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC})
+			return
+		}
+
+		switch strategy {
+		case "rebase":
+			err := gui.GitCommand.RebaseBranch("FETCH_HEAD")
+			_ = gui.handleGenericMergeCommandResult(err)
+		case "merge":
+			err := gui.GitCommand.Merge("FETCH_HEAD", commands.MergeOpts{})
+			_ = gui.handleGenericMergeCommandResult(err)
+		case "ff-only":
+			err := gui.GitCommand.Merge("FETCH_HEAD", commands.MergeOpts{FastForwardOnly: true})
+			_ = gui.handleGenericMergeCommandResult(err)
+		default:
+			_ = gui.createErrorPanel(fmt.Sprintf("git pull strategy '%s' unrecognised", strategy))
 		}
 	}()
 
@@ -515,10 +518,7 @@ func (gui *Gui) pushWithForceFlag(g *gocui.Gui, v *gocui.View, force bool, upstr
 		branchName := gui.getCheckedOutBranch().Name
 		err := gui.GitCommand.Push(branchName, force, upstream, args, gui.promptUserForCredential)
 		gui.HandleCredentialsPopup(err)
-		if err == nil {
-			_ = gui.closeConfirmationPrompt(gui.g, true)
-			_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC})
-		}
+		_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC})
 	}()
 	return nil
 }

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -477,7 +477,7 @@ func (gui *Gui) pullFiles(v *gocui.View, args string) error {
 	// what if we had a struct which contained an array of functions to run, each of which return a function, or perhaps write to a channel when they're done, and if there is no error, we run the next thing. In this case we first want to fetch, potentially handling a credential popup, then we want to rebase.
 
 	go func() {
-		err := gui.GitCommand.Pull(args, gui.waitForPassUname)
+		err := gui.GitCommand.Pull(args, gui.promptUserForCredential)
 		// gui.handleGenericMergeCommandResult(err)
 		gui.HandleCredentialsPopup(gui.g, err)
 	}()
@@ -491,7 +491,7 @@ func (gui *Gui) pushWithForceFlag(g *gocui.Gui, v *gocui.View, force bool, upstr
 	}
 	go func() {
 		branchName := gui.getCheckedOutBranch().Name
-		err := gui.GitCommand.Push(branchName, force, upstream, args, gui.waitForPassUname)
+		err := gui.GitCommand.Push(branchName, force, upstream, args, gui.promptUserForCredential)
 		gui.HandleCredentialsPopup(g, err)
 	}()
 	return nil

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -491,7 +491,7 @@ func (gui *Gui) pullWithMode(mode string, opts PullFilesOptions) error {
 			BranchName:              opts.BranchName,
 		},
 	)
-	gui.HandleCredentialsPopup(err)
+	gui.handleCredentialsPopup(err)
 	if err != nil {
 		return gui.refreshSidePanels(refreshOptions{mode: ASYNC})
 	}
@@ -518,7 +518,7 @@ func (gui *Gui) pushWithForceFlag(g *gocui.Gui, v *gocui.View, force bool, upstr
 	go func() {
 		branchName := gui.getCheckedOutBranch().Name
 		err := gui.GitCommand.Push(branchName, force, upstream, args, gui.promptUserForCredential)
-		gui.HandleCredentialsPopup(err)
+		gui.handleCredentialsPopup(err)
 		_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC})
 	}()
 	return nil

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -477,9 +477,7 @@ func (gui *Gui) pullFiles(v *gocui.View, args string) error {
 	// what if we had a struct which contained an array of functions to run, each of which return a function, or perhaps write to a channel when they're done, and if there is no error, we run the next thing. In this case we first want to fetch, potentially handling a credential popup, then we want to rebase.
 
 	go func() {
-		err := gui.GitCommand.Pull(args, func(passOrUname string) string {
-			return gui.waitForPassUname(gui.g, v, passOrUname)
-		})
+		err := gui.GitCommand.Pull(args, gui.waitForPassUname)
 		// gui.handleGenericMergeCommandResult(err)
 		gui.HandleCredentialsPopup(gui.g, err)
 	}()
@@ -493,9 +491,7 @@ func (gui *Gui) pushWithForceFlag(g *gocui.Gui, v *gocui.View, force bool, upstr
 	}
 	go func() {
 		branchName := gui.getCheckedOutBranch().Name
-		err := gui.GitCommand.Push(branchName, force, upstream, args, func(passOrUname string) string {
-			return gui.waitForPassUname(g, v, passOrUname)
-		})
+		err := gui.GitCommand.Push(branchName, force, upstream, args, gui.waitForPassUname)
 		gui.HandleCredentialsPopup(g, err)
 	}()
 	return nil

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -471,13 +471,17 @@ func (gui *Gui) pullFiles(v *gocui.View, args string) error {
 		return err
 	}
 
+	// we want to first fetch, handling username if it comes up, then either merge or rebase. If merging we might have a merge conflict, likewise if rebasing we might have a conflict too.
+	// we need a way of saying .then or .catch
+
+	// what if we had a struct which contained an array of functions to run, each of which return a function, or perhaps write to a channel when they're done, and if there is no error, we run the next thing. In this case we first want to fetch, potentially handling a credential popup, then we want to rebase.
+
 	go func() {
-		unamePassOpend := false
 		err := gui.GitCommand.Pull(args, func(passOrUname string) string {
-			unamePassOpend = true
 			return gui.waitForPassUname(gui.g, v, passOrUname)
 		})
-		gui.HandleCredentialsPopup(gui.g, unamePassOpend, err)
+		// gui.handleGenericMergeCommandResult(err)
+		gui.HandleCredentialsPopup(gui.g, err)
 	}()
 
 	return nil
@@ -488,13 +492,11 @@ func (gui *Gui) pushWithForceFlag(g *gocui.Gui, v *gocui.View, force bool, upstr
 		return err
 	}
 	go func() {
-		unamePassOpend := false
 		branchName := gui.getCheckedOutBranch().Name
 		err := gui.GitCommand.Push(branchName, force, upstream, args, func(passOrUname string) string {
-			unamePassOpend = true
 			return gui.waitForPassUname(g, v, passOrUname)
 		})
-		gui.HandleCredentialsPopup(g, unamePassOpend, err)
+		gui.HandleCredentialsPopup(g, err)
 	}()
 	return nil
 }

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -167,7 +167,7 @@ func (gui *Gui) handleInfoClick(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (gui *Gui) fetch(g *gocui.Gui, v *gocui.View, canAskForCredentials bool) (err error) {
-	err = gui.GitCommand.Fetch(gui.waitForPassUname, canAskForCredentials)
+	err = gui.GitCommand.Fetch(gui.promptUserForCredential, canAskForCredentials)
 
 	if canAskForCredentials && err != nil && strings.Contains(err.Error(), "exit status 128") {
 		colorFunction := color.New(color.FgRed).SprintFunc()

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -167,9 +167,7 @@ func (gui *Gui) handleInfoClick(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (gui *Gui) fetch(g *gocui.Gui, v *gocui.View, canAskForCredentials bool) (err error) {
-	err = gui.GitCommand.Fetch(func(passOrUname string) string {
-		return gui.waitForPassUname(gui.g, v, passOrUname)
-	}, canAskForCredentials)
+	err = gui.GitCommand.Fetch(gui.waitForPassUname, canAskForCredentials)
 
 	if canAskForCredentials && err != nil && strings.Contains(err.Error(), "exit status 128") {
 		colorFunction := color.New(color.FgRed).SprintFunc()

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -166,10 +166,8 @@ func (gui *Gui) handleInfoClick(g *gocui.Gui, v *gocui.View) error {
 	return nil
 }
 
-func (gui *Gui) fetch(g *gocui.Gui, v *gocui.View, canAskForCredentials bool) (unamePassOpend bool, err error) {
-	unamePassOpend = false
+func (gui *Gui) fetch(g *gocui.Gui, v *gocui.View, canAskForCredentials bool) (err error) {
 	err = gui.GitCommand.Fetch(func(passOrUname string) string {
-		unamePassOpend = true
 		return gui.waitForPassUname(gui.g, v, passOrUname)
 	}, canAskForCredentials)
 
@@ -184,5 +182,5 @@ func (gui *Gui) fetch(g *gocui.Gui, v *gocui.View, canAskForCredentials bool) (u
 
 	gui.refreshSidePanels(refreshOptions{scope: []int{BRANCHES, COMMITS, REMOTES, TAGS}, mode: ASYNC})
 
-	return unamePassOpend, err
+	return err
 }

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -501,12 +501,12 @@ func (gui *Gui) startBackgroundFetch() {
 	if !isNew {
 		time.After(60 * time.Second)
 	}
-	_, err := gui.fetch(gui.g, gui.g.CurrentView(), false)
+	err := gui.fetch(gui.g, gui.g.CurrentView(), false)
 	if err != nil && strings.Contains(err.Error(), "exit status 128") && isNew {
 		_ = gui.createConfirmationPanel(gui.g, gui.g.CurrentView(), true, gui.Tr.SLocalize("NoAutomaticGitFetchTitle"), gui.Tr.SLocalize("NoAutomaticGitFetchBody"), nil, nil)
 	} else {
 		gui.goEvery(time.Second*60, gui.stopChan, func() error {
-			_, err := gui.fetch(gui.g, gui.g.CurrentView(), false)
+			err := gui.fetch(gui.g, gui.g.CurrentView(), false)
 			return err
 		})
 	}

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -501,12 +501,12 @@ func (gui *Gui) startBackgroundFetch() {
 	if !isNew {
 		time.After(60 * time.Second)
 	}
-	err := gui.fetch(gui.g, gui.g.CurrentView(), false)
+	err := gui.fetch(false)
 	if err != nil && strings.Contains(err.Error(), "exit status 128") && isNew {
 		_ = gui.createConfirmationPanel(gui.g, gui.g.CurrentView(), true, gui.Tr.SLocalize("NoAutomaticGitFetchTitle"), gui.Tr.SLocalize("NoAutomaticGitFetchBody"), nil, nil)
 	} else {
 		gui.goEvery(time.Second*60, gui.stopChan, func() error {
-			err := gui.fetch(gui.g, gui.g.CurrentView(), false)
+			err := gui.fetch(false)
 			return err
 		})
 	}


### PR DESCRIPTION
This allows the user to configure pull modes different to the default pull mode i.e. merge:
```
git:
  pull:
    mode: 'rebase' # or 'merge' or 'ff-only'
```