### PR TITLE
Support match colors in `labelFormat` entry in menuFromCommand prompts

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -48,7 +48,7 @@ customCommands:
         command: 'git branch  -r --list {{index .PromptResponses 0}}/*'
         filter: '.*{{index .PromptResponses 0}}/(?P<branch>.*)'
         valueFormat: '{{ .branch }}'
-        labelFormat: ''
+        labelFormat: '{{ .branch | green }}'
 ```
 
 Looking at the command assigned to the 'n' key, here's what the result looks like:
@@ -110,8 +110,10 @@ The permitted prompt fields are:
 |                   | PS: named groups keep first match only                                           |            |
 | labelFormat       | (only applicable to 'menuFromCommand' prompts) how to format matched groups from | no         |
 |                   | the filter to construct the item's label (What's shown on screen). You can use   |            |
-|                   | named groups, or `{{ .group_GROUPID }}`. If this is not specified, `valueFormat` |            |
-|                   | is shown instead.                                                                |            |
+|                   | named groups, or `{{ .group_GROUPID }}`. You can also color each match with      |            |
+|                   | `{{ .group_GROUPID | colorname }}` (Color names from                             |            |
+|                   | [here](https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md))     |            |
+|                   | If `labelFormat` is not specified, `valueFormat` is shown instead.               |            |
 |                   | PS: named groups keep first match only                                           |            |
 
 The permitted option fields are:

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -136,7 +136,12 @@ func (gui *Gui) GenerateMenuCandidates(commandOutput, filter, valueFormat, label
 		return nil, gui.surfaceError(errors.New("unable to parse value format, error: " + err.Error()))
 	}
 
-	descTemp, err := template.New("format").Parse(labelFormat)
+	colorFuncMap := template.FuncMap{}
+	for k, v := range style.ColorMap {
+		colorFuncMap[k] = v.Foreground.Sprint
+	}
+
+	descTemp, err := template.New("format").Funcs(colorFuncMap).Parse(labelFormat)
 	if err != nil {
 		return nil, gui.surfaceError(errors.New("unable to parse label format, error: " + err.Error()))
 	}

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -136,10 +136,7 @@ func (gui *Gui) GenerateMenuCandidates(commandOutput, filter, valueFormat, label
 		return nil, gui.surfaceError(errors.New("unable to parse value format, error: " + err.Error()))
 	}
 
-	colorFuncMap := template.FuncMap{}
-	for k, v := range style.ColorMap {
-		colorFuncMap[k] = v.Foreground.Sprint
-	}
+	colorFuncMap := style.TemplateFuncMapAddColors(template.FuncMap{})
 
 	descTemp, err := template.New("format").Funcs(colorFuncMap).Parse(labelFormat)
 	if err != nil {

--- a/pkg/gui/style/basic_styles.go
+++ b/pkg/gui/style/basic_styles.go
@@ -2,6 +2,7 @@ package style
 
 import (
 	"github.com/gookit/color"
+	"text/template"
 )
 
 var (
@@ -50,4 +51,13 @@ func FromBasicFg(fg color.Color) TextStyle {
 
 func FromBasicBg(bg color.Color) TextStyle {
 	return New().SetBg(NewBasicColor(bg))
+}
+
+func TemplateFuncMapAddColors(m template.FuncMap) template.FuncMap {
+	for k, v := range ColorMap {
+		m[k] = v.Foreground.Sprint
+	}
+	m["underline"] = color.OpUnderscore.Sprint
+	m["bold"] = color.OpBold.Sprint
+	return m
 }

--- a/pkg/gui/style/basic_styles.go
+++ b/pkg/gui/style/basic_styles.go
@@ -27,6 +27,21 @@ var (
 
 	AttrUnderline = New().SetUnderline()
 	AttrBold      = New().SetBold()
+
+	ColorMap = map[string]struct {
+		Foreground TextStyle
+		Background TextStyle
+	}{
+		"default": {FgWhite, BgBlack},
+		"black":   {FgBlack, BgBlack},
+		"red":     {FgRed, BgRed},
+		"green":   {FgGreen, BgGreen},
+		"yellow":  {FgYellow, BgYellow},
+		"blue":    {FgBlue, BgBlue},
+		"magenta": {FgMagenta, BgMagenta},
+		"cyan":    {FgCyan, BgCyan},
+		"white":   {FgWhite, BgWhite},
+	}
 )
 
 func FromBasicFg(fg color.Color) TextStyle {

--- a/pkg/theme/style.go
+++ b/pkg/theme/style.go
@@ -6,20 +6,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
-var colorMap = map[string]struct {
-	foreground style.TextStyle
-	background style.TextStyle
-}{
-	"default": {style.FgWhite, style.BgBlack},
-	"black":   {style.FgBlack, style.BgBlack},
-	"red":     {style.FgRed, style.BgRed},
-	"green":   {style.FgGreen, style.BgGreen},
-	"yellow":  {style.FgYellow, style.BgYellow},
-	"blue":    {style.FgBlue, style.BgBlue},
-	"magenta": {style.FgMagenta, style.BgMagenta},
-	"cyan":    {style.FgCyan, style.BgCyan},
-	"white":   {style.FgWhite, style.BgWhite},
-}
+var colorMap = style.ColorMap
 
 func GetTextStyle(keys []string, background bool) style.TextStyle {
 	s := style.New()
@@ -37,9 +24,9 @@ func GetTextStyle(keys []string, background bool) style.TextStyle {
 			if present {
 				var c style.TextStyle
 				if background {
-					c = value.background
+					c = value.Background
 				} else {
-					c = value.foreground
+					c = value.Foreground
 				}
 				s = s.MergeStyle(c)
 			} else if utils.IsValidHexValue(key) {

--- a/pkg/theme/style.go
+++ b/pkg/theme/style.go
@@ -6,8 +6,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
-var colorMap = style.ColorMap
-
 func GetTextStyle(keys []string, background bool) style.TextStyle {
 	s := style.New()
 
@@ -20,7 +18,7 @@ func GetTextStyle(keys []string, background bool) style.TextStyle {
 		case "underline":
 			s = s.SetUnderline()
 		default:
-			value, present := colorMap[key]
+			value, present := style.ColorMap[key]
 			if present {
 				var c style.TextStyle
 				if background {


### PR DESCRIPTION
As suggested in #1416, now exposing (forground) coloring functions to the template engine which parses `labelFormat`.

With:
```yaml
customCommands:
  - key : '<c-a>'
    description: 'Search the whole history (From a ref and down) for an expression in a file'
    command: "git checkout {{index .PromptResponses 3}}"
    context: 'commits'
    prompts:
      - type: 'input'
        title: 'Search word:'
      - type: 'input'
        title: 'File/Subtree:'
      - type: 'input'
        title: 'Ref:'
        initialValue: "{{index .CheckedOutBranch.Name }}"
      - type: 'menuFromCommand'
        title: 'Commits:'
        command: "git log --oneline {{index .PromptResponses 2}} -S'{{index .PromptResponses 0}}' --all -- {{index .PromptResponses 1}}"
        filter: '(?P<commit_id>[0-9a-zA-Z]*) *(?P<commit_msg>.*)'
        valueFormat: '{{ .commit_id }}'
        labelFormat: '{{ .commit_id | green }} - {{ .commit_msg | yellow }}'
```
We get:
![2021-08-07_16-12](https://user-images.githubusercontent.com/34474472/128604884-5caa7081-8501-4778-95a3-82bab63c4678.png)