### PR TITLE
docs: add minimum macOS version 10.10 to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Github Sponsors is matching all donations dollar-for-dollar for 12 months so if 
 
 ### Binary Releases
 
-For Windows, Mac OS or Linux, you can download a binary release [here](../../releases).
+For Windows, Mac OS(10.10+) or Linux, you can download a binary release [here](../../releases).
 
 ### Homebrew
 


### PR DESCRIPTION
Adds the macOS minimum version to the installation instruction that fixes #810 