### PR TITLE
Support bare repositories

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/integrii/flaggy"
 	"github.com/jesseduffield/lazygit/pkg/app"
 	"github.com/jesseduffield/lazygit/pkg/config"
+	"github.com/jesseduffield/lazygit/pkg/env"
 )
 
 var (
@@ -63,11 +64,11 @@ func main() {
 	}
 
 	if workTree != "" {
-		os.Setenv("GIT_WORK_TREE", workTree)
+		env.SetGitWorkTreeEnv(workTree)
 	}
 
 	if gitDir != "" {
-		os.Setenv("GIT_DIR", gitDir)
+		env.SetGitDirEnv(gitDir)
 	}
 
 	if versionFlag {

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 	flaggy.DefaultParser.ShowVersionWithVersionFlag = false
 
 	repoPath := ""
-	flaggy.String(&repoPath, "p", "path", "Path of git repo. (Deprecated: use --git-dir for git directory and --work-tree for work tree directory)")
+	flaggy.String(&repoPath, "p", "path", "Path of git repo. (equivalent to --work-tree=<path> --git-dir=<path>/.git/)")
 
 	filterPath := ""
 	flaggy.String(&filterPath, "f", "filter", "Path to filter on in `git log -- <path>`. When in filter mode, the commits, reflog, and stash are filtered based on the given path, and some operations are restricted")

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aybabtme/humanlog"
 	"github.com/jesseduffield/lazygit/pkg/commands"
 	"github.com/jesseduffield/lazygit/pkg/config"
+	"github.com/jesseduffield/lazygit/pkg/env"
 	"github.com/jesseduffield/lazygit/pkg/gui"
 	"github.com/jesseduffield/lazygit/pkg/i18n"
 	"github.com/jesseduffield/lazygit/pkg/updates"
@@ -170,7 +171,7 @@ func (app *App) setupRepo() (bool, error) {
 		return false, err
 	}
 
-	if os.Getenv("GIT_DIR") != "" {
+	if env.GetGitDirEnv() != "" {
 		// we've been given the git dir directly. We'll verify this dir when initializing our GitCommand object
 		return false, nil
 	}
@@ -226,7 +227,7 @@ func (app *App) Run() error {
 }
 
 func gitDir() string {
-	dir := os.Getenv("GIT_DIR")
+	dir := env.GetGitDirEnv()
 	if dir == "" {
 		return ".git"
 	}

--- a/pkg/commands/commit_list_builder.go
+++ b/pkg/commands/commit_list_builder.go
@@ -194,7 +194,7 @@ func (c *CommitListBuilder) getRebasingCommits(rebaseMode string) ([]*Commit, er
 
 func (c *CommitListBuilder) getNormalRebasingCommits() ([]*Commit, error) {
 	rewrittenCount := 0
-	bytesContent, err := ioutil.ReadFile(fmt.Sprintf("%s/rebase-apply/rewritten", c.GitCommand.DotGitDir))
+	bytesContent, err := ioutil.ReadFile(filepath.Join(c.GitCommand.DotGitDir, "rebase-apply/rewritten"))
 	if err == nil {
 		content := string(bytesContent)
 		rewrittenCount = len(strings.Split(content, "\n"))
@@ -202,7 +202,7 @@ func (c *CommitListBuilder) getNormalRebasingCommits() ([]*Commit, error) {
 
 	// we know we're rebasing, so lets get all the files whose names have numbers
 	commits := []*Commit{}
-	err = filepath.Walk(fmt.Sprintf("%s/rebase-apply", c.GitCommand.DotGitDir), func(path string, f os.FileInfo, err error) error {
+	err = filepath.Walk(filepath.Join(c.GitCommand.DotGitDir, "rebase-apply"), func(path string, f os.FileInfo, err error) error {
 		if rewrittenCount > 0 {
 			rewrittenCount--
 			return nil
@@ -246,7 +246,7 @@ func (c *CommitListBuilder) getNormalRebasingCommits() ([]*Commit, error) {
 // and extracts out the sha and names of commits that we still have to go
 // in the rebase:
 func (c *CommitListBuilder) getInteractiveRebasingCommits() ([]*Commit, error) {
-	bytesContent, err := ioutil.ReadFile(fmt.Sprintf("%s/rebase-merge/git-rebase-todo", c.GitCommand.DotGitDir))
+	bytesContent, err := ioutil.ReadFile(filepath.Join(c.GitCommand.DotGitDir, "rebase-merge/git-rebase-todo"))
 	if err != nil {
 		c.Log.Error(fmt.Sprintf("error occurred reading git-rebase-todo: %s", err.Error()))
 		// we assume an error means the file doesn't exist so we just return

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -1427,3 +1427,9 @@ func (c *GitCommand) WorkingTreeState() string {
 	}
 	return "normal"
 }
+
+func (c *GitCommand) IsBareRepo() bool {
+	// note: could use `git rev-parse --is-bare-repository` if we wanna drop go-git
+	_, err := c.Repo.Worktree()
+	return err == gogit.ErrIsBareRepository
+}

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -105,7 +105,6 @@ type GitCommand struct {
 
 // NewGitCommand it runs git commands
 func NewGitCommand(log *logrus.Entry, osCommand *OSCommand, tr *i18n.Localizer, config config.AppConfigurer) (*GitCommand, error) {
-	// var worktree *gogit.Worktree
 	var repo *gogit.Repository
 
 	// see what our default push behaviour is

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -150,13 +150,13 @@ func TestNavigateToRepoRootDirectory(t *testing.T) {
 	}
 }
 
-// TestSetupRepositoryAndWorktree is a function.
-func TestSetupRepositoryAndWorktree(t *testing.T) {
+// TestSetupRepository is a function.
+func TestSetupRepository(t *testing.T) {
 	type scenario struct {
 		testName          string
 		openGitRepository func(string) (*gogit.Repository, error)
 		sLocalize         func(string) string
-		test              func(*gogit.Repository, *gogit.Worktree, error)
+		test              func(*gogit.Repository, error)
 	}
 
 	scenarios := []scenario{
@@ -168,7 +168,7 @@ func TestSetupRepositoryAndWorktree(t *testing.T) {
 			func(string) string {
 				return "error translated"
 			},
-			func(r *gogit.Repository, w *gogit.Worktree, err error) {
+			func(r *gogit.Repository, err error) {
 				assert.Error(t, err)
 				assert.EqualError(t, err, "error translated")
 			},
@@ -179,20 +179,9 @@ func TestSetupRepositoryAndWorktree(t *testing.T) {
 				return nil, fmt.Errorf("Error from inside gogit")
 			},
 			func(string) string { return "" },
-			func(r *gogit.Repository, w *gogit.Worktree, err error) {
+			func(r *gogit.Repository, err error) {
 				assert.Error(t, err)
 				assert.EqualError(t, err, "Error from inside gogit")
-			},
-		},
-		{
-			"An error occurred cause git repository is a bare repository",
-			func(string) (*gogit.Repository, error) {
-				return &gogit.Repository{}, nil
-			},
-			func(string) string { return "" },
-			func(r *gogit.Repository, w *gogit.Worktree, err error) {
-				assert.Error(t, err)
-				assert.Equal(t, gogit.ErrIsBareRepository, err)
 			},
 		},
 		{
@@ -204,9 +193,8 @@ func TestSetupRepositoryAndWorktree(t *testing.T) {
 				return r, nil
 			},
 			func(string) string { return "" },
-			func(r *gogit.Repository, w *gogit.Worktree, err error) {
+			func(r *gogit.Repository, err error) {
 				assert.NoError(t, err)
-				assert.NotNil(t, w)
 				assert.NotNil(t, r)
 			},
 		},
@@ -214,7 +202,7 @@ func TestSetupRepositoryAndWorktree(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.testName, func(t *testing.T) {
-			s.test(setupRepositoryAndWorktree(s.openGitRepository, s.sLocalize))
+			s.test(setupRepository(s.openGitRepository, s.sLocalize))
 		})
 	}
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,24 @@
+package env
+
+import "os"
+
+func GetGitDirEnv() string {
+	return os.Getenv("GIT_DIR")
+}
+
+func GetGitWorkTreeEnv() string {
+	return os.Getenv("GIT_WORK_TREE")
+}
+
+func SetGitDirEnv(value string) {
+	os.Setenv("GIT_DIR", value)
+}
+
+func SetGitWorkTreeEnv(value string) {
+	os.Setenv("GIT_WORK_TREE", value)
+}
+
+func UnsetGitDirEnvs() {
+	_ = os.Unsetenv("GIT_DIR")
+	_ = os.Unsetenv("GIT_WORK_TREE")
+}

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/jesseduffield/lazygit/pkg/commands"
+	"github.com/jesseduffield/lazygit/pkg/env"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
@@ -23,8 +24,7 @@ func (gui *Gui) handleCreateRecentReposMenu() error {
 				yellow.Sprint(innerPath),
 			},
 			onPress: func() error {
-				os.Unsetenv("GIT_WORK_TREE")
-				os.Unsetenv("GIT_DIR")
+				env.UnsetGitDirEnvs()
 				if err := os.Chdir(innerPath); err != nil {
 					return err
 				}

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -45,6 +45,14 @@ func (gui *Gui) handleCreateRecentReposMenu() error {
 // updateRecentRepoList registers the fact that we opened lazygit in this repo,
 // so that we can open the same repo via the 'recent repos' menu
 func (gui *Gui) updateRecentRepoList() error {
+	if gui.GitCommand.IsBareRepo() {
+		// we could totally do this but it would require storing both the git-dir and the
+		// worktree in our recent repos list, which is a change that would need to be
+		// backwards compatible
+		gui.Log.Info("Not appending bare repo to recent repo list")
+		return nil
+	}
+
 	recentRepos := gui.Config.GetAppState().RecentRepos
 	currentRepo, err := os.Getwd()
 	if err != nil {

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -23,6 +23,8 @@ func (gui *Gui) handleCreateRecentReposMenu() error {
 				yellow.Sprint(innerPath),
 			},
 			onPress: func() error {
+				os.Unsetenv("GIT_WORK_TREE")
+				os.Unsetenv("GIT_DIR")
 				if err := os.Chdir(innerPath); err != nil {
 					return err
 				}


### PR DESCRIPTION
The one main thing this is missing is storing the repo in the recent repos list but that would require updating the format of the recent repos (currently just a list of strings, we'd need it now to be a list of objects each containing a work-tree and a git-dir or some hybrid thing). If people really need that, please raise another issue!