### PR TITLE
A small change that enables direct lazygit directory config

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 	}
 
 	if configDirFlag {
-		fmt.Printf("%s\n", config.ConfigDir("jesseduffield"))
+		fmt.Printf("%s\n", config.ConfigDir())
 		os.Exit(0)
 	}
 

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 	}
 
 	if configDirFlag {
-		fmt.Printf("%s\n", config.ConfigDir())
+		fmt.Printf("%s\n", config.ConfigDir("jesseduffield"))
 		os.Exit(0)
 	}
 

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -81,28 +81,26 @@ func NewAppConfig(name, version, commit, date string, buildSource string, debugg
 	return appConfig, nil
 }
 
-func SelectDefaultConfiguration() string {
-	legacyConfigDirectory := ConfigDir("jesseduffield")
+func ConfigDir() string {
+	legacyConfigDirectory := configDirForVendor("jesseduffield")
 	if _, err := os.Stat(legacyConfigDirectory); !os.IsNotExist(err) {
 		return legacyConfigDirectory
 	}
-	configDirectory := ConfigDir("")
+	configDirectory := configDirForVendor("")
 	return configDirectory
 }
 
-func ConfigDir(vendor string) string {
+func configDirForVendor(vendor string) string {
 	envConfigDir := os.Getenv("CONFIG_DIR")
 	if envConfigDir != "" {
 		return envConfigDir
 	}
-	// chucking my name there is not for vanity purposes, the xdg spec (and that
-	// function) requires a vendor name. May as well line up with github
 	configDirs := xdg.New(vendor, "lazygit")
 	return configDirs.ConfigHome()
 }
 
 func findOrCreateConfigDir() (string, error) {
-	folder := SelectDefaultConfiguration()
+	folder := ConfigDir()
 	err := os.MkdirAll(folder, 0755)
 	if err != nil {
 		return "", err

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -81,21 +81,28 @@ func NewAppConfig(name, version, commit, date string, buildSource string, debugg
 	return appConfig, nil
 }
 
-func ConfigDir() string {
+func SelectDefaultConfiguration() string {
+	configDirectory := ConfigDir("")
+	if _, err := os.Stat(configDirectory); !os.IsNotExist(err) {
+		return configDirectory
+	}
+	legacyConfigDirectory := ConfigDir("jesseduffield")
+	return legacyConfigDirectory
+}
+
+func ConfigDir(vendor string) string {
 	envConfigDir := os.Getenv("CONFIG_DIR")
 	if envConfigDir != "" {
 		return envConfigDir
 	}
-
 	// chucking my name there is not for vanity purposes, the xdg spec (and that
 	// function) requires a vendor name. May as well line up with github
-	configDirs := xdg.New("jesseduffield", "lazygit")
+	configDirs := xdg.New(vendor, "lazygit")
 	return configDirs.ConfigHome()
 }
 
 func findOrCreateConfigDir() (string, error) {
-	folder := ConfigDir()
-
+	folder := SelectDefaultConfiguration()
 	err := os.MkdirAll(folder, 0755)
 	if err != nil {
 		return "", err

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -82,12 +82,12 @@ func NewAppConfig(name, version, commit, date string, buildSource string, debugg
 }
 
 func SelectDefaultConfiguration() string {
-	configDirectory := ConfigDir("")
-	if _, err := os.Stat(configDirectory); !os.IsNotExist(err) {
-		return configDirectory
-	}
 	legacyConfigDirectory := ConfigDir("jesseduffield")
-	return legacyConfigDirectory
+	if _, err := os.Stat(legacyConfigDirectory); !os.IsNotExist(err) {
+		return legacyConfigDirectory
+	}
+	configDirectory := ConfigDir("")
+	return configDirectory
 }
 
 func ConfigDir(vendor string) string {


### PR DESCRIPTION
This small change allows the usage of .config/lazygit instead of .config/jesseduffield/lazygit. \
Not because we don't like to work that jesse is doing but because terminal users are way to lazy to write another directory name if it can be omited ^^.

This change uses the fact that the package for concatenating the directory name is omit empty vendor names from the path