### PR TITLE
Make menuFromCommand format menu items and their description

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -47,7 +47,8 @@ customCommands:
         title: 'Remote branch:'
         command: 'git branch  -r --list {{index .PromptResponses 0}}/*'
         filter: '.*{{index .PromptResponses 0}}/(?P<branch>.*)'
-        format: '{{ .branch }}'
+        itemFormat: '{{ .branch }}'
+        descriptionFormat: ''
 ```
 
 Looking at the command assigned to the 'n' key, here's what the result looks like:
@@ -92,19 +93,24 @@ The permitted contexts are:
 
 The permitted prompt fields are:
 
-| _field_      | _description_                                                                    | _required_ |
-| ------------ | -------------------------------------------------------------------------------- | ---------- |
-| type         | one of 'input' or 'menu'                                                         | yes        |
-| title        | the title to display in the popup panel                                          | no         |
-| initialValue | (only applicable to 'input' prompts) the initial value to appear in the text box | no         |
-| options      | (only applicable to 'menu' prompts) the options to display in the menu           | no         |
-| command      | (only applicable to 'menuFromCommand' prompts) the command to run to generate    | yes        |
-|              | menu options                                                                     |            |
-| filter       | (only applicable to 'menuFromCommand' prompts) the regexp to run specifying      | yes        |
-|              | groups which are going to be kept from the command's output                      |            |
-| format       | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | yes        |
-|              | the filter. You can use named groups, or `{{ .group_GROUPID }}`.                 | yes        |
-|              | PS: named groups keep first match only                                           | yes        |
+| _field_           | _description_                                                                    | _required_ |
+| ------------      | -------------------------------------------------------------------------------- | ---------- |
+| type              | one of 'input' or 'menu'                                                         | yes        |
+| title             | the title to display in the popup panel                                          | no         |
+| initialValue      | (only applicable to 'input' prompts) the initial value to appear in the text box | no         |
+| options           | (only applicable to 'menu' prompts) the options to display in the menu           | no         |
+| command           | (only applicable to 'menuFromCommand' prompts) the command to run to generate    | yes        |
+|                   | menu options                                                                     |            |
+| filter            | (only applicable to 'menuFromCommand' prompts) the regexp to run specifying      | yes        |
+|                   | groups which are going to be kept from the command's output                      |            |
+| itemFormat        | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | yes        |
+|                   | the filter to construct a menu item. You can use named groups,                   | yes        |
+|                   | or `{{ .group_GROUPID }}`.                                                       |            |
+|                   | PS: named groups keep first match only                                           | yes        |
+| descriptionFormat | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | yes        |
+|                   | the filter to construct a menu item's description. You can use named groups,     | yes        |
+|                   | or `{{ .group_GROUPID }}`.                                                       |            |
+|                   | PS: named groups keep first match only                                           | yes        |
 
 The permitted option fields are:
 | _field_ | _description_ | _required_ |

--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -47,8 +47,8 @@ customCommands:
         title: 'Remote branch:'
         command: 'git branch  -r --list {{index .PromptResponses 0}}/*'
         filter: '.*{{index .PromptResponses 0}}/(?P<branch>.*)'
-        itemFormat: '{{ .branch }}'
-        descriptionFormat: ''
+        valueFormat: '{{ .branch }}'
+        labelFormat: ''
 ```
 
 Looking at the command assigned to the 'n' key, here's what the result looks like:
@@ -103,11 +103,11 @@ The permitted prompt fields are:
 |                   | menu options                                                                     |            |
 | filter            | (only applicable to 'menuFromCommand' prompts) the regexp to run specifying      | yes        |
 |                   | groups which are going to be kept from the command's output                      |            |
-| itemFormat        | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | yes        |
+| valueFormat        | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | yes        |
 |                   | the filter to construct a menu item. You can use named groups,                   | yes        |
 |                   | or `{{ .group_GROUPID }}`.                                                       |            |
 |                   | PS: named groups keep first match only                                           | yes        |
-| descriptionFormat | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | yes        |
+| labelFormat | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | yes        |
 |                   | the filter to construct a menu item's description. You can use named groups,     | yes        |
 |                   | or `{{ .group_GROUPID }}`.                                                       |            |
 |                   | PS: named groups keep first match only                                           | yes        |

--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -103,14 +103,16 @@ The permitted prompt fields are:
 |                   | menu options                                                                     |            |
 | filter            | (only applicable to 'menuFromCommand' prompts) the regexp to run specifying      | yes        |
 |                   | groups which are going to be kept from the command's output                      |            |
-| valueFormat        | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | yes        |
-|                   | the filter to construct a menu item. You can use named groups,                   | yes        |
+| valueFormat       | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | yes        |
+|                   | the filter to construct a menu item's value (What gets appended to prompt        |            |
+|                   | responses when the item is selected). You can use named groups,                  |            |
 |                   | or `{{ .group_GROUPID }}`.                                                       |            |
-|                   | PS: named groups keep first match only                                           | yes        |
-| labelFormat | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | yes        |
-|                   | the filter to construct a menu item's description. You can use named groups,     | yes        |
-|                   | or `{{ .group_GROUPID }}`.                                                       |            |
-|                   | PS: named groups keep first match only                                           | yes        |
+|                   | PS: named groups keep first match only                                           |            |
+| labelFormat       | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | no         |
+|                   | the filter to construct the item's label (What's shown on screen). You can use   |            |
+|                   | named groups, or `{{ .group_GROUPID }}`. If this is not specified, `valueFormat` |            |
+|                   | is shown instead.                                                                |            |
+|                   | PS: named groups keep first match only                                           |            |
 
 The permitted option fields are:
 | _field_ | _description_ | _required_ |

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -283,10 +283,10 @@ type CustomCommandPrompt struct {
 	Options []CustomCommandMenuOption
 
 	// this only applies to menuFromCommand
-	Command string `yaml:"command"`
-	Filter  string `yaml:"filter"`
-	TFormat string `yaml:"itemFormat"`
-	DFormat string `yaml:"descriptionFormat"`
+	Command     string `yaml:"command"`
+	Filter      string `yaml:"filter"`
+	ValueFormat string `yaml:"valueFormat"`
+	LabelFormat string `yaml:"labelFormat"`
 }
 
 type CustomCommandMenuOption struct {

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -285,7 +285,8 @@ type CustomCommandPrompt struct {
 	// this only applies to menuFromCommand
 	Command string `yaml:"command"`
 	Filter  string `yaml:"filter"`
-	Format  string `yaml:"format"`
+	TFormat string `yaml:"itemFormat"`
+	DFormat string `yaml:"descriptionFormat"`
 }
 
 type CustomCommandMenuOption struct {

--- a/pkg/gui/gui_test.go
+++ b/pkg/gui/gui_test.go
@@ -86,29 +86,34 @@ func TestGuiGenerateMenuCandidates(t *testing.T) {
 		testName string
 		cmdOut   string
 		filter   string
-		format   string
-		test     func([]string, error)
+		tFormat  string
+		dFormat  string
+		test     func([]string, []string, error)
 	}
 
 	scenarios := []scenario{
 		{
 			"Extract remote branch name",
 			"upstream/pr-1",
-			"upstream/(?P<branch>.*)",
+			"(?P<remote>[a-z_]+)/(?P<branch>.*)",
 			"{{ .branch }}",
-			func(actual []string, err error) {
+			"Remote: {{ .remote }}",
+			func(actualCandidate []string, actualDescr []string, err error) {
 				assert.NoError(t, err)
-				assert.EqualValues(t, "pr-1", actual[0])
+				assert.EqualValues(t, "pr-1", actualCandidate[0])
+				assert.EqualValues(t, "Remote: upstream", actualDescr[0])
 			},
 		},
 		{
-			"Multiple named groups",
+			"Multiple named groups with empty description",
 			"upstream/pr-1",
 			"(?P<remote>[a-z]*)/(?P<branch>.*)",
 			"{{ .branch }}|{{ .remote }}",
-			func(actual []string, err error) {
+			"",
+			func(actualCandidate []string, actualDescr []string, err error) {
 				assert.NoError(t, err)
-				assert.EqualValues(t, "pr-1|upstream", actual[0])
+				assert.EqualValues(t, "pr-1|upstream", actualCandidate[0])
+				assert.EqualValues(t, "", actualDescr[0])
 			},
 		},
 		{
@@ -116,16 +121,18 @@ func TestGuiGenerateMenuCandidates(t *testing.T) {
 			"upstream/pr-1",
 			"(?P<remote>[a-z]*)/(?P<branch>.*)",
 			"{{ .group_2 }}|{{ .group_1 }}",
-			func(actual []string, err error) {
+			"Remote: {{ .group_1 }}",
+			func(actualCandidate []string, actualDescr []string, err error) {
 				assert.NoError(t, err)
-				assert.EqualValues(t, "pr-1|upstream", actual[0])
+				assert.EqualValues(t, "pr-1|upstream", actualCandidate[0])
+				assert.EqualValues(t, "Remote: upstream", actualDescr[0])
 			},
 		},
 	}
 
 	for _, s := range scenarios {
 		t.Run(s.testName, func(t *testing.T) {
-			s.test(NewDummyGui().GenerateMenuCandidates(s.cmdOut, s.filter, s.format))
+			s.test(NewDummyGui().GenerateMenuCandidates(s.cmdOut, s.filter, s.tFormat, s.dFormat))
 		})
 	}
 }

--- a/pkg/gui/gui_test.go
+++ b/pkg/gui/gui_test.go
@@ -83,12 +83,12 @@ func runCmdHeadless(cmd *exec.Cmd) error {
 
 func TestGuiGenerateMenuCandidates(t *testing.T) {
 	type scenario struct {
-		testName string
-		cmdOut   string
-		filter   string
-		tFormat  string
-		dFormat  string
-		test     func([]string, []string, error)
+		testName    string
+		cmdOut      string
+		filter      string
+		valueFormat string
+		labelFormat string
+		test        func([]CommandMenuEntry, error)
 	}
 
 	scenarios := []scenario{
@@ -98,10 +98,10 @@ func TestGuiGenerateMenuCandidates(t *testing.T) {
 			"(?P<remote>[a-z_]+)/(?P<branch>.*)",
 			"{{ .branch }}",
 			"Remote: {{ .remote }}",
-			func(actualCandidate []string, actualDescr []string, err error) {
+			func(actualEntry []CommandMenuEntry, err error) {
 				assert.NoError(t, err)
-				assert.EqualValues(t, "pr-1", actualCandidate[0])
-				assert.EqualValues(t, "Remote: upstream", actualDescr[0])
+				assert.EqualValues(t, "pr-1", actualEntry[0].value)
+				assert.EqualValues(t, "Remote: upstream", actualEntry[0].label)
 			},
 		},
 		{
@@ -110,10 +110,10 @@ func TestGuiGenerateMenuCandidates(t *testing.T) {
 			"(?P<remote>[a-z]*)/(?P<branch>.*)",
 			"{{ .branch }}|{{ .remote }}",
 			"",
-			func(actualCandidate []string, actualDescr []string, err error) {
+			func(actualEntry []CommandMenuEntry, err error) {
 				assert.NoError(t, err)
-				assert.EqualValues(t, "pr-1|upstream", actualCandidate[0])
-				assert.EqualValues(t, "", actualDescr[0])
+				assert.EqualValues(t, "pr-1|upstream", actualEntry[0].value)
+				assert.EqualValues(t, "", actualEntry[0].label)
 			},
 		},
 		{
@@ -122,17 +122,17 @@ func TestGuiGenerateMenuCandidates(t *testing.T) {
 			"(?P<remote>[a-z]*)/(?P<branch>.*)",
 			"{{ .group_2 }}|{{ .group_1 }}",
 			"Remote: {{ .group_1 }}",
-			func(actualCandidate []string, actualDescr []string, err error) {
+			func(actualEntry []CommandMenuEntry, err error) {
 				assert.NoError(t, err)
-				assert.EqualValues(t, "pr-1|upstream", actualCandidate[0])
-				assert.EqualValues(t, "Remote: upstream", actualDescr[0])
+				assert.EqualValues(t, "pr-1|upstream", actualEntry[0].value)
+				assert.EqualValues(t, "Remote: upstream", actualEntry[0].label)
 			},
 		},
 	}
 
 	for _, s := range scenarios {
 		t.Run(s.testName, func(t *testing.T) {
-			s.test(NewDummyGui().GenerateMenuCandidates(s.cmdOut, s.filter, s.tFormat, s.dFormat))
+			s.test(NewDummyGui().GenerateMenuCandidates(s.cmdOut, s.filter, s.valueFormat, s.labelFormat))
 		})
 	}
 }

--- a/pkg/gui/gui_test.go
+++ b/pkg/gui/gui_test.go
@@ -105,7 +105,7 @@ func TestGuiGenerateMenuCandidates(t *testing.T) {
 			},
 		},
 		{
-			"Multiple named groups with empty description",
+			"Multiple named groups with empty labelFormat",
 			"upstream/pr-1",
 			"(?P<remote>[a-z]*)/(?P<branch>.*)",
 			"{{ .branch }}|{{ .remote }}",
@@ -113,7 +113,7 @@ func TestGuiGenerateMenuCandidates(t *testing.T) {
 			func(actualEntry []CommandMenuEntry, err error) {
 				assert.NoError(t, err)
 				assert.EqualValues(t, "pr-1|upstream", actualEntry[0].value)
-				assert.EqualValues(t, "", actualEntry[0].label)
+				assert.EqualValues(t, "pr-1|upstream", actualEntry[0].label)
 			},
 		},
 		{

--- a/pkg/gui/gui_test.go
+++ b/pkg/gui/gui_test.go
@@ -88,7 +88,7 @@ func TestGuiGenerateMenuCandidates(t *testing.T) {
 		filter      string
 		valueFormat string
 		labelFormat string
-		test        func([]CommandMenuEntry, error)
+		test        func([]commandMenuEntry, error)
 	}
 
 	scenarios := []scenario{
@@ -98,7 +98,7 @@ func TestGuiGenerateMenuCandidates(t *testing.T) {
 			"(?P<remote>[a-z_]+)/(?P<branch>.*)",
 			"{{ .branch }}",
 			"Remote: {{ .remote }}",
-			func(actualEntry []CommandMenuEntry, err error) {
+			func(actualEntry []commandMenuEntry, err error) {
 				assert.NoError(t, err)
 				assert.EqualValues(t, "pr-1", actualEntry[0].value)
 				assert.EqualValues(t, "Remote: upstream", actualEntry[0].label)
@@ -110,7 +110,7 @@ func TestGuiGenerateMenuCandidates(t *testing.T) {
 			"(?P<remote>[a-z]*)/(?P<branch>.*)",
 			"{{ .branch }}|{{ .remote }}",
 			"",
-			func(actualEntry []CommandMenuEntry, err error) {
+			func(actualEntry []commandMenuEntry, err error) {
 				assert.NoError(t, err)
 				assert.EqualValues(t, "pr-1|upstream", actualEntry[0].value)
 				assert.EqualValues(t, "pr-1|upstream", actualEntry[0].label)
@@ -122,7 +122,7 @@ func TestGuiGenerateMenuCandidates(t *testing.T) {
 			"(?P<remote>[a-z]*)/(?P<branch>.*)",
 			"{{ .group_2 }}|{{ .group_1 }}",
 			"Remote: {{ .group_1 }}",
-			func(actualEntry []CommandMenuEntry, err error) {
+			func(actualEntry []commandMenuEntry, err error) {
 				assert.NoError(t, err)
 				assert.EqualValues(t, "pr-1|upstream", actualEntry[0].value)
 				assert.EqualValues(t, "Remote: upstream", actualEntry[0].label)


### PR DESCRIPTION
This is a tiny PR related to #1390. Now, users can format the menu items themselves as well as their descriptions.
Kind of looks better when you want for example to see commit hash and message but only use the hash for checkout.

A good example is the following command; I'm searching for commits which touched some file and mentioned some word.
It would be really ugly to get only commit hashes from the log in the menu with no hint on what these commits do!

```yml
customCommands:
  - key : '<c-a>'
    description: 'Search the whole history (From a ref and down) for an expression in a file'
    command: "git checkout {{index .PromptResponses 3}}"
    context: 'commits'
    prompts:
      - type: 'input'
        title: 'Search word:'
      - type: 'input'
        title: 'File/Subtree:'
      - type: 'input'
        title: 'Ref:'
        initialValue: "{{index .CheckedOutBranch.Name }}"
      - type: 'menuFromCommand'
        title: 'Commits:'
        command: "git log --oneline {{index .PromptResponses 2}} -S'{{index .PromptResponses 0}}' --all -- {{index .PromptResponses 1}}"
        filter: '(?P<commit_id>[0-9a-zA-Z]*) *(?P<commit_msg>.*)'
        valueFormat: '{{ .commit_id }}'
        labelFormat: '{{ .commit_msg }}'
```