### PR TITLE
prefill commit reword editor

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -501,6 +501,13 @@ func (c *GitCommand) GetHeadCommitMessage() (string, error) {
 	return strings.TrimSpace(message), err
 }
 
+func (c *GitCommand) GetCommitMessage(commitSha string) (string, error) {
+	cmdStr := "git rev-list --format=%B --max-count=1 " + commitSha
+	messageWithHeader, err := c.OSCommand.RunCommandWithOutput(cmdStr)
+	message := strings.Join(strings.SplitAfter(messageWithHeader, "\n")[1:], "\n")
+	return strings.TrimSpace(message), err
+}
+
 // AmendHead amends HEAD with whatever is staged in your working tree
 func (c *GitCommand) AmendHead() (*exec.Cmd, error) {
 	command := "git commit --amend --no-edit --allow-empty"

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -216,7 +216,18 @@ func (gui *Gui) handleRenameCommit(g *gocui.Gui, v *gocui.View) error {
 	if gui.State.Panels.Commits.SelectedLine != 0 {
 		return gui.createErrorPanel(gui.Tr.SLocalize("OnlyRenameTopCommit"))
 	}
-	return gui.prompt(v, gui.Tr.SLocalize("renameCommit"), "", func(response string) error {
+
+	commit := gui.getSelectedCommit()
+	if commit == nil {
+		return nil
+	}
+
+	message, err := gui.GitCommand.GetCommitMessage(commit.Sha)
+	if err != nil {
+		return gui.surfaceError(err)
+	}
+
+	return gui.prompt(v, gui.Tr.SLocalize("renameCommit"), message, func(response string) error {
 		if err := gui.GitCommand.RenameCommit(response); err != nil {
 			return gui.surfaceError(err)
 		}


### PR DESCRIPTION
When rewording a commit we should be able to edit the previous message

fixes https://github.com/jesseduffield/lazygit/issues/879