### PR TITLE
PRs CI Build less types of go binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,37 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cache/go-build
-          key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}
+          key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-test
           restore-keys: |
             ${{runner.os}}-go-
-      - name: Format code
-        run: |
-          if [ $(find . ! -path "./vendor/*" -name "*.go" -exec gofmt -s -d {} \;|wc -l) -gt 0 ]; then
-           find . ! -path "./vendor/*" -name "*.go" -exec gofmt -s -d {} \;
-           exit 1
-          fi
       - name: Test code
         run: |
           ./test.sh
-      - name: Build binaries
-        uses: goreleaser/goreleaser-action@v1
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GOFLAGS: -mod=vendor
+      GOARCH: amd64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v1
         with:
-          args: --skip-publish --snapshot
+          go-version: 1.16.x
+      - name: Cache build
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/go-build
+          key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-build
+          restore-keys: |
+            ${{runner.os}}-go-
+      - name: Build linux binary
+        run: |
+          GOOS=linux go build
+      - name: Build windows binary
+        run: |
+          GOOS=windows go build
+      - name: Build darwin binary
+        run: |
+          GOOS=darwin go build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,3 +12,9 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: latest
+      - name: Format code
+        run: |
+          if [ $(find . ! -path "./vendor/*" -name "*.go" -exec gofmt -s -d {} \;|wc -l) -gt 0 ]; then
+           find . ! -path "./vendor/*" -name "*.go" -exec gofmt -s -d {} \;
+           exit 1
+          fi

--- a/pkg/secureexec/secureexec_windows.go
+++ b/pkg/secureexec/secureexec_windows.go
@@ -20,6 +20,8 @@ import (
 // you call `git status` from the command line directly but no harm in playing it
 // safe.
 
+This should fail the CI only on windows
+
 func Command(name string, args ...string) *exec.Cmd {
 	bin, err := safeexec.LookPath(name)
 	if err != nil {

--- a/pkg/secureexec/secureexec_windows.go
+++ b/pkg/secureexec/secureexec_windows.go
@@ -20,8 +20,6 @@ import (
 // you call `git status` from the command line directly but no harm in playing it
 // safe.
 
-This should fail the CI only on windows
-
 func Command(name string, args ...string) *exec.Cmd {
 	bin, err := safeexec.LookPath(name)
 	if err != nil {


### PR DESCRIPTION
The PR CI takes very long and that's quite annoying to wait for,
This separate the build step from the testing and linting and skips building for a lot of arches as we don't really have arch specific code 