### PR TITLE
Random tips

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -41,6 +41,7 @@ gui:
   skipUnstageLineWarning: false
   skipStashWarning: true
   showFileTree: false # for rendering changes files in a tree format
+  showRandomTip: true
   showCommandLog: true
   commandLogSize: 8
 git:

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -42,7 +42,7 @@ gui:
   skipStashWarning: true
   showFileTree: false # for rendering changes files in a tree format
   showCommandLog: true
-  commandLogSize: 1
+  commandLogSize: 8
 git:
   paging:
     colorArg: always

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/imdario/mergo v0.3.11
 	github.com/integrii/flaggy v1.4.0
 	github.com/jesseduffield/go-git/v5 v5.1.2-0.20201006095850-341962be15a4
-	github.com/jesseduffield/gocui v0.3.1-0.20210410011117-a2bb4baca390
+	github.com/jesseduffield/gocui v0.3.1-0.20210412111008-6ef019af3724
 	github.com/jesseduffield/termbox-go v0.0.0-20200823212418-a2289ed6aafe // indirect
 	github.com/jesseduffield/yaml v2.1.0+incompatible
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/imdario/mergo v0.3.11
 	github.com/integrii/flaggy v1.4.0
 	github.com/jesseduffield/go-git/v5 v5.1.2-0.20201006095850-341962be15a4
-	github.com/jesseduffield/gocui v0.3.1-0.20210412111008-6ef019af3724
+	github.com/jesseduffield/gocui v0.3.1-0.20210412113212-ee65bd542c08
 	github.com/jesseduffield/termbox-go v0.0.0-20200823212418-a2289ed6aafe // indirect
 	github.com/jesseduffield/yaml v2.1.0+incompatible
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/jesseduffield/gocui v0.3.1-0.20210410011117-a2bb4baca390 h1:Es72JiUjt
 github.com/jesseduffield/gocui v0.3.1-0.20210410011117-a2bb4baca390/go.mod h1:QWq79xplEoyhQO+dgpk3sojjTVRKjQklyTlzm5nC5Kg=
 github.com/jesseduffield/gocui v0.3.1-0.20210412111008-6ef019af3724 h1:U70Do3/OSw5n/oLJGPWsQHnos2p0yq8yAeD2muioJhQ=
 github.com/jesseduffield/gocui v0.3.1-0.20210412111008-6ef019af3724/go.mod h1:QWq79xplEoyhQO+dgpk3sojjTVRKjQklyTlzm5nC5Kg=
+github.com/jesseduffield/gocui v0.3.1-0.20210412113212-ee65bd542c08 h1:d003y2GByfR3PqN/JvxNuqyo8vx4m0epwY2hW7sNU80=
+github.com/jesseduffield/gocui v0.3.1-0.20210412113212-ee65bd542c08/go.mod h1:QWq79xplEoyhQO+dgpk3sojjTVRKjQklyTlzm5nC5Kg=
 github.com/jesseduffield/termbox-go v0.0.0-20200823212418-a2289ed6aafe h1:qsVhCf2RFyyKIUe/+gJblbCpXMUki9rZrHuEctg6M/E=
 github.com/jesseduffield/termbox-go v0.0.0-20200823212418-a2289ed6aafe/go.mod h1:anMibpZtqNxjDbxrcDEAwSdaJ37vyUeM1f/M4uekib4=
 github.com/jesseduffield/yaml v2.1.0+incompatible h1:HWQJ1gIv2zHKbDYNp0Jwjlj24K8aqpFHnMCynY1EpmE=

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/jesseduffield/gocui v0.3.1-0.20210409121040-210802112d8a h1:ocrSuZxQI
 github.com/jesseduffield/gocui v0.3.1-0.20210409121040-210802112d8a/go.mod h1:QWq79xplEoyhQO+dgpk3sojjTVRKjQklyTlzm5nC5Kg=
 github.com/jesseduffield/gocui v0.3.1-0.20210410011117-a2bb4baca390 h1:Es72JiUjt01TtvqCugdvOR91baB3DhuWF1DNuxA0frA=
 github.com/jesseduffield/gocui v0.3.1-0.20210410011117-a2bb4baca390/go.mod h1:QWq79xplEoyhQO+dgpk3sojjTVRKjQklyTlzm5nC5Kg=
+github.com/jesseduffield/gocui v0.3.1-0.20210412111008-6ef019af3724 h1:U70Do3/OSw5n/oLJGPWsQHnos2p0yq8yAeD2muioJhQ=
+github.com/jesseduffield/gocui v0.3.1-0.20210412111008-6ef019af3724/go.mod h1:QWq79xplEoyhQO+dgpk3sojjTVRKjQklyTlzm5nC5Kg=
 github.com/jesseduffield/termbox-go v0.0.0-20200823212418-a2289ed6aafe h1:qsVhCf2RFyyKIUe/+gJblbCpXMUki9rZrHuEctg6M/E=
 github.com/jesseduffield/termbox-go v0.0.0-20200823212418-a2289ed6aafe/go.mod h1:anMibpZtqNxjDbxrcDEAwSdaJ37vyUeM1f/M4uekib4=
 github.com/jesseduffield/yaml v2.1.0+incompatible h1:HWQJ1gIv2zHKbDYNp0Jwjlj24K8aqpFHnMCynY1EpmE=

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/integrii/flaggy"
 	"github.com/jesseduffield/lazygit/pkg/app"
 	"github.com/jesseduffield/lazygit/pkg/config"
+	"github.com/jesseduffield/lazygit/pkg/constants"
 	"github.com/jesseduffield/lazygit/pkg/env"
 	yaml "github.com/jesseduffield/yaml"
 )
@@ -134,6 +135,6 @@ func main() {
 		stackTrace := newErr.ErrorStack()
 		app.Log.Error(stackTrace)
 
-		log.Fatal(fmt.Sprintf("%s\n\n%s", app.Tr.ErrorOccurred, stackTrace))
+		log.Fatal(fmt.Sprintf("%s: %s\n\n%s", app.Tr.ErrorOccurred, constants.Links.Issues, stackTrace))
 	}
 }

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -103,6 +103,7 @@ type KeybindingConfig struct {
 	Submodules  KeybindingSubmodulesConfig  `yaml:"submodules"`
 }
 
+// damn looks like we have some inconsistencies here with -alt and -alt1
 type KeybindingUniversalConfig struct {
 	Quit                         string `yaml:"quit"`
 	QuitAlt1                     string `yaml:"quit-alt1"`
@@ -121,6 +122,8 @@ type KeybindingUniversalConfig struct {
 	NextBlock                    string `yaml:"nextBlock"`
 	PrevBlockAlt                 string `yaml:"prevBlock-alt"`
 	NextBlockAlt                 string `yaml:"nextBlock-alt"`
+	NextBlockAlt2                string `yaml:"nextBlock-alt2"`
+	PrevBlockAlt2                string `yaml:"prevBlock-alt2"`
 	NextMatch                    string `yaml:"nextMatch"`
 	PrevMatch                    string `yaml:"prevMatch"`
 	StartSearch                  string `yaml:"startSearch"`
@@ -352,6 +355,8 @@ func GetDefaultConfig() *UserConfig {
 				NextBlock:                    "<right>",
 				PrevBlockAlt:                 "h",
 				NextBlockAlt:                 "l",
+				PrevBlockAlt2:                "<backtab>",
+				NextBlockAlt2:                "<tab>",
 				NextMatch:                    "n",
 				PrevMatch:                    "N",
 				StartSearch:                  "/",

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -36,6 +36,7 @@ type GuiConfig struct {
 	CommitLength             CommitLengthConfig `yaml:"commitLength"`
 	SkipNoStagedFilesWarning bool               `yaml:"skipNoStagedFilesWarning"`
 	ShowFileTree             bool               `yaml:"showFileTree"`
+	ShowRandomTip            bool               `yaml:"showRandomTip"`
 	ShowCommandLog           bool               `yaml:"showCommandLog"`
 	CommandLogSize           int                `yaml:"commandLogSize"`
 }
@@ -303,6 +304,7 @@ func GetDefaultConfig() *UserConfig {
 			SkipNoStagedFilesWarning: false,
 			ShowCommandLog:           true,
 			ShowFileTree:             false,
+			ShowRandomTip:            true,
 			CommandLogSize:           8,
 		},
 		Git: GitConfig{

--- a/pkg/constants/links.go
+++ b/pkg/constants/links.go
@@ -1,0 +1,33 @@
+package constants
+
+type Docs struct {
+	CustomPagers      string
+	CustomCommands    string
+	CustomKeybindings string
+	Keybindings       string
+	Undoing           string
+	Config            string
+	Tutorial          string
+}
+
+var Links = struct {
+	Docs        Docs
+	Issues      string
+	Donate      string
+	Discussions string
+	RepoUrl     string
+}{
+	RepoUrl:     "https://github.com/jesseduffield/lazygit",
+	Issues:      "https://github.com/jesseduffield/lazygit/issues",
+	Donate:      "https://github.com/sponsors/jesseduffield",
+	Discussions: "https://github.com/jesseduffield/lazygit/discussions",
+	Docs: Docs{
+		CustomPagers:      "https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Pagers.md",
+		CustomKeybindings: "https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Custom_Keybindings.md",
+		CustomCommands:    "https://github.com/jesseduffield/lazygit/wiki/Custom-Commands-Compendium",
+		Keybindings:       "https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings",
+		Undoing:           "https://github.com/jesseduffield/lazygit/blob/master/docs/Undoing.md",
+		Config:            "https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md",
+		Tutorial:          "https://youtu.be/VDXvbHZYeKY",
+	},
+}

--- a/pkg/gui/command_log_panel.go
+++ b/pkg/gui/command_log_panel.go
@@ -46,12 +46,14 @@ func (gui *Gui) printCommandLogHeader() {
 	)
 	fmt.Fprintln(gui.Views.Extras, utils.ColoredString(introStr, color.FgCyan))
 
-	fmt.Fprintf(
-		gui.Views.Extras,
-		"%s: %s",
-		utils.ColoredString(gui.Tr.RandomTip, color.FgYellow),
-		utils.ColoredString(gui.getRandomTip(), color.FgGreen),
-	)
+	if gui.Config.GetUserConfig().Gui.ShowRandomTip {
+		fmt.Fprintf(
+			gui.Views.Extras,
+			"%s: %s",
+			utils.ColoredString(gui.Tr.RandomTip, color.FgYellow),
+			utils.ColoredString(gui.getRandomTip(), color.FgGreen),
+		)
+	}
 }
 
 func (gui *Gui) getRandomTip() string {

--- a/pkg/gui/command_log_panel.go
+++ b/pkg/gui/command_log_panel.go
@@ -2,10 +2,13 @@ package gui
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
+	"github.com/jesseduffield/lazygit/pkg/constants"
 	"github.com/jesseduffield/lazygit/pkg/theme"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
@@ -34,4 +37,149 @@ func (gui *Gui) GetOnRunCommand() func(entry oscommands.CmdLogEntry) {
 		indentedCmdStr := "  " + strings.Replace(entry.GetCmdStr(), "\n", "\n  ", -1)
 		fmt.Fprint(gui.Views.Extras, "\n"+utils.ColoredString(indentedCmdStr, clrAttr))
 	}
+}
+
+func (gui *Gui) printCommandLogHeader() {
+	introStr := fmt.Sprintf(
+		gui.Tr.CommandLogHeader,
+		gui.getKeyDisplay(gui.Config.GetUserConfig().Keybinding.Universal.ExtrasMenu),
+	)
+	fmt.Fprintln(gui.Views.Extras, utils.ColoredString(introStr, color.FgCyan))
+
+	fmt.Fprint(
+		gui.Views.Extras,
+		fmt.Sprintf(
+			"%s: %s",
+			utils.ColoredString(gui.Tr.RandomTip, color.FgYellow),
+			utils.ColoredString(gui.getRandomTip(), color.FgGreen),
+		),
+	)
+}
+
+func (gui *Gui) getRandomTip() string {
+	config := gui.Config.GetUserConfig().Keybinding
+
+	formattedKey := func(key string) string {
+		return gui.getKeyDisplay(key)
+	}
+
+	tips := []string{
+		// keybindings and lazygit-specific advice
+		fmt.Sprintf(
+			"To force push, press '%s' and then if the push is rejected you will be asked if you want to force push",
+			formattedKey(config.Universal.PushFiles),
+		),
+		fmt.Sprintf(
+			"To filter commits by path, press '%s'",
+			formattedKey(config.Universal.FilteringMenu),
+		),
+		fmt.Sprintf(
+			"To start an interactive rebase, press '%s' on a commit. You can always abort the rebase by pressing '%s' and selecting 'abort'",
+			formattedKey(config.Universal.Edit),
+			formattedKey(config.Universal.CreateRebaseOptionsMenu),
+		),
+		fmt.Sprintf(
+			"In flat file view, merge conflicts are sorted to the top. To switch to flat file view press '%s'",
+			formattedKey(config.Files.ToggleTreeView),
+		),
+		"If you want to learn Go and can think of ways to improve lazygit, join the team! Click 'Ask Question' and express your interest",
+		fmt.Sprintf(
+			"If you press '%s'/'%s' you can undo/redo your changes. Be wary though, this only applies to branches/commits, so only do this if your worktree is clear.\nDocs: %s",
+			formattedKey(config.Universal.Undo),
+			formattedKey(config.Universal.Redo),
+			constants.Links.Docs.Undoing,
+		),
+		fmt.Sprintf(
+			"to hard reset onto your current upstream branch, press '%s' in the files panel",
+			formattedKey(config.Files.ViewResetOptions),
+		),
+		fmt.Sprintf(
+			"To push a tag, navigate to the tag in the tags tab and press '%s'",
+			formattedKey(config.Branches.PushTag),
+		),
+		fmt.Sprintf(
+			"You can view the individual files of a stash entry by pressing '%s'",
+			formattedKey(config.Universal.GoInto),
+		),
+		fmt.Sprintf(
+			"You can diff two commits by pressing '%s' one one commit and then navigating to the other. You can then press '%s' to view the files of the diff",
+			formattedKey(config.Universal.DiffingMenu),
+			formattedKey(config.Universal.GoInto),
+		),
+		fmt.Sprintf(
+			"press '%s' on a commit to drop it (delete it)",
+			formattedKey(config.Universal.Remove),
+		),
+		fmt.Sprintf(
+			"If you need to pull out the big guns to resolve merge conflicts, you can press '%s' in the files panel to open 'git mergetool'",
+			formattedKey(config.Files.OpenMergeTool),
+		),
+		fmt.Sprintf(
+			"To revert a commit, press '%s' on that commit",
+			formattedKey(config.Commits.RevertCommit),
+		),
+		fmt.Sprintf(
+			"To escape a mode, for example cherry-picking, patch-building, diffing, or filtering mode, you can just spam the '%s' button. Unless of course you have `quitOnTopLevelReturn` enabled in your config",
+			formattedKey(config.Universal.Return),
+		),
+		fmt.Sprintf(
+			"To search for a string in your panel, press '%s'",
+			formattedKey(config.Universal.StartSearch),
+		),
+		fmt.Sprintf(
+			"You can page through the items of a panel using '%s' and '%s'",
+			formattedKey(config.Universal.PrevPage),
+			formattedKey(config.Universal.NextPage),
+		),
+		fmt.Sprintf(
+			"You can jump to the top/bottom of a panel using '%s' and '%s'",
+			formattedKey(config.Universal.GotoTop),
+			formattedKey(config.Universal.GotoBottom),
+		),
+		fmt.Sprintf(
+			"To collapse/expand a directory, press '%s'",
+			formattedKey(config.Universal.GoInto),
+		),
+		fmt.Sprintf(
+			"You can append your staged changes to an older commit by pressing '%s' on that commit",
+			formattedKey(config.Commits.AmendToCommit),
+		),
+		fmt.Sprintf(
+			"You can amend the last commit with your new file changes by pressing '%s' in the files panel",
+			formattedKey(config.Files.AmendLastCommit),
+		),
+		fmt.Sprintf(
+			"You can now navigate the side panels with '%s' and '%s'",
+			formattedKey(config.Universal.NextBlockAlt2),
+			formattedKey(config.Universal.PrevBlockAlt2),
+		),
+
+		"You can use lazygit with a bare repo by passing the --git-dir and --work-tree arguments as you would for the git CLI",
+
+		// general advice
+		"`git commit` is really just the programmer equivalent of saving your game. Always do it before embarking on an ambitious change!",
+		"Try to separate commits that refactor code from commits that add new functionality: if they're squashed into the one commit, it can be hard to spot what's new.",
+		"If you ever want to experiment, it's easy to create a new branch off your current one and go nuts, then delete it afterwards",
+		"Always read through the diff of your changes before assigning somebody to review your code. Better for you to catch any silly mistakes than your colleagues!",
+		"If something goes wrong, you can always checkout a commit from your reflog to return to an earlier state",
+		"The stash is a good place to save snippets of code that you always find yourself adding when debugging.",
+
+		// links
+		fmt.Sprintf(
+			"If you want a git diff with syntax colouring, check out lazygit's integration with delta:\n%s",
+			constants.Links.Docs.CustomPagers,
+		),
+		fmt.Sprintf(
+			"You can build your own custom menus and commands to run from within lazygit. For examples see:\n%s",
+			constants.Links.Docs.CustomCommands,
+		),
+		fmt.Sprintf(
+			"If you ever find a bug, do not hesistate to raise an issue on the repo:\n%s",
+			constants.Links.Issues,
+		),
+	}
+
+	rand.Seed(time.Now().UnixNano())
+	randomIndex := rand.Intn(len(tips))
+	return tips[randomIndex]
 }

--- a/pkg/gui/command_log_panel.go
+++ b/pkg/gui/command_log_panel.go
@@ -46,13 +46,11 @@ func (gui *Gui) printCommandLogHeader() {
 	)
 	fmt.Fprintln(gui.Views.Extras, utils.ColoredString(introStr, color.FgCyan))
 
-	fmt.Fprint(
+	fmt.Fprintf(
 		gui.Views.Extras,
-		fmt.Sprintf(
-			"%s: %s",
-			utils.ColoredString(gui.Tr.RandomTip, color.FgYellow),
-			utils.ColoredString(gui.getRandomTip(), color.FgGreen),
-		),
+		"%s: %s",
+		utils.ColoredString(gui.Tr.RandomTip, color.FgYellow),
+		utils.ColoredString(gui.getRandomTip(), color.FgGreen),
 	)
 }
 

--- a/pkg/gui/information_panel.go
+++ b/pkg/gui/information_panel.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
+	"github.com/jesseduffield/lazygit/pkg/constants"
 )
 
 func (gui *Gui) informationStr() string {
@@ -43,9 +44,9 @@ func (gui *Gui) handleInfoClick() error {
 
 	// if we're not in an active mode we show the donate button
 	if cx <= len(gui.Tr.Donate) {
-		return gui.OSCommand.OpenLink("https://github.com/sponsors/jesseduffield")
+		return gui.OSCommand.OpenLink(constants.Links.Donate)
 	} else if cx <= len(gui.Tr.Donate)+1+len(gui.Tr.AskQuestion) {
-		return gui.OSCommand.OpenLink("https://github.com/jesseduffield/lazygit/discussions")
+		return gui.OSCommand.OpenLink(constants.Links.Discussions)
 	}
 	return nil
 }

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -8,6 +8,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazygit/pkg/constants"
 )
 
 // Binding - a keybinding mapping a key and modifier to a handler. The keypress
@@ -53,7 +54,8 @@ var keyMapReversed = map[gocui.Key]string{
 	gocui.KeyArrowDown:  "▼",
 	gocui.KeyArrowLeft:  "◄",
 	gocui.KeyArrowRight: "►",
-	gocui.KeyTab:        "tab",   // ctrl+i
+	gocui.KeyTab:        "tab", // ctrl+i
+	gocui.KeyBacktab:    "shift+tab",
 	gocui.KeyEnter:      "enter", // ctrl+m
 	gocui.KeyAltEnter:   "alt+enter",
 	gocui.KeyEsc:        "esc",        // ctrl+[, ctrl+3
@@ -133,6 +135,7 @@ var keymap = map[string]interface{}{
 	"<c-_>":       gocui.KeyCtrlUnderscore,
 	"<backspace>": gocui.KeyBackspace,
 	"<tab>":       gocui.KeyTab,
+	"<backtab>":   gocui.KeyBacktab,
 	"<enter>":     gocui.KeyEnter,
 	"<a-enter>":   gocui.KeyAltEnter,
 	"<esc>":       gocui.KeyEsc,
@@ -188,7 +191,7 @@ func (gui *Gui) getKey(key string) interface{} {
 	if runeCount > 1 {
 		binding := keymap[strings.ToLower(key)]
 		if binding == nil {
-			log.Fatalf("Unrecognized key %s for keybinding. For permitted values see https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Custom_Keybindings.md", strings.ToLower(key))
+			log.Fatalf("Unrecognized key %s for keybinding. For permitted values see %s", strings.ToLower(key), constants.Links.Docs.CustomKeybindings)
 		} else {
 			return binding
 		}
@@ -1773,8 +1776,8 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			{ViewName: viewName, Key: gui.getKey(config.Universal.NextBlock), Modifier: gocui.ModNone, Handler: gui.nextSideWindow},
 			{ViewName: viewName, Key: gui.getKey(config.Universal.PrevBlockAlt), Modifier: gocui.ModNone, Handler: gui.previousSideWindow},
 			{ViewName: viewName, Key: gui.getKey(config.Universal.NextBlockAlt), Modifier: gocui.ModNone, Handler: gui.nextSideWindow},
-			{ViewName: viewName, Key: gocui.KeyBacktab, Modifier: gocui.ModNone, Handler: gui.previousSideWindow},
-			{ViewName: viewName, Key: gocui.KeyTab, Modifier: gocui.ModNone, Handler: gui.nextSideWindow},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.PrevBlockAlt2), Modifier: gocui.ModNone, Handler: gui.previousSideWindow},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.NextBlockAlt2), Modifier: gocui.ModNone, Handler: gui.nextSideWindow},
 		}...)
 	}
 

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -1,12 +1,8 @@
 package gui
 
 import (
-	"fmt"
-
-	"github.com/fatih/color"
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/theme"
-	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 const SEARCH_PREFIX = "search: "
@@ -125,6 +121,7 @@ func (gui *Gui) createAllViews() error {
 	gui.Views.Extras.Title = gui.Tr.CommandLog
 	gui.Views.Extras.FgColor = theme.GocuiDefaultTextColor
 	gui.Views.Extras.Autoscroll = true
+	gui.Views.Extras.Wrap = true
 	gui.printCommandLogHeader()
 
 	if _, err := gui.g.SetCurrentView(gui.defaultSideContext().GetViewName()); err != nil {
@@ -132,14 +129,6 @@ func (gui *Gui) createAllViews() error {
 	}
 
 	return nil
-}
-
-func (gui *Gui) printCommandLogHeader() {
-	introStr := fmt.Sprintf(
-		gui.Tr.CommandLogHeader,
-		gui.getKeyDisplay(gui.Config.GetUserConfig().Keybinding.Universal.ExtrasMenu),
-	)
-	fmt.Fprintln(gui.Views.Extras, utils.ColoredString(introStr, color.FgCyan))
 }
 
 // layout is called for every screen re-render e.g. when the screen is resized

--- a/pkg/gui/status_panel.go
+++ b/pkg/gui/status_panel.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/jesseduffield/lazygit/pkg/commands"
+	"github.com/jesseduffield/lazygit/pkg/constants"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
@@ -106,11 +107,11 @@ func (gui *Gui) handleStatusSelect() error {
 		[]string{
 			lazygitTitle(),
 			"Copyright (c) 2018 Jesse Duffield",
-			"Keybindings: https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings",
-			"Config Options: https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md",
-			"Tutorial: https://youtu.be/VDXvbHZYeKY",
-			"Raise an Issue: https://github.com/jesseduffield/lazygit/issues",
-			magenta.Sprint("Become a sponsor (github is matching all donations for 12 months): https://github.com/sponsors/jesseduffield"), // caffeine ain't free
+			fmt.Sprintf("Keybindings: %s", constants.Links.Docs.Keybindings),
+			fmt.Sprintf("Config Options: %s", constants.Links.Docs.Config),
+			fmt.Sprintf("Tutorial: %s", constants.Links.Docs.Tutorial),
+			fmt.Sprintf("Raise an Issue: %s", constants.Links.Issues),
+			magenta.Sprintf("Become a sponsor (github is matching all donations for 12 months): %s", constants.Links.Donate), // caffeine ain't free
 			gui.Tr.ReleaseNotes,
 		}, "\n\n")
 

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -207,7 +207,7 @@ func dutchTranslationSet() TranslationSet {
 		ConfirmMerge:                        "Weet je zeker dat je {{.selectedBranch}} in {{.checkedOutBranch}} wil mergen?",
 		FwdNoUpstream:                       "Kan niet de branch vooruitspoelen zonder upstream",
 		FwdCommitsToPush:                    "Je kan niet vooruitspoelen als de branch geen nieuwe commits heeft",
-		ErrorOccurred:                       "Er is iets fout gegaan! Zou je hier een issue aan willen maken: https://github.com/jesseduffield/lazygit/issues",
+		ErrorOccurred:                       "Er is iets fout gegaan! Zou je hier een issue aan willen maken",
 		NoRoom:                              "Niet genoeg ruimte",
 		YouAreHere:                          "JE BENT HIER",
 		LcRewordNotSupported:                "herformatteren van commits in interactief rebasen is nog niet ondersteund",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -449,6 +449,7 @@ type TranslationSet struct {
 	ToggleShowCommandLog                string
 	FocusCommandLog                     string
 	CommandLogHeader                    string
+	RandomTip                           string
 	Spans                               Spans
 }
 
@@ -960,7 +961,7 @@ func englishTranslationSet() TranslationSet {
 		ConfirmMerge:                        "Are you sure you want to merge {{.selectedBranch}} into {{.checkedOutBranch}}?",
 		FwdNoUpstream:                       "Cannot fast-forward a branch with no upstream",
 		FwdCommitsToPush:                    "Cannot fast-forward a branch with commits to push",
-		ErrorOccurred:                       "An error occurred! Please create an issue at https://github.com/jesseduffield/lazygit/issues",
+		ErrorOccurred:                       "An error occurred! Please create an issue at",
 		NoRoom:                              "Not enough room",
 		YouAreHere:                          "YOU ARE HERE",
 		LcRewordNotSupported:                "rewording commits while interactively rebasing is not currently supported",
@@ -1189,6 +1190,7 @@ func englishTranslationSet() TranslationSet {
 		ToggleShowCommandLog:                "Toggle show/hide command log",
 		FocusCommandLog:                     "Focus command log",
 		CommandLogHeader:                    "You can hide/focus this panel by pressing '%s' or hide it permanently in your config with `gui.showCommandLog: false`\n",
+		RandomTip:                           "Random Tip",
 		Spans: Spans{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)
 			CheckoutCommit:                    "Checkout commit",

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -145,7 +145,7 @@ func polishTranslationSet() TranslationSet {
 		ConfirmMerge:                        "Are you sure you want to merge {{.selectedBranch}} into {{.checkedOutBranch}}?",
 		FwdNoUpstream:                       "Cannot fast-forward a branch with no upstream",
 		FwdCommitsToPush:                    "Cannot fast-forward a branch with commits to push",
-		ErrorOccurred:                       "An error occurred! Please create an issue at https://github.com/jesseduffield/lazygit/issues",
+		ErrorOccurred:                       "An error occurred! Please create an issue at",
 		MainTitle:                           "Main",
 		NormalTitle:                         "Normal",
 		LcSoftReset:                         "soft reset",

--- a/pkg/updates/updates.go
+++ b/pkg/updates/updates.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 	"github.com/jesseduffield/lazygit/pkg/config"
+	"github.com/jesseduffield/lazygit/pkg/constants"
 	"github.com/jesseduffield/lazygit/pkg/i18n"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/sirupsen/logrus"
@@ -36,10 +37,6 @@ type Updaterer interface {
 	Update()
 }
 
-const (
-	PROJECT_URL = "https://github.com/jesseduffield/lazygit"
-)
-
 // NewUpdater creates a new updater
 func NewUpdater(log *logrus.Entry, config config.AppConfigurer, osCommand *oscommands.OSCommand, tr *i18n.TranslationSet) (*Updater, error) {
 	contextLogger := log.WithField("context", "updates")
@@ -53,7 +50,7 @@ func NewUpdater(log *logrus.Entry, config config.AppConfigurer, osCommand *oscom
 }
 
 func (u *Updater) getLatestVersionNumber() (string, error) {
-	req, err := http.NewRequest("GET", PROJECT_URL+"/releases/latest", nil)
+	req, err := http.NewRequest("GET", constants.Links.RepoUrl+"/releases/latest", nil)
 	if err != nil {
 		return "", err
 	}
@@ -235,7 +232,7 @@ func (u *Updater) zipExtension() string {
 func (u *Updater) getBinaryUrl(newVersion string) (string, error) {
 	url := fmt.Sprintf(
 		"%s/releases/download/%s/lazygit_%s_%s_%s.%s",
-		PROJECT_URL,
+		constants.Links.RepoUrl,
 		newVersion,
 		newVersion[1:],
 		u.mappedOs(runtime.GOOS),

--- a/vendor/github.com/jesseduffield/gocui/edit.go
+++ b/vendor/github.com/jesseduffield/gocui/edit.go
@@ -430,7 +430,7 @@ func (v *View) mergeLines(y int) error {
 	v.writeMutex.Lock()
 	defer v.writeMutex.Unlock()
 
-	v.tainted = true
+	v.clearViewLines()
 
 	_, y, err := v.realPosition(0, y)
 	if err != nil {

--- a/vendor/github.com/jesseduffield/gocui/gui.go
+++ b/vendor/github.com/jesseduffield/gocui/gui.go
@@ -272,7 +272,7 @@ func (g *Gui) SetView(name string, x0, y0, x1, y1 int, overlaps byte) (*View, er
 
 	if v, err := g.View(name); err == nil {
 		if v.x0 != x0 || v.x1 != x1 || v.y0 != y0 || v.y1 != y1 {
-			v.tainted = true
+			v.clearViewLines()
 		}
 
 		v.x0 = x0
@@ -660,11 +660,7 @@ func (g *Gui) handleEvent(ev *GocuiEvent) error {
 }
 
 func (g *Gui) onResize() {
-	for _, v := range g.views {
-		// wonder if we should be calling this in other contexts e.g. whenever the view's dimensions change in general
-		v.FlushStaleCells()
-	}
-	// Not sure if we actually need this
+	// not sure if we actually need this
 	// g.screen.Sync()
 }
 
@@ -677,7 +673,7 @@ func (g *Gui) flush() error {
 	// if GUI's size has changed, we need to redraw all views
 	if maxX != g.maxX || maxY != g.maxY {
 		for _, v := range g.views {
-			v.tainted = true
+			v.clearViewLines()
 		}
 	}
 	g.maxX, g.maxY = maxX, maxY

--- a/vendor/github.com/jesseduffield/gocui/gui.go
+++ b/vendor/github.com/jesseduffield/gocui/gui.go
@@ -651,12 +651,21 @@ func (g *Gui) handleEvent(ev *GocuiEvent) error {
 		return g.onKey(ev)
 	case eventError:
 		return ev.Err
-	// Not sure if this should be handled. It acts weirder when it's here
-	// case eventResize:
-	// 	return Sync()
+	case eventResize:
+		g.onResize()
+		return nil
 	default:
 		return nil
 	}
+}
+
+func (g *Gui) onResize() {
+	for _, v := range g.views {
+		// wonder if we should be calling this in other contexts e.g. whenever the view's dimensions change in general
+		v.FlushStaleCells()
+	}
+	// Not sure if we actually need this
+	// g.screen.Sync()
 }
 
 // flush updates the gui, re-drawing frames and buffers.

--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -683,7 +683,6 @@ func (v *View) FlushStaleCells() {
 	v.writeMutex.Lock()
 	defer v.writeMutex.Unlock()
 
-	v.rewind()
 	v.tainted = true
 	v.viewLines = nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,7 +149,7 @@ github.com/jesseduffield/go-git/v5/utils/merkletrie/filesystem
 github.com/jesseduffield/go-git/v5/utils/merkletrie/index
 github.com/jesseduffield/go-git/v5/utils/merkletrie/internal/frame
 github.com/jesseduffield/go-git/v5/utils/merkletrie/noder
-# github.com/jesseduffield/gocui v0.3.1-0.20210412111008-6ef019af3724
+# github.com/jesseduffield/gocui v0.3.1-0.20210412113212-ee65bd542c08
 ## explicit
 github.com/jesseduffield/gocui
 # github.com/jesseduffield/termbox-go v0.0.0-20200823212418-a2289ed6aafe

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,7 +149,7 @@ github.com/jesseduffield/go-git/v5/utils/merkletrie/filesystem
 github.com/jesseduffield/go-git/v5/utils/merkletrie/index
 github.com/jesseduffield/go-git/v5/utils/merkletrie/internal/frame
 github.com/jesseduffield/go-git/v5/utils/merkletrie/noder
-# github.com/jesseduffield/gocui v0.3.1-0.20210410011117-a2bb4baca390
+# github.com/jesseduffield/gocui v0.3.1-0.20210412111008-6ef019af3724
 ## explicit
 github.com/jesseduffield/gocui
 # github.com/jesseduffield/termbox-go v0.0.0-20200823212418-a2289ed6aafe


### PR DESCRIPTION
I noticed that some of the responses to my lazygit google form asked for features that already existed. I don't expect users to trawl through the list of keybindings to see what's available, because there are quite a few keybindings at that point, so I'm thinking that now we have a a new panel for displaying the log of commands, why not make use of that to display a random tip to the user upon opening lazygit? This will give the user some exposure to convenient keybindings so that they don't feel like they have to leave lazygit to do certain things.

![image](https://user-images.githubusercontent.com/8456633/114306564-7be79c80-9b1f-11eb-871e-6ceb5cf1a5b4.png)


I've also sprinkled in some general git advice. I might end up just removing that if it's deemed too ham-fisted, but we'll see how people react to it.

![image](https://user-images.githubusercontent.com/8456633/114306234-aa18ac80-9b1e-11eb-9cd5-6d4b815dcc29.png)
