### PR TITLE
Visualize the commits for all branches

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -48,6 +48,7 @@ Default path for the config file:
     skipHookPrefix: WIP
     autoFetch: true
     branchLogCmd: "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --"
+    allBranchesLogCmd: "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium"
     overrideGpg: false # prevents lazygit from spawning a separate process when using GPG
     disableForcePushing: false
   update:

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -1443,6 +1443,18 @@ func TestGitCommandGetBranchGraph(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestGitCommandGetAllBranchGraph(t *testing.T) {
+	gitCmd := NewDummyGitCommand()
+	gitCmd.OSCommand.Command = func(cmd string, args ...string) *exec.Cmd {
+		assert.EqualValues(t, "git", cmd)
+		assert.EqualValues(t, []string{"log", "--graph", "--all", "--color=always", "--abbrev-commit", "--decorate", "--date=relative", "--pretty=medium"}, args)
+		return exec.Command("echo")
+	}
+	cmdStr := gitCmd.Config.GetUserConfig().Git.AllBranchesLogCmd
+	_, err := gitCmd.OSCommand.RunCommandWithOutput(cmdStr)
+	assert.NoError(t, err)
+}
+
 // TestGitCommandDiff is a function.
 func TestGitCommandDiff(t *testing.T) {
 	type scenario struct {

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -49,6 +49,7 @@ type GitConfig struct {
 	SkipHookPrefix      string                        `yaml:"skipHookPrefix"`
 	AutoFetch           bool                          `yaml:"autoFetch"`
 	BranchLogCmd        string                        `yaml:"branchLogCmd"`
+	AllBranchesLogCmd   string                        `yaml:"allBranchesLogCmd"`
 	OverrideGpg         bool                          `yaml:"overrideGpg"`
 	DisableForcePushing bool                          `yaml:"disableForcePushing"`
 	CommitPrefixes      map[string]CommitPrefixConfig `yaml:"commitPrefixes"`
@@ -149,8 +150,9 @@ type KeybindingUniversalConfig struct {
 }
 
 type KeybindingStatusConfig struct {
-	CheckForUpdate string `yaml:"checkForUpdate"`
-	RecentRepos    string `yaml:"recentRepos"`
+	CheckForUpdate      string `yaml:"checkForUpdate"`
+	RecentRepos         string `yaml:"recentRepos"`
+	AllBranchesLogGraph string `yaml:"allBranchesLogGraph"`
 }
 
 type KeybindingFilesConfig struct {
@@ -297,7 +299,7 @@ func GetDefaultConfig() *UserConfig {
 			SkipHookPrefix:      "WIP",
 			AutoFetch:           true,
 			BranchLogCmd:        "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",
-			OverrideGpg:         false,
+			AllBranchesLogCmd:   "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium",
 			DisableForcePushing: false,
 			CommitPrefixes:      map[string]CommitPrefixConfig(nil),
 		},
@@ -367,8 +369,9 @@ func GetDefaultConfig() *UserConfig {
 				AppendNewline:                "<tab>",
 			},
 			Status: KeybindingStatusConfig{
-				CheckForUpdate: "u",
-				RecentRepos:    "<enter>",
+				CheckForUpdate:      "u",
+				RecentRepos:         "<enter>",
+				AllBranchesLogGraph: "a",
 			},
 			Files: KeybindingFilesConfig{
 				CommitChanges:            "c",

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -360,6 +360,12 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Description: gui.Tr.SwitchRepo,
 		},
 		{
+			ViewName:    "status",
+			Key:         gui.getKey(config.Status.AllBranchesLogGraph),
+			Handler:     gui.wrappedHandler(gui.handleShowAllBranchLogs),
+			Description: gui.Tr.AllBranchesLogGraph,
+		},
+		{
 			ViewName:    "files",
 			Contexts:    []string{FILES_CONTEXT_KEY},
 			Key:         gui.getKey(config.Files.CommitChanges),

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -363,7 +363,7 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			ViewName:    "status",
 			Key:         gui.getKey(config.Status.AllBranchesLogGraph),
 			Handler:     gui.wrappedHandler(gui.handleShowAllBranchLogs),
-			Description: gui.Tr.AllBranchesLogGraph,
+			Description: gui.Tr.LcAllBranchesLogGraph,
 		},
 		{
 			ViewName:    "files",

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -32,6 +32,20 @@ func (gui *Gui) handleCreateRecentReposMenu() error {
 	return gui.createMenu(gui.Tr.RecentRepos, menuItems, createMenuOptions{showCancel: true})
 }
 
+func (gui *Gui) handleShowAllBranchLogs() error {
+	cmd := gui.OSCommand.ExecutableFromString(
+		gui.Config.GetUserConfig().Git.AllBranchesLogCmd,
+	)
+	task := gui.createRunPtyTask(cmd)
+
+	return gui.refreshMainViews(refreshMainOpts{
+		main: &viewUpdateOpts{
+			title: "Log",
+			task:  task,
+		},
+	})
+}
+
 func (gui *Gui) dispatchSwitchToRepo(path string) error {
 	env.UnsetGitDirEnvs()
 	if err := os.Chdir(path); err != nil {

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -152,7 +152,7 @@ func dutchTranslationSet() TranslationSet {
 		LcMergeIntoCurrentBranch:            `merge in met huidige checked out branch`,
 		ConfirmQuit:                         `Weet je zeker dat je dit programma wil sluiten?`,
 		SwitchRepo:                          "wissel naar een recente repo",
-		AllBranchesLogGraph:                 `alle takken van het houtblok laten zien`,
+		LcAllBranchesLogGraph:               `alle takken van het houtblok laten zien`,
 		UnsupportedGitService:               `Niet-ondersteunde git-service`,
 		LcCreatePullRequest:                 `maak een pull-aanvraag`,
 		LcCopyPullRequestURL:                `kopieer de URL van het pull-verzoek naar het klembord`,

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -152,6 +152,7 @@ func dutchTranslationSet() TranslationSet {
 		LcMergeIntoCurrentBranch:            `merge in met huidige checked out branch`,
 		ConfirmQuit:                         `Weet je zeker dat je dit programma wil sluiten?`,
 		SwitchRepo:                          "wissel naar een recente repo",
+		AllBranchesLogGraph:                 `alle takken van het houtblok laten zien`,
 		UnsupportedGitService:               `Niet-ondersteunde git-service`,
 		LcCreatePullRequest:                 `maak een pull-aanvraag`,
 		LcCopyPullRequestURL:                `kopieer de URL van het pull-verzoek naar het klembord`,

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -164,6 +164,7 @@ type TranslationSet struct {
 	LcMergeIntoCurrentBranch            string
 	ConfirmQuit                         string
 	SwitchRepo                          string
+	AllBranchesLogGraph                 string
 	UnsupportedGitService               string
 	LcCreatePullRequest                 string
 	LcCopyPullRequestURL                string
@@ -666,6 +667,7 @@ func englishTranslationSet() TranslationSet {
 		LcMergeIntoCurrentBranch:            `merge into currently checked out branch`,
 		ConfirmQuit:                         `Are you sure you want to quit?`,
 		SwitchRepo:                          `switch to a recent repo`,
+		AllBranchesLogGraph:                 `show all branch logs`,
 		UnsupportedGitService:               `Unsupported git service`,
 		LcCreatePullRequest:                 `create pull request`,
 		LcCopyPullRequestURL:                `copy pull request URL to clipboard`,

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -164,7 +164,7 @@ type TranslationSet struct {
 	LcMergeIntoCurrentBranch            string
 	ConfirmQuit                         string
 	SwitchRepo                          string
-	AllBranchesLogGraph                 string
+	LcAllBranchesLogGraph               string
 	UnsupportedGitService               string
 	LcCreatePullRequest                 string
 	LcCopyPullRequestURL                string
@@ -667,7 +667,7 @@ func englishTranslationSet() TranslationSet {
 		LcMergeIntoCurrentBranch:            `merge into currently checked out branch`,
 		ConfirmQuit:                         `Are you sure you want to quit?`,
 		SwitchRepo:                          `switch to a recent repo`,
-		AllBranchesLogGraph:                 `show all branch logs`,
+		LcAllBranchesLogGraph:               `show all branch logs`,
 		UnsupportedGitService:               `Unsupported git service`,
 		LcCreatePullRequest:                 `create pull request`,
 		LcCopyPullRequestURL:                `copy pull request URL to clipboard`,

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -125,7 +125,7 @@ func polishTranslationSet() TranslationSet {
 		LcRefreshFiles:                      `odśwież pliki`,
 		LcMergeIntoCurrentBranch:            `scal do obecnej gałęzi`,
 		ConfirmQuit:                         `Na pewno chcesz wyjść z programu?`,
-		AllBranchesLogGraph:                 `pokazywać wszystkie logi branżowe`,
+		LcAllBranchesLogGraph:               `pokazywać wszystkie logi branżowe`,
 		UnsupportedGitService:               `Nieobsługiwana usługa git`,
 		LcCreatePullRequest:                 `utwórz żądanie wyciągnięcia`,
 		LcCopyPullRequestURL:                `skopiuj adres URL żądania ściągnięcia do schowka`,

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -125,6 +125,7 @@ func polishTranslationSet() TranslationSet {
 		LcRefreshFiles:                      `odśwież pliki`,
 		LcMergeIntoCurrentBranch:            `scal do obecnej gałęzi`,
 		ConfirmQuit:                         `Na pewno chcesz wyjść z programu?`,
+		AllBranchesLogGraph:                 `pokazywać wszystkie logi branżowe`,
 		UnsupportedGitService:               `Nieobsługiwana usługa git`,
 		LcCreatePullRequest:                 `utwórz żądanie wyciągnięcia`,
 		LcCopyPullRequestURL:                `skopiuj adres URL żądania ściągnięcia do schowka`,


### PR DESCRIPTION
Fixes https://github.com/jesseduffield/lazygit/issues/1053

Now I added the command called `allBranchesLogCmd` and you can see the all commit graph
I was not sure where to show the graph so for now I just show it in `Status` panel .
If you have any suggestions, please let me know. I am happy to update it.  


![image](https://user-images.githubusercontent.com/18569016/100421301-75560c80-30cb-11eb-9ad2-332954fd924d.png)
