### PR TITLE
More generic merge conflict detection

### DIFF
--- a/pkg/gui/mergeconflicts/find_conflicts.go
+++ b/pkg/gui/mergeconflicts/find_conflicts.go
@@ -48,18 +48,14 @@ func findConflicts(content string) []*mergeConflict {
 func determineLineType(line string) LineType {
 	trimmedLine := strings.TrimPrefix(line, "++")
 
-	mapping := map[string]LineType{
-		"^<<<<<<< (HEAD|MERGE_HEAD|Updated upstream|ours)(:.+)?$": START,
-		"^=======$":    MIDDLE,
-		"^>>>>>>> .*$": END,
+	switch {
+	case strings.HasPrefix(trimmedLine, "<<<<<<< "):
+		return START
+	case trimmedLine == "=======":
+		return MIDDLE
+	case strings.HasPrefix(trimmedLine, ">>>>>>> "):
+		return END
+	default:
+		return NOT_A_MARKER
 	}
-
-	for regexp_str, lineType := range mapping {
-		match, _ := regexp.MatchString(regexp_str, trimmedLine)
-		if match {
-			return lineType
-		}
-	}
-
-	return NOT_A_MARKER
 }

--- a/pkg/gui/mergeconflicts/find_conflicts.go
+++ b/pkg/gui/mergeconflicts/find_conflicts.go
@@ -1,7 +1,6 @@
 package mergeconflicts
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/jesseduffield/lazygit/pkg/utils"

--- a/pkg/gui/mergeconflicts/find_conflicts.go
+++ b/pkg/gui/mergeconflicts/find_conflicts.go
@@ -35,6 +35,8 @@ func findConflicts(content string) []*mergeConflict {
 		case END:
 			newConflict.end = i
 			conflicts = append(conflicts, newConflict)
+			// reset value to avoid any possible silent mutations in further iterations
+			newConflict = nil
 		default:
 			// line isn't a merge conflict marker so we just continue
 		}

--- a/pkg/gui/mergeconflicts/state_test.go
+++ b/pkg/gui/mergeconflicts/state_test.go
@@ -51,6 +51,13 @@ foo
 ++=======
 bar
 ++>>>>>>> branch
+
+<<<<<<< Updated upstream: foo/bar/baz.go
+foo
+bar
+=======
+baz
+>>>>>>> branch
 `,
 			expected: []*mergeConflict{
 				{
@@ -77,6 +84,11 @@ bar
 					start:  25,
 					middle: 27,
 					end:    29,
+				},
+				{
+					start:  31,
+					middle: 34,
+					end:    36,
 				},
 			},
 		},


### PR DESCRIPTION
The #1326 PR did not handle all cases from #1297. This PR changes the merge conflict detection to be more genetic towards the conflict markers. I have verified the new behaviour against the zip file mentioned in the issue.
If you feel like it is a bit dangerous, I could modify the code to check `<<<<<<< ` with each of `"HEAD"`, `"MERGE_HEAD"`, `"Updated upstream"`, `"ours"`.