### PR TITLE
allow overriding default confirm/escape keybindings

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -81,6 +81,8 @@ Default path for the config file:
       optionMenu-alt1: '?' # show help menu
       select: '<space>'
       goInto: '<enter>'
+      confirm: '<enter>'
+      confirm-alt1: 'y'
       remove: 'd'
       new: 'n'
       edit: 'e'

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -309,6 +309,8 @@ keybinding:
     optionMenu-alt1: '?'
     select: '<space>'
     goInto: '<enter>'
+    confirm: '<enter>'
+    confirm-alt1: 'y'
     remove: 'd'
     new: 'n'
     edit: 'e'

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -831,25 +831,25 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		},
 		{
 			ViewName: "commitMessage",
-			Key:      gocui.KeyEnter,
+			Key:      gui.getKey("universal.confirm"),
 			Modifier: gocui.ModNone,
 			Handler:  gui.handleCommitConfirm,
 		},
 		{
 			ViewName: "commitMessage",
-			Key:      gocui.KeyEsc,
+			Key:      gui.getKey("universal.return"),
 			Modifier: gocui.ModNone,
 			Handler:  gui.handleCommitClose,
 		},
 		{
 			ViewName: "credentials",
-			Key:      gocui.KeyEnter,
+			Key:      gui.getKey("universal.confirm"),
 			Modifier: gocui.ModNone,
 			Handler:  gui.handleSubmitCredential,
 		},
 		{
 			ViewName: "credentials",
-			Key:      gocui.KeyEsc,
+			Key:      gui.getKey("universal.return"),
 			Modifier: gocui.ModNone,
 			Handler:  gui.handleCloseCredentialsView,
 		},
@@ -1355,7 +1355,7 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		},
 		{
 			ViewName: "search",
-			Key:      gocui.KeyEnter,
+			Key:      gui.getKey("universal.confirm"),
 			Modifier: gocui.ModNone,
 			Handler:  gui.handleSearch,
 		},

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -32,8 +32,12 @@ func (gui *Gui) renderMenuOptions() error {
 	return gui.renderOptionsMap(optionsMap)
 }
 
+func (gui *Gui) menuConfirmationKeys() []interface{} {
+	return []interface{}{gui.getKey("universal.select"), gui.getKey("universal.confirm"), gui.getKey("universal.confirm-alt1")}
+}
+
 func (gui *Gui) handleMenuClose(g *gocui.Gui, v *gocui.View) error {
-	for _, key := range []gocui.Key{gocui.KeySpace, gocui.KeyEnter} {
+	for _, key := range gui.menuConfirmationKeys() {
 		if err := g.DeleteKeybinding("menu", key, gocui.ModNone); err != nil {
 			return err
 		}
@@ -104,7 +108,7 @@ func (gui *Gui) createMenu(title string, items []*menuItem, createMenuOptions cr
 
 	gui.State.Panels.Menu.OnPress = wrappedHandlePress
 
-	for _, key := range []gocui.Key{gocui.KeySpace, gocui.KeyEnter, 'y'} {
+	for _, key := range gui.menuConfirmationKeys() {
 		_ = gui.g.DeleteKeybinding("menu", key, gocui.ModNone)
 
 		if err := gui.g.SetKeybinding("menu", nil, key, gocui.ModNone, wrappedHandlePress); err != nil {


### PR DESCRIPTION
You can now rebind escape/confirm keybindings. You probably don't want to rebind either of these to a letter or you'll be unable to confirm a prompt dialog because it will just type the character. I have, however introduced a `confirm-alt1` keybinding which you could make into a letter for when you aren't being prompted to type anything.