### PR TITLE
Return whether the context has a parent or not along with that parent

### DIFF
--- a/pkg/gui/context.go
+++ b/pkg/gui/context.go
@@ -46,7 +46,9 @@ type Context interface {
 	SetWindowName(string)
 	GetKey() string
 	SetParentContext(Context)
-	GetParentContext() Context
+
+	// we return a bool here to tell us whether or not the returned value just wraps a nil
+	GetParentContext() (Context, bool)
 	GetOptionsMap() map[string]string
 }
 
@@ -80,8 +82,8 @@ func (c BasicContext) SetParentContext(Context) {
 	panic("can't set parent context on basic context")
 }
 
-func (c BasicContext) GetParentContext() Context {
-	panic("can't get parent context on basic context")
+func (c BasicContext) GetParentContext() (Context, bool) {
+	return nil, false
 }
 
 func (c BasicContext) HandleRender() error {

--- a/pkg/gui/list_context.go
+++ b/pkg/gui/list_context.go
@@ -23,7 +23,9 @@ type ListContext struct {
 	ResetMainViewOriginOnFocus bool
 	Kind                       int
 	ParentContext              Context
-	WindowName                 string
+	// we can't know on the calling end whether a Context is actually a nil value without reflection, so we're storing this flag here to tell us. There has got to be a better way around this.
+	hasParent  bool
+	WindowName string
 }
 
 type ListItem interface {
@@ -55,10 +57,11 @@ func (lc *ListContext) GetWindowName() string {
 
 func (lc *ListContext) SetParentContext(c Context) {
 	lc.ParentContext = c
+	lc.hasParent = true
 }
 
-func (lc *ListContext) GetParentContext() Context {
-	return lc.ParentContext
+func (lc *ListContext) GetParentContext() (Context, bool) {
+	return lc.ParentContext, lc.hasParent
 }
 
 func (lc *ListContext) GetSelectedItemId() string {

--- a/pkg/gui/quitting.go
+++ b/pkg/gui/quitting.go
@@ -36,9 +36,11 @@ func (gui *Gui) handleQuit() error {
 
 func (gui *Gui) handleTopLevelReturn(g *gocui.Gui, v *gocui.View) error {
 	currentContext := gui.currentContext()
-	if currentContext != nil && currentContext.GetParentContext() != nil {
+
+	parentContext, hasParent := currentContext.GetParentContext()
+	if hasParent && currentContext != nil && parentContext != nil {
 		// TODO: think about whether this should be marked as a return rather than adding to the stack
-		return gui.switchContext(currentContext.GetParentContext())
+		return gui.switchContext(parentContext)
 	}
 
 	for _, mode := range gui.modeStatuses() {


### PR DESCRIPTION
There has got to be a better way around this but if we're returning a Context
from a function (Context is an interface, not a concrete type), even if we
return nil, on the calling end it won't be equal to nil because an interface
value is a tuple of the type and the value meaning it's never itself nil,
unless both values in the tuple are nil.

So we're explicitly returning whether or not the underlying concrete type is nil.