### PR TITLE
the patch panel would crash if the filename contained an odd number of double quotes

### DIFF
--- a/pkg/commands/files.go
+++ b/pkg/commands/files.go
@@ -255,7 +255,7 @@ func (c *GitCommand) ShowFileDiffCmdStr(from string, to string, reverse bool, fi
 
 // CheckoutFile checks out the file for the given commit
 func (c *GitCommand) CheckoutFile(commitSha, fileName string) error {
-	return c.RunCommand("git checkout %s %s", commitSha, fileName)
+	return c.RunCommand("git checkout %s -- %s", commitSha, c.OSCommand.Quote(fileName))
 }
 
 // DiscardOldFileChanges discards changes to a file from an old commit

--- a/pkg/commands/files.go
+++ b/pkg/commands/files.go
@@ -250,7 +250,7 @@ func (c *GitCommand) ShowFileDiffCmdStr(from string, to string, reverse bool, fi
 		reverseFlag = " -R "
 	}
 
-	return fmt.Sprintf(`git diff --submodule --no-ext-diff --no-renames --color=%s %s %s %s -- "%s"`, colorArg, from, to, reverseFlag, fileName)
+	return fmt.Sprintf("git diff --submodule --no-ext-diff --no-renames --color=%s %s %s %s -- %s", colorArg, from, to, reverseFlag, c.OSCommand.Quote(fileName))
 }
 
 // CheckoutFile checks out the file for the given commit

--- a/pkg/commands/files_test.go
+++ b/pkg/commands/files_test.go
@@ -455,7 +455,7 @@ func TestGitCommandCheckoutFile(t *testing.T) {
 			"test999.txt",
 			test.CreateMockCommand(t, []*test.CommandSwapper{
 				{
-					Expect:  "git checkout 11af912 test999.txt",
+					Expect:  "git checkout 11af912 -- test999.txt",
 					Replace: "echo",
 				},
 			}),
@@ -469,7 +469,7 @@ func TestGitCommandCheckoutFile(t *testing.T) {
 			"test999.txt",
 			test.CreateMockCommand(t, []*test.CommandSwapper{
 				{
-					Expect:  "git checkout 11af912 test999.txt",
+					Expect:  "git checkout 11af912 -- test999.txt",
 					Replace: "test",
 				},
 			}),
@@ -606,7 +606,7 @@ func TestGitCommandDiscardOldFileChanges(t *testing.T) {
 					Replace: "echo",
 				},
 				{
-					Expect:  "git checkout HEAD^ test999.txt",
+					Expect:  "git checkout HEAD^ -- test999.txt",
 					Replace: "echo",
 				},
 				{


### PR DESCRIPTION
## 1. Fix crash when filename contains double quotes (#1433)

The error with spaces in the file name is fixed in #1433, but the job is not perfect.

The patch panel crashes when the filename contains an odd number of double quotes.

<details>
<summary>error log</summary>

```
Press enter to return to lazygit
panic: Starting quote has no ending quote.

goroutine 1 [running]:
github.com/mgutz/str.ToArgv(0xc0006746e0, 0x97, 0x1696bc0, 0xc000893e20, 0x1696bc0)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/vendor/github.com/mgutz/str/funcsPZ.go:377 +0x5d9
github.com/jesseduffield/lazygit/pkg/commands/oscommands.(*OSCommand).ExecutableFromString(0xc00007d680, 0xc0006746e0, 0x97, 0xc0005df000)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/pkg/commands/oscommands/os.go:195 +0x39
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).handleCommitFileSelect(0xc0001a8000, 0xc0001b6138, 0x17b2df8)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/pkg/gui/commit_files_panel.go:45 +0x16e
github.com/jesseduffield/lazygit/pkg/gui.(*ListContext).HandleFocus(0xc0001a6230, 0xc000785980, 0xb)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/pkg/gui/list_context.go:96 +0x178
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).activateContext(0xc0001a8000, 0x1866b38, 0xc0001a6230, 0x0, 0x0)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/pkg/gui/context.go:248 +0x309
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).pushContextDirect(0xc0001a8000, 0x1866b38, 0xc0001a6230, 0x1beae20, 0xc0006f2180)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/pkg/gui/context.go:117 +0x1f6
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).pushContext.func1(0xc0001b6000, 0xc00038b7c0, 0x0)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/pkg/gui/context.go:86 +0x3c
github.com/jesseduffield/gocui.(*Gui).consumeevents(0xc0001b6000, 0x0, 0x0)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/vendor/github.com/jesseduffield/gocui/gui.go:637 +0x1a2
github.com/jesseduffield/gocui.(*Gui).MainLoop(0xc0001b6000, 0xc000000004, 0xc000561a08)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/vendor/github.com/jesseduffield/gocui/gui.go:619 +0x1ec
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).Run(0xc0001a8000, 0x0, 0x0)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/pkg/gui/gui.go:540 +0x51b
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).RunAndHandleError.func1(0xc000256001, 0xc0001b4000)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/pkg/gui/gui.go:548 +0x45
github.com/jesseduffield/lazygit/pkg/utils.SafeWithError(0xc00029fb40, 0x0, 0x0)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/pkg/utils/utils.go:118 +0x62
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).RunAndHandleError(0xc0001a8000, 0x0, 0x1784295)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/pkg/gui/gui.go:547 +0x7d
github.com/jesseduffield/lazygit/pkg/app.(*App).Run(0xc00025ea10, 0xc00011c7e0, 0x0)
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/pkg/app/app.go:242 +0x6b
main.main()
        /private/tmp/lazygit-20210605-59301-6hnv7l/lazygit-0.28.2/main.go:127 +0xb7b
```

</details>

### how to reproduce

```sh
$ echo 'hello' > '"'
$ git add '"'
$ git commit -m 'test'
```

- Then launch lazygit and go to the commits panel
- Press enter on the "test" commit
- Crash

## 2. Fixed file checkout failing if filename contains spaces or starts with a hyphen

```sh
$ echo 'hello' > '--a'
$ git add -- '--a'
$ git commit -m 'test2'
```

- Then launch lazygit and go to the commits panel
- Press enter on the "test2" commit
- Press `c` on a file named `--a`

```
error: unknown option `a'
usage: git checkout [<options>] <branch>
   or: git checkout [<options>] [<branch>] -- <file>...

...
```
