### PR TITLE
prefil remote branch name

### DIFF
--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -468,7 +468,12 @@ func (gui *Gui) handleNewBranchOffCurrentItem() error {
 		},
 	)
 
-	return gui.prompt(message, "", func(response string) error {
+	prefilledName := ""
+	if context.GetKey() == REMOTE_BRANCHES_CONTEXT_KEY {
+		// will set to the remote's existing name
+		prefilledName = item.ID()
+	}
+	return gui.prompt(message, prefilledName, func(response string) error {
 		if err := gui.GitCommand.NewBranch(response, item.ID()); err != nil {
 			return err
 		}


### PR DESCRIPTION
when creating a new branch off of a remote branch, we should prefill the name