### PR TITLE
Support custom command keybindings

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -705,11 +705,6 @@ func (c *GitCommand) Checkout(branch string, options CheckoutOptions) error {
 	return c.OSCommand.RunCommandWithOptions(fmt.Sprintf("git checkout %s %s", forceArg, branch), RunCommandOptions{EnvVars: options.EnvVars})
 }
 
-// PrepareCommitSubProcess prepares a subprocess for `git commit`
-func (c *GitCommand) PrepareCommitSubProcess() *exec.Cmd {
-	return c.OSCommand.PrepareSubProcess("git", "commit")
-}
-
 // PrepareCommitAmendSubProcess prepares a subprocess for `git commit --amend --allow-empty`
 func (c *GitCommand) PrepareCommitAmendSubProcess() *exec.Cmd {
 	return c.OSCommand.PrepareSubProcess("git", "commit", "--amend", "--allow-empty")

--- a/pkg/gui/cherry_picking.go
+++ b/pkg/gui/cherry_picking.go
@@ -176,7 +176,7 @@ func (gui *Gui) rerenderContextViewIfPresent(contextKey string) error {
 		return nil
 	}
 
-	context := gui.contextForContextKey(contextKey)
+	context := gui.mustContextForContextKey(contextKey)
 
 	viewName := context.GetViewName()
 

--- a/pkg/gui/context.go
+++ b/pkg/gui/context.go
@@ -36,6 +36,29 @@ const (
 	COMMIT_MESSAGE_CONTEXT_KEY      = "commitMessage"
 )
 
+var allContextKeys = []string{
+	STATUS_CONTEXT_KEY,
+	FILES_CONTEXT_KEY,
+	LOCAL_BRANCHES_CONTEXT_KEY,
+	REMOTES_CONTEXT_KEY,
+	REMOTE_BRANCHES_CONTEXT_KEY,
+	TAGS_CONTEXT_KEY,
+	BRANCH_COMMITS_CONTEXT_KEY,
+	REFLOG_COMMITS_CONTEXT_KEY,
+	SUB_COMMITS_CONTEXT_KEY,
+	COMMIT_FILES_CONTEXT_KEY,
+	STASH_CONTEXT_KEY,
+	MAIN_NORMAL_CONTEXT_KEY,
+	MAIN_MERGING_CONTEXT_KEY,
+	MAIN_PATCH_BUILDING_CONTEXT_KEY,
+	MAIN_STAGING_CONTEXT_KEY,
+	MENU_CONTEXT_KEY,
+	CREDENTIALS_CONTEXT_KEY,
+	CONFIRMATION_CONTEXT_KEY,
+	SEARCH_CONTEXT_KEY,
+	COMMIT_MESSAGE_CONTEXT_KEY,
+}
+
 type Context interface {
 	HandleFocus() error
 	HandleFocusLost() error
@@ -672,14 +695,24 @@ type tabContext struct {
 	contexts []Context
 }
 
-func (gui *Gui) contextForContextKey(contextKey string) Context {
+func (gui *Gui) mustContextForContextKey(contextKey string) Context {
+	context, ok := gui.contextForContextKey(contextKey)
+
+	if !ok {
+		panic(fmt.Sprintf("context now found for key %s", contextKey))
+	}
+
+	return context
+}
+
+func (gui *Gui) contextForContextKey(contextKey string) (Context, bool) {
 	for _, context := range gui.allContexts() {
 		if context.GetKey() == contextKey {
-			return context
+			return context, true
 		}
 	}
 
-	panic(fmt.Sprintf("context now found for key %s", contextKey))
+	return nil, false
 }
 
 func (gui *Gui) rerenderView(viewName string) error {
@@ -689,7 +722,7 @@ func (gui *Gui) rerenderView(viewName string) error {
 	}
 
 	contextKey := v.Context
-	context := gui.contextForContextKey(contextKey)
+	context := gui.mustContextForContextKey(contextKey)
 
 	return context.HandleRender()
 }

--- a/pkg/gui/context.go
+++ b/pkg/gui/context.go
@@ -32,7 +32,7 @@ const (
 	MENU_CONTEXT_KEY                = "menu"
 	CREDENTIALS_CONTEXT_KEY         = "credentials"
 	CONFIRMATION_CONTEXT_KEY        = "confirmation"
-	SEARCH_CONTEXT_KEY              = "confirmation"
+	SEARCH_CONTEXT_KEY              = "search"
 	COMMIT_MESSAGE_CONTEXT_KEY      = "commitMessage"
 )
 

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -3,6 +3,7 @@ package gui
 import (
 	"bytes"
 	"log"
+	"strings"
 	"text/template"
 
 	"github.com/fatih/color"
@@ -211,12 +212,15 @@ func (gui *Gui) GetCustomCommandKeybindings() []*Binding {
 
 	for _, customCommand := range customCommands {
 		var viewName string
-		if customCommand.Context == "global" || customCommand.Context == "" {
+		switch customCommand.Context {
+		case "global":
 			viewName = ""
-		} else {
-			context := gui.contextForContextKey(customCommand.Context)
-			if context == nil {
-				log.Fatalf("Error when setting custom command keybindings: unknown context: %s", customCommand.Context)
+		case "":
+			log.Fatalf("Error parsing custom command keybindings: context not provided (use context: 'global' for the global context). Key: %s, Command: %s", customCommand.Key, customCommand.Command)
+		default:
+			context, ok := gui.contextForContextKey(customCommand.Context)
+			if !ok {
+				log.Fatalf("Error when setting custom command keybindings: unknown context: %s. Key: %s, Command: %s.\nPermitted contexts: %s", customCommand.Context, customCommand.Key, customCommand.Command, strings.Join(allContextKeys, ", "))
 			}
 			// here we assume that a given context will always belong to the same view.
 			// Currently this is a safe bet but it's by no means guaranteed in the long term

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -2,8 +2,10 @@ package gui
 
 import (
 	"bytes"
+	"log"
 	"text/template"
 
+	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands"
 )
 
@@ -21,7 +23,7 @@ type CustomCommandObjects struct {
 	CurrentBranch        *commands.Branch
 }
 
-func (gui *Gui) handleCustomCommandKeybinding(templateStr string) func() error {
+func (gui *Gui) handleCustomCommandKeybinding(customCommand CustomCommand) func() error {
 	return func() error {
 		objects := CustomCommandObjects{
 			SelectedFile:         gui.getSelectedFile(),
@@ -37,7 +39,7 @@ func (gui *Gui) handleCustomCommandKeybinding(templateStr string) func() error {
 			CurrentBranch:        gui.currentBranch(),
 		}
 
-		tmpl, err := template.New("custom command template").Parse(templateStr)
+		tmpl, err := template.New("custom command template").Parse(customCommand.Command)
 		if err != nil {
 			return gui.surfaceError(err)
 		}
@@ -49,11 +51,62 @@ func (gui *Gui) handleCustomCommandKeybinding(templateStr string) func() error {
 
 		cmdStr := buf.String()
 
+		if customCommand.Subprocess {
+			gui.PrepareSubProcess(cmdStr)
+			return nil
+		}
+
 		return gui.WithWaitingStatus(gui.Tr.SLocalize("runningCustomCommandStatus"), func() error {
+			gui.OSCommand.PrepareSubProcess(cmdStr)
+
 			if err := gui.OSCommand.RunCommand(cmdStr); err != nil {
 				return gui.surfaceError(err)
 			}
 			return gui.refreshSidePanels(refreshOptions{})
 		})
 	}
+}
+
+type CustomCommand struct {
+	Key        string `yaml:"key"`
+	Context    string `yaml:"context"`
+	Command    string `yaml:"command"`
+	Subprocess bool   `yaml:"subprocess"`
+}
+
+func (gui *Gui) GetCustomCommandKeybindings() []*Binding {
+	bindings := []*Binding{}
+
+	var customCommands []CustomCommand
+
+	if err := gui.Config.GetUserConfig().UnmarshalKey("customCommands", &customCommands); err != nil {
+		log.Fatalf("Error parsing custom command keybindings: %v", err)
+	}
+
+	for _, customCommand := range customCommands {
+		var viewName string
+		if customCommand.Context == "global" || customCommand.Context == "" {
+			viewName = ""
+		} else {
+			context := gui.contextForContextKey(customCommand.Context)
+			if context == nil {
+				log.Fatalf("Error when setting custom command keybindings: unknown context: %s", customCommand.Context)
+			}
+			// here we assume that a given context will always belong to the same view.
+			// Currently this is a safe bet but it's by no means guaranteed in the long term
+			// and we might need to make some changes in the future to support it.
+			viewName = context.GetViewName()
+		}
+
+		bindings = append(bindings, &Binding{
+			ViewName:    viewName,
+			Contexts:    []string{customCommand.Context},
+			Key:         gui.getKey(customCommand.Key),
+			Modifier:    gocui.ModNone,
+			Handler:     gui.wrappedHandler(gui.handleCustomCommandKeybinding(customCommand)),
+			Description: customCommand.Command,
+		})
+	}
+
+	return bindings
 }

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -21,57 +21,104 @@ type CustomCommandObjects struct {
 	SelectedStashEntry   *commands.StashEntry
 	SelectedCommitFile   *commands.CommitFile
 	CheckedOutBranch     *commands.Branch
+	PromptResponses      []string
+}
+
+func (gui *Gui) resolveTemplate(templateStr string, promptResponses []string) (string, error) {
+	objects := CustomCommandObjects{
+		SelectedFile:         gui.getSelectedFile(),
+		SelectedLocalCommit:  gui.getSelectedLocalCommit(),
+		SelectedReflogCommit: gui.getSelectedReflogCommit(),
+		SelectedLocalBranch:  gui.getSelectedBranch(),
+		SelectedRemoteBranch: gui.getSelectedRemoteBranch(),
+		SelectedRemote:       gui.getSelectedRemote(),
+		SelectedTag:          gui.getSelectedTag(),
+		SelectedStashEntry:   gui.getSelectedStashEntry(),
+		SelectedCommitFile:   gui.getSelectedCommitFile(),
+		SelectedSubCommit:    gui.getSelectedSubCommit(),
+		CheckedOutBranch:     gui.currentBranch(),
+		PromptResponses:      promptResponses,
+	}
+
+	tmpl, err := template.New("template").Parse(templateStr)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, objects); err != nil {
+		return "", err
+	}
+
+	cmdStr := buf.String()
+
+	return cmdStr, nil
 }
 
 func (gui *Gui) handleCustomCommandKeybinding(customCommand CustomCommand) func() error {
 	return func() error {
-		objects := CustomCommandObjects{
-			SelectedFile:         gui.getSelectedFile(),
-			SelectedLocalCommit:  gui.getSelectedLocalCommit(),
-			SelectedReflogCommit: gui.getSelectedReflogCommit(),
-			SelectedLocalBranch:  gui.getSelectedBranch(),
-			SelectedRemoteBranch: gui.getSelectedRemoteBranch(),
-			SelectedRemote:       gui.getSelectedRemote(),
-			SelectedTag:          gui.getSelectedTag(),
-			SelectedStashEntry:   gui.getSelectedStashEntry(),
-			SelectedCommitFile:   gui.getSelectedCommitFile(),
-			SelectedSubCommit:    gui.getSelectedSubCommit(),
-			CheckedOutBranch:     gui.currentBranch(),
-		}
+		promptResponses := make([]string, len(customCommand.Prompts))
 
-		tmpl, err := template.New("custom command template").Parse(customCommand.Command)
-		if err != nil {
-			return gui.surfaceError(err)
-		}
-
-		var buf bytes.Buffer
-		if err := tmpl.Execute(&buf, objects); err != nil {
-			return gui.surfaceError(err)
-		}
-
-		cmdStr := buf.String()
-
-		if customCommand.Subprocess {
-			gui.PrepareSubProcess(cmdStr)
-			return nil
-		}
-
-		return gui.WithWaitingStatus(gui.Tr.SLocalize("runningCustomCommandStatus"), func() error {
-			gui.OSCommand.PrepareSubProcess(cmdStr)
-
-			if err := gui.OSCommand.RunCommand(cmdStr); err != nil {
+		f := func() error {
+			cmdStr, err := gui.resolveTemplate(customCommand.Command, promptResponses)
+			if err != nil {
 				return gui.surfaceError(err)
 			}
-			return gui.refreshSidePanels(refreshOptions{})
-		})
+
+			if customCommand.Subprocess {
+				gui.PrepareSubProcess(cmdStr)
+				return nil
+			}
+
+			return gui.WithWaitingStatus(gui.Tr.SLocalize("runningCustomCommandStatus"), func() error {
+				gui.OSCommand.PrepareSubProcess(cmdStr)
+
+				if err := gui.OSCommand.RunCommand(cmdStr); err != nil {
+					return gui.surfaceError(err)
+				}
+				return gui.refreshSidePanels(refreshOptions{})
+			})
+		}
+
+		// if we have prompts we'll recursively wrap our confirm handlers with more prompts
+		// until we reach the actual command
+		for reverseIdx := range customCommand.Prompts {
+			idx := len(customCommand.Prompts) - 1 - reverseIdx
+
+			// going backwards so the outermost prompt is the first one
+			prompt := customCommand.Prompts[idx]
+
+			gui.Log.Warn(prompt.Title)
+
+			wrappedF := f // need to do this because f's value will change with each iteration
+			f = func() error {
+				return gui.prompt(
+					prompt.Title,
+					prompt.InitialValue,
+					func(str string) error {
+						promptResponses[idx] = str
+
+						return wrappedF()
+					},
+				)
+			}
+		}
+
+		return f()
 	}
 }
 
+type CustomCommandPrompt struct {
+	Title        string `yaml:"title"`
+	InitialValue string `yaml:"initialValue"`
+}
+
 type CustomCommand struct {
-	Key        string `yaml:"key"`
-	Context    string `yaml:"context"`
-	Command    string `yaml:"command"`
-	Subprocess bool   `yaml:"subprocess"`
+	Key        string                `yaml:"key"`
+	Context    string                `yaml:"context"`
+	Command    string                `yaml:"command"`
+	Subprocess bool                  `yaml:"subprocess"`
+	Prompts    []CustomCommandPrompt `yaml:"prompts"`
 }
 
 func (gui *Gui) GetCustomCommandKeybindings() []*Binding {

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -5,8 +5,10 @@ import (
 	"log"
 	"text/template"
 
+	"github.com/fatih/color"
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 type CustomCommandObjects struct {
@@ -92,7 +94,7 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand CustomCommand) func(
 			wrappedF := f
 
 			switch prompt.Type {
-			case "prompt":
+			case "input":
 				f = func() error {
 					title, err := gui.resolveTemplate(prompt.Title, promptResponses)
 					if err != nil {
@@ -142,7 +144,7 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand CustomCommand) func(
 						}
 
 						menuItems[i] = &menuItem{
-							displayStrings: []string{name, description},
+							displayStrings: []string{name, utils.ColoredString(description, color.FgYellow)},
 							onPress: func() error {
 								promptResponses[idx] = value
 
@@ -159,7 +161,7 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand CustomCommand) func(
 					return gui.createMenu(title, menuItems, createMenuOptions{showCancel: true})
 				}
 			default:
-				return gui.createErrorPanel("custom command prompt must have a type of 'prompt' or 'menu'")
+				return gui.createErrorPanel("custom command prompt must have a type of 'input' or 'menu'")
 			}
 
 		}
@@ -175,7 +177,7 @@ type CustomCommandMenuOption struct {
 }
 
 type CustomCommandPrompt struct {
-	Type  string `yaml:"type"` // one of 'prompt' and 'menu'
+	Type  string `yaml:"type"` // one of 'input' and 'menu'
 	Title string `yaml:"title"`
 
 	// this only apply to prompts

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -20,7 +20,7 @@ type CustomCommandObjects struct {
 	SelectedTag          *commands.Tag
 	SelectedStashEntry   *commands.StashEntry
 	SelectedCommitFile   *commands.CommitFile
-	CurrentBranch        *commands.Branch
+	CheckedOutBranch     *commands.Branch
 }
 
 func (gui *Gui) handleCustomCommandKeybinding(customCommand CustomCommand) func() error {
@@ -36,7 +36,7 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand CustomCommand) func(
 			SelectedStashEntry:   gui.getSelectedStashEntry(),
 			SelectedCommitFile:   gui.getSelectedCommitFile(),
 			SelectedSubCommit:    gui.getSelectedSubCommit(),
-			CurrentBranch:        gui.currentBranch(),
+			CheckedOutBranch:     gui.currentBranch(),
 		}
 
 		tmpl, err := template.New("custom command template").Parse(customCommand.Command)

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -1,0 +1,59 @@
+package gui
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/jesseduffield/lazygit/pkg/commands"
+)
+
+type CustomCommandObjects struct {
+	SelectedLocalCommit  *commands.Commit
+	SelectedReflogCommit *commands.Commit
+	SelectedSubCommit    *commands.Commit
+	SelectedFile         *commands.File
+	SelectedLocalBranch  *commands.Branch
+	SelectedRemoteBranch *commands.RemoteBranch
+	SelectedRemote       *commands.Remote
+	SelectedTag          *commands.Tag
+	SelectedStashEntry   *commands.StashEntry
+	SelectedCommitFile   *commands.CommitFile
+	CurrentBranch        *commands.Branch
+}
+
+func (gui *Gui) handleCustomCommandKeybinding(templateStr string) func() error {
+	return func() error {
+		objects := CustomCommandObjects{
+			SelectedFile:         gui.getSelectedFile(),
+			SelectedLocalCommit:  gui.getSelectedLocalCommit(),
+			SelectedReflogCommit: gui.getSelectedReflogCommit(),
+			SelectedLocalBranch:  gui.getSelectedBranch(),
+			SelectedRemoteBranch: gui.getSelectedRemoteBranch(),
+			SelectedRemote:       gui.getSelectedRemote(),
+			SelectedTag:          gui.getSelectedTag(),
+			SelectedStashEntry:   gui.getSelectedStashEntry(),
+			SelectedCommitFile:   gui.getSelectedCommitFile(),
+			SelectedSubCommit:    gui.getSelectedSubCommit(),
+			CurrentBranch:        gui.currentBranch(),
+		}
+
+		tmpl, err := template.New("custom command template").Parse(templateStr)
+		if err != nil {
+			return gui.surfaceError(err)
+		}
+
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, objects); err != nil {
+			return gui.surfaceError(err)
+		}
+
+		cmdStr := buf.String()
+
+		return gui.WithWaitingStatus(gui.Tr.SLocalize("runningCustomCommandStatus"), func() error {
+			if err := gui.OSCommand.RunCommand(cmdStr); err != nil {
+				return gui.surfaceError(err)
+			}
+			return gui.refreshSidePanels(refreshOptions{})
+		})
+	}
+}

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -121,7 +121,12 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand CustomCommand) func(
 					for i, option := range prompt.Options {
 						option := option
 
-						name, err := gui.resolveTemplate(option.Name, promptResponses)
+						nameTemplate := option.Name
+						if nameTemplate == "" {
+							// this allows you to only pass values rather than bother with names/descriptions
+							nameTemplate = option.Value
+						}
+						name, err := gui.resolveTemplate(nameTemplate, promptResponses)
 						if err != nil {
 							return gui.surfaceError(err)
 						}

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -72,7 +72,11 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand CustomCommand) func(
 				return nil
 			}
 
-			return gui.WithWaitingStatus(gui.Tr.SLocalize("runningCustomCommandStatus"), func() error {
+			loadingText := customCommand.LoadingText
+			if loadingText == "" {
+				loadingText = gui.Tr.SLocalize("runningCustomCommandStatus")
+			}
+			return gui.WithWaitingStatus(loadingText, func() error {
 				gui.OSCommand.PrepareSubProcess(cmdStr)
 
 				if err := gui.OSCommand.RunCommand(cmdStr); err != nil {
@@ -188,11 +192,12 @@ type CustomCommandPrompt struct {
 }
 
 type CustomCommand struct {
-	Key        string                `yaml:"key"`
-	Context    string                `yaml:"context"`
-	Command    string                `yaml:"command"`
-	Subprocess bool                  `yaml:"subprocess"`
-	Prompts    []CustomCommandPrompt `yaml:"prompts"`
+	Key         string                `yaml:"key"`
+	Context     string                `yaml:"context"`
+	Command     string                `yaml:"command"`
+	Subprocess  bool                  `yaml:"subprocess"`
+	Prompts     []CustomCommandPrompt `yaml:"prompts"`
+	LoadingText string                `yaml:"loadingText"`
 }
 
 func (gui *Gui) GetCustomCommandKeybindings() []*Binding {

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands"
 	"github.com/jesseduffield/lazygit/pkg/utils"
+	"github.com/mgutz/str"
 )
 
 // list panel functions
@@ -356,13 +357,14 @@ func (gui *Gui) handleCommitEditorPress() error {
 		})
 	}
 
-	gui.PrepareSubProcess("git", "commit")
+	gui.PrepareSubProcess("git commit")
 	return nil
 }
 
 // PrepareSubProcess - prepare a subprocess for execution and tell the gui to switch to it
-func (gui *Gui) PrepareSubProcess(commands ...string) {
-	gui.SubProcess = gui.GitCommand.PrepareCommitSubProcess()
+func (gui *Gui) PrepareSubProcess(command string) {
+	splitCmd := str.ToArgv(command)
+	gui.SubProcess = gui.OSCommand.PrepareSubProcess(splitCmd[0], splitCmd[1:]...)
 	gui.g.Update(func(g *gocui.Gui) error {
 		return gui.Errors.ErrSubProcess
 	})

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -189,7 +189,7 @@ func (gui *Gui) getKey(name string) interface{} {
 	if runeCount > 1 {
 		binding := keymap[strings.ToLower(key)]
 		if binding == nil {
-			log.Fatalf("Unrecognized key %s for keybinding %s", strings.ToLower(key), name)
+			log.Fatalf("Unrecognized key %s for keybinding %s. For permitted values see https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Custom_Keybindings.md", strings.ToLower(key), name)
 		} else {
 			return binding
 		}

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1563,41 +1563,6 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 	return bindings
 }
 
-func (gui *Gui) GetCustomCommandKeybindings() []*Binding {
-	bindings := []*Binding{}
-
-	ms := gui.Config.GetUserConfig().GetStringMap("customCommands")
-	for contextKey := range ms {
-		var viewName string
-		if contextKey == "global" {
-			viewName = ""
-		} else {
-			context := gui.contextForContextKey(contextKey)
-			if context == nil {
-				log.Fatalf("Error when setting custom command keybindings: unknown context: %s", contextKey)
-			}
-			// here we assume that a given context will always belong to the same view.
-			// Currently this is a safe bet but it's by no means guaranteed in the long term
-			// and we might need to make some changes in the future to support it.
-			viewName = context.GetViewName()
-		}
-
-		keyMap := gui.Config.GetUserConfig().GetStringMapString(fmt.Sprintf("customCommands.%s", contextKey))
-		for key, command := range keyMap {
-			bindings = append(bindings, &Binding{
-				ViewName:    viewName,
-				Contexts:    []string{contextKey},
-				Key:         gui.getKey(key),
-				Modifier:    gocui.ModNone,
-				Handler:     gui.wrappedHandler(gui.handleCustomCommandKeybinding(command)),
-				Description: command,
-			})
-		}
-	}
-
-	return bindings
-}
-
 func (gui *Gui) keybindings() error {
 	bindings := gui.GetCustomCommandKeybindings()
 

--- a/pkg/gui/options_menu_panel.go
+++ b/pkg/gui/options_menu_panel.go
@@ -12,7 +12,7 @@ func (gui *Gui) getBindings(v *gocui.View) []*Binding {
 		bindingsGlobal, bindingsPanel []*Binding
 	)
 
-	bindings := gui.GetInitialKeybindings()
+	bindings := append(gui.GetInitialKeybindings(), gui.GetCustomCommandKeybindings()...)
 
 	for _, binding := range bindings {
 		if GetKeyDisplay(binding.Key) != "" && binding.Description != "" {
@@ -39,17 +39,17 @@ func (gui *Gui) handleCreateOptionsMenu(g *gocui.Gui, v *gocui.View) error {
 	menuItems := make([]*menuItem, len(bindings))
 
 	for i, binding := range bindings {
-		innerBinding := binding // note to self, never close over loop variables
+		binding := binding // note to self, never close over loop variables
 		menuItems[i] = &menuItem{
-			displayStrings: []string{GetKeyDisplay(innerBinding.Key), innerBinding.Description},
+			displayStrings: []string{GetKeyDisplay(binding.Key), binding.Description},
 			onPress: func() error {
-				if innerBinding.Key == nil {
+				if binding.Key == nil {
 					return nil
 				}
 				if err := gui.handleMenuClose(g, v); err != nil {
 					return err
 				}
-				return innerBinding.Handler(g, v)
+				return binding.Handler(g, v)
 			},
 		}
 	}

--- a/pkg/gui/remotes_panel.go
+++ b/pkg/gui/remotes_panel.go
@@ -58,7 +58,7 @@ func (gui *Gui) refreshRemotes() error {
 		}
 	}
 
-	return gui.postRefreshUpdate(gui.contextForContextKey(gui.getBranchesView().Context))
+	return gui.postRefreshUpdate(gui.mustContextForContextKey(gui.getBranchesView().Context))
 }
 
 func (gui *Gui) handleRemoteEnter() error {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1188,6 +1188,9 @@ func addEnglish(i18nObject *i18n.Bundle) error {
 		}, &i18n.Message{
 			ID:    "minGitVersionError",
 			Other: "Git version must be at least 2.0 (i.e. from 2014 onwards). Please upgrade your git version. Alternatively raise an issue at https://github.com/jesseduffield/lazygit/issues for lazygit to be more backwards compatible.",
+		}, &i18n.Message{
+			ID:    "runningCustomCommandStatus",
+			Other: "running custom command",
 		},
 	)
 }


### PR DESCRIPTION
You can now add custom command keybindings in your config.yml like so:
```
customCommands:
  - key: '<c-r>'
    command: 'hub browse -- "commit/{{.SelectedLocalCommit.Sha}}"'
    context: 'commits'
  - key: 'a'
    command: "git {{if .SelectedFile.HasUnstagedChanges}} add {{else}} reset {{end}} {{.SelectedFile.Name}}"
    context: 'files'
  - key: 'C'
    command: "git commit"
    context: 'global'
    subprocess: true
  - key: 'n'
    prompts:
      - type: 'menu'
        title: 'What kind of branch is it?'
        options:
          - name: 'feature'
            description: 'a feature branch'
            value: 'feature'
          - name: 'hotfix'
            description: 'a hotfix branch'
            value: 'hotfix'
          - name: 'release'
            description: 'a release branch'
            value: 'release'
      - type: 'input'
        title: 'What is the new branch name?'
        initialValue: ''
    command: "git flow {{index .PromptResponses 0}} start {{index .PromptResponses 1}}"
    context: 'localBranches'
    loadingText: 'creating branch'
```

Custom command keybindings will appear alongside inbuilt keybindings when you view the options menu by pressing 'x'

For a given custom command, here are the allowed fields:
| *field*       | *description*         | required |
|-----------------|----------------------|-|
| key | the key to trigger the command. Use a single letter or one of the values from [here](https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Custom_Keybindings.md) | yes |
| command | the command to run | yes |
| context | the context in which to listen for the key (see below) | yes |
| subprocess | whether you want the command to run in a subprocess (necessary if you want to view the output of the command or provide user input) | no |
| prompts | a list of prompts that will request user input before running the final command | no |
| loadingText | text to display while waiting for command to finish | no |

The permitted contexts are:

| *context*       | *description*         |
|-----------------|----------------------|
| status | the 'Status' tab |
| files | the 'Files' tab |
| localBranches | the 'Local Branches' tab |
| remotes | the 'Remotes' tab |
| remoteBranches | the context you get when pressing enter on a remote in the remotes tab |
| tags | the 'Tags' tab |
| commits | the 'Commits' tab |
| reflogCommits | the 'Reflog' tab |
| subCommits | the context you see when pressing enter on a branch |
| commitFiles | the context you see when pressing enter on a commit or stash entry (warning, might be renamed in future) |
| stash | the 'Stash' tab |
| global | this keybinding will take affect everywhere |

The permitted prompt fields are:

| *field*       | *description*         | *required* |
|-----------------|----------------------|-|
| type | one of 'input' or 'menu' | yes |
| title | the title to display in the popup panel | no |
| initialValue | (only applicable to 'input' prompts) the initial value to appear in the text box | no|
| options | (only applicable to 'menu' prompts) the options to display in the menu | no |

The permitted option fields are:
| *field*       | *description*         | *required* |
|-----------------|----------------------|-|
| name | the string which will appear first on the line | no |
| description | the string which will appear second on the line | no |
| value | the value that will be stored in `.PromptResponses` if the option is selected | yes |

If an option has no name the value will be displayed to the user in place of the name, so you're allowed to only include the value like so:
```
    prompts:
      - type: 'menu'
        title: 'What kind of branch is it?'
        options:
          - value: 'feature'
          - value: 'hotfix'
          - value: 'release'
```


### Placeholder values

Your commands can contain placeholder strings using Go's [template syntax](https://jan.newmarch.name/go/template/chapter-template.html). The template syntax is pretty powerful, letting you do things like conditionals if you want, but for the most part you'll simply want to be accessing the fields on the following things:
```
SelectedLocalCommit
SelectedReflogCommit
SelectedSubCommit
SelectedFile
SelectedLocalBranch
SelectedRemoteBranch
SelectedRemote
SelectedTag
SelectedStashEntry
SelectedCommitFile
CheckedOutBranch
```

To see what fields are available on e.g. the `SelectedFile`, see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/commands/file.go) (all the modelling lives in the same directory). Note that the custom commands feature does not guarantee backwards compatibility (until we hit lazygit version 1.0 of course) which means a field you're accessing on an object may no longer be available from one release to the next. Typically however, all you'll need is `{{.SelectedFile.Name}}`, `{{.SelectedLocalCommit.Sha}}` and `{{.SelectedBranch.Name}}`. In the future we will likely introduce a tighter interface that exposes a limited set of fields for each model.

### Keybinding collisions
If your custom keybinding collides with an inbuilt keybinding that is defined for the same context, only the custom keybinding will be executed. This also applies to the global context. However, one caveat is that if you have a custom keybinding defined on the global context for some key, and there is an in-built keybinding defined for the same key and for a specific context (say the 'files' context), then the in-built keybinding will take precedence. See how to change in-built keybindings [here](https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#keybindings)

