### PR TITLE
#1345 - viewLines is nil after mergeLines() so we have a panic

### DIFF
--- a/vendor/github.com/jesseduffield/gocui/edit.go
+++ b/vendor/github.com/jesseduffield/gocui/edit.go
@@ -160,18 +160,10 @@ func (v *View) EditDelete(back bool) {
 		return
 	}
 
-	maxX, _ := v.Size()
 	if back {
 		if x == 0 { // start of the line
 			if y < 1 {
 				return
-			}
-
-			var maxPrevWidth int
-			if v.Wrap {
-				maxPrevWidth = maxX
-			} else {
-				maxPrevWidth = maxInt
 			}
 
 			if v.viewLines[y].linesX == 0 { // regular line

--- a/vendor/github.com/jesseduffield/gocui/edit.go
+++ b/vendor/github.com/jesseduffield/gocui/edit.go
@@ -175,10 +175,10 @@ func (v *View) EditDelete(back bool) {
 			}
 
 			if v.viewLines[y].linesX == 0 { // regular line
+				p := len(v.viewLines[y-1].line)
 				v.mergeLines(v.cy - 1)
-				if len(v.viewLines[y-1].line) < maxPrevWidth {
-					v.MoveCursor(-1, 0, true)
-				}
+				n, _ := v.deleteRune(p-1, v.cy-1)
+				v.MoveCursor(p-n, -1, true)
 			} else { // wrapped line
 				n, _ := v.deleteRune(len(v.viewLines[y-1].line)-1, v.cy-1)
 				v.MoveCursor(-n, 0, true)


### PR DESCRIPTION
PR is related to #1345 issue where we have a panic. 
The reason is viewLines is nil after mergeLines() is called. Yep.
So I delete last rune on prev line when backspace is pressed on empty last line.