### PR TITLE
Check default branch for the repository

### DIFF
--- a/pkg/commands/branches.go
+++ b/pkg/commands/branches.go
@@ -77,11 +77,6 @@ func (c *GitCommand) GetUpstreamForBranch(branchName string) (string, error) {
 	return strings.TrimSpace(output), err
 }
 
-func (c *GitCommand) RevParseAbbrevRef(branchName string) (string, error) {
-	output, err := c.OSCommand.RunCommandWithOutput("git rev-parse --abbrev-ref %s", branchName)
-	return strings.TrimSpace(output), err
-}
-
 func (c *GitCommand) GetBranchGraphCmdStr(branchName string) string {
 	branchLogCmdTemplate := c.Config.GetUserConfig().Git.BranchLogCmd
 	templateValues := map[string]string{

--- a/pkg/commands/branches.go
+++ b/pkg/commands/branches.go
@@ -77,6 +77,11 @@ func (c *GitCommand) GetUpstreamForBranch(branchName string) (string, error) {
 	return strings.TrimSpace(output), err
 }
 
+func (c *GitCommand) RevParseAbbrevRef(branchName string) (string, error) {
+	output, err := c.OSCommand.RunCommandWithOutput("git rev-parse --abbrev-ref %s", branchName)
+	return strings.TrimSpace(output), err
+}
+
 func (c *GitCommand) GetBranchGraphCmdStr(branchName string) string {
 	branchLogCmdTemplate := c.Config.GetUserConfig().Git.BranchLogCmd
 	templateValues := map[string]string{

--- a/pkg/commands/loading_commits.go
+++ b/pkg/commands/loading_commits.go
@@ -315,17 +315,8 @@ func (c *CommitListBuilder) setCommitMergedStatuses(refName string, commits []*m
 	return commits, nil
 }
 
-// Check if [branch "master"] or [branch "main"] has merge in .git/config. If there are no
-// merge paths available in the local config, use the init.defaultBranch from the global
-// configuration file. Ignoring file not found errors and default to baseBranch = "master".
 func getBaseBranch(c *CommitListBuilder) (string, error) {
 	baseBranch := ""
-
-	output, _ := c.GitCommand.RevParseAbbrevRef("origin/HEAD")
-	if output != "" {
-		split := strings.Split(output, "/")
-		return split[len(split)-1], nil
-	}
 
 	baseBranch, _ = c.GitCommand.getLocalGitConfig("init.defaultBranch")
 	if baseBranch != "" {

--- a/pkg/commands/loading_commits.go
+++ b/pkg/commands/loading_commits.go
@@ -320,11 +320,10 @@ func (c *CommitListBuilder) setCommitMergedStatuses(refName string, commits []*m
 // configuration file. Ignoring file not found errors and default to baseBranch = "master".
 func getBaseBranch(c *CommitListBuilder) (string, error) {
 	baseBranch := ""
-	merge, _ := c.GitCommand.getLocalGitConfig("branch.master.merge")
-	merge, _ = c.GitCommand.getLocalGitConfig("branch.main.merge")
 
-	if merge != "" {
-		split := strings.Split(merge, "/")
+	output, _ := c.GitCommand.RevParseAbbrevRef("origin/HEAD")
+	if output != "" {
+		split := strings.Split(output, "/")
 		return split[len(split)-1], nil
 	}
 


### PR DESCRIPTION
Implement getBaseBranch function to check the default branch is set for the project either in local config with `branch.master.merge` or `branch.main.merge` or `init.defaultBranch`.

If the default branch is not set there, check the global config for `init.defaultBranch`.

Please let me know if there are any issues!

Closes issue #1062