### PR TITLE
added support for using spaces on branch names when creating new ones.

### DIFF
--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -497,7 +497,7 @@ func (gui *Gui) handleNewBranchOffCurrentItem() error {
 		title:          message,
 		initialContent: prefilledName,
 		handleConfirm: func(response string) error {
-			if err := gui.GitCommand.NewBranch(response, item.ID()); err != nil {
+			if err := gui.GitCommand.NewBranch(sanitizedBranchName(response), item.ID()); err != nil {
 				return err
 			}
 
@@ -533,7 +533,7 @@ func (gui *Gui) getBranchNames() []string {
 func (gui *Gui) findBranchNameSuggestions(input string) []*types.Suggestion {
 	branchNames := gui.getBranchNames()
 
-	matchingBranchNames := utils.FuzzySearch(input, branchNames)
+	matchingBranchNames := utils.FuzzySearch(sanitizedBranchName(input), branchNames)
 
 	suggestions := make([]*types.Suggestion, len(matchingBranchNames))
 	for i, branchName := range matchingBranchNames {
@@ -544,4 +544,10 @@ func (gui *Gui) findBranchNameSuggestions(input string) []*types.Suggestion {
 	}
 
 	return suggestions
+}
+
+// sanitizedBranchName will remove all spaces in favor of a dash "-" to meet
+// git's branch naming requirement.
+func sanitizedBranchName(input string) string {
+	return strings.ReplaceAll(input, " ", "-")
 }


### PR DESCRIPTION
Hello! started using this tool lately (and love it) since most GUIs can't keep up the size of the repo I maintain at work. One feature I miss is being able to create branches with spaces in the name, this is something that Sourcetree supports (image below).

This change will allow for the user to do that, not sure if you guys find benefit on this as do I, or if maybe I missed it somewhere else. Something cool would be to show the preview on the top right of the prompt as its done with the char count in the commit prompt, but not sure how to do that. Happy to update PR if someone provides guidance.

Thank you!

![image](https://user-images.githubusercontent.com/9199755/107288346-4e07ae00-6a31-11eb-98b7-2ec9340f1891.png)
