### PR TITLE
Generate menu options from a Git Command with a filter

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -103,8 +103,8 @@ The permitted prompt fields are:
 | filter       | (only applicable to 'menuFromCommand' prompts) the regexp to run specifying      | yes        |
 |              | groups which are going to be kept from the command's output                      |            |
 | format       | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | yes        |
-|              | the filter. You can use named groups, or `{{ .group_GROUPID_MATCHID }}`.         | yes        |
-|              | PS: named groups keep last non-empty match                                       | yes        |
+|              | the filter. You can use named groups, or `{{ .group_GROUPID }}`.                 | yes        |
+|              | PS: named groups keep first match only                                           | yes        |
 
 The permitted option fields are:
 | _field_ | _description_ | _required_ |

--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -46,7 +46,8 @@ customCommands:
       - type: 'menuFromCommand'
         title: 'Remote branch:'
         command: 'git branch  -r --list {{index .PromptResponses 0}}/*'
-        filter: '.*{{index .PromptResponses 0}}/(.*)'
+        filter: '.*{{index .PromptResponses 0}}/(?P<branch>.*)'
+        format: '{{ .branch }}'
 ```
 
 Looking at the command assigned to the 'n' key, here's what the result looks like:
@@ -99,8 +100,11 @@ The permitted prompt fields are:
 | options      | (only applicable to 'menu' prompts) the options to display in the menu           | no         |
 | command      | (only applicable to 'menuFromCommand' prompts) the command to run to generate    | yes        |
 |              | menu options                                                                     |            |
-| filter       | (only applicable to 'menuFromCommand' prompts) the regexp to run specify groups  | yes        |
-|              | which are going to be kept from the command's output                             |            |
+| filter       | (only applicable to 'menuFromCommand' prompts) the regexp to run specifying      | yes        |
+|              | groups which are going to be kept from the command's output                      |            |
+| format       | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | yes        |
+|              | the filter. You can use named groups, or `{{ .group_GROUPID_MATCHID }}`.         | yes        |
+|              | PS: named groups keep last non-empty match                                       | yes        |
 
 The permitted option fields are:
 | _field_ | _description_ | _required_ |

--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -35,6 +35,18 @@ customCommands:
     command: "git flow {{index .PromptResponses 0}} start {{index .PromptResponses 1}}"
     context: 'localBranches'
     loadingText: 'creating branch'
+  - key : 'r'
+    description: 'Checkout a remote branch as FETCH_HEAD'
+    command: "git fetch {{index .PromptResponses 0}} {{index .PromptResponses 1}} && git checkout FETCH_HEAD"
+    context: 'remotes'
+    prompts:
+      - type: 'input'
+        title: 'Remote:'
+        initialValue: "{{index .SelectedRemote.Name }}"
+      - type: 'menuFromCommand'
+        title: 'Remote branch:'
+        command: 'git branch  -r --list {{index .PromptResponses 0}}/*'
+        filter: '.*{{index .PromptResponses 0}}/(.*)'
 ```
 
 Looking at the command assigned to the 'n' key, here's what the result looks like:
@@ -85,6 +97,10 @@ The permitted prompt fields are:
 | title        | the title to display in the popup panel                                          | no         |
 | initialValue | (only applicable to 'input' prompts) the initial value to appear in the text box | no         |
 | options      | (only applicable to 'menu' prompts) the options to display in the menu           | no         |
+| command      | (only applicable to 'menuFromCommand' prompts) the command to run to generate    | yes        |
+|              | menu options                                                                     |            |
+| filter       | (only applicable to 'menuFromCommand' prompts) the regexp to run specify groups  | yes        |
+|              | which are going to be kept from the command's output                             |            |
 
 The permitted option fields are:
 | _field_ | _description_ | _required_ |

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -281,9 +281,9 @@ type CustomCommandPrompt struct {
 	// this only applies to menus
 	Options []CustomCommandMenuOption
 
-        // this only applies to menuFromCommand
-        Command string `yaml:"command"`
-        Filter string `yaml:"filter"`
+	// this only applies to menuFromCommand
+	Command string `yaml:"command"`
+	Filter  string `yaml:"filter"`
 }
 
 type CustomCommandMenuOption struct {

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -284,6 +284,7 @@ type CustomCommandPrompt struct {
 	// this only applies to menuFromCommand
 	Command string `yaml:"command"`
 	Filter  string `yaml:"filter"`
+	Format  string `yaml:"format"`
 }
 
 type CustomCommandMenuOption struct {

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -280,6 +280,10 @@ type CustomCommandPrompt struct {
 
 	// this only applies to menus
 	Options []CustomCommandMenuOption
+
+        // this only applies to menuFromCommand
+        Command string `yaml:"command"`
+        Filter string `yaml:"filter"`
 }
 
 type CustomCommandMenuOption struct {

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -54,6 +54,149 @@ func (gui *Gui) resolveTemplate(templateStr string, promptResponses []string) (s
 	return utils.ResolveTemplate(templateStr, objects)
 }
 
+func (gui *Gui) inputPrompt(prompt config.CustomCommandPrompt, promptResponses []string, responseIdx int, wrappedF func() error) error {
+	title, err := gui.resolveTemplate(prompt.Title, promptResponses)
+	if err != nil {
+		return gui.surfaceError(err)
+	}
+
+	initialValue, err := gui.resolveTemplate(prompt.InitialValue, promptResponses)
+	if err != nil {
+		return gui.surfaceError(err)
+	}
+
+	return gui.prompt(promptOpts{
+		title:          title,
+		initialContent: initialValue,
+		handleConfirm: func(str string) error {
+			promptResponses[responseIdx] = str
+			return wrappedF()
+		},
+	})
+}
+
+func (gui *Gui) menuPrompt(prompt config.CustomCommandPrompt, promptResponses []string, responseIdx int, wrappedF func() error) error {
+	// need to make a menu here some how
+	menuItems := make([]*menuItem, len(prompt.Options))
+	for i, option := range prompt.Options {
+		option := option
+
+		nameTemplate := option.Name
+		if nameTemplate == "" {
+			// this allows you to only pass values rather than bother with names/descriptions
+			nameTemplate = option.Value
+		}
+		name, err := gui.resolveTemplate(nameTemplate, promptResponses)
+		if err != nil {
+			return gui.surfaceError(err)
+		}
+
+		description, err := gui.resolveTemplate(option.Description, promptResponses)
+		if err != nil {
+			return gui.surfaceError(err)
+		}
+
+		value, err := gui.resolveTemplate(option.Value, promptResponses)
+		if err != nil {
+			return gui.surfaceError(err)
+		}
+
+		menuItems[i] = &menuItem{
+			displayStrings: []string{name, utils.ColoredString(description, color.FgYellow)},
+			onPress: func() error {
+				promptResponses[responseIdx] = value
+				return wrappedF()
+			},
+		}
+	}
+
+	title, err := gui.resolveTemplate(prompt.Title, promptResponses)
+	if err != nil {
+		return gui.surfaceError(err)
+	}
+
+	return gui.createMenu(title, menuItems, createMenuOptions{showCancel: true})
+}
+func (gui *Gui) generateMenuCandidates(commandOutput string, filter string, format string) ([]string, error) {
+	candidates := []string{}
+	reg, err := regexp.Compile(filter)
+	if err != nil {
+		return candidates, gui.surfaceError(errors.New("unable to parse filter regex, error: " + err.Error()))
+	}
+	buff := bytes.NewBuffer(nil)
+	temp, err := template.New("format").Parse(format)
+	if err != nil {
+		return candidates, gui.surfaceError(errors.New("unable to parse format, error: " + err.Error()))
+	}
+	for _, str := range strings.Split(string(commandOutput), "\n") {
+		if str == "" {
+			continue
+		}
+		tmplData := map[string]string{}
+		out := reg.FindAllStringSubmatch(str, -1)
+		if len(out) > 0 {
+			for groupIdx, group := range reg.SubexpNames() {
+				// Record matched group with group ids
+				matchName := "group_" + strconv.Itoa(groupIdx)
+				tmplData[matchName] = group
+				// Record last named group non-empty matches as group matches
+				if group != "" {
+					tmplData[group] = out[0][groupIdx]
+				}
+			}
+		}
+		err = temp.Execute(buff, tmplData)
+		if err != nil {
+			return candidates, gui.surfaceError(err)
+		}
+
+		candidates = append(candidates, strings.TrimSpace(buff.String()))
+		buff.Reset()
+	}
+	return candidates, err
+}
+
+func (gui *Gui) menuPromptFromCommand(prompt config.CustomCommandPrompt, promptResponses []string, responseIdx int, wrappedF func() error) error {
+	// Collect cmd to run from config
+	cmdStr, err := gui.resolveTemplate(prompt.Command, promptResponses)
+	if err != nil {
+		return gui.surfaceError(err)
+	}
+
+	// Collect Filter regexp
+	filter, err := gui.resolveTemplate(prompt.Filter, promptResponses)
+	if err != nil {
+		return gui.surfaceError(err)
+	}
+
+	// Run and save output
+	message, err := gui.GitCommand.RunCommandWithOutput(cmdStr)
+	if err != nil {
+		return gui.surfaceError(err)
+	}
+
+	// Need to make a menu out of what the cmd has displayed
+	candidates, err := gui.generateMenuCandidates(message, filter, prompt.Format)
+
+	menuItems := make([]*menuItem, len(candidates))
+	for i := range candidates {
+		menuItems[i] = &menuItem{
+			displayStrings: []string{candidates[i]},
+			onPress: func() error {
+				promptResponses[responseIdx] = candidates[i]
+				return wrappedF()
+			},
+		}
+	}
+
+	title, err := gui.resolveTemplate(prompt.Title, promptResponses)
+	if err != nil {
+		return gui.surfaceError(err)
+	}
+
+	return gui.createMenu(title, menuItems, createMenuOptions{showCancel: true})
+}
+
 func (gui *Gui) handleCustomCommandKeybinding(customCommand config.CustomCommand) func() error {
 	return func() error {
 		promptResponses := make([]string, len(customCommand.Prompts))
@@ -94,144 +237,15 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand config.CustomCommand
 			switch prompt.Type {
 			case "input":
 				f = func() error {
-					title, err := gui.resolveTemplate(prompt.Title, promptResponses)
-					if err != nil {
-						return gui.surfaceError(err)
-					}
-
-					initialValue, err := gui.resolveTemplate(prompt.InitialValue, promptResponses)
-					if err != nil {
-						return gui.surfaceError(err)
-					}
-
-					return gui.prompt(promptOpts{
-						title:          title,
-						initialContent: initialValue,
-						handleConfirm: func(str string) error {
-							promptResponses[idx] = str
-
-							return wrappedF()
-						},
-					})
+					return gui.inputPrompt(prompt, promptResponses, idx, wrappedF)
 				}
 			case "menu":
 				f = func() error {
-					// need to make a menu here some how
-					menuItems := make([]*menuItem, len(prompt.Options))
-					for i, option := range prompt.Options {
-						option := option
-
-						nameTemplate := option.Name
-						if nameTemplate == "" {
-							// this allows you to only pass values rather than bother with names/descriptions
-							nameTemplate = option.Value
-						}
-						name, err := gui.resolveTemplate(nameTemplate, promptResponses)
-						if err != nil {
-							return gui.surfaceError(err)
-						}
-
-						description, err := gui.resolveTemplate(option.Description, promptResponses)
-						if err != nil {
-							return gui.surfaceError(err)
-						}
-
-						value, err := gui.resolveTemplate(option.Value, promptResponses)
-						if err != nil {
-							return gui.surfaceError(err)
-						}
-
-						menuItems[i] = &menuItem{
-							displayStrings: []string{name, utils.ColoredString(description, color.FgYellow)},
-							onPress: func() error {
-								promptResponses[idx] = value
-
-								return wrappedF()
-							},
-						}
-					}
-
-					title, err := gui.resolveTemplate(prompt.Title, promptResponses)
-					if err != nil {
-						return gui.surfaceError(err)
-					}
-
-					return gui.createMenu(title, menuItems, createMenuOptions{showCancel: true})
+					return gui.menuPrompt(prompt, promptResponses, idx, wrappedF)
 				}
 			case "menuFromCommand":
 				f = func() error {
-					// Collect cmd to run from config
-					cmdStr, err := gui.resolveTemplate(prompt.Command, promptResponses)
-					if err != nil {
-						return gui.surfaceError(err)
-					}
-
-					// Collect Filter regexp
-					filter, err := gui.resolveTemplate(prompt.Filter, promptResponses)
-					if err != nil {
-						return gui.surfaceError(err)
-					}
-					reg, err := regexp.Compile(filter)
-					if err != nil {
-						return gui.surfaceError(errors.New("unable to parse filter regex, error: " + err.Error()))
-					}
-
-					// Run and save output
-					message, err := gui.GitCommand.RunCommandWithOutput(cmdStr)
-					if err != nil {
-						return gui.surfaceError(err)
-					}
-
-					// Need to make a menu out of what the cmd has displayed
-					candidates := []string{}
-					buff := bytes.NewBuffer(nil)
-					temp, err := template.New("format").Parse(prompt.Format)
-					if err != nil {
-						return gui.surfaceError(errors.New("unable to parse format, error: " + err.Error()))
-					}
-					for _, str := range strings.Split(string(message), "\n") {
-						if str == "" {
-							continue
-						}
-						tmplData := map[string]string{}
-						out := reg.FindAllStringSubmatch(str, -1)
-						if len(out) > 0 {
-							for groupIdx, group := range reg.SubexpNames() {
-								// Record matched group with group ids
-								matchName := "group_" + strconv.Itoa(groupIdx)
-								tmplData[matchName] = group
-								// Record last named group non-empty matches as group matches
-								if group != "" {
-									tmplData[group] = out[0][idx]
-								}
-							}
-						}
-						err = temp.Execute(buff, tmplData)
-						if err != nil {
-							return gui.surfaceError(err)
-						}
-
-						candidates = append(candidates, strings.TrimSpace(buff.String()))
-						buff.Reset()
-					}
-
-					menuItems := make([]*menuItem, len(candidates))
-					for i := range candidates {
-						menuItems[i] = &menuItem{
-							displayStrings: []string{candidates[i]},
-							onPress: func() error {
-								promptResponses[idx] = candidates[i]
-								return wrappedF()
-							},
-						}
-					}
-
-					title, err := gui.resolveTemplate(prompt.Title, promptResponses)
-					if err != nil {
-						return gui.surfaceError(err)
-					}
-
-					return gui.createMenu(title, menuItems, createMenuOptions{showCancel: true})
+					return gui.menuPromptFromCommand(prompt, promptResponses, idx, wrappedF)
 				}
 			default:
 				return gui.createErrorPanel("custom command prompt must have a type of 'input', 'menu' or 'menuFromCommand'")

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -139,7 +139,7 @@ func (gui *Gui) GenerateMenuCandidates(commandOutput string, filter string, form
 			for groupIdx, group := range reg.SubexpNames() {
 				// Record matched group with group ids
 				matchName := "group_" + strconv.Itoa(groupIdx)
-				tmplData[matchName] =  out[0][groupIdx]
+				tmplData[matchName] = out[0][groupIdx]
 				// Record last named group non-empty matches as group matches
 				if group != "" {
 					tmplData[group] = out[0][groupIdx]

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -185,7 +185,10 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand config.CustomCommand
 					// Need to make a menu out of what the cmd has displayed
 					candidates := []string{}
 					buff := bytes.NewBuffer(nil)
-					temp := template.Must(template.New("format").Parse(prompt.Format))
+					temp, err := template.New("format").Parse(prompt.Format)
+					if err != nil {
+						return gui.surfaceError(errors.New("unable to parse format, error: " + err.Error()))
+					}
 					for _, str := range strings.Split(string(message), "\n") {
 						if str == "" {
 							continue
@@ -203,7 +206,11 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand config.CustomCommand
 								}
 							}
 						}
-						temp.Execute(buff, tmplData)
+						err = temp.Execute(buff, tmplData)
+						if err != nil {
+							return gui.surfaceError(err)
+						}
+
 						candidates = append(candidates, strings.TrimSpace(buff.String()))
 						buff.Reset()
 					}

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -179,11 +179,11 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand config.CustomCommand
                                         var candidates []string
                                         reg := regexp.MustCompile(filter)
                                         for _,str := range strings.Split(string(message), "\n"){
-                                            cand := str
+                                            cand := ""
                                             if str != "" {
 					        for i := 1; i < (reg.NumSubexp()+1); i++ {
-                                                    trim := reg.ReplaceAllString(str, "${"+fmt.Sprint(i)+"}")
-                                                    cand = strings.Trim(cand, trim)
+                                                    keep := reg.ReplaceAllString(str, "${"+fmt.Sprint(i)+"}")
+                                                    cand += keep
                                                 }
                                                 candidates = append(candidates, cand)
                                             }

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -117,7 +117,8 @@ func (gui *Gui) menuPrompt(prompt config.CustomCommandPrompt, promptResponses []
 
 	return gui.createMenu(title, menuItems, createMenuOptions{showCancel: true})
 }
-func (gui *Gui) generateMenuCandidates(commandOutput string, filter string, format string) ([]string, error) {
+
+func (gui *Gui) GenerateMenuCandidates(commandOutput string, filter string, format string) ([]string, error) {
 	candidates := []string{}
 	reg, err := regexp.Compile(filter)
 	if err != nil {
@@ -138,7 +139,7 @@ func (gui *Gui) generateMenuCandidates(commandOutput string, filter string, form
 			for groupIdx, group := range reg.SubexpNames() {
 				// Record matched group with group ids
 				matchName := "group_" + strconv.Itoa(groupIdx)
-				tmplData[matchName] = group
+				tmplData[matchName] =  out[0][groupIdx]
 				// Record last named group non-empty matches as group matches
 				if group != "" {
 					tmplData[group] = out[0][groupIdx]
@@ -176,7 +177,10 @@ func (gui *Gui) menuPromptFromCommand(prompt config.CustomCommandPrompt, promptR
 	}
 
 	// Need to make a menu out of what the cmd has displayed
-	candidates, err := gui.generateMenuCandidates(message, filter, prompt.Format)
+	candidates, err := gui.GenerateMenuCandidates(message, filter, prompt.Format)
+	if err != nil {
+		return gui.surfaceError(err)
+	}
 
 	menuItems := make([]*menuItem, len(candidates))
 	for i := range candidates {

--- a/pkg/gui/dummies.go
+++ b/pkg/gui/dummies.go
@@ -1,21 +1,21 @@
 package gui
 
 import (
-	"github.com/jesseduffield/lazygit/pkg/config"
-	"github.com/jesseduffield/lazygit/pkg/utils"
-	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 	"github.com/jesseduffield/lazygit/pkg/commands"
+	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
+	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/i18n"
 	"github.com/jesseduffield/lazygit/pkg/updates"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 // NewDummyGui creates a new dummy GUI for testing
 func NewDummyUpdater() *updates.Updater {
-    DummyUpdater, _ := updates.NewUpdater(utils.NewDummyLog(), config.NewDummyAppConfig(), oscommands.NewDummyOSCommand(), i18n.NewTranslationSet(utils.NewDummyLog()))
-    return DummyUpdater
+	DummyUpdater, _ := updates.NewUpdater(utils.NewDummyLog(), config.NewDummyAppConfig(), oscommands.NewDummyOSCommand(), i18n.NewTranslationSet(utils.NewDummyLog()))
+	return DummyUpdater
 }
 
 func NewDummyGui() *Gui {
-        DummyGui, _ := NewGui(utils.NewDummyLog(), commands.NewDummyGitCommand(), oscommands.NewDummyOSCommand(), i18n.NewTranslationSet(utils.NewDummyLog()), config.NewDummyAppConfig(), NewDummyUpdater(), "", false)
+	DummyGui, _ := NewGui(utils.NewDummyLog(), commands.NewDummyGitCommand(), oscommands.NewDummyOSCommand(), i18n.NewTranslationSet(utils.NewDummyLog()), config.NewDummyAppConfig(), NewDummyUpdater(), "", false)
 	return DummyGui
 }

--- a/pkg/gui/dummies.go
+++ b/pkg/gui/dummies.go
@@ -1,0 +1,21 @@
+package gui
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	"github.com/jesseduffield/lazygit/pkg/utils"
+	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
+	"github.com/jesseduffield/lazygit/pkg/commands"
+	"github.com/jesseduffield/lazygit/pkg/i18n"
+	"github.com/jesseduffield/lazygit/pkg/updates"
+)
+
+// NewDummyGui creates a new dummy GUI for testing
+func NewDummyUpdater() *updates.Updater {
+    DummyUpdater, _ := updates.NewUpdater(utils.NewDummyLog(), config.NewDummyAppConfig(), oscommands.NewDummyOSCommand(), i18n.NewTranslationSet(utils.NewDummyLog()))
+    return DummyUpdater
+}
+
+func NewDummyGui() *Gui {
+        DummyGui, _ := NewGui(utils.NewDummyLog(), commands.NewDummyGitCommand(), oscommands.NewDummyOSCommand(), i18n.NewTranslationSet(utils.NewDummyLog()), config.NewDummyAppConfig(), NewDummyUpdater(), "", false)
+	return DummyGui
+}

--- a/pkg/gui/gui_test.go
+++ b/pkg/gui/gui_test.go
@@ -80,3 +80,52 @@ func runCmdHeadless(cmd *exec.Cmd) error {
 
 	return f.Close()
 }
+
+func TestGuiGenerateMenuCandidates(t *testing.T) {
+	type scenario struct {
+		testName string
+		cmdOut   string
+		filter   string
+                format   string
+		test     func([]string, error)
+	}
+
+	scenarios := []scenario{
+		{
+			"Extract remote branch name",
+                        "upstream/pr-1",
+                        "upstream/(?P<branch>.*)",
+                        "{{ .branch }}",
+			func(actual []string, err error) {
+                            assert.NoError(t, err)
+                            assert.EqualValues(t, "pr-1", actual[0])
+			},
+		},
+		{
+			"Multiple named groups",
+                        "upstream/pr-1",
+                        "(?P<remote>[a-z]*)/(?P<branch>.*)",
+                        "{{ .branch }}|{{ .remote }}",
+			func(actual []string, err error) {
+                            assert.NoError(t, err)
+                            assert.EqualValues(t, "pr-1|upstream", actual[0])
+			},
+		},
+		{
+			"Multiple named groups with group ids",
+                        "upstream/pr-1",
+                        "(?P<remote>[a-z]*)/(?P<branch>.*)",
+                        "{{ .group_2 }}|{{ .group_1 }}",
+			func(actual []string, err error) {
+                            assert.NoError(t, err)
+                            assert.EqualValues(t, "pr-1|upstream", actual[0])
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			s.test(NewDummyGui().GenerateMenuCandidates(s.cmdOut, s.filter, s.format))
+		})
+	}
+}

--- a/pkg/gui/gui_test.go
+++ b/pkg/gui/gui_test.go
@@ -86,39 +86,39 @@ func TestGuiGenerateMenuCandidates(t *testing.T) {
 		testName string
 		cmdOut   string
 		filter   string
-                format   string
+		format   string
 		test     func([]string, error)
 	}
 
 	scenarios := []scenario{
 		{
 			"Extract remote branch name",
-                        "upstream/pr-1",
-                        "upstream/(?P<branch>.*)",
-                        "{{ .branch }}",
+			"upstream/pr-1",
+			"upstream/(?P<branch>.*)",
+			"{{ .branch }}",
 			func(actual []string, err error) {
-                            assert.NoError(t, err)
-                            assert.EqualValues(t, "pr-1", actual[0])
+				assert.NoError(t, err)
+				assert.EqualValues(t, "pr-1", actual[0])
 			},
 		},
 		{
 			"Multiple named groups",
-                        "upstream/pr-1",
-                        "(?P<remote>[a-z]*)/(?P<branch>.*)",
-                        "{{ .branch }}|{{ .remote }}",
+			"upstream/pr-1",
+			"(?P<remote>[a-z]*)/(?P<branch>.*)",
+			"{{ .branch }}|{{ .remote }}",
 			func(actual []string, err error) {
-                            assert.NoError(t, err)
-                            assert.EqualValues(t, "pr-1|upstream", actual[0])
+				assert.NoError(t, err)
+				assert.EqualValues(t, "pr-1|upstream", actual[0])
 			},
 		},
 		{
 			"Multiple named groups with group ids",
-                        "upstream/pr-1",
-                        "(?P<remote>[a-z]*)/(?P<branch>.*)",
-                        "{{ .group_2 }}|{{ .group_1 }}",
+			"upstream/pr-1",
+			"(?P<remote>[a-z]*)/(?P<branch>.*)",
+			"{{ .group_2 }}|{{ .group_1 }}",
 			func(actual []string, err error) {
-                            assert.NoError(t, err)
-                            assert.EqualValues(t, "pr-1|upstream", actual[0])
+				assert.NoError(t, err)
+				assert.EqualValues(t, "pr-1|upstream", actual[0])
 			},
 		},
 	}


### PR DESCRIPTION
As described is #1388, I needed the functionality of running a git command, saving its output and using
it to generate a menu of options for a custom command.

As a bonus, a filter, accepting a `regexp` where the captured groups are collected from the output of the command, can be
used to alter command output before generating the menu options.


I'm using this to checkout a remote branch (Mostly for non-github PRs) without merging:
```yml
customCommands:
  - key : 'r'
    description: 'Checkout a remote branch as FETCH_HEAD'
    command: "git fetch {{index .PromptResponses 0}} {{index .PromptResponses 1}} && git checkout FETCH_HEAD"
    context: 'remotes'
    prompts:
      - type: 'input'
        title: 'Remote:'
        initialValue: "{{index .SelectedRemote.Name }}"
      - type: 'menuFromCommand'
        title: 'Remote branch:'
        command: 'git branch  -r --list {{index .PromptResponses 0}}/*'
        filter: '.*{{index .PromptResponses 0}}/(.*)'
```

This looks like this on lazygit repo (upstream for me, one can also use `menuFromCommand` to generate registered remotes):
![2021-07-17_19-36](https://user-images.githubusercontent.com/34474472/126046617-b22e02f4-a017-4d24-9467-334f495fd685.png)

Disclaimer: I don't know much Go, so maybe there are better ways to do this; I welcome suggestions.