### PR TITLE
Edit command as user OS config option

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -62,8 +62,8 @@ git:
   overrideGpg: false # prevents lazygit from spawning a separate process when using GPG
   disableForcePushing: false
 os:
-  editCommand: '' # see EditCommand section
-  openCommand: # see OpenCommand section
+  editCommand: '' # see 'Configuring File Editing' section
+  openCommand: ''
 refresher:
   refreshInterval: 10 # file/submodule refresh interval in seconds
   fetchInterval: 60 # re-fetch interval in seconds
@@ -217,17 +217,21 @@ os:
 ```
 
 ### Configuring File Editing
-Lazygit will run edit with the first set option:
+
+Lazygit will edit a file with the first set editor in the following:
+
 1. config.yaml
+
 ```yaml
 os:
-  editCommand:
+  editCommand: 'vim' # as an example
 ```
-2. $(git config core.editor)
-3. $GIT_EDITOR
-4. $VISUAL
-5. $EDITOR
-6. $(which vi)
+
+2. \$(git config core.editor)
+3. \$GIT_EDITOR
+4. \$VISUAL
+5. \$EDITOR
+6. \$(which vi)
 
 Lazygit will log an error if none of these options are set.
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -61,6 +61,9 @@ git:
   allBranchesLogCmd: 'git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium'
   overrideGpg: false # prevents lazygit from spawning a separate process when using GPG
   disableForcePushing: false
+os:
+  editCommand: '' # see EditCommand section
+  openCommand: # see OpenCommand section
 refresher:
   refreshInterval: 10 # file/submodule refresh interval in seconds
   fetchInterval: 60 # re-fetch interval in seconds
@@ -212,6 +215,21 @@ os:
 os:
   openCommand: 'open {{filename}}'
 ```
+
+### EditCommand
+Lazygit will run edit with the first non-empty command:
+1. config.yaml
+```yaml
+os:
+  editCommand:
+```
+2. $(git config core.editor)
+3. $GIT_EDITOR
+4. $VISUAL
+5. $EDITOR
+6. vi (if found through `which vi`)
+
+Lazygit will log an error if none of these commands are non-empty.
 
 ### Recommended Config Values
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -216,8 +216,8 @@ os:
   openCommand: 'open {{filename}}'
 ```
 
-### EditCommand
-Lazygit will run edit with the first non-empty command:
+### Configuring File Editing
+Lazygit will run edit with the first set option:
 1. config.yaml
 ```yaml
 os:
@@ -227,9 +227,9 @@ os:
 3. $GIT_EDITOR
 4. $VISUAL
 5. $EDITOR
-6. vi (if found through `which vi`)
+6. $(which vi)
 
-Lazygit will log an error if none of these commands are non-empty.
+Lazygit will log an error if none of these options are set.
 
 ### Recommended Config Values
 

--- a/pkg/commands/files.go
+++ b/pkg/commands/files.go
@@ -318,7 +318,11 @@ func (c *GitCommand) ResetAndClean() error {
 }
 
 func (c *GitCommand) EditFileCmdStr(filename string) (string, error) {
-	editor := c.GetConfigValue("core.editor")
+	editor := c.Config.GetUserConfig().OS.EditCommand
+
+	if editor == "" {
+		editor = c.GetConfigValue("core.editor")
+	}
 
 	if editor == "" {
 		editor = c.OSCommand.Getenv("GIT_EDITOR")

--- a/pkg/commands/files.go
+++ b/pkg/commands/files.go
@@ -339,7 +339,7 @@ func (c *GitCommand) EditFileCmdStr(filename string) (string, error) {
 		}
 	}
 	if editor == "" {
-		return "", errors.New("No editor defined in $GIT_EDITOR, $VISUAL, $EDITOR, or git config")
+		return "", errors.New("No editor defined in config file, $GIT_EDITOR, $VISUAL, $EDITOR, or git config")
 	}
 
 	return fmt.Sprintf("%s %s", editor, c.OSCommand.Quote(filename)), nil

--- a/pkg/commands/files_test.go
+++ b/pkg/commands/files_test.go
@@ -720,6 +720,7 @@ func TestGitCommandRemoveUntrackedFiles(t *testing.T) {
 func TestEditFileCmdStr(t *testing.T) {
 	type scenario struct {
 		filename          string
+		configEditCommand string
 		command           func(string, ...string) *exec.Cmd
 		getenv            func(string) string
 		getGitConfigValue func(string) (string, error)
@@ -729,6 +730,7 @@ func TestEditFileCmdStr(t *testing.T) {
 	scenarios := []scenario{
 		{
 			"test",
+			"",
 			func(name string, arg ...string) *exec.Cmd {
 				return secureexec.Command("exit", "1")
 			},
@@ -744,6 +746,25 @@ func TestEditFileCmdStr(t *testing.T) {
 		},
 		{
 			"test",
+			"nano",
+			func(name string, args ...string) *exec.Cmd {
+				assert.Equal(t, "which", name)
+				return secureexec.Command("echo")
+			},
+			func(env string) string {
+				return ""
+			},
+			func(cf string) (string, error) {
+				return "", nil
+			},
+			func(cmdStr string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "nano \"test\"", cmdStr)
+			},
+		},
+		{
+			"test",
+			"",
 			func(name string, arg ...string) *exec.Cmd {
 				assert.Equal(t, "which", name)
 				return secureexec.Command("exit", "1")
@@ -761,6 +782,7 @@ func TestEditFileCmdStr(t *testing.T) {
 		},
 		{
 			"test",
+			"",
 			func(name string, arg ...string) *exec.Cmd {
 				assert.Equal(t, "which", name)
 				return secureexec.Command("exit", "1")
@@ -781,6 +803,7 @@ func TestEditFileCmdStr(t *testing.T) {
 		},
 		{
 			"test",
+			"",
 			func(name string, arg ...string) *exec.Cmd {
 				assert.Equal(t, "which", name)
 				return secureexec.Command("exit", "1")
@@ -802,6 +825,7 @@ func TestEditFileCmdStr(t *testing.T) {
 		},
 		{
 			"test",
+			"",
 			func(name string, arg ...string) *exec.Cmd {
 				assert.Equal(t, "which", name)
 				return secureexec.Command("echo")
@@ -819,6 +843,7 @@ func TestEditFileCmdStr(t *testing.T) {
 		},
 		{
 			"file/with space",
+			"",
 			func(name string, args ...string) *exec.Cmd {
 				assert.Equal(t, "which", name)
 				return secureexec.Command("echo")
@@ -838,6 +863,7 @@ func TestEditFileCmdStr(t *testing.T) {
 
 	for _, s := range scenarios {
 		gitCmd := NewDummyGitCommand()
+		gitCmd.Config.GetUserConfig().OS.EditCommand = s.configEditCommand
 		gitCmd.OSCommand.Command = s.command
 		gitCmd.OSCommand.Getenv = s.getenv
 		gitCmd.getGitConfigValue = s.getGitConfigValue

--- a/pkg/config/config_default_platform.go
+++ b/pkg/config/config_default_platform.go
@@ -5,6 +5,7 @@ package config
 // GetPlatformDefaultConfig gets the defaults for the platform
 func GetPlatformDefaultConfig() OSConfig {
 	return OSConfig{
+		EditCommand:     ``,
 		OpenCommand:     "open {{filename}}",
 		OpenLinkCommand: "open {{link}}",
 	}

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -3,6 +3,7 @@ package config
 // GetPlatformDefaultConfig gets the defaults for the platform
 func GetPlatformDefaultConfig() OSConfig {
 	return OSConfig{
+		EditCommand:     ``,
 		OpenCommand:     `sh -c "xdg-open {{filename}} >/dev/null"`,
 		OpenLinkCommand: `sh -c "xdg-open {{link}} >/dev/null"`,
 	}

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -3,6 +3,7 @@ package config
 // GetPlatformDefaultConfig gets the defaults for the platform
 func GetPlatformDefaultConfig() OSConfig {
 	return OSConfig{
+		EditCommand:     ``,
 		OpenCommand:     `cmd /c "start "" {{filename}}"`,
 		OpenLinkCommand: `cmd /c "start "" {{link}}"`,
 	}

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -247,6 +247,9 @@ type KeybindingSubmodulesConfig struct {
 
 // OSConfig contains config on the level of the os
 type OSConfig struct {
+	// EditCommand is the command for editing a file
+	EditCommand string `yaml:"editCommand,omitempty"`
+
 	// OpenCommand is the command for opening a file
 	OpenCommand string `yaml:"openCommand,omitempty"`
 


### PR DESCRIPTION
Adding `os.editCommand` as an optional user config, similar to `os.openCommand`. If omitted in the config, falls back to the previous options. If included in the config, run `{{os.openCommand}} {{filename}}`.

### Testing
* Fedora Linux
* Empty config / config without os.editCommand
* config including os.editCommand = nano, vim, etc.

### Caveats
* New to go programming language, so not sure about code quality, especially the testing code
* I added empty default configurations for non-Linux, but only have a Linux machine to test on

### Docs
I haven't wrote any docs, but if the maintainers decide this is a desired feature, I can draft something up. To my knowledge, there currently is not any sections that describes how lazygit chooses the text editor for editCommand, so maybe I could add a section on that in `Config.md`.