### PR TITLE
prevent crash when removing remote with no urls

### DIFF
--- a/pkg/gui/remotes_panel.go
+++ b/pkg/gui/remotes_panel.go
@@ -106,7 +106,7 @@ func (gui *Gui) handleRemoveRemote(g *gocui.Gui, v *gocui.View) error {
 		prompt: gui.Tr.LcRemoveRemotePrompt + " '" + remote.Name + "'?",
 		handleConfirm: func() error {
 			if err := gui.GitCommand.RemoveRemote(remote.Name); err != nil {
-				return err
+				return gui.surfaceError(err)
 			}
 
 			return gui.refreshSidePanels(refreshOptions{scope: []int{BRANCHES, REMOTES}})


### PR DESCRIPTION
Might need to do an audit of places where we're not gracefully handling errors like this