### PR TITLE
more treeish files

### DIFF
--- a/pkg/gui/filetree/build_tree_test.go
+++ b/pkg/gui/filetree/build_tree_test.go
@@ -54,23 +54,33 @@ func TestBuildTreeFromFiles(t *testing.T) {
 			name: "paths that can be compressed",
 			files: []*models.File{
 				{
-					Name: "dir1/a",
+					Name: "dir1/dir3/a",
 				},
 				{
-					Name: "dir2/b",
+					Name: "dir2/dir4/b",
 				},
 			},
 			expected: &FileNode{
 				Path: "",
 				Children: []*FileNode{
 					{
-						File:             &models.File{Name: "dir1/a"},
-						Path:             "dir1/a",
+						Path: "dir1/dir3",
+						Children: []*FileNode{
+							{
+								File: &models.File{Name: "dir1/dir3/a"},
+								Path: "dir1/dir3/a",
+							},
+						},
 						CompressionLevel: 1,
 					},
 					{
-						File:             &models.File{Name: "dir2/b"},
-						Path:             "dir2/b",
+						Path: "dir2/dir4",
+						Children: []*FileNode{
+							{
+								File: &models.File{Name: "dir2/dir4/b"},
+								Path: "dir2/dir4/b",
+							},
+						},
 						CompressionLevel: 1,
 					},
 				},
@@ -201,12 +211,12 @@ func TestBuildFlatTreeFromFiles(t *testing.T) {
 					{
 						File:             &models.File{Name: "dir1/a"},
 						Path:             "dir1/a",
-						CompressionLevel: 1,
+						CompressionLevel: 0,
 					},
 					{
 						File:             &models.File{Name: "dir2/b"},
 						Path:             "dir2/b",
-						CompressionLevel: 1,
+						CompressionLevel: 0,
 					},
 				},
 			},
@@ -351,23 +361,33 @@ func TestBuildTreeFromCommitFiles(t *testing.T) {
 			name: "paths that can be compressed",
 			files: []*models.CommitFile{
 				{
-					Name: "dir1/a",
+					Name: "dir1/dir3/a",
 				},
 				{
-					Name: "dir2/b",
+					Name: "dir2/dir4/b",
 				},
 			},
 			expected: &CommitFileNode{
 				Path: "",
 				Children: []*CommitFileNode{
 					{
-						File:             &models.CommitFile{Name: "dir1/a"},
-						Path:             "dir1/a",
+						Path: "dir1/dir3",
+						Children: []*CommitFileNode{
+							{
+								File: &models.CommitFile{Name: "dir1/dir3/a"},
+								Path: "dir1/dir3/a",
+							},
+						},
 						CompressionLevel: 1,
 					},
 					{
-						File:             &models.CommitFile{Name: "dir2/b"},
-						Path:             "dir2/b",
+						Path: "dir2/dir4",
+						Children: []*CommitFileNode{
+							{
+								File: &models.CommitFile{Name: "dir2/dir4/b"},
+								Path: "dir2/dir4/b",
+							},
+						},
 						CompressionLevel: 1,
 					},
 				},
@@ -464,12 +484,12 @@ func TestBuildFlatTreeFromCommitFiles(t *testing.T) {
 					{
 						File:             &models.CommitFile{Name: "dir1/a"},
 						Path:             "dir1/a",
-						CompressionLevel: 1,
+						CompressionLevel: 0,
 					},
 					{
 						File:             &models.CommitFile{Name: "dir2/b"},
 						Path:             "dir2/b",
-						CompressionLevel: 1,
+						CompressionLevel: 0,
 					},
 				},
 			},

--- a/pkg/gui/filetree/file_node_test.go
+++ b/pkg/gui/filetree/file_node_test.go
@@ -84,9 +84,13 @@ func TestCompress(t *testing.T) {
 				Path: "",
 				Children: []*FileNode{
 					{
-						Path:             "dir1/file2",
-						File:             &models.File{Name: "file2", ShortStatus: "M ", HasUnstagedChanges: true},
-						CompressionLevel: 1,
+						Path: "dir1",
+						Children: []*FileNode{
+							{
+								File: &models.File{Name: "file2", ShortStatus: "M ", HasUnstagedChanges: true},
+								Path: "dir1/file2",
+							},
+						},
 					},
 					{
 						Path: "dir2",
@@ -102,9 +106,14 @@ func TestCompress(t *testing.T) {
 						},
 					},
 					{
-						Path:             "dir3/dir3-1/file5",
-						File:             &models.File{Name: "file5", ShortStatus: "M ", HasUnstagedChanges: true},
-						CompressionLevel: 2,
+						Path:             "dir3/dir3-1",
+						CompressionLevel: 1,
+						Children: []*FileNode{
+							{
+								File: &models.File{Name: "file5", ShortStatus: "M ", HasUnstagedChanges: true},
+								Path: "dir3/dir3-1/file5",
+							},
+						},
 					},
 					{
 						File: &models.File{Name: "file1", ShortStatus: "M ", HasUnstagedChanges: true},

--- a/pkg/gui/filetree/inode.go
+++ b/pkg/gui/filetree/inode.go
@@ -170,7 +170,7 @@ func compressAux(node INode) INode {
 	children := node.GetChildren()
 	for i := range children {
 		grandchildren := children[i].GetChildren()
-		for len(grandchildren) == 1 {
+		for len(grandchildren) == 1 && !grandchildren[0].IsLeaf() {
 			grandchildren[0].SetCompressionLevel(children[i].GetCompressionLevel() + 1)
 			children[i] = grandchildren[0]
 			grandchildren = children[i].GetChildren()


### PR DESCRIPTION
Now we'll always show a file on a separate line to the directories. This makes it a little more obvious you're in tree-view and helps you see the whole file name if you're short on horizontal space

![image](https://user-images.githubusercontent.com/8456633/127143342-0b3f4f7d-5acc-4462-bef4-3506dee2e401.png)
