### PR TITLE
Fix panic during merge conflict #1375

### DIFF
--- a/pkg/gui/mergeconflicts/find_conflicts.go
+++ b/pkg/gui/mergeconflicts/find_conflicts.go
@@ -30,10 +30,14 @@ func findConflicts(content string) []*mergeConflict {
 		case START:
 			newConflict = &mergeConflict{start: i}
 		case MIDDLE:
-			newConflict.middle = i
+			if newConflict != nil {
+				newConflict.middle = i
+			}
 		case END:
-			newConflict.end = i
-			conflicts = append(conflicts, newConflict)
+			if newConflict != nil {
+				newConflict.end = i
+				conflicts = append(conflicts, newConflict)
+			}
 			// reset value to avoid any possible silent mutations in further iterations
 			newConflict = nil
 		default:


### PR DESCRIPTION
Fix #1375

## To reproduce

```sh
# Create a file contains '======='
$ echo '=======' >test.txt
$ git add test.txt
$ git commit -m 'common commit'

# Commit changes in the main branch
$ echo 'A' >>test.txt
$ git commit -am 'commit A'

# Commit changes in another branch
$ git switch -c another HEAD~
$ echo 'B' >>test.txt
$ git commit -am 'commit B'

# Return to the main branch and merge `another`
$ git switch -
$ git merge another # conflict

$ cat test.txt
=======
<<<<<<< HEAD
A
=======
B
>>>>>>> another


$ lazygit
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x15b7d88]
...
```
