### PR TITLE
1418 Fixing test failure due to ColorLevel in test renderers

### DIFF
--- a/pkg/gui/filetree/file_manager_test.go
+++ b/pkg/gui/filetree/file_manager_test.go
@@ -3,11 +3,15 @@ package filetree
 import (
 	"testing"
 
+	"github.com/gookit/color"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/xo/terminfo"
 )
 
 func TestRender(t *testing.T) {
+	color.ForceSetColorLevel(terminfo.ColorLevelNone)
+
 	scenarios := []struct {
 		name           string
 		root           *FileNode


### PR DESCRIPTION
  #1418 fixed test failing due to ```ForceSetColorLevel``` in ```pkg/gui/style/style_test.go```