### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ scoop install lazygit
 
 ### Arch Linux
 
-Packages for Arch Linux are available via AUR (Arch User Repository).
+Packages for Arch Linux are available via pacman and AUR (Arch User Repository).
 
 There are two packages. The stable one which is built with the latest release
 and the git version which builds from the most recent commit.
 
-- Stable: <https://aur.archlinux.org/packages/lazygit/>
+- Stable: `sudo pacman -S lazygit`
 - Development: <https://aur.archlinux.org/packages/lazygit-git/>
 
 Instruction of how to install AUR content can be found here:


### PR DESCRIPTION
While trying to install I found this part of the README outdated. I tried to make as few modifications as possible while also guiding new users to the correct way of installation.