### PR TITLE
Update list notation to correct item numbering

### DIFF
--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -460,7 +460,7 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 1) If you want to learn about lazygit's features, watch this vid:
    https://youtu.be/CPLdltN7wgE
 
-3) If you're using git, that makes you a programmer! With your help we can make lazygit better, so consider becoming a contributor and joining the fun at
+2) If you're using git, that makes you a programmer! With your help we can make lazygit better, so consider becoming a contributor and joining the fun at
    https://github.com/jesseduffield/lazygit`,
 		}, &i18n.Message{
 			ID:    "GitconfigParseErr",


### PR DESCRIPTION
I assume there was a different number two in the past, and it was deleted. This PR fixes number three which should be number two now.