### PR TITLE
fix panic when trying to open file at line by line panel

### DIFF
--- a/pkg/gui/line_by_line_panel.go
+++ b/pkg/gui/line_by_line_panel.go
@@ -1,8 +1,6 @@
 package gui
 
 import (
-	"fmt"
-
 	"github.com/go-errors/errors"
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/patch"
@@ -349,11 +347,7 @@ func (gui *Gui) handleOpenFileAtLine() error {
 			return errors.Errorf("unknown main context: %s", gui.State.MainContext)
 		}
 
-		// need to look at current index, then work out what my hunk's header information is, and see how far my line is away from the hunk header
-		selectedHunk := state.PatchParser.GetHunkContainingLine(state.SelectedLineIdx, 0)
-		lineNumber := selectedHunk.LineNumberOfLine(state.SelectedLineIdx)
-		filenameWithLineNum := fmt.Sprintf("%s:%d", filename, lineNumber)
-		if err := gui.OSCommand.OpenFile(filenameWithLineNum); err != nil {
+		if err := gui.OSCommand.OpenFile(filename); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
As described in #1187, when trying to open a file at the line by line panel, a panic generated.

The issue appears to be that we were trying to open files with line
number append to it  - i.e. `file.go:123` - causing an error on the
execution of the command for opening the file.

I'm sure there's some context as to why it was implemented that way
so any feedback would be great :)

Fixes #1187