### PR TITLE
show github pr number in branches list

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -39,8 +39,8 @@
 
 <pre>
   <kbd>space</kbd>: checkout
-  <kbd>o</kbd>: create pull request
-  <kbd>O</kbd>: create pull request options
+  <kbd>o</kbd>: create / show pull request
+  <kbd>O</kbd>: create / show pull request options
   <kbd>ctrl+y</kbd>: copy pull request URL to clipboard
   <kbd>c</kbd>: checkout by name
   <kbd>F</kbd>: force checkout

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -39,7 +39,7 @@
 
 <pre>
   <kbd>space</kbd>: uitchecken
-  <kbd>o</kbd>: maak een pull-request
+  <kbd>o</kbd>: maak of laat een pull-request zien
   <kbd>O</kbd>: bekijk opties voor pull-aanvraag
   <kbd>ctrl+y</kbd>: kopieer de URL van het pull-verzoek naar het klembord
   <kbd>c</kbd>: uitchecken bij naam

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-errors/errors"
 
 	gogit "github.com/jesseduffield/go-git/v5"
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 	"github.com/jesseduffield/lazygit/pkg/commands/patch"
 	"github.com/jesseduffield/lazygit/pkg/config"
@@ -39,6 +40,8 @@ type GitCommand struct {
 
 	// Push to current determines whether the user has configured to push to the remote branch of the same name as the current or not
 	PushToCurrent bool
+
+	GithubRecentPRs map[string]models.GithubPullRequest
 }
 
 // NewGitCommand it runs git commands

--- a/pkg/commands/github.go
+++ b/pkg/commands/github.go
@@ -1,0 +1,65 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
+)
+
+func (c *GitCommand) GithubMostRecentPRs() map[string]models.GithubPullRequest {
+	commandOutput, err := c.OSCommand.RunCommandWithOutput("gh pr list --limit 50 --state all --json state,url,number,headRefName,headRepositoryOwner")
+	if err != nil {
+		fmt.Println(1, err)
+		return nil
+	}
+
+	prs := []models.GithubPullRequest{}
+	err = json.Unmarshal([]byte(commandOutput), &prs)
+	if err != nil {
+		fmt.Println(2, err)
+		return nil
+	}
+
+	res := map[string]models.GithubPullRequest{}
+	for _, pr := range prs {
+		res[pr.HeadRepositoryOwner.Login+":"+pr.HeadRefName] = pr
+	}
+	return res
+}
+
+func (c *GitCommand) InjectGithubPullRequests(prs map[string]models.GithubPullRequest, branches []*models.Branch) bool {
+	if len(prs) == 0 {
+		return false
+	}
+
+	remotesToOwnersMap, _ := c.GetRemotesToOwnersMap()
+	if len(remotesToOwnersMap) == 0 {
+		return false
+	}
+
+	foundBranchWithGithubPullRequest := false
+
+	for _, branch := range branches {
+		if branch.UpstreamName == "" {
+			continue
+		}
+
+		remoteAndName := strings.SplitN(branch.UpstreamName, "/", 2)
+		owner, foundRemoteOwner := remotesToOwnersMap[remoteAndName[0]]
+		if len(remoteAndName) != 2 || !foundRemoteOwner {
+			continue
+		}
+
+		pr, hasPr := prs[owner+":"+remoteAndName[1]]
+		if !hasPr {
+			continue
+		}
+
+		foundBranchWithGithubPullRequest = true
+		branch.PR = &pr
+	}
+
+	return foundBranchWithGithubPullRequest
+}

--- a/pkg/commands/github_test.go
+++ b/pkg/commands/github_test.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/jesseduffield/lazygit/pkg/secureexec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGithubMostRecentPRs(t *testing.T) {
+	scenarios := []struct {
+		testName string
+		response string
+		expect   map[string]models.GithubPullRequest
+	}{
+		{
+			"no response",
+			"",
+			nil,
+		},
+		{
+			"error response",
+			"none of the git remotes configured for this repository point to a known GitHub host. To tell gh about a new GitHub host, please use `gh auth login`",
+			nil,
+		},
+		{
+			"empty response",
+			"[]",
+			map[string]models.GithubPullRequest{},
+		},
+		{
+			"response with data",
+			`[{
+				"headRefName": "command-log-2",
+				"number": 1249,
+				"state": "MERGED",
+				"url": "https://github.com/jesseduffield/lazygit/pull/1249",
+				"headRepositoryOwner": {
+					"id": "MDQ6VXNlcjg0NTY2MzM=",
+					"name": "Jesse Duffield",
+					"login": "jesseduffield"
+				}
+			}]`,
+			map[string]models.GithubPullRequest{
+				"jesseduffield:command-log-2": {
+					HeadRefName: "command-log-2",
+					Number:      1249,
+					State:       "MERGED",
+					Url:         "https://github.com/jesseduffield/lazygit/pull/1249",
+					HeadRepositoryOwner: models.GithubRepositoryOwner{
+						ID:    "MDQ6VXNlcjg0NTY2MzM=",
+						Name:  "Jesse Duffield",
+						Login: "jesseduffield",
+					},
+				},
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			gitCmd := NewDummyGitCommand()
+			gitCmd.OSCommand.Command = func(cmd string, args ...string) *exec.Cmd {
+				assert.EqualValues(t, "gh", cmd)
+				assert.EqualValues(t, []string{"pr", "list", "--limit", "50", "--state", "all", "--json", "state,url,number,headRefName,headRepositoryOwner"}, args)
+				return secureexec.Command("echo", s.response)
+			}
+
+			res := gitCmd.GithubMostRecentPRs()
+			assert.Equal(t, s.expect, res)
+		})
+	}
+}

--- a/pkg/commands/loading_branches.go
+++ b/pkg/commands/loading_branches.go
@@ -99,8 +99,8 @@ func (b *BranchListBuilder) obtainBranches() []*models.Branch {
 }
 
 // Build the list of branches for the current repo
-func (b *BranchListBuilder) Build() []*models.Branch {
-	branches := b.obtainBranches()
+func (b *BranchListBuilder) Build() (branches []*models.Branch, branchesWithGithubPullRequests bool) {
+	branches = b.obtainBranches()
 
 	reflogBranches := b.obtainReflogBranches()
 
@@ -138,9 +138,17 @@ outer:
 		if err != nil {
 			panic(err)
 		}
-		branches = append([]*models.Branch{{Name: currentBranchName, DisplayName: currentBranchDisplayName, Head: true, Recency: "  *"}}, branches...)
+		branches = append([]*models.Branch{{
+			Name:        currentBranchName,
+			DisplayName: currentBranchDisplayName,
+			Head:        true,
+			Recency:     "  *",
+		}}, branches...)
 	}
-	return branches
+
+	branchesWithGithubPullRequests = b.GitCommand.InjectGithubPullRequests(b.GitCommand.GithubRecentPRs, branches)
+
+	return
 }
 
 // TODO: only look at the new reflog commits, and otherwise store the recencies in

--- a/pkg/commands/models/branch.go
+++ b/pkg/commands/models/branch.go
@@ -11,6 +11,7 @@ type Branch struct {
 	Pullables    string
 	UpstreamName string
 	Head         bool
+	PR           *GithubPullRequest
 }
 
 func (b *Branch) RefName() string {

--- a/pkg/commands/models/github.go
+++ b/pkg/commands/models/github.go
@@ -1,0 +1,15 @@
+package models
+
+type GithubPullRequest struct {
+	HeadRefName         string                `json:"headRefName"`
+	Number              int                   `json:"number"`
+	State               string                `json:"state"` // "MERGED", "OPEN", "CLOSED"
+	Url                 string                `json:"url"`
+	HeadRepositoryOwner GithubRepositoryOwner `json:"headRepositoryOwner"`
+}
+
+type GithubRepositoryOwner struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Login string `json:"login"`
+}

--- a/pkg/commands/pull_request.go
+++ b/pkg/commands/pull_request.go
@@ -153,34 +153,9 @@ func (pr *PullRequest) getPullRequestURL(from string, to string) (string, error)
 		return "", errors.New(pr.GitCommand.Tr.UnsupportedGitService)
 	}
 
-	repoInfo := getRepoInfoFromURL(repoURL)
+	repoInfo := GetRepoInfoFromURL(repoURL)
 
 	pullRequestURL := gitService.PullRequestURL(repoInfo.Owner, repoInfo.Repository, from, to)
 
 	return pullRequestURL, nil
-}
-
-func getRepoInfoFromURL(url string) *RepoInformation {
-	isHTTP := strings.HasPrefix(url, "http")
-
-	if isHTTP {
-		splits := strings.Split(url, "/")
-		owner := strings.Join(splits[3:len(splits)-1], "/")
-		repo := strings.TrimSuffix(splits[len(splits)-1], ".git")
-
-		return &RepoInformation{
-			Owner:      owner,
-			Repository: repo,
-		}
-	}
-
-	tmpSplit := strings.Split(url, ":")
-	splits := strings.Split(tmpSplit[1], "/")
-	owner := strings.Join(splits[0:len(splits)-1], "/")
-	repo := strings.TrimSuffix(splits[len(splits)-1], ".git")
-
-	return &RepoInformation{
-		Owner:      owner,
-		Repository: repo,
-	}
 }

--- a/pkg/commands/pull_request_test.go
+++ b/pkg/commands/pull_request_test.go
@@ -38,7 +38,7 @@ func TestGetRepoInfoFromURL(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.testName, func(t *testing.T) {
-			s.test(getRepoInfoFromURL(s.repoURL))
+			s.test(GetRepoInfoFromURL(s.repoURL))
 		})
 	}
 }

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -192,19 +192,19 @@ type KeybindingFilesConfig struct {
 }
 
 type KeybindingBranchesConfig struct {
-	CreatePullRequest      string `yaml:"createPullRequest"`
-	ViewPullRequestOptions string `yaml:"viewPullRequestOptions"`
-	CopyPullRequestURL     string `yaml:"copyPullRequestURL"`
-	CheckoutBranchByName   string `yaml:"checkoutBranchByName"`
-	ForceCheckoutBranch    string `yaml:"forceCheckoutBranch"`
-	RebaseBranch           string `yaml:"rebaseBranch"`
-	RenameBranch           string `yaml:"renameBranch"`
-	MergeIntoCurrentBranch string `yaml:"mergeIntoCurrentBranch"`
-	ViewGitFlowOptions     string `yaml:"viewGitFlowOptions"`
-	FastForward            string `yaml:"fastForward"`
-	PushTag                string `yaml:"pushTag"`
-	SetUpstream            string `yaml:"setUpstream"`
-	FetchRemote            string `yaml:"fetchRemote"`
+	CreateOrShowPullRequest string `yaml:"createPullRequest"`
+	ViewPullRequestOptions  string `yaml:"viewPullRequestOptions"`
+	CopyPullRequestURL      string `yaml:"copyPullRequestURL"`
+	CheckoutBranchByName    string `yaml:"checkoutBranchByName"`
+	ForceCheckoutBranch     string `yaml:"forceCheckoutBranch"`
+	RebaseBranch            string `yaml:"rebaseBranch"`
+	RenameBranch            string `yaml:"renameBranch"`
+	MergeIntoCurrentBranch  string `yaml:"mergeIntoCurrentBranch"`
+	ViewGitFlowOptions      string `yaml:"viewGitFlowOptions"`
+	FastForward             string `yaml:"fastForward"`
+	PushTag                 string `yaml:"pushTag"`
+	SetUpstream             string `yaml:"setUpstream"`
+	FetchRemote             string `yaml:"fetchRemote"`
 }
 
 type KeybindingCommitsConfig struct {
@@ -436,19 +436,19 @@ func GetDefaultConfig() *UserConfig {
 				OpenMergeTool:            "M",
 			},
 			Branches: KeybindingBranchesConfig{
-				CopyPullRequestURL:     "<c-y>",
-				CreatePullRequest:      "o",
-				ViewPullRequestOptions: "O",
-				CheckoutBranchByName:   "c",
-				ForceCheckoutBranch:    "F",
-				RebaseBranch:           "r",
-				RenameBranch:           "R",
-				MergeIntoCurrentBranch: "M",
-				ViewGitFlowOptions:     "i",
-				FastForward:            "f",
-				PushTag:                "P",
-				SetUpstream:            "u",
-				FetchRemote:            "f",
+				CopyPullRequestURL:      "<c-y>",
+				CreateOrShowPullRequest: "o",
+				ViewPullRequestOptions:  "O",
+				CheckoutBranchByName:    "c",
+				ForceCheckoutBranch:     "F",
+				RebaseBranch:            "r",
+				RenameBranch:            "R",
+				MergeIntoCurrentBranch:  "M",
+				ViewGitFlowOptions:      "i",
+				FastForward:             "f",
+				PushTag:                 "P",
+				SetUpstream:             "u",
+				FetchRemote:             "f",
 			},
 			Commits: KeybindingCommitsConfig{
 				SquashDown:                   "s",

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -61,12 +61,23 @@ func (gui *Gui) handleCommitSelect() error {
 func (gui *Gui) refreshReflogCommitsConsideringStartup() {
 	switch gui.State.StartupStage {
 	case INITIAL:
+		var wg sync.WaitGroup
+		wg.Add(1)
+
 		go utils.Safe(func() {
 			_ = gui.refreshReflogCommits()
 			gui.refreshBranches()
 			gui.State.StartupStage = COMPLETE
+			wg.Done()
 		})
-
+		go utils.Safe(func() {
+			// The github cli can be quite slow so we load the github PRs sparately
+			gui.refreshGithubPullRequests()
+			wg.Wait()
+			gui.State.BranchesWithGithubPullRequests = gui.GitCommand.InjectGithubPullRequests(gui.GitCommand.GithubRecentPRs, gui.State.Branches)
+			_ = gui.postRefreshUpdate(gui.State.Contexts.Branches)
+			gui.refreshStatus()
+		})
 	case COMPLETE:
 		_ = gui.refreshReflogCommits()
 	}

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -289,12 +289,13 @@ type guiMutexes struct {
 type guiState struct {
 	// the file panels (files and commit files) can render as a tree, so we have
 	// managers for them which handle rendering a flat list of files in tree form
-	FileManager       *filetree.FileManager
-	CommitFileManager *filetree.CommitFileManager
-	Submodules        []*models.SubmoduleConfig
-	Branches          []*models.Branch
-	Commits           []*models.Commit
-	StashEntries      []*models.StashEntry
+	FileManager                    *filetree.FileManager
+	CommitFileManager              *filetree.CommitFileManager
+	Submodules                     []*models.SubmoduleConfig
+	Branches                       []*models.Branch
+	BranchesWithGithubPullRequests bool
+	Commits                        []*models.Commit
+	StashEntries                   []*models.StashEntry
 	// Suggestions will sometimes appear when typing into a prompt
 	Suggestions []*types.Suggestion
 	// FilteredReflogCommits are the ones that appear in the reflog panel.

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -541,16 +541,16 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		{
 			ViewName:    "branches",
 			Contexts:    []string{string(LOCAL_BRANCHES_CONTEXT_KEY)},
-			Key:         gui.getKey(config.Branches.CreatePullRequest),
-			Handler:     gui.handleCreatePullRequestPress,
-			Description: gui.Tr.LcCreatePullRequest,
+			Key:         gui.getKey(config.Branches.CreateOrShowPullRequest),
+			Handler:     gui.handleCreateOrShowPullRequestPress,
+			Description: gui.Tr.LcCreateOrShowPullRequest,
 		},
 		{
 			ViewName:    "branches",
 			Contexts:    []string{string(LOCAL_BRANCHES_CONTEXT_KEY)},
 			Key:         gui.getKey(config.Branches.ViewPullRequestOptions),
-			Handler:     gui.handleCreatePullRequestMenu,
-			Description: gui.Tr.LcCreatePullRequestOptions,
+			Handler:     gui.handleCreateOrOpenPullRequestMenu,
+			Description: gui.Tr.LcCreateOrOpenPullRequestOptions,
 			OpensMenu:   true,
 		},
 		{

--- a/pkg/gui/list_context_config.go
+++ b/pkg/gui/list_context_config.go
@@ -70,7 +70,12 @@ func (gui *Gui) branchesListContext() *ListContext {
 		Gui:                        gui,
 		ResetMainViewOriginOnFocus: true,
 		GetDisplayStrings: func() [][]string {
-			return presentation.GetBranchListDisplayStrings(gui.State.Branches, gui.State.ScreenMode != SCREEN_NORMAL, gui.State.Modes.Diffing.Ref)
+			return presentation.GetBranchListDisplayStrings(
+				gui.State.Branches,
+				gui.State.ScreenMode != SCREEN_NORMAL,
+				gui.State.Modes.Diffing.Ref,
+				gui.State.BranchesWithGithubPullRequests,
+			)
 		},
 		SelectedItem: func() (ListItem, bool) {
 			item := gui.getSelectedBranch()

--- a/pkg/gui/pull_request_menu_panel.go
+++ b/pkg/gui/pull_request_menu_panel.go
@@ -2,13 +2,14 @@ package gui
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/jesseduffield/lazygit/pkg/commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 )
 
-func (gui *Gui) createPullRequestMenu(selectedBranch *models.Branch, checkedOutBranch *models.Branch) error {
+func (gui *Gui) createOrOpenPullRequestMenu(selectedBranch *models.Branch, checkedOutBranch *models.Branch) error {
 	menuItems := make([]*menuItem, 0, 4)
 
 	fromToDisplayStrings := func(from string, to string) []string {
@@ -38,6 +39,15 @@ func (gui *Gui) createPullRequestMenu(selectedBranch *models.Branch, checkedOutB
 		}
 	}
 
+	if selectedBranch.PR != nil {
+		menuItems = append(menuItems, &menuItem{
+			displayString: "open #" + strconv.Itoa(selectedBranch.PR.Number),
+			onPress: func() error {
+				return gui.OSCommand.OpenLink(selectedBranch.PR.Url)
+			},
+		})
+	}
+
 	if selectedBranch != checkedOutBranch {
 		menuItems = append(menuItems,
 			&menuItem{
@@ -52,7 +62,7 @@ func (gui *Gui) createPullRequestMenu(selectedBranch *models.Branch, checkedOutB
 
 	menuItems = append(menuItems, menuItemsForBranch(selectedBranch)...)
 
-	return gui.createMenu(fmt.Sprintf(gui.Tr.CreatePullRequestOptions), menuItems, createMenuOptions{showCancel: true})
+	return gui.createMenu(fmt.Sprintf(gui.Tr.CreateOrOpenPullRequestOptions), menuItems, createMenuOptions{showCancel: true})
 }
 
 func (gui *Gui) createPullRequest(from string, to string) error {
@@ -61,7 +71,7 @@ func (gui *Gui) createPullRequest(from string, to string) error {
 	if err != nil {
 		return gui.surfaceError(err)
 	}
-	gui.OnRunCommand(oscommands.NewCmdLogEntry(fmt.Sprintf(gui.Tr.CreatingPullRequestAtUrl, url), gui.Tr.CreatePullRequest, false))
+	gui.OnRunCommand(oscommands.NewCmdLogEntry(fmt.Sprintf(gui.Tr.CreatingPullRequestAtUrl, url), gui.Tr.CreateOrShowPullRequest, false))
 
 	return nil
 }

--- a/pkg/i18n/chinese.go
+++ b/pkg/i18n/chinese.go
@@ -176,7 +176,7 @@ func chineseTranslationSet() TranslationSet {
 		SwitchRepo:                          `切换到最近的仓库`,
 		LcAllBranchesLogGraph:               `显示所有分支日志`,
 		UnsupportedGitService:               `不支持的git服务`,
-		LcCreatePullRequest:                 `创建pull请求`,
+		LcCreateOrShowPullRequest:           `创建pull请求`,
 		LcCopyPullRequestURL:                `将拉取请求URL复制到剪贴板`,
 		NoBranchOnRemote:                    `该分支在远程上不存在。您需要先将其推送到远程.`,
 		LcFetch:                             `fetch`,

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -154,7 +154,7 @@ func dutchTranslationSet() TranslationSet {
 		SwitchRepo:                          "wissel naar een recente repo",
 		LcAllBranchesLogGraph:               `alle logs van de branch laten zien`,
 		UnsupportedGitService:               `Niet-ondersteunde git-service`,
-		LcCreatePullRequest:                 `maak een pull-request`,
+		LcCreateOrShowPullRequest:           `maak of laat een pull-request zien`,
 		LcCopyPullRequestURL:                `kopieer de URL van het pull-verzoek naar het klembord`,
 		NoBranchOnRemote:                    `Deze branch bestaat niet op de remote. U moet het eerst naar de remote pushen.`,
 		LcFetch:                             `fetch`,
@@ -396,7 +396,7 @@ func dutchTranslationSet() TranslationSet {
 		LcInitSubmodule:                     "initialiseer submodule",
 		LcViewBulkSubmoduleOptions:          "bekijk bulk submodule opties",
 		LcViewStashFiles:                    "bekijk bestanden van stash entry",
-		CreatePullRequestOptions:            "Bekijk opties voor pull-aanvraag",
-		LcCreatePullRequestOptions:          "bekijk opties voor pull-aanvraag",
+		CreateOrOpenPullRequestOptions:      "Bekijk opties voor pull-aanvraag",
+		LcCreateOrOpenPullRequestOptions:    "bekijk opties voor pull-aanvraag",
 	}
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -169,7 +169,7 @@ type TranslationSet struct {
 	SwitchRepo                          string
 	LcAllBranchesLogGraph               string
 	UnsupportedGitService               string
-	LcCreatePullRequest                 string
+	LcCreateOrShowPullRequest           string
 	LcCopyPullRequestURL                string
 	NoBranchOnRemote                    string
 	LcFetch                             string
@@ -454,11 +454,11 @@ type TranslationSet struct {
 	ToggleWhitespaceInDiffView          string
 	IgnoringWhitespaceInDiffView        string
 	ShowingWhitespaceInDiffView         string
-	CreatePullRequestOptions            string
-	LcCreatePullRequestOptions          string
+	CreateOrOpenPullRequestOptions      string
+	LcCreateOrOpenPullRequestOptions    string
 	LcDefaultBranch                     string
 	LcSelectBranch                      string
-	CreatePullRequest                   string
+	CreateOrShowPullRequest             string
 	CreatingPullRequestAtUrl            string
 	Spans                               Spans
 }
@@ -720,7 +720,7 @@ func englishTranslationSet() TranslationSet {
 		SwitchRepo:                          `switch to a recent repo`,
 		LcAllBranchesLogGraph:               `show all branch logs`,
 		UnsupportedGitService:               `Unsupported git service`,
-		LcCreatePullRequest:                 `create pull request`,
+		LcCreateOrShowPullRequest:           `create / show pull request`,
 		LcCopyPullRequestURL:                `copy pull request URL to clipboard`,
 		NoBranchOnRemote:                    `This branch doesn't exist on remote. You need to push it to remote first.`,
 		LcFetch:                             `fetch`,
@@ -1007,9 +1007,9 @@ func englishTranslationSet() TranslationSet {
 		ToggleWhitespaceInDiffView:          "Toggle whether or not whitespace changes are shown in the diff view",
 		IgnoringWhitespaceInDiffView:        "Whitespace will be ignored in the diff view",
 		ShowingWhitespaceInDiffView:         "Whitespace will be shown in the diff view",
-		CreatePullRequest:                   "Create pull request",
-		CreatePullRequestOptions:            "Create pull request options",
-		LcCreatePullRequestOptions:          "create pull request options",
+		CreateOrShowPullRequest:             "Create / show pull request",
+		CreateOrOpenPullRequestOptions:      "Create / show pull request options",
+		LcCreateOrOpenPullRequestOptions:    "create / show pull request options",
 		LcDefaultBranch:                     "default branch",
 		LcSelectBranch:                      "select branch",
 		CreatingPullRequestAtUrl:            "Creating pull request at URL: %s",

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -127,7 +127,7 @@ func polishTranslationSet() TranslationSet {
 		ConfirmQuit:                         `Na pewno chcesz wyjść z programu?`,
 		LcAllBranchesLogGraph:               `pokazywać wszystkie logi branżowe`,
 		UnsupportedGitService:               `Nieobsługiwana usługa git`,
-		LcCreatePullRequest:                 `utwórz żądanie wyciągnięcia`,
+		LcCreateOrShowPullRequest:           `utwórz żądanie wyciągnięcia`,
 		LcCopyPullRequestURL:                `skopiuj adres URL żądania ściągnięcia do schowka`,
 		NoBranchOnRemote:                    `Ta gałąź nie istnieje na zdalnym. Najpierw musisz go odepchnąć na odległość.`,
 		LcFetch:                             `fetch`,
@@ -255,7 +255,7 @@ func polishTranslationSet() TranslationSet {
 		PullRequestURLCopiedToClipboard:     "URL żądania ściągnięcia skopiowany do schowka",
 		CommitMessageCopiedToClipboard:      "Commit message skopiowany do schowka",
 		LcCopiedToClipboard:                 "skopiowany do schowka",
-		CreatePullRequestOptions:            "Utwórz opcje żądania ściągnięcia",
-		LcCreatePullRequestOptions:          "utwórz opcje żądania ściągnięcia",
+		CreateOrOpenPullRequestOptions:      "Utwórz opcje żądania ściągnięcia",
+		LcCreateOrOpenPullRequestOptions:    "utwórz opcje żądania ściągnięcia",
 	}
 }


### PR DESCRIPTION
This tries to use the github CLI (gh) to get the top PRs  
The PR numbers are shown in the branches panel and when pressing `o` on a branch with a PR it opens the pr in the browser

<img width="407" alt="image" src="https://user-images.githubusercontent.com/15320763/127388165-9778abba-8501-4447-a74f-1d905d005fcb.png">

Created a issue on the gh repo for also exposing the PR checks as that would be a nice addition https://github.com/cli/cli/issues/4054