### PR TITLE
fix(gocui/edit): fix a bug related to inserting and deleting wide characters

### DIFF
--- a/vendor/github.com/jesseduffield/gocui/edit.go
+++ b/vendor/github.com/jesseduffield/gocui/edit.go
@@ -343,22 +343,31 @@ func (v *View) writeRune(x, y int, ch rune) error {
 	}
 
 	olen := len(v.lines[y])
+	w := runewidth.RuneWidth(ch)
 
 	var s []cell
 	if x >= len(v.lines[y]) {
-		s = make([]cell, x-len(v.lines[y])+1)
+		s = make([]cell, x-len(v.lines[y])+w)
 	} else if !v.Overwrite {
-		s = make([]cell, 1)
+		s = make([]cell, w)
 	}
 	v.lines[y] = append(v.lines[y], s...)
 
-	if !v.Overwrite || (v.Overwrite && x >= olen-1) {
-		copy(v.lines[y][x+1:], v.lines[y][x:])
+	if !v.Overwrite || (v.Overwrite && x >= olen-w) {
+		copy(v.lines[y][x+w:], v.lines[y][x:])
 	}
 	v.lines[y][x] = cell{
 		fgColor: v.FgColor,
 		bgColor: v.BgColor,
 		chr:     ch,
+	}
+
+	for i := 1; i < w; i++ {
+		v.lines[y][x+i] = cell{
+			fgColor: v.FgColor,
+			bgColor: v.BgColor,
+			chr:     '\x00',
+		}
 	}
 
 	return nil
@@ -384,7 +393,7 @@ func (v *View) deleteRune(x, y int) (int, error) {
 		w := runewidth.RuneWidth(v.lines[y][i].chr)
 		tw += w
 		if tw > x {
-			v.lines[y] = append(v.lines[y][:i], v.lines[y][i+1:]...)
+			v.lines[y] = append(v.lines[y][:i], v.lines[y][i+w:]...)
 			return w, nil
 		}
 


### PR DESCRIPTION
When we enter a string containing the wide character like "あいうえお" in edit (e.g. commit message), the content of `v.lines [y]` becomes `['あ' '\0' 'い' '\0' 'う' '\0' 'え' '\0' 'お' | ]`. (`|` means cursor)

![image](https://user-images.githubusercontent.com/10097437/102503618-40821780-40c3-11eb-9cba-a2b27edc9c11.png)

At this time, since `x == 9` and `len(v.lines[y]) == 9`, even if i enter `backspace`, the last character `お` is not deleted.

https://github.com/jesseduffield/lazygit/blob/13b9a8bc9a1d0c98469ba39888e71d1c79dc7cc1/vendor/github.com/jesseduffield/gocui/edit.go#L378-L380

So I added a null character to the end of `v.lines[y]` when writing wide characters were inserted with `writeRune()` to make it work properly. `['あ' '\0' 'い' '\0' 'う' '\0' 'え' '\0' 'お' '\0' | ]`
