### PR TITLE
Fix pattern in commitPrefix example

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -328,7 +328,7 @@ Example:
   git:
     commitPrefixes:
       my_project: # This is repository folder name
-        pattern: "^\\w+\\/(\\w+-\\w+)"
+        pattern: "^\\w+\\/(\\w+-\\w+).*"
         replace: "[$1] "
 ```
 


### PR DESCRIPTION
Commit Prefixes does not work for me.
It was issuing
```
EXAMPLE-123: rest-of-the-branch-name
```
instead of
```
EXAMPLE-123: 
```