### PR TITLE
Show which branches have unmerged changes

### DIFF
--- a/pkg/commands/loading_branches_test.go
+++ b/pkg/commands/loading_branches_test.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
+	"github.com/jesseduffield/lazygit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func newDummyBranchListBuilder() (*BranchListBuilder, *oscommands.OSCommand) {
+	osCommand := oscommands.NewDummyOSCommand()
+
+	return &BranchListBuilder{
+		Log:           utils.NewDummyLog(),
+		GitCommand:    NewDummyGitCommandWithOSCommand(osCommand),
+		ReflogCommits: []*models.Commit{},
+	}, osCommand
+}
+
+func TestBranchListBuilderLoadsMergedStatus(t *testing.T) {
+	type scenario struct {
+		testName string
+		command  func(string, ...string) *exec.Cmd
+		test     func([]*models.Branch)
+	}
+
+	scenarios := []scenario{
+		{
+			"exactly the branches listed by branch --merged are marked as merged",
+			func(cmd string, args ...string) *exec.Cmd {
+				assert.EqualValues(t, "git", cmd)
+
+				switch args[0] {
+				case "for-each-ref":
+					assert.EqualValues(t, []string{"for-each-ref", "--sort=-committerdate", "--format=%(HEAD)|%(refname:short)|%(upstream:short)|%(upstream:track)", "refs/heads"}, args)
+					return exec.Command("echo", "*|merged1||\n |unmerged1||\n |merged2||\n |unmerged2||")
+				case "branch":
+					assert.EqualValues(t, []string{"branch", "--format=%(refname:short)", "--merged"}, args)
+					return exec.Command("echo", "merged1\nmerged2")
+				}
+				return nil
+			},
+			func(output []*models.Branch) {
+				merged := []string{}
+				unmerged := []string{}
+				for _, b := range output {
+					if b.Merged {
+						merged = append(merged, b.Name)
+					} else {
+						unmerged = append(unmerged, b.Name)
+					}
+				}
+				assert.EqualValues(t, []string{"merged1", "merged2"}, merged)
+				assert.EqualValues(t, []string{"unmerged1", "unmerged2"}, unmerged)
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			b, os := newDummyBranchListBuilder()
+			os.SetCommand(s.command)
+			s.test(b.Build())
+		})
+	}
+}

--- a/pkg/commands/models/branch.go
+++ b/pkg/commands/models/branch.go
@@ -11,6 +11,7 @@ type Branch struct {
 	Pullables    string
 	UpstreamName string
 	Head         bool
+	Merged       bool
 }
 
 func (b *Branch) RefName() string {

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -42,6 +42,10 @@ func getBranchDisplayStrings(b *models.Branch, fullDescription bool, diffed bool
 		coloredName = fmt.Sprintf("%s %s", coloredName, track)
 	}
 
+	if !b.Merged {
+		coloredName = coloredName + utils.ColoredString("Δ", color.Bold, color.FgMagenta)
+	}
+
 	recencyColor := color.FgCyan
 	if b.Recency == "  *" {
 		recencyColor = color.FgGreen


### PR DESCRIPTION
This would close #1147.

This pull requests adds an indicator next to branches that have unmerged changes with respect to the current branch.

For example, in the screenshot below, the delta next to `expand` indicates that the branch is ahead of `master` (which is currently checked out). The lack of a delta next to `editor` indicates that this branch is behind `master` and can be safely deleted.

![screenshot](https://user-images.githubusercontent.com/56928508/105547691-0e398a80-5cff-11eb-8ca4-a65eb9245bcb.png)

This is my first time working on this project, and I'm not very familiar with Go, so let me know if I need to make any changes. I tried to follow the approach used for the `Pullables`/`Pushables` indicator for the implementation. For the tests, I tried following the approach used in `loading_commits_test.go`.

Thanks for the great work on lazygit!