### PR TITLE
gui: ReplaceAll -> Replace

### DIFF
--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -196,7 +196,7 @@ func (gui *Gui) handleCopySelectedSideContextItemToClipboard() error {
 		return gui.surfaceError(err)
 	}
 
-	truncatedItemId := utils.TruncateWithEllipsis(strings.ReplaceAll(itemId, "\n", " "), 50)
+	truncatedItemId := utils.TruncateWithEllipsis(strings.Replace(itemId, "\n", " ", -1), 50)
 
 	gui.raiseToast(fmt.Sprintf("'%s' %s", truncatedItemId, gui.Tr.LcCopiedToClipboard))
 


### PR DESCRIPTION
Fix compatibility with older Go compiler versions

@jesseduffield please remember to not use ReplaceAll 😄 