### PR TITLE
Handle alternate merge conflict format; add tests

### DIFF
--- a/pkg/gui/mergeconflicts/state.go
+++ b/pkg/gui/mergeconflicts/state.go
@@ -104,6 +104,10 @@ func findConflicts(content string) []*mergeConflict {
 		case "=======":
 			newConflict.middle = i
 		default:
+			// Sometimes these lines look like "<<<<<<< HEAD:foo/bar/baz.go" so handle that case as well.
+			if strings.HasPrefix(trimmedLine, "<<<<<<< HEAD:") {
+				newConflict = &mergeConflict{start: i}
+			}
 			if strings.HasPrefix(trimmedLine, ">>>>>>> ") {
 				newConflict.end = i
 				conflicts = append(conflicts, newConflict)

--- a/pkg/gui/mergeconflicts/state_test.go
+++ b/pkg/gui/mergeconflicts/state_test.go
@@ -1,0 +1,90 @@
+package mergeconflicts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindConflicts(t *testing.T) {
+	type scenario struct {
+		name     string
+		content  string
+		expected []*mergeConflict
+	}
+
+	scenarios := []scenario{
+		{
+			name:     "empty",
+			content:  "",
+			expected: []*mergeConflict{},
+		},
+		{
+			name: "various conflicts",
+			content: `++<<<<<<< HEAD
+foo
+++=======
+bar
+++>>>>>>> branch
+
+<<<<<<< HEAD: foo/bar/baz.go
+foo
+bar
+=======
+baz
+>>>>>>> branch
+
+++<<<<<<< MERGE_HEAD
+foo
+++=======
+bar
+++>>>>>>> branch
+
+++<<<<<<< Updated upstream
+foo
+++=======
+bar
+++>>>>>>> branch
+
+++<<<<<<< ours
+foo
+++=======
+bar
+++>>>>>>> branch
+`,
+			expected: []*mergeConflict{
+				{
+					start:  0,
+					middle: 2,
+					end:    4,
+				},
+				{
+					start:  6,
+					middle: 9,
+					end:    11,
+				},
+				{
+					start:  13,
+					middle: 15,
+					end:    17,
+				},
+				{
+					start:  19,
+					middle: 21,
+					end:    23,
+				},
+				{
+					start:  25,
+					middle: 27,
+					end:    29,
+				},
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			assert.EqualValues(t, s.expected, findConflicts(s.content))
+		})
+	}
+}


### PR DESCRIPTION
LazyGit kept crashing on me when I tried to view a particular merge conflict diff that had an alternate `HEAD` line so I looked into it and it was a pretty easy fix.

I verified everything worked by building `lazygit` locally and then using it to view the same merge conflict that crashed earlier and it no longer crashed. I was able to resolve the conflict without issues.

This appears to resolve #1297