### PR TITLE
Fix typo in random tip

### DIFF
--- a/pkg/gui/command_log_panel.go
+++ b/pkg/gui/command_log_panel.go
@@ -102,7 +102,7 @@ func (gui *Gui) getRandomTip() string {
 			formattedKey(config.Universal.GoInto),
 		),
 		fmt.Sprintf(
-			"You can diff two commits by pressing '%s' one one commit and then navigating to the other. You can then press '%s' to view the files of the diff",
+			"You can diff two commits by pressing '%s' on one commit and then navigating to the other. You can then press '%s' to view the files of the diff",
 			formattedKey(config.Universal.DiffingMenu),
 			formattedKey(config.Universal.GoInto),
 		),


### PR DESCRIPTION
Quite enjoy the random tips in the application, came across a typo during a session.

![image](https://user-images.githubusercontent.com/5339066/123565579-c1ebfc80-d800-11eb-80b1-aef919f75a63.png)

I think `one one` is intended to be `on one` in the image.