### PR TITLE
fix renamed files looking wrong

### DIFF
--- a/pkg/commands/files.go
+++ b/pkg/commands/files.go
@@ -21,7 +21,7 @@ func (c *GitCommand) CatFile(fileName string) (string, error) {
 // StageFile stages a file
 func (c *GitCommand) StageFile(fileName string) error {
 	// renamed files look like "file1 -> file2"
-	fileNames := strings.Split(fileName, " -> ")
+	fileNames := strings.Split(fileName, models.RENAME_SEPARATOR)
 	return c.OSCommand.RunCommand("git add -- %s", c.OSCommand.Quote(fileNames[len(fileNames)-1]))
 }
 
@@ -43,7 +43,7 @@ func (c *GitCommand) UnStageFile(fileName string, tracked bool) error {
 	}
 
 	// renamed files look like "file1 -> file2"
-	fileNames := strings.Split(fileName, " -> ")
+	fileNames := strings.Split(fileName, models.RENAME_SEPARATOR)
 	for _, name := range fileNames {
 		if err := c.OSCommand.RunCommand(command, c.OSCommand.Quote(name)); err != nil {
 			return err
@@ -63,7 +63,7 @@ func (c *GitCommand) BeforeAndAfterFileForRename(file *models.File) (*models.Fil
 	// all files, passing the --no-renames flag and then recursively call the function
 	// again for the before file and after file. At some point we should fix the abstraction itself
 
-	split := strings.Split(file.Name, " -> ")
+	split := strings.Split(file.Name, models.RENAME_SEPARATOR)
 	filesWithoutRenames := c.GetStatusFiles(GetStatusFileOptions{NoRenames: true})
 	var beforeFile *models.File
 	var afterFile *models.File
@@ -143,7 +143,7 @@ func (c *GitCommand) WorktreeFileDiffCmdStr(file *models.File, plain bool, cache
 	cachedArg := ""
 	trackedArg := "--"
 	colorArg := c.colorArg()
-	split := strings.Split(file.Name, " -> ") // in case of a renamed file we get the new filename
+	split := strings.Split(file.Name, models.RENAME_SEPARATOR) // in case of a renamed file we get the new filename
 	fileName := c.OSCommand.Quote(split[len(split)-1])
 	if cached {
 		cachedArg = "--cached"

--- a/pkg/commands/loading_commit_files.go
+++ b/pkg/commands/loading_commit_files.go
@@ -14,7 +14,7 @@ func (c *GitCommand) GetFilesInDiff(from string, to string, reverse bool, patchM
 		reverseFlag = " -R "
 	}
 
-	filenames, err := c.OSCommand.RunCommandWithOutput("git diff --submodule --no-ext-diff --name-status -z %s %s %s", reverseFlag, from, to)
+	filenames, err := c.OSCommand.RunCommandWithOutput("git diff --submodule --no-ext-diff --name-status -z --no-renames %s %s %s", reverseFlag, from, to)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/loading_files.go
+++ b/pkg/commands/loading_files.go
@@ -77,8 +77,19 @@ func (c *GitCommand) GitStatus(opts GitStatusOptions) (string, error) {
 		return "", err
 	}
 
-	statusLines = strings.Replace(statusLines, "\x00", "\n", -1)
-	return statusLines, nil
+	splitLines := strings.Split(statusLines, "\x00")
+	// if a line starts with 'R' then the next line is the original file.
+	for i := 0; i < len(splitLines)-1; i++ {
+		original := splitLines[i]
+		if strings.HasPrefix(original, "R  ") {
+			next := splitLines[i+1]
+			updated := "R  " + next + models.RENAME_SEPARATOR + strings.TrimPrefix(original, "R  ")
+			splitLines[i] = updated
+			splitLines = append(splitLines[0:i+1], splitLines[i+2:]...)
+		}
+	}
+
+	return strings.Join(splitLines, "\n"), nil
 }
 
 // MergeStatusFiles merge status files


### PR DESCRIPTION
We recently introduced a bug where renamed files became malformed in the files panel because when using the -z arg in git status, renames are separated with the NULL character, meaning we need to piece that together manually on our end