### PR TITLE
Command log 2

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -41,7 +41,8 @@ gui:
   skipUnstageLineWarning: false
   skipStashWarning: true
   showFileTree: false # for rendering changes files in a tree format
-  showCommandLog:
+  showCommandLog: true
+  commandLogSize: 1
 git:
   paging:
     colorArg: always

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -37,6 +37,7 @@ type GuiConfig struct {
 	SkipNoStagedFilesWarning bool               `yaml:"skipNoStagedFilesWarning"`
 	ShowFileTree             bool               `yaml:"showFileTree"`
 	ShowCommandLog           bool               `yaml:"showCommandLog"`
+	CommandLogSize           int                `yaml:"commandLogSize"`
 }
 
 type ThemeConfig struct {
@@ -297,6 +298,9 @@ func GetDefaultConfig() *UserConfig {
 			},
 			CommitLength:             CommitLengthConfig{Show: true},
 			SkipNoStagedFilesWarning: false,
+			ShowCommandLog:           true,
+			ShowFileTree:             false,
+			CommandLogSize:           8,
 		},
 		Git: GitConfig{
 			Paging: PagingConfig{

--- a/pkg/gui/arrangement.go
+++ b/pkg/gui/arrangement.go
@@ -150,7 +150,8 @@ func (gui *Gui) getWindowDimensions(informationStr string, appStatus string) map
 
 	extrasWindowSize := 0
 	if gui.ShowExtrasWindow {
-		extrasWindowSize = 10
+		frameSize := 2
+		extrasWindowSize = gui.Config.GetUserConfig().Gui.CommandLogSize + frameSize
 		if gui.currentStaticContext().GetKey() == COMMAND_LOG_CONTEXT_KEY {
 			extrasWindowSize = 40
 		}

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -87,7 +87,7 @@ func (gui *Gui) handleBranchPress() error {
 		return gui.createErrorPanel(gui.Tr.AlreadyCheckedOutBranch)
 	}
 	branch := gui.getSelectedBranch()
-	return gui.handleCheckoutRef(branch.Name, handleCheckoutRefOptions{span: "Checkout branch"})
+	return gui.handleCheckoutRef(branch.Name, handleCheckoutRefOptions{span: gui.Tr.Spans.CheckoutBranch})
 }
 
 func (gui *Gui) handleCreatePullRequestPress() error {
@@ -139,7 +139,7 @@ func (gui *Gui) handleForceCheckout() error {
 		title:  title,
 		prompt: message,
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan("Force checkout branch").Checkout(branch.Name, commands.CheckoutOptions{Force: true}); err != nil {
+			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.ForceCheckoutBranch).Checkout(branch.Name, commands.CheckoutOptions{Force: true}); err != nil {
 				_ = gui.surfaceError(err)
 			}
 			return gui.refreshSidePanels(refreshOptions{mode: ASYNC})
@@ -294,7 +294,7 @@ func (gui *Gui) deleteNamedBranch(selectedBranch *models.Branch, force bool) err
 		title:  title,
 		prompt: message,
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan("Delete branch").DeleteBranch(selectedBranch.Name, force); err != nil {
+			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DeleteBranch).DeleteBranch(selectedBranch.Name, force); err != nil {
 				errMessage := err.Error()
 				if !force && strings.Contains(errMessage, "is not fully merged") {
 					return gui.deleteNamedBranch(selectedBranch, true)
@@ -330,7 +330,7 @@ func (gui *Gui) mergeBranchIntoCheckedOutBranch(branchName string) error {
 		title:  gui.Tr.MergingTitle,
 		prompt: prompt,
 		handleConfirm: func() error {
-			err := gui.GitCommand.WithSpan("Merge").Merge(branchName, commands.MergeOpts{})
+			err := gui.GitCommand.WithSpan(gui.Tr.Spans.Merge).Merge(branchName, commands.MergeOpts{})
 			return gui.handleGenericMergeCommandResult(err)
 		},
 	})
@@ -371,7 +371,7 @@ func (gui *Gui) handleRebaseOntoBranch(selectedBranchName string) error {
 		title:  gui.Tr.RebasingTitle,
 		prompt: prompt,
 		handleConfirm: func() error {
-			err := gui.GitCommand.WithSpan("Rebase branch").RebaseBranch(selectedBranchName)
+			err := gui.GitCommand.WithSpan(gui.Tr.Spans.RebaseBranch).RebaseBranch(selectedBranchName)
 			return gui.handleGenericMergeCommandResult(err)
 		},
 	})
@@ -397,7 +397,7 @@ func (gui *Gui) handleFastForward() error {
 		return gui.surfaceError(err)
 	}
 
-	span := "Fast forward branch"
+	span := gui.Tr.Spans.FastForwardBranch
 
 	split := strings.Split(upstream, "/")
 	remoteName := split[0]
@@ -444,7 +444,7 @@ func (gui *Gui) handleRenameBranch() error {
 			title:          gui.Tr.NewBranchNamePrompt + " " + branch.Name + ":",
 			initialContent: branch.Name,
 			handleConfirm: func(newBranchName string) error {
-				if err := gui.GitCommand.WithSpan("Rename branch").RenameBranch(branch.Name, newBranchName); err != nil {
+				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.RenameBranch).RenameBranch(branch.Name, newBranchName); err != nil {
 					return gui.surfaceError(err)
 				}
 
@@ -513,7 +513,7 @@ func (gui *Gui) handleNewBranchOffCurrentItem() error {
 		title:          message,
 		initialContent: prefilledName,
 		handleConfirm: func(response string) error {
-			if err := gui.GitCommand.WithSpan("Create branch").NewBranch(sanitizedBranchName(response), item.ID()); err != nil {
+			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.CreateBranch).NewBranch(sanitizedBranchName(response), item.ID()); err != nil {
 				return err
 			}
 

--- a/pkg/gui/cherry_picking.go
+++ b/pkg/gui/cherry_picking.go
@@ -148,7 +148,7 @@ func (gui *Gui) HandlePasteCommits() error {
 		prompt: gui.Tr.SureCherryPick,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.CherryPickingStatus, func() error {
-				err := gui.GitCommand.WithSpan("(Cherry-pick) Paste commits").CherryPickCommits(gui.State.Modes.CherryPicking.CherryPickedCommits)
+				err := gui.GitCommand.WithSpan(gui.Tr.Spans.CherryPick).CherryPickCommits(gui.State.Modes.CherryPicking.CherryPickedCommits)
 				return gui.handleGenericMergeCommandResult(err)
 			})
 		},

--- a/pkg/gui/command_log_panel.go
+++ b/pkg/gui/command_log_panel.go
@@ -1,0 +1,37 @@
+package gui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
+	"github.com/jesseduffield/lazygit/pkg/theme"
+	"github.com/jesseduffield/lazygit/pkg/utils"
+)
+
+func (gui *Gui) GetOnRunCommand() func(entry oscommands.CmdLogEntry) {
+	// closing over this so that nobody else can modify it
+	currentSpan := ""
+
+	return func(entry oscommands.CmdLogEntry) {
+		if gui.Views.Extras == nil {
+			return
+		}
+
+		gui.Views.Extras.Autoscroll = true
+
+		if entry.GetSpan() != currentSpan {
+			fmt.Fprint(gui.Views.Extras, "\n"+utils.ColoredString(entry.GetSpan(), color.FgYellow))
+			currentSpan = entry.GetSpan()
+		}
+
+		clrAttr := theme.DefaultTextColor
+		if !entry.GetCommandLine() {
+			clrAttr = color.FgMagenta
+		}
+		gui.CmdLog = append(gui.CmdLog, entry.GetCmdStr())
+		indentedCmdStr := "  " + strings.Replace(entry.GetCmdStr(), "\n", "\n  ", -1)
+		fmt.Fprint(gui.Views.Extras, "\n"+utils.ColoredString(indentedCmdStr, clrAttr))
+	}
+}

--- a/pkg/gui/commit_files_panel.go
+++ b/pkg/gui/commit_files_panel.go
@@ -62,7 +62,7 @@ func (gui *Gui) handleCheckoutCommitFile() error {
 		return nil
 	}
 
-	if err := gui.GitCommand.WithSpan("Checkout file").CheckoutFile(gui.State.CommitFileManager.GetParent(), node.GetPath()); err != nil {
+	if err := gui.GitCommand.WithSpan(gui.Tr.Spans.CheckoutFile).CheckoutFile(gui.State.CommitFileManager.GetParent(), node.GetPath()); err != nil {
 		return gui.surfaceError(err)
 	}
 
@@ -81,7 +81,7 @@ func (gui *Gui) handleDiscardOldFileChange() error {
 		prompt: gui.Tr.DiscardFileChangesPrompt,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
-				if err := gui.GitCommand.WithSpan("Discard old file change").DiscardOldFileChanges(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, fileName); err != nil {
+				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DiscardOldFileChange).DiscardOldFileChanges(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, fileName); err != nil {
 					if err := gui.handleGenericMergeCommandResult(err); err != nil {
 						return err
 					}

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -21,7 +21,7 @@ func (gui *Gui) handleCommitConfirm() error {
 	}
 
 	cmdStr := gui.GitCommand.CommitCmdStr(message, flags)
-	gui.OnRunCommand(oscommands.NewCmdLogEntry(cmdStr, "Commit", true))
+	gui.OnRunCommand(oscommands.NewCmdLogEntry(cmdStr, gui.Tr.Spans.Commit, true))
 	return gui.withGpgHandling(cmdStr, gui.Tr.CommittingStatus, func() error {
 		_ = gui.returnFromContext()
 		gui.clearEditorView(gui.Views.CommitMessage)

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -171,7 +171,7 @@ func (gui *Gui) handleCommitSquashDown() error {
 		prompt: gui.Tr.SureSquashThisCommit,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.SquashingStatus, func() error {
-				err := gui.GitCommand.WithSpan("Squash commit down").InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "squash")
+				err := gui.GitCommand.WithSpan(gui.Tr.Spans.SquashCommitDown).InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "squash")
 				return gui.handleGenericMergeCommandResult(err)
 			})
 		},
@@ -200,7 +200,7 @@ func (gui *Gui) handleCommitFixup() error {
 		prompt: gui.Tr.SureFixupThisCommit,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.FixingStatus, func() error {
-				err := gui.GitCommand.WithSpan("Fixup commit").InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "fixup")
+				err := gui.GitCommand.WithSpan(gui.Tr.Spans.FixupCommit).InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "fixup")
 				return gui.handleGenericMergeCommandResult(err)
 			})
 		},
@@ -238,7 +238,7 @@ func (gui *Gui) handleRenameCommit() error {
 		title:          gui.Tr.LcRenameCommit,
 		initialContent: message,
 		handleConfirm: func(response string) error {
-			if err := gui.GitCommand.WithSpan("Reword commit").RenameCommit(response); err != nil {
+			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.RewordCommit).RenameCommit(response); err != nil {
 				return gui.surfaceError(err)
 			}
 
@@ -260,7 +260,7 @@ func (gui *Gui) handleRenameCommitEditor() error {
 		return nil
 	}
 
-	subProcess, err := gui.GitCommand.WithSpan("Reword commit").RewordCommit(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx)
+	subProcess, err := gui.GitCommand.WithSpan(gui.Tr.Spans.RewordCommit).RewordCommit(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx)
 	if err != nil {
 		return gui.surfaceError(err)
 	}
@@ -319,7 +319,7 @@ func (gui *Gui) handleCommitDelete() error {
 		prompt: gui.Tr.DeleteCommitPrompt,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.DeletingStatus, func() error {
-				err := gui.GitCommand.WithSpan("Drop commit").InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "drop")
+				err := gui.GitCommand.WithSpan(gui.Tr.Spans.DropCommit).InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "drop")
 				return gui.handleGenericMergeCommandResult(err)
 			})
 		},
@@ -331,7 +331,7 @@ func (gui *Gui) handleCommitMoveDown() error {
 		return err
 	}
 
-	span := "Move commit down"
+	span := gui.Tr.Spans.MoveCommitDown
 
 	index := gui.State.Panels.Commits.SelectedLineIdx
 	selectedCommit := gui.State.Commits[index]
@@ -374,7 +374,7 @@ func (gui *Gui) handleCommitMoveUp() error {
 		return nil
 	}
 
-	span := "Move commit up"
+	span := gui.Tr.Spans.MoveCommitUp
 
 	selectedCommit := gui.State.Commits[index]
 	if selectedCommit.Status == "rebasing" {
@@ -416,7 +416,7 @@ func (gui *Gui) handleCommitEdit() error {
 	}
 
 	return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
-		err = gui.GitCommand.WithSpan("Edit commit").InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "edit")
+		err = gui.GitCommand.WithSpan(gui.Tr.Spans.EditCommit).InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "edit")
 		return gui.handleGenericMergeCommandResult(err)
 	})
 }
@@ -431,7 +431,7 @@ func (gui *Gui) handleCommitAmendTo() error {
 		prompt: gui.Tr.AmendCommitPrompt,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.AmendingStatus, func() error {
-				err := gui.GitCommand.WithSpan("Amend commit").AmendTo(gui.State.Commits[gui.State.Panels.Commits.SelectedLineIdx].Sha)
+				err := gui.GitCommand.WithSpan(gui.Tr.Spans.AmendCommit).AmendTo(gui.State.Commits[gui.State.Panels.Commits.SelectedLineIdx].Sha)
 				return gui.handleGenericMergeCommandResult(err)
 			})
 		},
@@ -461,7 +461,7 @@ func (gui *Gui) handleCommitRevert() error {
 		return err
 	}
 
-	if err := gui.GitCommand.WithSpan("Revert commit").Revert(gui.State.Commits[gui.State.Panels.Commits.SelectedLineIdx].Sha); err != nil {
+	if err := gui.GitCommand.WithSpan(gui.Tr.Spans.RevertCommit).Revert(gui.State.Commits[gui.State.Panels.Commits.SelectedLineIdx].Sha); err != nil {
 		return gui.surfaceError(err)
 	}
 	gui.State.Panels.Commits.SelectedLineIdx++
@@ -498,7 +498,7 @@ func (gui *Gui) handleCreateFixupCommit() error {
 		title:  gui.Tr.CreateFixupCommit,
 		prompt: prompt,
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan("Create fixup commit").CreateFixupCommit(commit.Sha); err != nil {
+			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.CreateFixupCommit).CreateFixupCommit(commit.Sha); err != nil {
 				return gui.surfaceError(err)
 			}
 
@@ -529,7 +529,7 @@ func (gui *Gui) handleSquashAllAboveFixupCommits() error {
 		prompt: prompt,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.SquashingStatus, func() error {
-				err := gui.GitCommand.WithSpan("Squash all above fixup commits").SquashAllAboveFixupCommits(commit.Sha)
+				err := gui.GitCommand.WithSpan(gui.Tr.Spans.SquashAllAboveFixupCommits).SquashAllAboveFixupCommits(commit.Sha)
 				return gui.handleGenericMergeCommandResult(err)
 			})
 		},
@@ -552,7 +552,7 @@ func (gui *Gui) handleCreateLightweightTag(commitSha string) error {
 	return gui.prompt(promptOpts{
 		title: gui.Tr.TagNameTitle,
 		handleConfirm: func(response string) error {
-			if err := gui.GitCommand.WithSpan("Create lightweight tag").CreateLightweightTag(response, commitSha); err != nil {
+			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.CreateLightweightTag).CreateLightweightTag(response, commitSha); err != nil {
 				return gui.surfaceError(err)
 			}
 			return gui.refreshSidePanels(refreshOptions{mode: ASYNC, scope: []RefreshableView{COMMITS, TAGS}})
@@ -570,7 +570,7 @@ func (gui *Gui) handleCheckoutCommit() error {
 		title:  gui.Tr.LcCheckoutCommit,
 		prompt: gui.Tr.SureCheckoutThisCommit,
 		handleConfirm: func() error {
-			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{span: "Checkout commit"})
+			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{span: gui.Tr.Spans.CheckoutCommit})
 		},
 	})
 }
@@ -625,7 +625,7 @@ func (gui *Gui) handleCopySelectedCommitMessageToClipboard() error {
 		return gui.surfaceError(err)
 	}
 
-	if err := gui.OSCommand.WithSpan("Copy commit message to clipboard").CopyToClipboard(message); err != nil {
+	if err := gui.OSCommand.WithSpan(gui.Tr.Spans.CopyCommitMessageToClipboard).CopyToClipboard(message); err != nil {
 		return gui.surfaceError(err)
 	}
 

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -68,7 +68,7 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand config.CustomCommand
 				loadingText = gui.Tr.LcRunningCustomCommandStatus
 			}
 			return gui.WithWaitingStatus(loadingText, func() error {
-				if err := gui.OSCommand.WithSpan("Custom command").RunShellCommand(cmdStr); err != nil {
+				if err := gui.OSCommand.WithSpan(gui.Tr.Spans.CustomCommand).RunShellCommand(cmdStr); err != nil {
 					return gui.surfaceError(err)
 				}
 				return gui.refreshSidePanels(refreshOptions{})

--- a/pkg/gui/discard_changes_menu_panel.go
+++ b/pkg/gui/discard_changes_menu_panel.go
@@ -12,7 +12,7 @@ func (gui *Gui) handleCreateDiscardMenu() error {
 			{
 				displayString: gui.Tr.LcDiscardAllChanges,
 				onPress: func() error {
-					if err := gui.GitCommand.WithSpan("Discard all changes in directory").DiscardAllDirChanges(node); err != nil {
+					if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DiscardAllChangesInDirectory).DiscardAllDirChanges(node); err != nil {
 						return gui.surfaceError(err)
 					}
 					return gui.refreshSidePanels(refreshOptions{mode: ASYNC, scope: []RefreshableView{FILES}})
@@ -24,7 +24,7 @@ func (gui *Gui) handleCreateDiscardMenu() error {
 			menuItems = append(menuItems, &menuItem{
 				displayString: gui.Tr.LcDiscardUnstagedChanges,
 				onPress: func() error {
-					if err := gui.GitCommand.WithSpan("Discard unstaged changes in directory").DiscardUnstagedDirChanges(node); err != nil {
+					if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DiscardUnstagedChangesInDirectory).DiscardUnstagedDirChanges(node); err != nil {
 						return gui.surfaceError(err)
 					}
 
@@ -53,7 +53,7 @@ func (gui *Gui) handleCreateDiscardMenu() error {
 					displayString: gui.Tr.LcDiscardAllChanges,
 					onPress: func() error {
 						gui.Log.Warn("HA?")
-						if err := gui.GitCommand.WithSpan("Discard all changes in file").DiscardAllFileChanges(file); err != nil {
+						if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DiscardAllChangesInFile).DiscardAllFileChanges(file); err != nil {
 							return gui.surfaceError(err)
 						}
 						return gui.refreshSidePanels(refreshOptions{mode: ASYNC, scope: []RefreshableView{FILES}})
@@ -65,7 +65,7 @@ func (gui *Gui) handleCreateDiscardMenu() error {
 				menuItems = append(menuItems, &menuItem{
 					displayString: gui.Tr.LcDiscardUnstagedChanges,
 					onPress: func() error {
-						if err := gui.GitCommand.WithSpan("Discard all unstaged changes in file").DiscardUnstagedFileChanges(file); err != nil {
+						if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DiscardAllUnstagedChangesInFile).DiscardUnstagedFileChanges(file); err != nil {
 							return gui.surfaceError(err)
 						}
 

--- a/pkg/gui/git_flow.go
+++ b/pkg/gui/git_flow.go
@@ -32,7 +32,7 @@ func (gui *Gui) gitFlowFinishBranch(gitFlowConfig string, branchName string) err
 	}
 
 	return gui.runSubprocessWithSuspenseAndRefresh(
-		gui.OSCommand.WithSpan("Git flow finish").PrepareSubProcess("git", "flow", branchType, "finish", suffix),
+		gui.OSCommand.WithSpan(gui.Tr.Spans.GitFlowFinish).PrepareSubProcess("git", "flow", branchType, "finish", suffix),
 	)
 }
 
@@ -56,7 +56,7 @@ func (gui *Gui) handleCreateGitFlowMenu() error {
 				title: title,
 				handleConfirm: func(name string) error {
 					return gui.runSubprocessWithSuspenseAndRefresh(
-						gui.OSCommand.WithSpan("Git Flow start").PrepareSubProcess("git", "flow", branchType, "start", name),
+						gui.OSCommand.WithSpan(gui.Tr.Spans.GitFlowStart).PrepareSubProcess("git", "flow", branchType, "start", name),
 					)
 				},
 			})

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -215,7 +215,7 @@ func (gui *Gui) handleCopySelectedSideContextItemToClipboard() error {
 		return nil
 	}
 
-	if err := gui.OSCommand.WithSpan("Copy to clipboard").CopyToClipboard(itemId); err != nil {
+	if err := gui.OSCommand.WithSpan(gui.Tr.Spans.CopyToClipboard).CopyToClipboard(itemId); err != nil {
 		return gui.surfaceError(err)
 	}
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -473,35 +473,38 @@ func NewGui(log *logrus.Entry, gitCommand *commands.GitCommand, oSCommand *oscom
 
 	gui.watchFilesForChanges()
 
-	onRunCommand := func() func(entry oscommands.CmdLogEntry) {
-		currentSpan := ""
-
-		return func(entry oscommands.CmdLogEntry) {
-			if gui.Views.Extras == nil {
-				return
-			}
-
-			gui.Views.Extras.Autoscroll = true
-
-			if entry.GetSpan() != currentSpan {
-				fmt.Fprintln(gui.Views.Extras, utils.ColoredString(entry.GetSpan(), color.FgYellow))
-				currentSpan = entry.GetSpan()
-			}
-
-			clrAttr := theme.DefaultTextColor
-			if !entry.GetCommandLine() {
-				clrAttr = color.FgMagenta
-			}
-			gui.CmdLog = append(gui.CmdLog, entry.GetCmdStr())
-			indentedCmdStr := "  " + strings.Replace(entry.GetCmdStr(), "\n", "\n  ", -1)
-			fmt.Fprintln(gui.Views.Extras, utils.ColoredString(indentedCmdStr, clrAttr))
-		}
-	}()
+	onRunCommand := gui.GetOnRunCommand()
 
 	oSCommand.SetOnRunCommand(onRunCommand)
 	gui.OnRunCommand = onRunCommand
 
 	return gui, nil
+}
+
+func (gui *Gui) GetOnRunCommand() func(entry oscommands.CmdLogEntry) {
+	// closing over this so that nobody else can modify it
+	currentSpan := ""
+
+	return func(entry oscommands.CmdLogEntry) {
+		if gui.Views.Extras == nil {
+			return
+		}
+
+		gui.Views.Extras.Autoscroll = true
+
+		if entry.GetSpan() != currentSpan {
+			fmt.Fprintln(gui.Views.Extras, utils.ColoredString(entry.GetSpan(), color.FgYellow))
+			currentSpan = entry.GetSpan()
+		}
+
+		clrAttr := theme.DefaultTextColor
+		if !entry.GetCommandLine() {
+			clrAttr = color.FgMagenta
+		}
+		gui.CmdLog = append(gui.CmdLog, entry.GetCmdStr())
+		indentedCmdStr := "  " + strings.Replace(entry.GetCmdStr(), "\n", "\n  ", -1)
+		fmt.Fprintln(gui.Views.Extras, utils.ColoredString(indentedCmdStr, clrAttr))
+	}
 }
 
 // Run setup the gui with keybindings and start the mainloop

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -474,37 +474,10 @@ func NewGui(log *logrus.Entry, gitCommand *commands.GitCommand, oSCommand *oscom
 	gui.watchFilesForChanges()
 
 	onRunCommand := gui.GetOnRunCommand()
-
 	oSCommand.SetOnRunCommand(onRunCommand)
 	gui.OnRunCommand = onRunCommand
 
 	return gui, nil
-}
-
-func (gui *Gui) GetOnRunCommand() func(entry oscommands.CmdLogEntry) {
-	// closing over this so that nobody else can modify it
-	currentSpan := ""
-
-	return func(entry oscommands.CmdLogEntry) {
-		if gui.Views.Extras == nil {
-			return
-		}
-
-		gui.Views.Extras.Autoscroll = true
-
-		if entry.GetSpan() != currentSpan {
-			fmt.Fprintln(gui.Views.Extras, utils.ColoredString(entry.GetSpan(), color.FgYellow))
-			currentSpan = entry.GetSpan()
-		}
-
-		clrAttr := theme.DefaultTextColor
-		if !entry.GetCommandLine() {
-			clrAttr = color.FgMagenta
-		}
-		gui.CmdLog = append(gui.CmdLog, entry.GetCmdStr())
-		indentedCmdStr := "  " + strings.Replace(entry.GetCmdStr(), "\n", "\n  ", -1)
-		fmt.Fprintln(gui.Views.Extras, utils.ColoredString(indentedCmdStr, clrAttr))
-	}
 }
 
 // Run setup the gui with keybindings and start the mainloop

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -1,8 +1,12 @@
 package gui
 
 import (
+	"fmt"
+
+	"github.com/fatih/color"
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/theme"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 const SEARCH_PREFIX = "search: "
@@ -121,12 +125,21 @@ func (gui *Gui) createAllViews() error {
 	gui.Views.Extras.Title = gui.Tr.CommandLog
 	gui.Views.Extras.FgColor = theme.GocuiDefaultTextColor
 	gui.Views.Extras.Autoscroll = true
+	gui.printCommandLogHeader()
 
 	if _, err := gui.g.SetCurrentView(gui.defaultSideContext().GetViewName()); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (gui *Gui) printCommandLogHeader() {
+	introStr := fmt.Sprintf(
+		gui.Tr.CommandLogHeader,
+		gui.getKeyDisplay(gui.Config.GetUserConfig().Keybinding.Universal.ExtrasMenu),
+	)
+	fmt.Fprintln(gui.Views.Extras, utils.ColoredString(introStr, color.FgCyan))
 }
 
 // layout is called for every screen re-render e.g. when the screen is resized

--- a/pkg/gui/patch_options_panel.go
+++ b/pkg/gui/patch_options_panel.go
@@ -98,7 +98,7 @@ func (gui *Gui) handleDeletePatchFromCommit() error {
 
 	return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
 		commitIndex := gui.getPatchCommitIndex()
-		err := gui.GitCommand.WithSpan("Remove patch from commit").DeletePatchesFromCommit(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager)
+		err := gui.GitCommand.WithSpan(gui.Tr.Spans.RemovePatchFromCommit).DeletePatchesFromCommit(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager)
 		return gui.handleGenericMergeCommandResult(err)
 	})
 }
@@ -114,7 +114,7 @@ func (gui *Gui) handleMovePatchToSelectedCommit() error {
 
 	return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
 		commitIndex := gui.getPatchCommitIndex()
-		err := gui.GitCommand.WithSpan("Move patch to selected commit").MovePatchToSelectedCommit(gui.State.Commits, commitIndex, gui.State.Panels.Commits.SelectedLineIdx, gui.GitCommand.PatchManager)
+		err := gui.GitCommand.WithSpan(gui.Tr.Spans.MovePatchToSelectedCommit).MovePatchToSelectedCommit(gui.State.Commits, commitIndex, gui.State.Panels.Commits.SelectedLineIdx, gui.GitCommand.PatchManager)
 		return gui.handleGenericMergeCommandResult(err)
 	})
 }
@@ -131,7 +131,7 @@ func (gui *Gui) handleMovePatchIntoWorkingTree() error {
 	pull := func(stash bool) error {
 		return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
 			commitIndex := gui.getPatchCommitIndex()
-			err := gui.GitCommand.WithSpan("Move patch into index").MovePatchIntoIndex(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager, stash)
+			err := gui.GitCommand.WithSpan(gui.Tr.Spans.MovePatchIntoIndex).MovePatchIntoIndex(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager, stash)
 			return gui.handleGenericMergeCommandResult(err)
 		})
 	}
@@ -160,7 +160,7 @@ func (gui *Gui) handlePullPatchIntoNewCommit() error {
 
 	return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
 		commitIndex := gui.getPatchCommitIndex()
-		err := gui.GitCommand.WithSpan("Move patch into new commit").PullPatchIntoNewCommit(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager)
+		err := gui.GitCommand.WithSpan(gui.Tr.Spans.MovePatchIntoNewCommit).PullPatchIntoNewCommit(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager)
 		return gui.handleGenericMergeCommandResult(err)
 	})
 }
@@ -170,7 +170,7 @@ func (gui *Gui) handleApplyPatch(reverse bool) error {
 		return err
 	}
 
-	span := "Apply patch"
+	span := gui.Tr.Spans.ApplyPatch
 	if reverse {
 		span = "Apply patch in reverse"
 	}

--- a/pkg/gui/reflog_panel.go
+++ b/pkg/gui/reflog_panel.go
@@ -92,7 +92,7 @@ func (gui *Gui) handleCheckoutReflogCommit() error {
 		title:  gui.Tr.LcCheckoutCommit,
 		prompt: gui.Tr.SureCheckoutThisCommit,
 		handleConfirm: func() error {
-			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{span: "Checkout reflog commit"})
+			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{span: gui.Tr.Spans.CheckoutReflogCommit})
 		},
 	})
 	if err != nil {

--- a/pkg/gui/remote_branches_panel.go
+++ b/pkg/gui/remote_branches_panel.go
@@ -59,7 +59,7 @@ func (gui *Gui) handleDeleteRemoteBranch() error {
 		prompt: message,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.DeletingStatus, func() error {
-				err := gui.GitCommand.WithSpan("Delete remote branch").DeleteRemoteBranch(remoteBranch.RemoteName, remoteBranch.Name, gui.promptUserForCredential)
+				err := gui.GitCommand.WithSpan(gui.Tr.Spans.DeleteRemoteBranch).DeleteRemoteBranch(remoteBranch.RemoteName, remoteBranch.Name, gui.promptUserForCredential)
 				gui.handleCredentialsPopup(err)
 
 				return gui.refreshSidePanels(refreshOptions{scope: []RefreshableView{BRANCHES, REMOTES}})
@@ -89,7 +89,7 @@ func (gui *Gui) handleSetBranchUpstream() error {
 		title:  gui.Tr.SetUpstreamTitle,
 		prompt: message,
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan("Set branch upstream").SetBranchUpstream(selectedBranch.RemoteName, selectedBranch.Name, checkedOutBranch.Name); err != nil {
+			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.SetBranchUpstream).SetBranchUpstream(selectedBranch.RemoteName, selectedBranch.Name, checkedOutBranch.Name); err != nil {
 				return err
 			}
 

--- a/pkg/gui/remotes_panel.go
+++ b/pkg/gui/remotes_panel.go
@@ -85,7 +85,7 @@ func (gui *Gui) handleAddRemote() error {
 			return gui.prompt(promptOpts{
 				title: gui.Tr.LcNewRemoteUrl,
 				handleConfirm: func(remoteUrl string) error {
-					if err := gui.GitCommand.WithSpan("Add remote").AddRemote(remoteName, remoteUrl); err != nil {
+					if err := gui.GitCommand.WithSpan(gui.Tr.Spans.AddRemote).AddRemote(remoteName, remoteUrl); err != nil {
 						return err
 					}
 					return gui.refreshSidePanels(refreshOptions{scope: []RefreshableView{REMOTES}})
@@ -106,7 +106,7 @@ func (gui *Gui) handleRemoveRemote() error {
 		title:  gui.Tr.LcRemoveRemote,
 		prompt: gui.Tr.LcRemoveRemotePrompt + " '" + remote.Name + "'?",
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan("Remove remote").RemoveRemote(remote.Name); err != nil {
+			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.RemoveRemote).RemoveRemote(remote.Name); err != nil {
 				return gui.surfaceError(err)
 			}
 
@@ -128,7 +128,7 @@ func (gui *Gui) handleEditRemote() error {
 		},
 	)
 
-	gitCommand := gui.GitCommand.WithSpan("Update remote")
+	gitCommand := gui.GitCommand.WithSpan(gui.Tr.Spans.UpdateRemote)
 
 	return gui.prompt(promptOpts{
 		title:          editNameMessage,

--- a/pkg/gui/staging_panel.go
+++ b/pkg/gui/staging_panel.go
@@ -142,7 +142,7 @@ func (gui *Gui) applySelection(reverse bool, state *lBlPanelState) error {
 	if !reverse || state.SecondaryFocused {
 		applyFlags = append(applyFlags, "cached")
 	}
-	err := gui.GitCommand.WithSpan("Apply patch").ApplyPatch(patch, applyFlags...)
+	err := gui.GitCommand.WithSpan(gui.Tr.Spans.ApplyPatch).ApplyPatch(patch, applyFlags...)
 	if err != nil {
 		return gui.surfaceError(err)
 	}

--- a/pkg/gui/stash_panel.go
+++ b/pkg/gui/stash_panel.go
@@ -106,7 +106,7 @@ func (gui *Gui) stashDo(method string) error {
 
 		return gui.createErrorPanel(errorMessage)
 	}
-	if err := gui.GitCommand.WithSpan("Stash").StashDo(stashEntry.Index, method); err != nil {
+	if err := gui.GitCommand.WithSpan(gui.Tr.Spans.Stash).StashDo(stashEntry.Index, method); err != nil {
 		return gui.surfaceError(err)
 	}
 	return gui.refreshSidePanels(refreshOptions{scope: []RefreshableView{STASH, FILES}})

--- a/pkg/gui/sub_commits_panel.go
+++ b/pkg/gui/sub_commits_panel.go
@@ -48,7 +48,7 @@ func (gui *Gui) handleCheckoutSubCommit() error {
 		title:  gui.Tr.LcCheckoutCommit,
 		prompt: gui.Tr.SureCheckoutThisCommit,
 		handleConfirm: func() error {
-			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{span: "Checkout commit"})
+			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{span: gui.Tr.Spans.CheckoutCommit})
 		},
 	})
 	if err != nil {

--- a/pkg/gui/submodules_panel.go
+++ b/pkg/gui/submodules_panel.go
@@ -81,7 +81,7 @@ func (gui *Gui) removeSubmodule(submodule *models.SubmoduleConfig) error {
 		title:  gui.Tr.RemoveSubmodule,
 		prompt: fmt.Sprintf(gui.Tr.RemoveSubmodulePrompt, submodule.Name),
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan("Remove submodule").SubmoduleDelete(submodule); err != nil {
+			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.RemoveSubmodule).SubmoduleDelete(submodule); err != nil {
 				return gui.surfaceError(err)
 			}
 
@@ -107,7 +107,7 @@ func (gui *Gui) fileForSubmodule(submodule *models.SubmoduleConfig) *models.File
 }
 
 func (gui *Gui) resetSubmodule(submodule *models.SubmoduleConfig) error {
-	gitCommand := gui.GitCommand.WithSpan("Reset submodule")
+	gitCommand := gui.GitCommand.WithSpan(gui.Tr.Spans.ResetSubmodule)
 
 	file := gui.fileForSubmodule(submodule)
 	if file != nil {
@@ -142,7 +142,7 @@ func (gui *Gui) handleAddSubmodule() error {
 						initialContent: submoduleName,
 						handleConfirm: func(submodulePath string) error {
 							return gui.WithWaitingStatus(gui.Tr.LcAddingSubmoduleStatus, func() error {
-								err := gui.GitCommand.WithSpan("Add submodule").SubmoduleAdd(submoduleName, submodulePath, submoduleUrl)
+								err := gui.GitCommand.WithSpan(gui.Tr.Spans.AddSubmodule).SubmoduleAdd(submoduleName, submodulePath, submoduleUrl)
 								gui.handleCredentialsPopup(err)
 
 								return gui.refreshSidePanels(refreshOptions{scope: []RefreshableView{SUBMODULES}})
@@ -162,7 +162,7 @@ func (gui *Gui) handleEditSubmoduleUrl(submodule *models.SubmoduleConfig) error 
 		initialContent: submodule.Url,
 		handleConfirm: func(newUrl string) error {
 			return gui.WithWaitingStatus(gui.Tr.LcUpdatingSubmoduleUrlStatus, func() error {
-				err := gui.GitCommand.WithSpan("Update submodule URL").SubmoduleUpdateUrl(submodule.Name, submodule.Path, newUrl)
+				err := gui.GitCommand.WithSpan(gui.Tr.Spans.UpdateSubmoduleUrl).SubmoduleUpdateUrl(submodule.Name, submodule.Path, newUrl)
 				gui.handleCredentialsPopup(err)
 
 				return gui.refreshSidePanels(refreshOptions{scope: []RefreshableView{SUBMODULES}})
@@ -173,7 +173,7 @@ func (gui *Gui) handleEditSubmoduleUrl(submodule *models.SubmoduleConfig) error 
 
 func (gui *Gui) handleSubmoduleInit(submodule *models.SubmoduleConfig) error {
 	return gui.WithWaitingStatus(gui.Tr.LcInitializingSubmoduleStatus, func() error {
-		err := gui.GitCommand.WithSpan("Initialise submodule").SubmoduleInit(submodule.Path)
+		err := gui.GitCommand.WithSpan(gui.Tr.Spans.InitialiseSubmodule).SubmoduleInit(submodule.Path)
 		gui.handleCredentialsPopup(err)
 
 		return gui.refreshSidePanels(refreshOptions{scope: []RefreshableView{SUBMODULES}})
@@ -216,7 +216,7 @@ func (gui *Gui) handleBulkSubmoduleActionsMenu() error {
 			displayStrings: []string{gui.Tr.LcBulkInitSubmodules, utils.ColoredString(gui.GitCommand.SubmoduleBulkInitCmdStr(), color.FgGreen)},
 			onPress: func() error {
 				return gui.WithWaitingStatus(gui.Tr.LcRunningCommand, func() error {
-					if err := gui.OSCommand.WithSpan("Bulk initialise submodules").RunCommand(gui.GitCommand.SubmoduleBulkInitCmdStr()); err != nil {
+					if err := gui.OSCommand.WithSpan(gui.Tr.Spans.BulkInitialiseSubmodules).RunCommand(gui.GitCommand.SubmoduleBulkInitCmdStr()); err != nil {
 						return gui.surfaceError(err)
 					}
 
@@ -228,7 +228,7 @@ func (gui *Gui) handleBulkSubmoduleActionsMenu() error {
 			displayStrings: []string{gui.Tr.LcBulkUpdateSubmodules, utils.ColoredString(gui.GitCommand.SubmoduleBulkUpdateCmdStr(), color.FgYellow)},
 			onPress: func() error {
 				return gui.WithWaitingStatus(gui.Tr.LcRunningCommand, func() error {
-					if err := gui.OSCommand.WithSpan("Bulk update submodules").RunCommand(gui.GitCommand.SubmoduleBulkUpdateCmdStr()); err != nil {
+					if err := gui.OSCommand.WithSpan(gui.Tr.Spans.BulkUpdateSubmodules).RunCommand(gui.GitCommand.SubmoduleBulkUpdateCmdStr()); err != nil {
 						return gui.surfaceError(err)
 					}
 
@@ -240,7 +240,7 @@ func (gui *Gui) handleBulkSubmoduleActionsMenu() error {
 			displayStrings: []string{gui.Tr.LcSubmoduleStashAndReset, utils.ColoredString(fmt.Sprintf("git stash in each submodule && %s", gui.GitCommand.SubmoduleForceBulkUpdateCmdStr()), color.FgRed)},
 			onPress: func() error {
 				return gui.WithWaitingStatus(gui.Tr.LcRunningCommand, func() error {
-					if err := gui.GitCommand.WithSpan("Bulk stash and reset submodules").ResetSubmodules(gui.State.Submodules); err != nil {
+					if err := gui.GitCommand.WithSpan(gui.Tr.Spans.BulkStashAndResetSubmodules).ResetSubmodules(gui.State.Submodules); err != nil {
 						return gui.surfaceError(err)
 					}
 
@@ -252,7 +252,7 @@ func (gui *Gui) handleBulkSubmoduleActionsMenu() error {
 			displayStrings: []string{gui.Tr.LcBulkDeinitSubmodules, utils.ColoredString(gui.GitCommand.SubmoduleBulkDeinitCmdStr(), color.FgRed)},
 			onPress: func() error {
 				return gui.WithWaitingStatus(gui.Tr.LcRunningCommand, func() error {
-					if err := gui.OSCommand.WithSpan("Bulk deinitialise submodules").RunCommand(gui.GitCommand.SubmoduleBulkDeinitCmdStr()); err != nil {
+					if err := gui.OSCommand.WithSpan(gui.Tr.Spans.BulkDeinitialiseSubmodules).RunCommand(gui.GitCommand.SubmoduleBulkDeinitCmdStr()); err != nil {
 						return gui.surfaceError(err)
 					}
 
@@ -267,7 +267,7 @@ func (gui *Gui) handleBulkSubmoduleActionsMenu() error {
 
 func (gui *Gui) handleUpdateSubmodule(submodule *models.SubmoduleConfig) error {
 	return gui.WithWaitingStatus(gui.Tr.LcUpdatingSubmoduleStatus, func() error {
-		err := gui.GitCommand.WithSpan("Update submodule").SubmoduleUpdate(submodule.Path)
+		err := gui.GitCommand.WithSpan(gui.Tr.Spans.UpdateSubmodule).SubmoduleUpdate(submodule.Path)
 		gui.handleCredentialsPopup(err)
 
 		return gui.refreshSidePanels(refreshOptions{scope: []RefreshableView{SUBMODULES}})

--- a/pkg/gui/tags_panel.go
+++ b/pkg/gui/tags_panel.go
@@ -19,7 +19,7 @@ func (gui *Gui) handleCreateTag() error {
 		title: gui.Tr.CreateTagTitle,
 		handleConfirm: func(tagName string) error {
 			// leaving commit SHA blank so that we're just creating the tag for the current commit
-			if err := gui.GitCommand.WithSpan("Create lightweight tag").CreateLightweightTag(tagName, ""); err != nil {
+			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.CreateLightweightTag).CreateLightweightTag(tagName, ""); err != nil {
 				return gui.surfaceError(err)
 			}
 			return gui.refreshSidePanels(refreshOptions{scope: []RefreshableView{COMMITS, TAGS}, then: func() {
@@ -86,7 +86,7 @@ func (gui *Gui) withSelectedTag(f func(tag *models.Tag) error) func() error {
 }
 
 func (gui *Gui) handleCheckoutTag(tag *models.Tag) error {
-	if err := gui.handleCheckoutRef(tag.Name, handleCheckoutRefOptions{span: "Checkout tag"}); err != nil {
+	if err := gui.handleCheckoutRef(tag.Name, handleCheckoutRefOptions{span: gui.Tr.Spans.CheckoutTag}); err != nil {
 		return err
 	}
 	return gui.pushContext(gui.State.Contexts.Branches)
@@ -104,7 +104,7 @@ func (gui *Gui) handleDeleteTag(tag *models.Tag) error {
 		title:  gui.Tr.DeleteTagTitle,
 		prompt: prompt,
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan("Delete tag").DeleteTag(tag.Name); err != nil {
+			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DeleteTag).DeleteTag(tag.Name); err != nil {
 				return gui.surfaceError(err)
 			}
 			return gui.refreshSidePanels(refreshOptions{mode: ASYNC, scope: []RefreshableView{COMMITS, TAGS}})
@@ -125,7 +125,7 @@ func (gui *Gui) handlePushTag(tag *models.Tag) error {
 		initialContent: "origin",
 		handleConfirm: func(response string) error {
 			return gui.WithWaitingStatus(gui.Tr.PushingTagStatus, func() error {
-				err := gui.GitCommand.WithSpan("Push tag").PushTag(response, tag.Name, gui.promptUserForCredential)
+				err := gui.GitCommand.WithSpan(gui.Tr.Spans.PushTag).PushTag(response, tag.Name, gui.promptUserForCredential)
 				gui.handleCredentialsPopup(err)
 
 				return nil

--- a/pkg/gui/undoing.go
+++ b/pkg/gui/undoing.go
@@ -93,7 +93,7 @@ func (gui *Gui) reflogUndo() error {
 		return gui.createErrorPanel(gui.Tr.LcCantUndoWhileRebasing)
 	}
 
-	span := "Undo"
+	span := gui.Tr.Spans.Undo
 
 	return gui.parseReflogForActions(func(counter int, action reflogAction) (bool, error) {
 		if counter != 0 {
@@ -128,7 +128,7 @@ func (gui *Gui) reflogRedo() error {
 		return gui.createErrorPanel(gui.Tr.LcCantRedoWhileRebasing)
 	}
 
-	span := "Redo"
+	span := gui.Tr.Spans.Redo
 
 	return gui.parseReflogForActions(func(counter int, action reflogAction) (bool, error) {
 		// if we're redoing and the counter is zero, we just return

--- a/pkg/gui/workspace_reset_options_panel.go
+++ b/pkg/gui/workspace_reset_options_panel.go
@@ -21,7 +21,7 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint(nukeStr),
 			},
 			onPress: func() error {
-				if err := gui.GitCommand.WithSpan("Nuke working tree").ResetAndClean(); err != nil {
+				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.NukeWorkingTree).ResetAndClean(); err != nil {
 					return gui.surfaceError(err)
 				}
 
@@ -34,7 +34,7 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git checkout -- ."),
 			},
 			onPress: func() error {
-				if err := gui.GitCommand.WithSpan("Discard unstaged file changes").DiscardAnyUnstagedFileChanges(); err != nil {
+				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DiscardUnstagedFileChanges).DiscardAnyUnstagedFileChanges(); err != nil {
 					return gui.surfaceError(err)
 				}
 
@@ -47,7 +47,7 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git clean -fd"),
 			},
 			onPress: func() error {
-				if err := gui.GitCommand.WithSpan("Remove untracked files").RemoveUntrackedFiles(); err != nil {
+				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.RemoveUntrackedFiles).RemoveUntrackedFiles(); err != nil {
 					return gui.surfaceError(err)
 				}
 
@@ -60,7 +60,7 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git reset --soft HEAD"),
 			},
 			onPress: func() error {
-				if err := gui.GitCommand.WithSpan("Soft reset").ResetSoft("HEAD"); err != nil {
+				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.SoftReset).ResetSoft("HEAD"); err != nil {
 					return gui.surfaceError(err)
 				}
 
@@ -73,7 +73,7 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git reset --mixed HEAD"),
 			},
 			onPress: func() error {
-				if err := gui.GitCommand.WithSpan("Mixed reset").ResetMixed("HEAD"); err != nil {
+				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.MixedReset).ResetMixed("HEAD"); err != nil {
 					return gui.surfaceError(err)
 				}
 
@@ -86,7 +86,7 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git reset --hard HEAD"),
 			},
 			onPress: func() error {
-				if err := gui.GitCommand.WithSpan("Hard reset").ResetHard("HEAD"); err != nil {
+				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.HardReset).ResetHard("HEAD"); err != nil {
 					return gui.surfaceError(err)
 				}
 

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -448,6 +448,88 @@ type TranslationSet struct {
 	CommandLog                          string
 	ToggleShowCommandLog                string
 	FocusCommandLog                     string
+	Spans                               Spans
+}
+
+type Spans struct {
+	CheckoutCommit                    string
+	CheckoutReflogCommit              string
+	CheckoutTag                       string
+	CheckoutBranch                    string
+	ForceCheckoutBranch               string
+	DeleteBranch                      string
+	Merge                             string
+	RebaseBranch                      string
+	RenameBranch                      string
+	CreateBranch                      string
+	FastForwardBranch                 string
+	CherryPick                        string
+	CheckoutFile                      string
+	DiscardOldFileChange              string
+	SquashCommitDown                  string
+	FixupCommit                       string
+	RewordCommit                      string
+	DropCommit                        string
+	EditCommit                        string
+	AmendCommit                       string
+	RevertCommit                      string
+	CreateFixupCommit                 string
+	SquashAllAboveFixupCommits        string
+	MoveCommitUp                      string
+	MoveCommitDown                    string
+	CopyCommitMessageToClipboard      string
+	CustomCommand                     string
+	DiscardAllChangesInDirectory      string
+	DiscardUnstagedChangesInDirectory string
+	DiscardAllChangesInFile           string
+	DiscardAllUnstagedChangesInFile   string
+	StageFile                         string
+	UnstageFile                       string
+	UnstageAllFiles                   string
+	StageAllFiles                     string
+	IgnoreFile                        string
+	Commit                            string
+	EditFile                          string
+	Push                              string
+	Pull                              string
+	OpenFile                          string
+	StashAllChanges                   string
+	StashStagedChanges                string
+	GitFlowFinish                     string
+	GitFlowStart                      string
+	CopyToClipboard                   string
+	RemovePatchFromCommit             string
+	MovePatchToSelectedCommit         string
+	MovePatchIntoIndex                string
+	MovePatchIntoNewCommit            string
+	DeleteRemoteBranch                string
+	SetBranchUpstream                 string
+	AddRemote                         string
+	RemoveRemote                      string
+	UpdateRemote                      string
+	ApplyPatch                        string
+	Stash                             string
+	RemoveSubmodule                   string
+	ResetSubmodule                    string
+	AddSubmodule                      string
+	UpdateSubmoduleUrl                string
+	InitialiseSubmodule               string
+	BulkInitialiseSubmodules          string
+	BulkUpdateSubmodules              string
+	BulkStashAndResetSubmodules       string
+	BulkDeinitialiseSubmodules        string
+	UpdateSubmodule                   string
+	CreateLightweightTag              string
+	DeleteTag                         string
+	PushTag                           string
+	NukeWorkingTree                   string
+	DiscardUnstagedFileChanges        string
+	RemoveUntrackedFiles              string
+	SoftReset                         string
+	MixedReset                        string
+	HardReset                         string
+	Undo                              string
+	Redo                              string
 }
 
 const englishReleaseNotes = `lazygit 0.27.1-0.27.4 Release notes
@@ -1105,5 +1187,86 @@ func englishTranslationSet() TranslationSet {
 		CommandLog:                          "Command Log",
 		ToggleShowCommandLog:                "Toggle show/hide command log",
 		FocusCommandLog:                     "Focus command log",
+		Spans: Spans{
+			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)
+			CheckoutCommit:                    "Checkout commit",
+			CheckoutReflogCommit:              "Checkout reflog commit",
+			CheckoutTag:                       "Checkout tag",
+			CheckoutBranch:                    "Checkout branch",
+			ForceCheckoutBranch:               "Force checkout branch",
+			DeleteBranch:                      "Delete branch",
+			Merge:                             "Merge",
+			RebaseBranch:                      "Rebase branch",
+			RenameBranch:                      "Rename branch",
+			CreateBranch:                      "Create branch",
+			CherryPick:                        "(Cherry-pick) Paste commits",
+			CheckoutFile:                      "Checkout file",
+			DiscardOldFileChange:              "Discard old file change",
+			SquashCommitDown:                  "Squash commit down",
+			FixupCommit:                       "Fixup commit",
+			RewordCommit:                      "Reword commit",
+			DropCommit:                        "Drop commit",
+			EditCommit:                        "Edit commit",
+			AmendCommit:                       "Amend commit",
+			RevertCommit:                      "Revert commit",
+			CreateFixupCommit:                 "Create fixup commit",
+			SquashAllAboveFixupCommits:        "Squash all above fixup commits",
+			CreateLightweightTag:              "Create lightweight tag",
+			CopyCommitMessageToClipboard:      "Copy commit message to clipboard",
+			MoveCommitUp:                      "Move commit up",
+			MoveCommitDown:                    "Move commit down",
+			CustomCommand:                     "Custom command",
+			DiscardAllChangesInDirectory:      "Discard all changes in directory",
+			DiscardUnstagedChangesInDirectory: "Discard unstaged changes in directory",
+			DiscardAllChangesInFile:           "Discard all changes in file",
+			DiscardAllUnstagedChangesInFile:   "Discard all unstaged changes in file",
+			StageFile:                         "Stage file",
+			UnstageFile:                       "Unstage file",
+			UnstageAllFiles:                   "Unstage all files",
+			StageAllFiles:                     "Stage all files",
+			IgnoreFile:                        "Ignore file",
+			Commit:                            "Commit",
+			EditFile:                          "Edit file",
+			Push:                              "Push",
+			Pull:                              "Pull",
+			OpenFile:                          "Open file",
+			StashAllChanges:                   "Stash all changes",
+			StashStagedChanges:                "Stash staged changes",
+			GitFlowFinish:                     "Git flow finish",
+			GitFlowStart:                      "Git Flow start",
+			CopyToClipboard:                   "Copy to clipboard",
+			RemovePatchFromCommit:             "Remove patch from commit",
+			MovePatchToSelectedCommit:         "Move patch to selected commit",
+			MovePatchIntoIndex:                "Move patch into index",
+			MovePatchIntoNewCommit:            "Move patch into new commit",
+			DeleteRemoteBranch:                "Delete remote branch",
+			SetBranchUpstream:                 "Set branch upstream",
+			AddRemote:                         "Add remote",
+			RemoveRemote:                      "Remove remote",
+			UpdateRemote:                      "Update remote",
+			ApplyPatch:                        "Apply patch",
+			Stash:                             "Stash",
+			RemoveSubmodule:                   "Remove submodule",
+			ResetSubmodule:                    "Reset submodule",
+			AddSubmodule:                      "Add submodule",
+			UpdateSubmoduleUrl:                "Update submodule URL",
+			InitialiseSubmodule:               "Initialise submodule",
+			BulkInitialiseSubmodules:          "Bulk initialise submodules",
+			BulkUpdateSubmodules:              "Bulk update submodules",
+			BulkStashAndResetSubmodules:       "Bulk stash and reset submodules",
+			BulkDeinitialiseSubmodules:        "Bulk deinitialise submodules",
+			UpdateSubmodule:                   "Update submodule",
+			DeleteTag:                         "Delete tag",
+			PushTag:                           "Push tag",
+			NukeWorkingTree:                   "Nuke working tree",
+			DiscardUnstagedFileChanges:        "Discard unstaged file changes",
+			RemoveUntrackedFiles:              "Remove untracked files",
+			SoftReset:                         "Soft reset",
+			MixedReset:                        "Mixed reset",
+			HardReset:                         "Hard reset",
+			FastForwardBranch:                 "Fast forward branch",
+			Undo:                              "Undo",
+			Redo:                              "Redo",
+		},
 	}
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -448,6 +448,7 @@ type TranslationSet struct {
 	CommandLog                          string
 	ToggleShowCommandLog                string
 	FocusCommandLog                     string
+	CommandLogHeader                    string
 	Spans                               Spans
 }
 
@@ -1187,6 +1188,7 @@ func englishTranslationSet() TranslationSet {
 		CommandLog:                          "Command Log",
 		ToggleShowCommandLog:                "Toggle show/hide command log",
 		FocusCommandLog:                     "Focus command log",
+		CommandLogHeader:                    "You can hide/focus this panel by pressing '%s' or hide it permanently in your config with `gui.showCommandLog: false`\n",
 		Spans: Spans{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)
 			CheckoutCommit:                    "Checkout commit",


### PR DESCRIPTION
Some small improvements to the command log feature. I'm moving the span titles into i18n, but some further work is required to do some deduping: they're very much doubling up with existing keybinding descriptions and we should really just have one source of truth for those.

![image](https://user-images.githubusercontent.com/8456633/114300325-1d142a00-9b03-11eb-824b-a747b1f64e0c.png)

Interested to get some people's thoughts on this feature i.e.:
1) is it awkward in any way? Could it be improved upon?
2) Should this panel appear by default?

Being able to see which commands are executed is the main thing people have voiced in the feedback form I put up a couple days ago:

![image](https://user-images.githubusercontent.com/8456633/114300429-a3307080-9b03-11eb-9e3e-7c3ebd4d0a05.png)

So I'm leaning towards making this appear by default. What are our thoughts? @dawidd6 @peppy @mjarkk @glvr182 @kristijanhusak  @fsmiamoto 