### PR TITLE
Support copy file name

### DIFF
--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -453,6 +453,12 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Description: gui.Tr.SLocalize("fetch"),
 		},
 		{
+			ViewName:    "files",
+			Key:         gui.getKey("universal.copyToClipboard"),
+			Handler:     gui.wrappedHandler(gui.handleCopySelectedSideContextItemToClipboard),
+			Description: gui.Tr.SLocalize("copyFileNameToClipboard"),
+		},
+		{
 			ViewName:    "",
 			Key:         gui.getKey("universal.executeCustomCommand"),
 			Handler:     gui.handleCustomCommand,
@@ -866,6 +872,12 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Key:         gui.getKey("universal.copyToClipboard"),
 			Handler:     gui.wrappedHandler(gui.handleCopySelectedSideContextItemToClipboard),
 			Description: gui.Tr.SLocalize("copyCommitShaToClipboard"),
+		},
+		{
+			ViewName:    "commitFiles",
+			Key:         gui.getKey("universal.copyToClipboard"),
+			Handler:     gui.wrappedHandler(gui.handleCopySelectedSideContextItemToClipboard),
+			Description: gui.Tr.SLocalize("copyCommitFileNameToClipboard"),
 		},
 		{
 			ViewName:    "branches",

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -1146,10 +1146,10 @@ func addDutch(i18nObject *i18n.Bundle) error {
 			Other: "copieer branch name naar clipboard",
 		}, &i18n.Message{
 			ID:    "copyFileNameToClipboard",
-			Other: "Kopieer de bestandsnaam naar het klembord",
+			Other: "kopieer de bestandsnaam naar het klembord",
 		}, &i18n.Message{
 			ID:    "copyCommitFileNameToClipboard",
-			Other: "Kopieer de vastgelegde bestandsnaam naar het klembord",
+			Other: "kopieer de vastgelegde bestandsnaam naar het klembord",
 		}, &i18n.Message{
 			ID:    "commitPrefixPatternError",
 			Other: "Fout in commitPrefix patroon",

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -1145,6 +1145,12 @@ func addDutch(i18nObject *i18n.Bundle) error {
 			ID:    "copyBranchNameToClipboard",
 			Other: "copieer branch name naar clipboard",
 		}, &i18n.Message{
+			ID:    "copyFileNameToClipboard",
+			Other: "Kopieer de bestandsnaam naar het klembord",
+		}, &i18n.Message{
+			ID:    "copyCommitFileNameToClipboard",
+			Other: "Kopieer de vastgelegde bestandsnaam naar het klembord",
+		}, &i18n.Message{
 			ID:    "commitPrefixPatternError",
 			Other: "Fout in commitPrefix patroon",
 		}, &i18n.Message{

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1150,6 +1150,12 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			ID:    "copyBranchNameToClipboard",
 			Other: "copy branch name to clipboard",
 		}, &i18n.Message{
+			ID:    "copyFileNameToClipboard",
+			Other: "Copy the file name to the clipboard",
+		}, &i18n.Message{
+			ID:    "copyCommitFileNameToClipboard",
+			Other: "Copy the committed file name to the clipboard",
+		}, &i18n.Message{
 			ID:    "commitPrefixPatternError",
 			Other: "Error in commitPrefix pattern",
 		}, &i18n.Message{

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1151,7 +1151,7 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			Other: "copy branch name to clipboard",
 		}, &i18n.Message{
 			ID:    "copyFileNameToClipboard",
-			Other: "Copy the file name to the clipboard",
+			Other: "copy the file name to the clipboard",
 		}, &i18n.Message{
 			ID:    "copyCommitFileNameToClipboard",
 			Other: "Copy the committed file name to the clipboard",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1154,7 +1154,7 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 			Other: "copy the file name to the clipboard",
 		}, &i18n.Message{
 			ID:    "copyCommitFileNameToClipboard",
-			Other: "Copy the committed file name to the clipboard",
+			Other: "copy the committed file name to the clipboard",
 		}, &i18n.Message{
 			ID:    "commitPrefixPatternError",
 			Other: "Error in commitPrefix pattern",


### PR DESCRIPTION
Fix #998

You can copy the file nae by clicking `ctrl+o` in inside of a commit or inside the files panel.
This is my first pr to this repo 
If you have any comments, please let me know 😄 