### PR TITLE
Read pull mode from git configuration

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -54,7 +54,7 @@ git:
     # extra args passed to `git merge`, e.g. --no-ff
     args: ''
   pull:
-    mode: 'merge' # one of 'merge' | 'rebase' | 'ff-only'
+    mode: 'auto' # one of 'auto' | 'merge' | 'rebase' | 'ff-only', auto reads from git configuration
   skipHookPrefix: WIP
   autoFetch: true
   branchLogCmd: 'git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --'

--- a/pkg/commands/sync_test.go
+++ b/pkg/commands/sync_test.go
@@ -96,3 +96,128 @@ func TestGitCommandPush(t *testing.T) {
 		})
 	}
 }
+
+type getPullModeScenario struct {
+	testName              string
+	getGitConfigValueMock func(string) (string, error)
+	configPullModeValue   string
+	test                  func(string)
+}
+
+func TestGetPullMode(t *testing.T) {
+
+	scenarios := getPullModeScenarios(t)
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			gitCmd := NewDummyGitCommand()
+			gitCmd.getGitConfigValue = s.getGitConfigValueMock
+			s.test(gitCmd.GetPullMode(s.configPullModeValue))
+		})
+	}
+}
+
+func getPullModeScenarios(t *testing.T) []getPullModeScenario {
+	return []getPullModeScenario{
+		{
+			testName: "Merge is default",
+			getGitConfigValueMock: func(s string) (string, error) {
+				return "", nil
+			},
+			configPullModeValue: "auto",
+			test: func(actual string) {
+				assert.Equal(t, "merge", actual)
+			},
+		}, {
+			testName: "Reads rebase when pull.rebase is true",
+			getGitConfigValueMock: func(s string) (string, error) {
+				if s == "pull.rebase" {
+					return "true", nil
+				}
+				return "", nil
+			},
+			configPullModeValue: "auto",
+			test: func(actual string) {
+				assert.Equal(t, "rebase", actual)
+			},
+		}, {
+			testName: "Reads ff-only when pull.ff is only",
+			getGitConfigValueMock: func(s string) (string, error) {
+				if s == "pull.ff" {
+					return "only", nil
+				}
+				return "", nil
+			},
+			configPullModeValue: "auto",
+			test: func(actual string) {
+				assert.Equal(t, "ff-only", actual)
+			},
+		}, {
+			testName: "Reads rebase when rebase is true and ff is only",
+			getGitConfigValueMock: func(s string) (string, error) {
+				if s == "pull.rebase" {
+					return "true", nil
+				}
+				if s == "pull.ff" {
+					return "only", nil
+				}
+				return "", nil
+			},
+			configPullModeValue: "auto",
+			test: func(actual string) {
+				assert.Equal(t, "rebase", actual)
+			},
+		}, {
+			testName: "Reads rebase when pull.rebase is true",
+			getGitConfigValueMock: func(s string) (string, error) {
+				if s == "pull.rebase" {
+					return "true", nil
+				}
+				return "", nil
+			},
+			configPullModeValue: "auto",
+			test: func(actual string) {
+				assert.Equal(t, "rebase", actual)
+			},
+		}, {
+			testName: "Reads ff-only when pull.ff is only",
+			getGitConfigValueMock: func(s string) (string, error) {
+				if s == "pull.ff" {
+					return "only", nil
+				}
+				return "", nil
+			},
+			configPullModeValue: "auto",
+			test: func(actual string) {
+				assert.Equal(t, "ff-only", actual)
+			},
+		}, {
+			testName: "Respects merge config",
+			getGitConfigValueMock: func(s string) (string, error) {
+				return "", nil
+			},
+			configPullModeValue: "merge",
+			test: func(actual string) {
+				assert.Equal(t, "merge", actual)
+			},
+		}, {
+			testName: "Respects rebase config",
+			getGitConfigValueMock: func(s string) (string, error) {
+				return "", nil
+			},
+			configPullModeValue: "rebase",
+			test: func(actual string) {
+				assert.Equal(t, "rebase", actual)
+			},
+		}, {
+			testName: "Respects ff-only config",
+			getGitConfigValueMock: func(s string) (string, error) {
+				return "", nil
+			},
+			configPullModeValue: "ff-only",
+			test: func(actual string) {
+				assert.Equal(t, "ff-only", actual)
+			},
+		},
+	}
+}

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -1,9 +1,5 @@
 package config
 
-import (
-	"github.com/jesseduffield/lazygit/pkg/secureexec"
-)
-
 type UserConfig struct {
 	Gui                  GuiConfig        `yaml:"gui"`
 	Git                  GitConfig        `yaml:"git"`
@@ -321,7 +317,7 @@ func GetDefaultConfig() *UserConfig {
 				Args:         "",
 			},
 			Pull: PullConfig{
-				Mode: getPullModeFromGitConfig(),
+				Mode: "merge",
 			},
 			SkipHookPrefix:      "WIP",
 			AutoFetch:           true,
@@ -481,18 +477,4 @@ func GetDefaultConfig() *UserConfig {
 		Services:             map[string]string(nil),
 		NotARepository:       "prompt",
 	}
-}
-
-func getPullModeFromGitConfig() string {
-	rebaseOut, rebaseErr := secureexec.Command("git config --get pull.rebase").Output()
-	if rebaseErr == nil && rebaseOut[0] == 't' {
-		return "rebase"
-	}
-
-	ffOut, ffErr := secureexec.Command("git config --get pull.ff").Output()
-	if ffErr == nil && ffOut[0] == 't' {
-		return "ff-only"
-	}
-
-	return "merge"
 }

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -317,7 +317,7 @@ func GetDefaultConfig() *UserConfig {
 				Args:         "",
 			},
 			Pull: PullConfig{
-				Mode: "merge",
+				Mode: "auto",
 			},
 			SkipHookPrefix:      "WIP",
 			AutoFetch:           true,

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"github.com/jesseduffield/lazygit/pkg/secureexec"
+)
+
 type UserConfig struct {
 	Gui                  GuiConfig        `yaml:"gui"`
 	Git                  GitConfig        `yaml:"git"`
@@ -317,7 +321,7 @@ func GetDefaultConfig() *UserConfig {
 				Args:         "",
 			},
 			Pull: PullConfig{
-				Mode: "merge",
+				Mode: getPullModeFromGitConfig(),
 			},
 			SkipHookPrefix:      "WIP",
 			AutoFetch:           true,
@@ -477,4 +481,18 @@ func GetDefaultConfig() *UserConfig {
 		Services:             map[string]string(nil),
 		NotARepository:       "prompt",
 	}
+}
+
+func getPullModeFromGitConfig() string {
+	rebaseOut, rebaseErr := secureexec.Command("git config --get pull.rebase").Output()
+	if rebaseErr == nil && rebaseOut[0] == 't' {
+		return "rebase"
+	}
+
+	ffOut, ffErr := secureexec.Command("git config --get pull.ff").Output()
+	if ffErr == nil && ffOut[0] == 't' {
+		return "ff-only"
+	}
+
+	return "merge"
 }

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"sync"
 
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands"
@@ -661,40 +660,13 @@ func (gui *Gui) pullFiles(opts PullFilesOptions) error {
 		return err
 	}
 
-	mode := gui.getPullMode()
+	mode := &gui.Config.GetUserConfig().Git.Pull.Mode
+	*mode = gui.GitCommand.GetPullMode(*mode)
 
 	// TODO: this doesn't look like a good idea. Why the goroutine?
-	go utils.Safe(func() { _ = gui.pullWithMode(mode, opts) })
+	go utils.Safe(func() { _ = gui.pullWithMode(*mode, opts) })
 
 	return nil
-}
-
-func (gui *Gui) getPullMode() string {
-	mode := &gui.Config.GetUserConfig().Git.Pull.Mode
-	if *mode == "auto" {
-		var isRebase bool
-		var isFf bool
-		var wg sync.WaitGroup
-		wg.Add(2)
-		go func() {
-			isRebase = gui.GitCommand.GetConfigValue("pull.rebase") == "true"
-			wg.Done()
-		}()
-		go func() {
-			isFf = gui.GitCommand.GetConfigValue("pull.ff") == "true"
-			wg.Done()
-		}()
-		wg.Wait()
-
-		if isRebase {
-			*mode = "rebase"
-		} else if isFf {
-			*mode = "ff-only"
-		} else {
-			*mode = "merge"
-		}
-	}
-	return *mode
 }
 
 func (gui *Gui) pullWithMode(mode string, opts PullFilesOptions) error {


### PR DESCRIPTION
Replace the hardcoded `merge` pull default behavior and asks git about it first. The order is the following:

 - Checks lazygit's configuration file
 - If not, asks git
 - If not, defaults to `merge`

If test cases are required, I'll have to ask for some help. I've also considered replacing the raw strings with enums but found no clean way of doing that in golang.

Closes #1151 
Closes #1188 
Related #1180 