### PR TITLE
Limitations Section sentence mixup corrected

### DIFF
--- a/docs/Undoing.md
+++ b/docs/Undoing.md
@@ -19,6 +19,6 @@ Because lazygit just uses the reflog to keep track of things, it doesn't matter 
 
 There are limitations: firstly, lazygit can only undo things that are recorded in the reflog. That means changes to your working tree or stash aren't covered. Secondly, anything permanent you do like pushing to a remote can't be undone. Thirdly, actions like creating a branch won't be undone, because they're not stored in the reflog.
 
-If you are mid-rebase, undo/redo is not supported, because the reflog doesn't enough contain information about what specific things have happened inside that rebase. If you want to undo out of a rebase, it's best to abort the rebase (the default keybinding for bringing up rebase options is 'm').
+If you are mid-rebase, undo/redo is not supported, because the reflog doesn't contain enough information about what specific things have happened inside that rebase. If you want to undo out of a rebase, it's best to abort the rebase (the default keybinding for bringing up rebase options is 'm').
 
 Undo/Redo is a new feature so if you find a bug let us know. The worst case scenario is that you'll just need to look at your reflog and manually put yourself back on track.


### PR DESCRIPTION
> If you are mid-rebase, undo/redo is not supported, because the reflog doesn't **enough contain** information about what specific things have happened inside that rebase.

changed to

> If you are mid-rebase, undo/redo is not supported, because the reflog doesn't **contain enough** information about what specific things have happened inside that rebase.