### PR TITLE
Improve command execution with strange file names.

### DIFF
--- a/pkg/commands/files.go
+++ b/pkg/commands/files.go
@@ -141,7 +141,7 @@ func (c *GitCommand) WorktreeFileDiff(file *models.File, plain bool, cached bool
 
 func (c *GitCommand) WorktreeFileDiffCmdStr(file *models.File, plain bool, cached bool) string {
 	cachedArg := ""
-	trackedArg := ""
+	trackedArg := "--"
 	colorArg := c.colorArg()
 	split := strings.Split(file.Name, " -> ") // in case of a renamed file we get the new filename
 	fileName := c.OSCommand.Quote(split[len(split)-1])
@@ -149,13 +149,13 @@ func (c *GitCommand) WorktreeFileDiffCmdStr(file *models.File, plain bool, cache
 		cachedArg = "--cached"
 	}
 	if !file.Tracked && !file.HasStagedChanges && !cached {
-		trackedArg = "--no-index /dev/null"
+		trackedArg = "--no-index -- /dev/null"
 	}
 	if plain {
 		colorArg = "never"
 	}
 
-	return fmt.Sprintf("git diff --submodule --no-ext-diff --color=%s %s %s -- %s", colorArg, cachedArg, trackedArg, fileName)
+	return fmt.Sprintf("git diff --submodule --no-ext-diff --color=%s %s %s %s", colorArg, cachedArg, trackedArg, fileName)
 }
 
 func (c *GitCommand) ApplyPatch(patch string, flags ...string) error {

--- a/pkg/commands/files.go
+++ b/pkg/commands/files.go
@@ -22,7 +22,7 @@ func (c *GitCommand) CatFile(fileName string) (string, error) {
 func (c *GitCommand) StageFile(fileName string) error {
 	// renamed files look like "file1 -> file2"
 	fileNames := strings.Split(fileName, " -> ")
-	return c.OSCommand.RunCommand("git add %s", c.OSCommand.Quote(fileNames[len(fileNames)-1]))
+	return c.OSCommand.RunCommand("git add -- %s", c.OSCommand.Quote(fileNames[len(fileNames)-1]))
 }
 
 // StageAll stages all files
@@ -37,9 +37,9 @@ func (c *GitCommand) UnstageAll() error {
 
 // UnStageFile unstages a file
 func (c *GitCommand) UnStageFile(fileName string, tracked bool) error {
-	command := "git rm --cached --force %s"
+	command := "git rm --cached --force -- %s"
 	if tracked {
-		command = "git reset HEAD %s"
+		command = "git reset HEAD -- %s"
 	}
 
 	// renamed files look like "file1 -> file2"
@@ -141,7 +141,7 @@ func (c *GitCommand) WorktreeFileDiff(file *models.File, plain bool, cached bool
 
 func (c *GitCommand) WorktreeFileDiffCmdStr(file *models.File, plain bool, cached bool) string {
 	cachedArg := ""
-	trackedArg := "--"
+	trackedArg := ""
 	colorArg := c.colorArg()
 	split := strings.Split(file.Name, " -> ") // in case of a renamed file we get the new filename
 	fileName := c.OSCommand.Quote(split[len(split)-1])
@@ -155,7 +155,7 @@ func (c *GitCommand) WorktreeFileDiffCmdStr(file *models.File, plain bool, cache
 		colorArg = "never"
 	}
 
-	return fmt.Sprintf("git diff --submodule --no-ext-diff --color=%s %s %s %s", colorArg, cachedArg, trackedArg, fileName)
+	return fmt.Sprintf("git diff --submodule --no-ext-diff --color=%s %s %s -- %s", colorArg, cachedArg, trackedArg, fileName)
 }
 
 func (c *GitCommand) ApplyPatch(patch string, flags ...string) error {

--- a/pkg/commands/git_test.go
+++ b/pkg/commands/git_test.go
@@ -1037,7 +1037,7 @@ func TestGitCommandStageFile(t *testing.T) {
 	gitCmd := NewDummyGitCommand()
 	gitCmd.OSCommand.Command = func(cmd string, args ...string) *exec.Cmd {
 		assert.EqualValues(t, "git", cmd)
-		assert.EqualValues(t, []string{"add", "test.txt"}, args)
+		assert.EqualValues(t, []string{"add", "--", "test.txt"}, args)
 
 		return secureexec.Command("echo")
 	}
@@ -1059,7 +1059,7 @@ func TestGitCommandUnstageFile(t *testing.T) {
 			"Remove an untracked file from staging",
 			func(cmd string, args ...string) *exec.Cmd {
 				assert.EqualValues(t, "git", cmd)
-				assert.EqualValues(t, []string{"rm", "--cached", "--force", "test.txt"}, args)
+				assert.EqualValues(t, []string{"rm", "--cached", "--force", "--", "test.txt"}, args)
 
 				return secureexec.Command("echo")
 			},
@@ -1072,7 +1072,7 @@ func TestGitCommandUnstageFile(t *testing.T) {
 			"Remove a tracked file from staging",
 			func(cmd string, args ...string) *exec.Cmd {
 				assert.EqualValues(t, "git", cmd)
-				assert.EqualValues(t, []string{"reset", "HEAD", "test.txt"}, args)
+				assert.EqualValues(t, []string{"reset", "HEAD", "--", "test.txt"}, args)
 
 				return secureexec.Command("echo")
 			},
@@ -1455,7 +1455,7 @@ func TestGitCommandDiff(t *testing.T) {
 			"File not tracked and file has no staged changes",
 			func(cmd string, args ...string) *exec.Cmd {
 				assert.EqualValues(t, "git", cmd)
-				assert.EqualValues(t, []string{"diff", "--submodule", "--no-ext-diff", "--color=always", "--no-index", "/dev/null", "test.txt"}, args)
+				assert.EqualValues(t, []string{"diff", "--submodule", "--no-ext-diff", "--color=always", "--no-index", "--", "/dev/null", "test.txt"}, args)
 
 				return secureexec.Command("echo")
 			},

--- a/pkg/commands/loading_files.go
+++ b/pkg/commands/loading_files.go
@@ -37,7 +37,7 @@ func (c *GitCommand) GetStatusFiles(opts GetStatusFileOptions) []*models.File {
 		change := statusString[0:2]
 		stagedChange := change[0:1]
 		unstagedChange := statusString[1:2]
-		filename := c.OSCommand.Unquote(statusString[3:])
+		filename := statusString[3:]
 		untracked := utils.IncludesString([]string{"??", "A ", "AM"}, change)
 		hasNoStagedChanges := utils.IncludesString([]string{" ", "U", "?"}, stagedChange)
 		hasMergeConflicts := utils.IncludesString([]string{"DD", "AA", "UU", "AU", "UA", "UD", "DU"}, change)

--- a/pkg/commands/loading_files.go
+++ b/pkg/commands/loading_files.go
@@ -72,7 +72,13 @@ func (c *GitCommand) GitStatus(opts GitStatusOptions) (string, error) {
 		noRenamesFlag = "--no-renames"
 	}
 
-	return c.OSCommand.RunCommandWithOutput("git status %s --porcelain %s", opts.UntrackedFilesArg, noRenamesFlag)
+	statusLines, err := c.OSCommand.RunCommandWithOutput("git status %s --porcelain -z %s", opts.UntrackedFilesArg, noRenamesFlag)
+	if err != nil {
+		return "", err
+	}
+
+	statusLines = strings.Replace(statusLines, "\x00", "\n", -1)
+	return statusLines, nil
 }
 
 // MergeStatusFiles merge status files

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -253,12 +253,6 @@ func (c *OSCommand) Quote(message string) string {
 	return escapedQuote + message + escapedQuote
 }
 
-// Unquote removes wrapping quotations marks if they are present
-// this is needed for removing quotes from staged filenames with spaces
-func (c *OSCommand) Unquote(message string) string {
-	return strings.Replace(message, `"`, "", -1)
-}
-
 // AppendLineToFile adds a new line in file
 func (c *OSCommand) AppendLineToFile(filename, line string) error {
 	f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)

--- a/pkg/commands/oscommands/os_test.go
+++ b/pkg/commands/oscommands/os_test.go
@@ -147,17 +147,6 @@ func TestOSCommandQuoteDoubleQuote(t *testing.T) {
 	assert.EqualValues(t, expected, actual)
 }
 
-// TestOSCommandUnquote is a function.
-func TestOSCommandUnquote(t *testing.T) {
-	osCommand := NewDummyOSCommand()
-
-	actual := osCommand.Unquote(`hello "test"`)
-
-	expected := "hello test"
-
-	assert.EqualValues(t, expected, actual)
-}
-
 // TestOSCommandFileType is a function.
 func TestOSCommandFileType(t *testing.T) {
 	type scenario struct {


### PR DESCRIPTION
Fixed a problem where some commands would fail if the file name contained spaces, `"`, or multibyte characters (without `git config core.quotePath false`).

related: #378

- `"` in a filename (left: PR, right: master)

<img width="1257" alt="スクリーンショット 2021-03-02 12 58 06" src="https://user-images.githubusercontent.com/10097437/109596554-d6253300-7b59-11eb-848a-cbbdd2f4e00c.png">

- then, when we type `space`, `git add ...` will fail (master)
<img width="799" alt="スクリーンショット 2021-03-02 13 19 24" src="https://user-images.githubusercontent.com/10097437/109596680-108ed000-7b5a-11eb-933a-fc0778439e19.png">

- a filename starting with `-` (left: PR, right: master)

<img width="1251" alt="スクリーンショット 2021-03-02 12 58 23" src="https://user-images.githubusercontent.com/10097437/109596917-83984680-7b5a-11eb-9cd7-32c44c77b822.png">

- multibyte characters (left: PR, right: master)

<img width="1254" alt="スクリーンショット 2021-03-02 12 58 48" src="https://user-images.githubusercontent.com/10097437/109597024-c0643d80-7b5a-11eb-83c8-fbcd8224515d.png">

- in history (left: PR, right: master)

<img width="1254" alt="スクリーンショット 2021-03-02 13 04 30" src="https://user-images.githubusercontent.com/10097437/109597148-015c5200-7b5b-11eb-8023-174c1ddc3e80.png">
