### PR TITLE
suffix $CONFIG_DIR with lazygit

### DIFF
--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -94,7 +95,7 @@ func ConfigDir() string {
 func configDirForVendor(vendor string) string {
 	envConfigDir := os.Getenv("CONFIG_DIR")
 	if envConfigDir != "" {
-		return envConfigDir
+		return path.Join(envConfigDir, "lazygit")
 	}
 	configDirs := xdg.New(vendor, "lazygit")
 	return configDirs.ConfigHome()


### PR DESCRIPTION
$CONFIG_DIR is such a generic variable i think it's meant to be the config dir we place `lazygit/config.yml` inside of not `config.yml` directly inside of