### PR TITLE
Fix staged renamed file with unstaged in file pane #1408

### DIFF
--- a/pkg/commands/loading_files.go
+++ b/pkg/commands/loading_files.go
@@ -94,10 +94,11 @@ func (c *GitCommand) GitStatus(opts GitStatusOptions) ([]string, error) {
 		original := splitLines[i]
 		if len(original) < 2 {
 			continue
-		} else if strings.HasPrefix(original, "R  ") {
+		} else if strings.HasPrefix(original, "R") {
 			// if a line starts with 'R' then the next line is the original file.
 			next := strings.TrimSpace(splitLines[i+1])
-			original = "R  " + next + RENAME_SEPARATOR + strings.TrimPrefix(original, "R  ")
+			prefix := original[:3] // /^R. /
+			original = prefix + next + RENAME_SEPARATOR + strings.TrimPrefix(original, prefix)
 			i++
 		}
 		response = append(response, original)

--- a/pkg/commands/loading_files.go
+++ b/pkg/commands/loading_files.go
@@ -24,36 +24,29 @@ func (c *GitCommand) GetStatusFiles(opts GetStatusFileOptions) []*models.File {
 	}
 	untrackedFilesArg := fmt.Sprintf("--untracked-files=%s", untrackedFilesSetting)
 
-	statusStrings, err := c.GitStatus(GitStatusOptions{NoRenames: opts.NoRenames, UntrackedFilesArg: untrackedFilesArg})
+	statuses, err := c.GitStatus(GitStatusOptions{NoRenames: opts.NoRenames, UntrackedFilesArg: untrackedFilesArg})
 	if err != nil {
 		c.Log.Error(err)
 	}
 	files := []*models.File{}
 
-	for _, statusString := range statusStrings {
-		if strings.HasPrefix(statusString, "warning") {
-			c.Log.Warningf("warning when calling git status: %s", statusString)
+	for _, status := range statuses {
+		if strings.HasPrefix(status.StatusString, "warning") {
+			c.Log.Warningf("warning when calling git status: %s", status.StatusString)
 			continue
 		}
-		change := statusString[0:2]
+		change := status.Change
 		stagedChange := change[0:1]
-		unstagedChange := statusString[1:2]
-		name := statusString[3:]
+		unstagedChange := change[1:2]
 		untracked := utils.IncludesString([]string{"??", "A ", "AM"}, change)
 		hasNoStagedChanges := utils.IncludesString([]string{" ", "U", "?"}, stagedChange)
 		hasMergeConflicts := utils.IncludesString([]string{"DD", "AA", "UU", "AU", "UA", "UD", "DU"}, change)
 		hasInlineMergeConflicts := utils.IncludesString([]string{"UU", "AA"}, change)
-		previousName := ""
-		if strings.Contains(name, RENAME_SEPARATOR) {
-			split := strings.Split(name, RENAME_SEPARATOR)
-			name = split[1]
-			previousName = split[0]
-		}
 
 		file := &models.File{
-			Name:                    name,
-			PreviousName:            previousName,
-			DisplayString:           statusString,
+			Name:                    status.Name,
+			PreviousName:            status.PreviousName,
+			DisplayString:           status.StatusString,
 			HasStagedChanges:        !hasNoStagedChanges,
 			HasUnstagedChanges:      unstagedChange != " ",
 			Tracked:                 !untracked,
@@ -61,7 +54,7 @@ func (c *GitCommand) GetStatusFiles(opts GetStatusFileOptions) []*models.File {
 			Added:                   unstagedChange == "A" || untracked,
 			HasMergeConflicts:       hasMergeConflicts,
 			HasInlineMergeConflicts: hasInlineMergeConflicts,
-			Type:                    c.OSCommand.FileType(name),
+			Type:                    c.OSCommand.FileType(status.Name),
 			ShortStatus:             change,
 		}
 		files = append(files, file)
@@ -70,13 +63,20 @@ func (c *GitCommand) GetStatusFiles(opts GetStatusFileOptions) []*models.File {
 	return files
 }
 
-// GitStatus returns the plaintext short status of the repo
+// GitStatus returns the file status of the repo
 type GitStatusOptions struct {
 	NoRenames         bool
 	UntrackedFilesArg string
 }
 
-func (c *GitCommand) GitStatus(opts GitStatusOptions) ([]string, error) {
+type FileStatus struct {
+	StatusString string
+	Change       string // ??, MM, AM, ...
+	Name         string
+	PreviousName string
+}
+
+func (c *GitCommand) GitStatus(opts GitStatusOptions) ([]FileStatus, error) {
 	noRenamesFlag := ""
 	if opts.NoRenames {
 		noRenamesFlag = "--no-renames"
@@ -84,24 +84,34 @@ func (c *GitCommand) GitStatus(opts GitStatusOptions) ([]string, error) {
 
 	statusLines, err := c.RunCommandWithOutput("git status %s --porcelain -z %s", opts.UntrackedFilesArg, noRenamesFlag)
 	if err != nil {
-		return []string{}, err
+		return []FileStatus{}, err
 	}
 
 	splitLines := strings.Split(statusLines, "\x00")
-	response := []string{}
+	response := []FileStatus{}
 
 	for i := 0; i < len(splitLines); i++ {
 		original := splitLines[i]
-		if len(original) < 2 {
+
+		if len(original) < 3 {
 			continue
-		} else if strings.HasPrefix(original, "R") {
+		}
+
+		status := FileStatus{
+			StatusString: original,
+			Change:       original[:2],
+			Name:         original[3:],
+			PreviousName: "",
+		}
+
+		if strings.HasPrefix(status.Change, "R") {
 			// if a line starts with 'R' then the next line is the original file.
-			next := strings.TrimSpace(splitLines[i+1])
-			prefix := original[:3] // /^R. /
-			original = prefix + next + RENAME_SEPARATOR + strings.TrimPrefix(original, prefix)
+			status.PreviousName = strings.TrimSpace(splitLines[i+1])
+			status.StatusString = fmt.Sprintf("%s %s -> %s", status.Change, status.PreviousName, status.Name)
 			i++
 		}
-		response = append(response, original)
+
+		response = append(response, status)
 	}
 
 	return response, nil

--- a/pkg/commands/loading_files.go
+++ b/pkg/commands/loading_files.go
@@ -8,8 +8,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
-const RENAME_SEPARATOR = " -> "
-
 // GetStatusFiles git status files
 type GetStatusFileOptions struct {
 	NoRenames bool

--- a/pkg/commands/loading_files_test.go
+++ b/pkg/commands/loading_files_test.go
@@ -139,6 +139,81 @@ func TestGitCommandGetStatusFiles(t *testing.T) {
 				assert.EqualValues(t, expected, files)
 			},
 		},
+		{
+			"Renamed files",
+			func(cmd string, args ...string) *exec.Cmd {
+				return secureexec.Command(
+					"printf",
+					`R  after1.txt\0before1.txt\0RM after2.txt\0before2.txt`,
+				)
+			},
+			func(files []*models.File) {
+				assert.Len(t, files, 2)
+
+				expected := []*models.File{
+					{
+						Name:                    "after1.txt",
+						PreviousName:            "before1.txt",
+						HasStagedChanges:        true,
+						HasUnstagedChanges:      false,
+						Tracked:                 true,
+						Added:                   false,
+						Deleted:                 false,
+						HasMergeConflicts:       false,
+						HasInlineMergeConflicts: false,
+						DisplayString:           "R  before1.txt -> after1.txt",
+						Type:                    "other",
+						ShortStatus:             "R ",
+					},
+					{
+						Name:                    "after2.txt",
+						PreviousName:            "before2.txt",
+						HasStagedChanges:        true,
+						HasUnstagedChanges:      true,
+						Tracked:                 true,
+						Added:                   false,
+						Deleted:                 false,
+						HasMergeConflicts:       false,
+						HasInlineMergeConflicts: false,
+						DisplayString:           "RM before2.txt -> after2.txt",
+						Type:                    "other",
+						ShortStatus:             "RM",
+					},
+				}
+
+				assert.EqualValues(t, expected, files)
+			},
+		},
+		{
+			"File with arrow in name",
+			func(cmd string, args ...string) *exec.Cmd {
+				return secureexec.Command(
+					"printf",
+					`?? a -> b.txt`,
+				)
+			},
+			func(files []*models.File) {
+				assert.Len(t, files, 1)
+
+				expected := []*models.File{
+					{
+						Name:                    "a -> b.txt",
+						HasStagedChanges:        false,
+						HasUnstagedChanges:      true,
+						Tracked:                 false,
+						Added:                   true,
+						Deleted:                 false,
+						HasMergeConflicts:       false,
+						HasInlineMergeConflicts: false,
+						DisplayString:           "?? a -> b.txt",
+						Type:                    "other",
+						ShortStatus:             "??",
+					},
+				}
+
+				assert.EqualValues(t, expected, files)
+			},
+		},
 	}
 
 	for _, s := range scenarios {

--- a/pkg/commands/models/file.go
+++ b/pkg/commands/models/file.go
@@ -29,8 +29,6 @@ type IFile interface {
 	GetPath() string
 }
 
-const RENAME_SEPARATOR = " -> "
-
 func (f *File) IsRename() bool {
 	return f.PreviousName != ""
 }


### PR DESCRIPTION
Fixed #1408, and support filenames containing ` -> ` in the name.

<table>
<tr>
	<td>before</td>
	<td>after</td>
</tr>
<tr>
	<td>
<img width="799" alt="スクリーンショット 2021-08-16 20 09 05" src="https://user-images.githubusercontent.com/10097437/129554747-e6fe14ff-6244-49e1-a45a-d394ca120874.png">
</td>
	<td><img width="801" alt="スクリーンショット 2021-08-16 20 04 35" src="https://user-images.githubusercontent.com/10097437/129554485-61f11126-fb0b-4cd4-9210-306abbd49bfb.png"></td>
</tr>
<tr>
	<td>
<img width="796" alt="スクリーンショット 2021-08-16 23 16 22" src="https://user-images.githubusercontent.com/10097437/129578457-27f5d607-f6a6-432c-9be7-455be5f98e5a.png">
</td>
	<td>
<img width="798" alt="スクリーンショット 2021-08-16 23 16 50" src="https://user-images.githubusercontent.com/10097437/129578477-87ab4000-1bf3-461a-bfbc-6713fcd70179.png">
</td>
</tr>
</table>

