### PR TITLE
drop merge commits when interactive rebasing just like git CLI

### DIFF
--- a/pkg/commands/commit.go
+++ b/pkg/commands/commit.go
@@ -12,6 +12,9 @@ type Commit struct {
 	ExtraInfo     string // something like 'HEAD -> master, tag: v0.15.2'
 	Author        string
 	UnixTimestamp int64
+
+	// IsMerge tells us whether we're dealing with a merge commit i.e. a commit with two parents
+	IsMerge bool
 }
 
 func (c *Commit) ShortSha() string {

--- a/pkg/commands/commit_list_builder_test.go
+++ b/pkg/commands/commit_list_builder_test.go
@@ -13,11 +13,10 @@ func NewDummyCommitListBuilder() *CommitListBuilder {
 	osCommand := NewDummyOSCommand()
 
 	return &CommitListBuilder{
-		Log:                 NewDummyLog(),
-		GitCommand:          NewDummyGitCommandWithOSCommand(osCommand),
-		OSCommand:           osCommand,
-		Tr:                  i18n.NewLocalizer(NewDummyLog()),
-		CherryPickedCommits: []*Commit{},
+		Log:        NewDummyLog(),
+		GitCommand: NewDummyGitCommandWithOSCommand(osCommand),
+		OSCommand:  osCommand,
+		Tr:         i18n.NewLocalizer(NewDummyLog()),
 	}
 }
 

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -1639,7 +1639,7 @@ func TestGitCommandRebaseBranch(t *testing.T) {
 			"master",
 			test.CreateMockCommand(t, []*test.CommandSwapper{
 				{
-					Expect:  "git rebase --interactive --autostash --keep-empty --rebase-merges master",
+					Expect:  "git rebase --interactive --autostash --keep-empty master",
 					Replace: "echo",
 				},
 			}),
@@ -1652,7 +1652,7 @@ func TestGitCommandRebaseBranch(t *testing.T) {
 			"master",
 			test.CreateMockCommand(t, []*test.CommandSwapper{
 				{
-					Expect:  "git rebase --interactive --autostash --keep-empty --rebase-merges master",
+					Expect:  "git rebase --interactive --autostash --keep-empty master",
 					Replace: "test",
 				},
 			}),
@@ -1775,7 +1775,7 @@ func TestGitCommandDiscardOldFileChanges(t *testing.T) {
 			"test999.txt",
 			test.CreateMockCommand(t, []*test.CommandSwapper{
 				{
-					Expect:  "git rebase --interactive --autostash --keep-empty --rebase-merges abcdef",
+					Expect:  "git rebase --interactive --autostash --keep-empty abcdef",
 					Replace: "echo",
 				},
 				{

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -297,6 +297,7 @@ type guiState struct {
 	RefreshingFilesMutex  sync.Mutex
 	RefreshingStatusMutex sync.Mutex
 	FetchMutex            sync.Mutex
+	BranchCommitsMutex    sync.Mutex
 	Searching             searchingState
 	ScreenMode            int
 	SideView              *gocui.View

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -32,7 +32,6 @@ func getFullDescriptionDisplayStringsForCommit(c *commands.Commit, cherryPickedC
 	yellow := color.New(color.FgYellow)
 	green := color.New(color.FgGreen)
 	blue := color.New(color.FgBlue)
-	cyan := color.New(color.FgCyan)
 	defaultColor := color.New(theme.DefaultTextColor)
 	diffedColor := color.New(theme.DiffTerminalColor)
 
@@ -66,7 +65,7 @@ func getFullDescriptionDisplayStringsForCommit(c *commands.Commit, cherryPickedC
 	tagString := ""
 	secondColumnString := blue.Sprint(utils.UnixToDate(c.UnixTimestamp))
 	if c.Action != "" {
-		secondColumnString = cyan.Sprint(c.Action)
+		secondColumnString = color.New(actionColorMap(c.Action)).Sprint(c.Action)
 	} else if c.ExtraInfo != "" {
 		tagColor := color.New(color.FgMagenta, color.Bold)
 		tagString = utils.ColoredStringDirect(c.ExtraInfo, tagColor) + " "
@@ -82,7 +81,6 @@ func getDisplayStringsForCommit(c *commands.Commit, cherryPickedCommitShaMap map
 	yellow := color.New(color.FgYellow)
 	green := color.New(color.FgGreen)
 	blue := color.New(color.FgBlue)
-	cyan := color.New(color.FgCyan)
 	defaultColor := color.New(theme.DefaultTextColor)
 	diffedColor := color.New(theme.DiffTerminalColor)
 
@@ -116,11 +114,26 @@ func getDisplayStringsForCommit(c *commands.Commit, cherryPickedCommitShaMap map
 	actionString := ""
 	tagString := ""
 	if c.Action != "" {
-		actionString = cyan.Sprint(utils.WithPadding(c.Action, 7)) + " "
+		actionString = color.New(actionColorMap(c.Action)).Sprint(utils.WithPadding(c.Action, 7)) + " "
 	} else if len(c.Tags) > 0 {
 		tagColor := color.New(color.FgMagenta, color.Bold)
 		tagString = utils.ColoredStringDirect(strings.Join(c.Tags, " "), tagColor) + " "
 	}
 
 	return []string{shaColor.Sprint(c.ShortSha()), actionString + tagString + defaultColor.Sprint(c.Name)}
+}
+
+func actionColorMap(str string) color.Attribute {
+	switch str {
+	case "pick":
+		return color.FgCyan
+	case "drop":
+		return color.FgRed
+	case "edit":
+		return color.FgGreen
+	case "fixup":
+		return color.FgMagenta
+	default:
+		return color.FgYellow
+	}
 }

--- a/pkg/gui/sub_commits_panel.go
+++ b/pkg/gui/sub_commits_panel.go
@@ -77,7 +77,7 @@ func (gui *Gui) handleViewSubCommitFiles() error {
 
 func (gui *Gui) switchToSubCommitsContext(refName string) error {
 	// need to populate my sub commits
-	builder := commands.NewCommitListBuilder(gui.Log, gui.GitCommand, gui.OSCommand, gui.Tr, gui.State.Modes.CherryPicking.CherryPickedCommits)
+	builder := commands.NewCommitListBuilder(gui.Log, gui.GitCommand, gui.OSCommand, gui.Tr)
 
 	commits, err := builder.GetCommits(
 		commands.GetCommitsOptions{


### PR DESCRIPTION
from the [docs](https://git-scm.com/docs/git-rebase):
>--rebase-merges[=(rebase-cousins|no-rebase-cousins)]
>By default, a rebase will simply drop merge commits from the todo list, and put the rebased commits into a single, linear branch. With --rebase-merges, the rebase will instead try to preserve the branching structure within the commits that are to be rebased, by recreating the merge commits. Any resolved merge conflicts or manual amendments in these merge commits will have to be resolved/re-applied manually.
