### PR TITLE
Configurable refresh and fetch rate

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -50,6 +50,9 @@ Default path for the config file:
     branchLogCmd: "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --"
     overrideGpg: false # prevents lazygit from spawning a separate process when using GPG
     disableForcePushing: false
+  refresher:
+    refreshInterval: 10 # file/submodule refresh interval in seconds
+    fetchInterval: 60 # re-fetch interval in seconds
   update:
     method: prompt # can be: prompt | background | never
     days: 14 # how often an update is checked for

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -4,6 +4,7 @@ type UserConfig struct {
 	Gui                  GuiConfig        `yaml:"gui"`
 	Git                  GitConfig        `yaml:"git"`
 	Update               UpdateConfig     `yaml:"update"`
+	Refresher            RefresherConfig  `yaml:"refresher"`
 	Reporting            string           `yaml:"reporting"`
 	SplashUpdatesIndex   int              `yaml:"splashUpdatesIndex"`
 	ConfirmOnQuit        bool             `yaml:"confirmOnQuit"`
@@ -14,6 +15,11 @@ type UserConfig struct {
 	DisableStartupPopups bool              `yaml:"disableStartupPopups"`
 	CustomCommands       []CustomCommand   `yaml:"customCommands"`
 	Services             map[string]string `yaml:"services"`
+}
+
+type RefresherConfig struct {
+	RefreshInterval int `yaml:"refreshInterval"`
+	FetchInterval   int `yaml:"fetchInterval"`
 }
 
 type GuiConfig struct {
@@ -299,6 +305,10 @@ func GetDefaultConfig() *UserConfig {
 			OverrideGpg:         false,
 			DisableForcePushing: false,
 			CommitPrefixes:      map[string]CommitPrefixConfig(nil),
+		},
+		Refresher: RefresherConfig{
+			RefreshInterval: 10,
+			FetchInterval:   60,
 		},
 		Update: UpdateConfig{
 			Method: "prompt",

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -480,7 +480,7 @@ func (gui *Gui) Run() error {
 		go utils.Safe(gui.startBackgroundFetch)
 	}
 
-	gui.goEvery(time.Second*10, gui.stopChan, gui.refreshFilesAndSubmodules)
+	gui.goEvery(time.Second*time.Duration(userConfig.Refresher.RefreshInterval), gui.stopChan, gui.refreshFilesAndSubmodules)
 
 	g.SetManager(gocui.ManagerFunc(gui.layout), gocui.ManagerFunc(gui.getFocusLayout()))
 
@@ -627,8 +627,9 @@ func (gui *Gui) goEvery(interval time.Duration, stop chan struct{}, function fun
 func (gui *Gui) startBackgroundFetch() {
 	gui.waitForIntro.Wait()
 	isNew := gui.Config.GetIsNewRepo()
+	userConfig := gui.Config.GetUserConfig()
 	if !isNew {
-		time.After(60 * time.Second)
+		time.After(time.Duration(userConfig.Refresher.FetchInterval) * time.Second)
 	}
 	err := gui.fetch(false)
 	if err != nil && strings.Contains(err.Error(), "exit status 128") && isNew {
@@ -637,7 +638,7 @@ func (gui *Gui) startBackgroundFetch() {
 			prompt: gui.Tr.NoAutomaticGitFetchBody,
 		})
 	} else {
-		gui.goEvery(time.Second*60, gui.stopChan, func() error {
+		gui.goEvery(time.Second*time.Duration(userConfig.Refresher.FetchInterval), gui.stopChan, func() error {
 			err := gui.fetch(false)
 			return err
 		})


### PR DESCRIPTION
Implements the request in #894 

Adding configurations for the refresh interval as well as the fetch interval.

Config:

```yaml
refresher:
    refreshInterval: 10 # file/submodule refresh interval in seconds
    fetchInterval: 60 # re-fetch interval in seconds
```


Manually tested as I was not able to find a test that checked the frequency of goEvery in any test