### PR TITLE
Update quoting for OpenFile command on Linux

### DIFF
--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -301,10 +301,15 @@ func sanitisedCommandOutput(output []byte, err error) (string, error) {
 // OpenFile opens a file with the given
 func (c *OSCommand) OpenFile(filename string) error {
 	commandTemplate := c.Config.GetUserConfig().OS.OpenCommand
-	templateValues := map[string]string{
-		"filename": c.Quote(filename),
+	quoted := c.Quote(filename)
+	if c.Platform.OS == "linux" {
+		// Add extra quoting to avoid issues with shell command string
+		quoted = c.Quote(quoted)
+		quoted = quoted[1 : len(quoted)-1]
 	}
-
+	templateValues := map[string]string{
+		"filename": quoted,
+	}
 	command := utils.ResolvePlaceholderString(commandTemplate, templateValues)
 	err := c.RunCommand(command)
 	return err

--- a/pkg/commands/oscommands/os_test.go
+++ b/pkg/commands/oscommands/os_test.go
@@ -103,8 +103,83 @@ func TestOSCommandOpenFile(t *testing.T) {
 
 	for _, s := range scenarios {
 		OSCmd := NewDummyOSCommand()
+		OSCmd.Platform.OS = "darwin"
 		OSCmd.Command = s.command
 		OSCmd.Config.GetUserConfig().OS.OpenCommand = "open {{filename}}"
+
+		s.test(OSCmd.OpenFile(s.filename))
+	}
+}
+
+// TestOSCommandOpenFile tests the OpenFile command on Linux
+func TestOSCommandOpenFileLinux(t *testing.T) {
+	type scenario struct {
+		filename string
+		command  func(string, ...string) *exec.Cmd
+		test     func(error)
+	}
+
+	scenarios := []scenario{
+		{
+			"test",
+			func(name string, arg ...string) *exec.Cmd {
+				return secureexec.Command("exit", "1")
+			},
+			func(err error) {
+				assert.Error(t, err)
+			},
+		},
+		{
+			"test",
+			func(name string, arg ...string) *exec.Cmd {
+				assert.Equal(t, "sh", name)
+				assert.Equal(t, []string{"-c", "xdg-open \"test\" > /dev/null"}, arg)
+				return secureexec.Command("echo")
+			},
+			func(err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			"filename with spaces",
+			func(name string, arg ...string) *exec.Cmd {
+				assert.Equal(t, "sh", name)
+				assert.Equal(t, []string{"-c", "xdg-open \"filename with spaces\" > /dev/null"}, arg)
+				return secureexec.Command("echo")
+			},
+			func(err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			"let's_test_with_single_quote",
+			func(name string, arg ...string) *exec.Cmd {
+				assert.Equal(t, "sh", name)
+				assert.Equal(t, []string{"-c", "xdg-open \"let's_test_with_single_quote\" > /dev/null"}, arg)
+				return secureexec.Command("echo")
+			},
+			func(err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			"$USER.txt",
+			func(name string, arg ...string) *exec.Cmd {
+				assert.Equal(t, "sh", name)
+				assert.Equal(t, []string{"-c", "xdg-open \"\\$USER.txt\" > /dev/null"}, arg)
+				return secureexec.Command("echo")
+			},
+			func(err error) {
+				assert.NoError(t, err)
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		OSCmd := NewDummyOSCommand()
+		OSCmd.Command = s.command
+		OSCmd.Platform.OS = "linux"
+		OSCmd.Config.GetUserConfig().OS.OpenCommand = `sh -c "xdg-open {{filename}} > /dev/null"`
 
 		s.test(OSCmd.OpenFile(s.filename))
 	}


### PR DESCRIPTION
Currently with have issues on Linux while opening files for the following two cases:
- The filename has spaces
![image](https://user-images.githubusercontent.com/20388082/117591949-07e3e880-b10d-11eb-91fb-9b105e4759cf.png)

- The filename contains environment variables e.g. `$USER.txt`
![image](https://user-images.githubusercontent.com/20388082/117591938-fe5a8080-b10c-11eb-8dfa-aeafa8b6ef24.png)

How to reproduce the behavior:
```sh
$ touch 'ola tudo bem'
$ touch '$USER'
# The two commands below are the ones lazygit currently generates for opening files
$ sh -c "xdg-open "ola tudo bem" >/dev/null"
xdg-open: file 'ola' does not exist
$ sh -c "xdg-open "\$USER" >/dev/null" # $USER = shigueo
xdg-open: file 'shigueo' does not exit
```
Fixes #1305 