### PR TITLE
Credentials popup concept

### DIFF
--- a/pkg/commands/exec_live_win.go
+++ b/pkg/commands/exec_live_win.go
@@ -4,6 +4,6 @@ package commands
 
 // RunCommandWithOutputLiveWrapper runs a command live but because of windows compatibility this command can't be ran there
 // TODO: Remove this hack and replace it with a proper way to run commands live on windows
-func RunCommandWithOutputLiveWrapper(c *OSCommand, command string, output func(string) string) error {
+func RunCommandWithOutputLiveWrapper(c *OSCommand, command string, updates func(AuthUpdate), stdin *chan string) error {
 	return c.RunCommand(command)
 }

--- a/pkg/commands/exec_live_win.go
+++ b/pkg/commands/exec_live_win.go
@@ -4,6 +4,6 @@ package commands
 
 // RunCommandWithOutputLiveWrapper runs a command live but because of windows compatibility this command can't be ran there
 // TODO: Remove this hack and replace it with a proper way to run commands live on windows
-func RunCommandWithOutputLiveWrapper(c *OSCommand, command string, updates func(AuthUpdate), stdin *chan string) error {
+func RunCommandWithOutputLiveWrapper(c *OSCommand, command string, stdOutWords func(string), stdIn *chan string) error {
 	return c.RunCommand(command)
 }

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -378,9 +378,9 @@ func (c *GitCommand) RebaseBranch(branchName string) error {
 }
 
 type FetchOptions struct {
-	PromptUserForCredential func(string) string
-	RemoteName              string
-	BranchName              string
+	RemoteName string
+	BranchName string
+	Auth       *AuthInput
 }
 
 // Fetch fetch git repo
@@ -394,12 +394,7 @@ func (c *GitCommand) Fetch(opts FetchOptions) error {
 		command = fmt.Sprintf("%s %s", command, opts.BranchName)
 	}
 
-	return c.OSCommand.DetectUnamePass(command, func(question string) string {
-		if opts.PromptUserForCredential != nil {
-			return opts.PromptUserForCredential(question)
-		}
-		return "\n"
-	})
+	return c.OSCommand.DetectUnamePass(command, opts.Auth)
 }
 
 // ResetToCommit reset to commit
@@ -526,7 +521,7 @@ func (c *GitCommand) AmendHead() (*exec.Cmd, error) {
 }
 
 // Push pushes to a branch
-func (c *GitCommand) Push(branchName string, force bool, upstream string, args string, promptUserForCredential func(string) string) error {
+func (c *GitCommand) Push(branchName string, force bool, upstream string, args string, auth *AuthInput) error {
 	forceFlag := ""
 	if force {
 		forceFlag = "--force-with-lease"
@@ -538,7 +533,7 @@ func (c *GitCommand) Push(branchName string, force bool, upstream string, args s
 	}
 
 	cmd := fmt.Sprintf("git push --follow-tags %s %s %s", forceFlag, setUpstreamArg, args)
-	return c.OSCommand.DetectUnamePass(cmd, promptUserForCredential)
+	return c.OSCommand.DetectUnamePass(cmd, auth)
 }
 
 // CatFile obtains the content of a file
@@ -806,9 +801,9 @@ func (c *GitCommand) ApplyPatch(patch string, flags ...string) error {
 	return c.OSCommand.RunCommand("git apply %s %s", flagStr, c.OSCommand.Quote(filepath))
 }
 
-func (c *GitCommand) FastForward(branchName string, remoteName string, remoteBranchName string, promptUserForCredential func(string) string) error {
+func (c *GitCommand) FastForward(branchName string, remoteName string, remoteBranchName string, auth *AuthInput) error {
 	command := fmt.Sprintf("git fetch %s %s:%s", remoteName, remoteBranchName, branchName)
-	return c.OSCommand.DetectUnamePass(command, promptUserForCredential)
+	return c.OSCommand.DetectUnamePass(command, auth)
 }
 
 func (c *GitCommand) RunSkipEditorCommand(command string) error {

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -386,10 +386,12 @@ func (gui *Gui) handleFastForward(g *gocui.Gui, v *gocui.View) error {
 	go func() {
 		_ = gui.createLoaderPanel(v, message)
 
+		auth := gui.getCredentialsHandler(message)
+
 		if gui.State.Panels.Branches.SelectedLineIdx == 0 {
-			_ = gui.pullWithMode("ff-only", PullFilesOptions{})
+			_ = gui.pullWithMode("ff-only", PullFilesOptions{}, auth)
 		} else {
-			err := gui.GitCommand.FastForward(branch.Name, remoteName, remoteBranchName, gui.promptUserForCredential)
+			err := gui.GitCommand.FastForward(branch.Name, remoteName, remoteBranchName, auth)
 			gui.handleCredentialsPopup(err)
 			_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC, scope: []int{BRANCHES}})
 		}

--- a/pkg/gui/context.go
+++ b/pkg/gui/context.go
@@ -391,6 +391,7 @@ func (gui *Gui) switchContextToView(viewName string) error {
 	return gui.switchContext(gui.State.ViewContextMap[viewName])
 }
 
+// TODO: add documentation about this function
 func (gui *Gui) returnFromContext() error {
 	gui.g.Update(func(*gocui.Gui) error {
 		// TODO: add mutexes

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -169,7 +169,7 @@ func (gui *Gui) fetch(canPromptForCredentials bool) (err error) {
 
 	fetchOpts := commands.FetchOptions{}
 	if canPromptForCredentials {
-		fetchOpts.PromptUserForCredential = gui.promptUserForCredential
+		fetchOpts.Auth = gui.getCredentialsHandler(gui.Tr.SLocalize("PushWait"))
 	}
 
 	err = gui.GitCommand.Fetch(fetchOpts)
@@ -185,11 +185,11 @@ func (gui *Gui) fetch(canPromptForCredentials bool) (err error) {
 
 func (gui *Gui) handleCopySelectedSideContextItemToClipboard() error {
 	// important to note that this assumes we've selected an item in a side context
-	itemId := gui.getSideContextSelectedItemId()
+	itemID := gui.getSideContextSelectedItemId()
 
-	if itemId == "" {
+	if itemID == "" {
 		return nil
 	}
 
-	return gui.OSCommand.CopyToClipboard(itemId)
+	return gui.OSCommand.CopyToClipboard(itemID)
 }

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -97,7 +97,8 @@ type Gui struct {
 	Errors               SentinelErrors
 	Updater              *updates.Updater
 	statusManager        *statusManager
-	credentials          credentials
+	credentialsInput     chan string
+	credentialsInputOpen bool
 	waitForIntro         sync.WaitGroup
 	fileWatcher          *fileWatcher
 	viewBufferManagerMap map[string]*tasks.ViewBufferManager

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -207,6 +207,9 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			credentialsView.Title = gui.Tr.SLocalize("CredentialsUsername")
 			credentialsView.FgColor = textColor
 			credentialsView.Editable = true
+
+			// This view might have a ticker so we need to start the ticker here
+			gui.g.StartTicking()
 		}
 	}
 


### PR DESCRIPTION
A concept for handeling all things asked by git as long as it's asked in the pty

@jesseduffield It still has a bug where i can't get rid of the credentials popup and i'm not sure why.  

Some things that could get optimized but maybe not for this MR:  
- Replace credentials title with language specific tittle if it matches a certain regex.  
- When the above is detected we can skip the 300ms wait before changing from the loading box to a input box.
- Some lines in the git output might take very long like pushing lots of code to a server, we could add a blacklist with regexes that will never cause the loading box to change into a input box