### PR TITLE
allow rebasing onto remote branch

### DIFF
--- a/pkg/gui/remote_branches_panel.go
+++ b/pkg/gui/remote_branches_panel.go
@@ -93,7 +93,7 @@ func (gui *Gui) handleDeleteRemoteBranch(g *gocui.Gui, v *gocui.View) error {
 	if remoteBranch == nil {
 		return nil
 	}
-	message := fmt.Sprintf("%s '%s/%s'?", gui.Tr.SLocalize("DeleteRemoteBranchMessage"), remoteBranch.RemoteName, remoteBranch.Name)
+	message := fmt.Sprintf("%s '%s'?", gui.Tr.SLocalize("DeleteRemoteBranchMessage"), remoteBranch.FullName())
 	return gui.createConfirmationPanel(g, v, true, gui.Tr.SLocalize("DeleteRemoteBranch"), message, func(*gocui.Gui, *gocui.View) error {
 		return gui.WithWaitingStatus(gui.Tr.SLocalize("DeletingStatus"), func() error {
 			if err := gui.GitCommand.DeleteRemoteBranch(remoteBranch.RemoteName, remoteBranch.Name); err != nil {
@@ -106,7 +106,7 @@ func (gui *Gui) handleDeleteRemoteBranch(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (gui *Gui) handleRebaseOntoRemoteBranch(g *gocui.Gui, v *gocui.View) error {
-	selectedBranchName := gui.getSelectedRemoteBranch().Name
+	selectedBranchName := gui.getSelectedRemoteBranch().FullName()
 	return gui.handleRebaseOntoBranch(selectedBranchName)
 }
 
@@ -137,7 +137,7 @@ func (gui *Gui) handleCreateResetToRemoteBranchMenu(g *gocui.Gui, v *gocui.View)
 		return nil
 	}
 
-	return gui.createResetMenu(fmt.Sprintf("%s/%s", selectedBranch.RemoteName, selectedBranch.Name))
+	return gui.createResetMenu(selectedBranch.FullName())
 }
 
 func (gui *Gui) handleNewBranchOffRemote(g *gocui.Gui, v *gocui.View) error {


### PR DESCRIPTION
When we _can_ use the full name of the remote branch, we _should_