### PR TITLE
Fix documentation path for Linux config file

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -2,7 +2,7 @@
 
 Default path for the config file:
 
-* Linux: `~/.config/lazygit/config.yml`
+* Linux: `~/.config/jesseduffield/lazygit/config.yml`
 * MacOS: `~/Library/Application Support/jesseduffield/lazygit/config.yml`
 * Windows: `%APPDATA%\jesseduffield\lazygit\config.yml`
 


### PR DESCRIPTION
The listed config file directory for Linux is incorrect.