### PR TITLE
workflows: update PPA repo as part of CD process

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,3 +26,20 @@ jobs:
         with:
           token: ${{secrets.GITHUB_API_TOKEN}}
           formula: lazygit
+      - name: Checkout PPA repo
+        uses: actions/checkout@v2
+        with:
+          repository: dawidd6/lazygit-debian
+          token: ${{secrets.GITHUB_API_TOKEN}}
+          fetch-depth: 0
+      - name: Update PPA repo
+        run: |
+          version="$(echo "$GITHUB_REF" | sed 's@refs/tags/v@@')"
+          sudo apt install -y git-buildpackage
+          git fetch --tags https://github.com/$GITHUB_REPOSITORY
+          gbp import-ref -u "$version"
+          gbp dch -D xenial -N "$version"-1
+          git add debian/changelog
+          git commit -S -m "d/changelog: dch $version"
+          gbp tag
+          git push --tags origin master


### PR DESCRIPTION
Should fix: https://github.com/jesseduffield/lazygit/issues/1048

Note, that it isn't tested.

The process of PPA updating is:
1. GitHub Actions CD pushes new tag to dawidd6/lazygit-debian
2. Launchpad after a few hours syncs the repo
3. New packages are built

This is the best way I can think of to automate the process and not needing to touch Launchpad.