### PR TITLE
Add initialContent on branch rename

### DIFF
--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -435,6 +435,7 @@ func (gui *Gui) handleRenameBranch(g *gocui.Gui, v *gocui.View) error {
 	promptForNewName := func() error {
 		return gui.prompt(promptOpts{
 			title: gui.Tr.NewBranchNamePrompt + " " + branch.Name + ":",
+			initialContent: branch.Name,
 			handleConfirm: func(newBranchName string) error {
 				if err := gui.GitCommand.RenameBranch(branch.Name, newBranchName); err != nil {
 					return gui.surfaceError(err)

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -434,7 +434,7 @@ func (gui *Gui) handleRenameBranch(g *gocui.Gui, v *gocui.View) error {
 
 	promptForNewName := func() error {
 		return gui.prompt(promptOpts{
-			title: gui.Tr.NewBranchNamePrompt + " " + branch.Name + ":",
+			title:          gui.Tr.NewBranchNamePrompt + " " + branch.Name + ":",
 			initialContent: branch.Name,
 			handleConfirm: func(newBranchName string) error {
 				if err := gui.GitCommand.RenameBranch(branch.Name, newBranchName); err != nil {


### PR DESCRIPTION
Added initialContent to branch rename. On branch rename, previous branch name now appears. Branch renames are usually due to mistakes in naming, this makes it easier to fix.


Related to issue [#1153](https://github.com/jesseduffield/lazygit/issues/1153)