### PR TITLE
Banning users to ignore the ".gitignore" file.

### DIFF
--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -247,8 +247,11 @@ func (gui *Gui) handleStageAll(g *gocui.Gui, v *gocui.View) error {
 
 func (gui *Gui) handleIgnoreFile(g *gocui.Gui, v *gocui.View) error {
 	file := gui.getSelectedFile()
-	if file == nil || file.Name == ".gitignore" {
+	if file == nil {
 		return nil
+	}
+	if file.Name == ".gitignore" {
+		return gui.createErrorPanel("Cannot ignore .gitignore")
 	}
 
 	if file.Tracked {

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -247,7 +247,7 @@ func (gui *Gui) handleStageAll(g *gocui.Gui, v *gocui.View) error {
 
 func (gui *Gui) handleIgnoreFile(g *gocui.Gui, v *gocui.View) error {
 	file := gui.getSelectedFile()
-	if file == nil {
+	if file == nil || file.Name == ".gitignore" {
 		return nil
 	}
 


### PR DESCRIPTION
Fix #839

Banning users to ignore the `.gitignore` file. 
Ignore "i" command when you try to add `.gitignore` in `.gitignore` file.
If you have any comments, please let me know. Especially should I show message like "You can't ignore .gitignore file." or not when users try to ignore the `.gitignore` file. 