### PR TITLE
Remove origin prefix when creating local branch based from origin

### DIFF
--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -505,8 +505,8 @@ func (gui *Gui) handleNewBranchOffCurrentItem() error {
 
 	prefilledName := ""
 	if context.GetKey() == REMOTE_BRANCHES_CONTEXT_KEY {
-		// will set to the remote's existing name
-		prefilledName = item.ID()
+		// will set to the remote's branch name without the remote name
+		prefilledName = strings.SplitAfterN(item.ID(), "/", 2)[1]
 	}
 
 	return gui.prompt(promptOpts{


### PR DESCRIPTION
Hello,

Thank you for this very nice project. Here is my contribution to solve an issue.

This removes the remote name from the local branch name suggestion when checking out a remote branch. Because the remote has not always `origin` as a name, I cannot simply do `strings.TrimLeft(Item.ID(), "origin/")`.

There should always be a `/` in the string because it is always prefixed with the remote name. It should then not be a problem to use `[1]`.

Let me know if you need anything else for this PR.

Closes: #1108