### PR TITLE
Fix stash submodule #1436

### DIFF
--- a/pkg/commands/submodules.go
+++ b/pkg/commands/submodules.go
@@ -69,7 +69,7 @@ func (c *GitCommand) SubmoduleStash(submodule *models.SubmoduleConfig) error {
 		return nil
 	}
 
-	return c.RunCommand("git -C %s stash --include-untracked", submodule.Path)
+	return c.RunCommand("git -C %s stash --include-untracked", c.OSCommand.Quote(submodule.Path))
 }
 
 func (c *GitCommand) SubmoduleReset(submodule *models.SubmoduleConfig) error {


### PR DESCRIPTION
Fix https://github.com/jesseduffield/lazygit/issues/1436#issuecomment-899465481 maybe caused by `git -C PATH stash --include-untracked`.