### PR TITLE
stricter CI

### DIFF
--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -71,7 +71,7 @@ func RunTests(
 			logf("path: %s", testPath)
 
 			// three retries at normal speed for the sake of flakey tests
-			speeds = append(speeds, 1, 1, 1, 0.5, 0.5)
+			speeds = append(speeds, 1)
 			for i, speed := range speeds {
 				logf("%s: attempting test at speed %f\n", test.Name, speed)
 


### PR DESCRIPTION
be less lenient on CI failures because they might represent an intermittent bug