### PR TITLE
Allow --follow-tags to be disabled by "push.followTags" git config

### DIFF
--- a/pkg/commands/sync.go
+++ b/pkg/commands/sync.go
@@ -24,6 +24,15 @@ func (c *GitCommand) usingGpg() bool {
 
 // Push pushes to a branch
 func (c *GitCommand) Push(branchName string, force bool, upstream string, args string, promptUserForCredential func(string) string) error {
+	followTagsFlag := "--follow-tags"
+	followsign, _ := c.getLocalGitConfig("push.followTags")
+	if followsign == "" {
+		followsign, _ = c.getGlobalGitConfig("push.followTags")
+		if followsign == "false" {
+			followTagsFlag = ""
+		}
+	}
+
 	forceFlag := ""
 	if force {
 		forceFlag = "--force-with-lease"
@@ -34,7 +43,7 @@ func (c *GitCommand) Push(branchName string, force bool, upstream string, args s
 		setUpstreamArg = "--set-upstream " + upstream
 	}
 
-	cmd := fmt.Sprintf("git push --follow-tags %s %s %s", forceFlag, setUpstreamArg, args)
+	cmd := fmt.Sprintf("git push %s %s %s %s", followTagsFlag, forceFlag, setUpstreamArg, args)
 	return c.OSCommand.DetectUnamePass(cmd, promptUserForCredential)
 }
 

--- a/pkg/commands/sync.go
+++ b/pkg/commands/sync.go
@@ -26,7 +26,9 @@ func (c *GitCommand) usingGpg() bool {
 func (c *GitCommand) Push(branchName string, force bool, upstream string, args string, promptUserForCredential func(string) string) error {
 	followTagsFlag := "--follow-tags"
 	followsign, _ := c.getLocalGitConfig("push.followTags")
-	if followsign == "" {
+	if followsign == "false" {
+		followTagsFlag = ""
+	} else if followsign == "" {
 		followsign, _ = c.getGlobalGitConfig("push.followTags")
 		if followsign == "false" {
 			followTagsFlag = ""


### PR DESCRIPTION
Default to the existing behavior of sending `--follow-tags` on pushes, but allow for either the local or global git config to set "push.followTags" to false to disable the flag.