### PR TITLE
Allow changing the context size in diffs

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -76,6 +76,7 @@ git:
   overrideGpg: false # prevents lazygit from spawning a separate process when using GPG
   disableForcePushing: false
   parseEmoji: false
+  diffContextSize: 3 # how many lines of context are shown around a change in diffs
 os:
   editCommand: '' # see 'Configuring File Editing' section
   editCommandTemplate: '{{editor}} {{filename}}'

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -155,6 +155,7 @@ keybinding:
     extrasMenu: '@'
     toggleWhitespaceInDiffView: '<c-w>'
     increaseContextInDiffView: '}'
+    decreaseContextInDiffView: '{'
   status:
     checkForUpdate: 'u'
     recentRepos: '<enter>'

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -154,6 +154,7 @@ keybinding:
     appendNewline: '<a-enter>'
     extrasMenu: '@'
     toggleWhitespaceInDiffView: '<c-w>'
+    increaseContextInDiffView: '}'
   status:
     checkForUpdate: 'u'
     recentRepos: '<enter>'

--- a/pkg/commands/commits.go
+++ b/pkg/commands/commits.go
@@ -61,11 +61,12 @@ func (c *GitCommand) AmendHeadCmdStr() string {
 }
 
 func (c *GitCommand) ShowCmdStr(sha string, filterPath string) string {
+	contextSize := c.Config.GetUserConfig().Git.DiffContextSize
 	filterPathArg := ""
 	if filterPath != "" {
 		filterPathArg = fmt.Sprintf(" -- %s", c.OSCommand.Quote(filterPath))
 	}
-	return fmt.Sprintf("git show --submodule --color=%s --no-renames --stat -p %s %s", c.colorArg(), sha, filterPathArg)
+	return fmt.Sprintf("git show --submodule --color=%s --unified=%d --no-renames --stat -p %s %s", c.colorArg(), contextSize, sha, filterPathArg)
 }
 
 // Revert reverts the selected commit by sha

--- a/pkg/commands/commits_test.go
+++ b/pkg/commands/commits_test.go
@@ -110,3 +110,43 @@ func TestGitCommandCreateFixupCommit(t *testing.T) {
 		})
 	}
 }
+
+// TestGitCommandShowCmdStr is a function.
+func TestGitCommandShowCmdStr(t *testing.T) {
+	type scenario struct {
+		testName    string
+		filterPath  string
+		contextSize int
+		expected    string
+	}
+
+	scenarios := []scenario{
+		{
+			testName:    "Default case without filter path",
+			filterPath:  "",
+			contextSize: 3,
+			expected:    "git show --submodule --color=always --unified=3 --no-renames --stat -p 1234567890 ",
+		},
+		{
+			testName:    "Default case with filter path",
+			filterPath:  "file.txt",
+			contextSize: 3,
+			expected:    "git show --submodule --color=always --unified=3 --no-renames --stat -p 1234567890  -- \"file.txt\"",
+		},
+		{
+			testName:    "Show diff with custom context size",
+			filterPath:  "",
+			contextSize: 77,
+			expected:    "git show --submodule --color=always --unified=77 --no-renames --stat -p 1234567890 ",
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			gitCmd := NewDummyGitCommand()
+			gitCmd.Config.GetUserConfig().Git.DiffContextSize = s.contextSize
+			cmdStr := gitCmd.ShowCmdStr("1234567890", s.filterPath)
+			assert.Equal(t, s.expected, cmdStr)
+		})
+	}
+}

--- a/pkg/commands/commits_test.go
+++ b/pkg/commands/commits_test.go
@@ -120,6 +120,8 @@ func TestGitCommandShowCmdStr(t *testing.T) {
 		expected    string
 	}
 
+	gitCmd := NewDummyGitCommand()
+
 	scenarios := []scenario{
 		{
 			testName:    "Default case without filter path",
@@ -131,7 +133,7 @@ func TestGitCommandShowCmdStr(t *testing.T) {
 			testName:    "Default case with filter path",
 			filterPath:  "file.txt",
 			contextSize: 3,
-			expected:    "git show --submodule --color=always --unified=3 --no-renames --stat -p 1234567890  -- \"file.txt\"",
+			expected:    "git show --submodule --color=always --unified=3 --no-renames --stat -p 1234567890  -- " + gitCmd.OSCommand.Quote("file.txt"),
 		},
 		{
 			testName:    "Show diff with custom context size",
@@ -143,7 +145,6 @@ func TestGitCommandShowCmdStr(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.testName, func(t *testing.T) {
-			gitCmd := NewDummyGitCommand()
 			gitCmd.Config.GetUserConfig().Git.DiffContextSize = s.contextSize
 			cmdStr := gitCmd.ShowCmdStr("1234567890", s.filterPath)
 			assert.Equal(t, s.expected, cmdStr)

--- a/pkg/commands/files.go
+++ b/pkg/commands/files.go
@@ -207,6 +207,7 @@ func (c *GitCommand) WorktreeFileDiffCmdStr(node models.IFile, plain bool, cache
 	colorArg := c.colorArg()
 	quotedPath := c.OSCommand.Quote(node.GetPath())
 	ignoreWhitespaceArg := ""
+	contextSize := c.Config.GetUserConfig().Git.DiffContextSize
 	if cached {
 		cachedArg = "--cached"
 	}
@@ -220,7 +221,7 @@ func (c *GitCommand) WorktreeFileDiffCmdStr(node models.IFile, plain bool, cache
 		ignoreWhitespaceArg = "--ignore-all-space"
 	}
 
-	return fmt.Sprintf("git diff --submodule --no-ext-diff --color=%s %s %s %s %s", colorArg, ignoreWhitespaceArg, cachedArg, trackedArg, quotedPath)
+	return fmt.Sprintf("git diff --submodule --no-ext-diff --unified=%d --color=%s %s %s %s %s", contextSize, colorArg, ignoreWhitespaceArg, cachedArg, trackedArg, quotedPath)
 }
 
 func (c *GitCommand) ApplyPatch(patch string, flags ...string) error {

--- a/pkg/commands/files.go
+++ b/pkg/commands/files.go
@@ -248,6 +248,7 @@ func (c *GitCommand) ShowFileDiff(from string, to string, reverse bool, fileName
 
 func (c *GitCommand) ShowFileDiffCmdStr(from string, to string, reverse bool, fileName string, plain bool) string {
 	colorArg := c.colorArg()
+	contextSize := c.Config.GetUserConfig().Git.DiffContextSize
 	if plain {
 		colorArg = "never"
 	}
@@ -257,7 +258,7 @@ func (c *GitCommand) ShowFileDiffCmdStr(from string, to string, reverse bool, fi
 		reverseFlag = " -R "
 	}
 
-	return fmt.Sprintf("git diff --submodule --no-ext-diff --no-renames --color=%s %s %s %s -- %s", colorArg, from, to, reverseFlag, c.OSCommand.Quote(fileName))
+	return fmt.Sprintf("git diff --submodule --no-ext-diff --unified=%d --no-renames --color=%s %s %s %s -- %s", contextSize, colorArg, from, to, reverseFlag, c.OSCommand.Quote(fileName))
 }
 
 // CheckoutFile checks out the file for the given commit

--- a/pkg/commands/files_test.go
+++ b/pkg/commands/files_test.go
@@ -444,13 +444,13 @@ func TestGitCommandDiff(t *testing.T) {
 // TestGitCommandShowFileDiff is a function.
 func TestGitCommandShowFileDiff(t *testing.T) {
 	type scenario struct {
-		testName         string
-		command          func(string, ...string) *exec.Cmd
-		from             string
-		to               string
-		reverse          bool
-		plain            bool
-		contextSize      int
+		testName    string
+		command     func(string, ...string) *exec.Cmd
+		from        string
+		to          string
+		reverse     bool
+		plain       bool
+		contextSize int
 	}
 
 	scenarios := []scenario{
@@ -489,7 +489,7 @@ func TestGitCommandShowFileDiff(t *testing.T) {
 			gitCmd := NewDummyGitCommand()
 			gitCmd.OSCommand.Command = s.command
 			gitCmd.Config.GetUserConfig().Git.DiffContextSize = s.contextSize
-			gitCmd.ShowFileDiff(s.from, s.to, s.reverse, "test.txt", s.plain)
+			_, _ = gitCmd.ShowFileDiff(s.from, s.to, s.reverse, "test.txt", s.plain)
 		})
 	}
 }

--- a/pkg/commands/files_test.go
+++ b/pkg/commands/files_test.go
@@ -441,6 +441,59 @@ func TestGitCommandDiff(t *testing.T) {
 	}
 }
 
+// TestGitCommandShowFileDiff is a function.
+func TestGitCommandShowFileDiff(t *testing.T) {
+	type scenario struct {
+		testName         string
+		command          func(string, ...string) *exec.Cmd
+		from             string
+		to               string
+		reverse          bool
+		plain            bool
+		contextSize      int
+	}
+
+	scenarios := []scenario{
+		{
+			"Default case",
+			func(cmd string, args ...string) *exec.Cmd {
+				assert.EqualValues(t, "git", cmd)
+				assert.EqualValues(t, []string{"diff", "--submodule", "--no-ext-diff", "--unified=3", "--no-renames", "--color=always", "1234567890", "0987654321", "--", "test.txt"}, args)
+
+				return secureexec.Command("echo")
+			},
+			"1234567890",
+			"0987654321",
+			false,
+			false,
+			3,
+		},
+		{
+			"Show diff with custom context size",
+			func(cmd string, args ...string) *exec.Cmd {
+				assert.EqualValues(t, "git", cmd)
+				assert.EqualValues(t, []string{"diff", "--submodule", "--no-ext-diff", "--unified=123", "--no-renames", "--color=always", "1234567890", "0987654321", "--", "test.txt"}, args)
+
+				return secureexec.Command("echo")
+			},
+			"1234567890",
+			"0987654321",
+			false,
+			false,
+			123,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			gitCmd := NewDummyGitCommand()
+			gitCmd.OSCommand.Command = s.command
+			gitCmd.Config.GetUserConfig().Git.DiffContextSize = s.contextSize
+			gitCmd.ShowFileDiff(s.from, s.to, s.reverse, "test.txt", s.plain)
+		})
+	}
+}
+
 // TestGitCommandCheckoutFile is a function.
 func TestGitCommandCheckoutFile(t *testing.T) {
 	type scenario struct {

--- a/pkg/commands/stash_entries.go
+++ b/pkg/commands/stash_entries.go
@@ -15,7 +15,7 @@ func (c *GitCommand) StashSave(message string) error {
 
 // GetStashEntryDiff stash diff
 func (c *GitCommand) ShowStashEntryCmdStr(index int) string {
-	return fmt.Sprintf("git stash show -p --stat --color=%s stash@{%d}", c.colorArg(), index)
+	return fmt.Sprintf("git stash show -p --stat --color=%s --unified=%d stash@{%d}", c.colorArg(), c.Config.GetUserConfig().Git.DiffContextSize, index)
 }
 
 // StashSaveStagedChanges stashes only the currently staged changes. This takes a few steps

--- a/pkg/commands/stash_entries_test.go
+++ b/pkg/commands/stash_entries_test.go
@@ -33,3 +33,37 @@ func TestGitCommandStashSave(t *testing.T) {
 
 	assert.NoError(t, gitCmd.StashSave("A stash message"))
 }
+
+// TestGitCommandShowStashEntryCmdStr is a function.
+func TestGitCommandShowStashEntryCmdStr(t *testing.T) {
+	type scenario struct {
+		testName    string
+		index       int
+		contextSize int
+		expected    string
+	}
+
+	scenarios := []scenario{
+		{
+			testName:    "Default case",
+			index:       5,
+			contextSize: 3,
+			expected:    "git stash show -p --stat --color=always --unified=3 stash@{5}",
+		},
+		{
+			testName:    "Show diff with custom context size",
+			index:       5,
+			contextSize: 77,
+			expected:    "git stash show -p --stat --color=always --unified=77 stash@{5}",
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			gitCmd := NewDummyGitCommand()
+			gitCmd.Config.GetUserConfig().Git.DiffContextSize = s.contextSize
+			cmdStr := gitCmd.ShowStashEntryCmdStr(s.index)
+			assert.Equal(t, s.expected, cmdStr)
+		})
+	}
+}

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -177,6 +177,7 @@ type KeybindingUniversalConfig struct {
 	AppendNewline                string   `yaml:"appendNewline"`
 	ExtrasMenu                   string   `yaml:"extrasMenu"`
 	ToggleWhitespaceInDiffView   string   `yaml:"toggleWhitespaceInDiffView"`
+	IncreaseContextInDiffView    string   `yaml:"increaseContextInDiffView"`
 }
 
 type KeybindingStatusConfig struct {
@@ -438,6 +439,7 @@ func GetDefaultConfig() *UserConfig {
 				AppendNewline:                "<a-enter>",
 				ExtrasMenu:                   "@",
 				ToggleWhitespaceInDiffView:   "<c-w>",
+				IncreaseContextInDiffView:    "}",
 			},
 			Status: KeybindingStatusConfig{
 				CheckForUpdate:      "u",

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -70,9 +70,9 @@ type GitConfig struct {
 	DisableForcePushing bool                          `yaml:"disableForcePushing"`
 	CommitPrefixes      map[string]CommitPrefixConfig `yaml:"commitPrefixes"`
 	// this shoudl really be under 'gui', not 'git'
-	ParseEmoji bool      `yaml:"parseEmoji"`
-	Log        LogConfig `yaml:"log"`
-	DiffContextSize     int                           `yaml:"diffContextSize"`
+	ParseEmoji      bool      `yaml:"parseEmoji"`
+	Log             LogConfig `yaml:"log"`
+	DiffContextSize int       `yaml:"diffContextSize"`
 }
 
 type PagingConfig struct {

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -72,6 +72,7 @@ type GitConfig struct {
 	// this shoudl really be under 'gui', not 'git'
 	ParseEmoji bool      `yaml:"parseEmoji"`
 	Log        LogConfig `yaml:"log"`
+	DiffContextSize     int                           `yaml:"diffContextSize"`
 }
 
 type PagingConfig struct {
@@ -359,6 +360,7 @@ func GetDefaultConfig() *UserConfig {
 			DisableForcePushing: false,
 			CommitPrefixes:      map[string]CommitPrefixConfig(nil),
 			ParseEmoji:          false,
+			DiffContextSize:     3,
 		},
 		Refresher: RefresherConfig{
 			RefreshInterval: 10,

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -178,6 +178,7 @@ type KeybindingUniversalConfig struct {
 	ExtrasMenu                   string   `yaml:"extrasMenu"`
 	ToggleWhitespaceInDiffView   string   `yaml:"toggleWhitespaceInDiffView"`
 	IncreaseContextInDiffView    string   `yaml:"increaseContextInDiffView"`
+	DecreaseContextInDiffView    string   `yaml:"decreaseContextInDiffView"`
 }
 
 type KeybindingStatusConfig struct {
@@ -440,6 +441,7 @@ func GetDefaultConfig() *UserConfig {
 				ExtrasMenu:                   "@",
 				ToggleWhitespaceInDiffView:   "<c-w>",
 				IncreaseContextInDiffView:    "}",
+				DecreaseContextInDiffView:    "{",
 			},
 			Status: KeybindingStatusConfig{
 				CheckForUpdate:      "u",

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -25,7 +25,7 @@ func (gui *Gui) getSelectedBranch() *models.Branch {
 	return gui.State.Branches[selectedLine]
 }
 
-func (gui *Gui) handleBranchSelect() error {
+func (gui *Gui) branchesRenderToMain() error {
 	var task updateTask
 	branch := gui.getSelectedBranch()
 	if branch == nil {

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -24,7 +24,7 @@ func (gui *Gui) getSelectedLocalCommit() *models.Commit {
 	return gui.State.Commits[selectedLine]
 }
 
-func (gui *Gui) handleCommitSelect() error {
+func (gui *Gui) onCommitFocus() error {
 	state := gui.State.Panels.Commits
 	if state.SelectedLineIdx > COMMIT_THRESHOLD && state.LimitCommits {
 		state.LimitCommits = false
@@ -37,6 +37,10 @@ func (gui *Gui) handleCommitSelect() error {
 
 	gui.escapeLineByLinePanel()
 
+	return nil
+}
+
+func (gui *Gui) branchCommitsRenderToMain() error {
 	var task updateTask
 	commit := gui.getSelectedLocalCommit()
 	if commit == nil {

--- a/pkg/gui/confirmation_panel.go
+++ b/pkg/gui/confirmation_panel.go
@@ -1,5 +1,3 @@
-// lots of this has been directly ported from one of the example files, will brush up later
-
 package gui
 
 import (
@@ -7,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/jesseduffield/gocui"
-	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/theme"
 	"github.com/jesseduffield/lazygit/pkg/utils"
@@ -44,30 +41,15 @@ type promptOpts struct {
 }
 
 func (gui *Gui) ask(opts askOpts) error {
-	return gui.createPopupPanel(createPopupPanelOpts{
-		title:               opts.title,
-		prompt:              opts.prompt,
-		handleConfirm:       opts.handleConfirm,
-		handleClose:         opts.handleClose,
-		handlersManageFocus: opts.handlersManageFocus,
-	})
+	return gui.PopupHandler.Ask(opts)
 }
 
 func (gui *Gui) prompt(opts promptOpts) error {
-	return gui.createPopupPanel(createPopupPanelOpts{
-		title:               opts.title,
-		prompt:              opts.initialContent,
-		editable:            true,
-		handleConfirmPrompt: opts.handleConfirm,
-		findSuggestionsFunc: opts.findSuggestionsFunc,
-	})
+	return gui.PopupHandler.Prompt(opts)
 }
 
 func (gui *Gui) createLoaderPanel(prompt string) error {
-	return gui.createPopupPanel(createPopupPanelOpts{
-		prompt:    prompt,
-		hasLoader: true,
-	})
+	return gui.PopupHandler.Loader(prompt)
 }
 
 func (gui *Gui) wrappedConfirmationFunction(handlersManageFocus bool, function func() error) func() error {
@@ -339,15 +321,7 @@ func (gui *Gui) wrappedHandler(f func() error) func(g *gocui.Gui, v *gocui.View)
 }
 
 func (gui *Gui) createErrorPanel(message string) error {
-	coloredMessage := style.FgRed.Sprint(strings.TrimSpace(message))
-	if err := gui.refreshSidePanels(refreshOptions{mode: ASYNC}); err != nil {
-		return err
-	}
-
-	return gui.ask(askOpts{
-		title:  gui.Tr.Error,
-		prompt: coloredMessage,
-	})
+	return gui.PopupHandler.Error(message)
 }
 
 func (gui *Gui) surfaceError(err error) error {

--- a/pkg/gui/context.go
+++ b/pkg/gui/context.go
@@ -169,7 +169,7 @@ func (gui *Gui) deactivateContext(c Context) error {
 	}
 
 	// if we are the kind of context that is sent to back upon deactivation, we should do that
-	if view != nil && c.GetKind() == TEMPORARY_POPUP || c.GetKind() == PERSISTENT_POPUP || c.GetKey() == COMMIT_FILES_CONTEXT_KEY {
+	if view != nil && (c.GetKind() == TEMPORARY_POPUP || c.GetKind() == PERSISTENT_POPUP || c.GetKey() == COMMIT_FILES_CONTEXT_KEY) {
 		view.Visible = false
 	}
 

--- a/pkg/gui/context_config.go
+++ b/pkg/gui/context_config.go
@@ -141,6 +141,9 @@ func (gui *Gui) contextTree() ContextTree {
 				// TODO: centralise the code here
 				// return gui.refreshStagingPanel(false, -1)
 			},
+			OnRender: func() error {
+				return gui.handleRefreshStagingPanel(false, -1)
+			},
 			Kind:     MAIN_CONTEXT,
 			ViewName: "main",
 			Key:      MAIN_STAGING_CONTEXT_KEY,
@@ -150,6 +153,9 @@ func (gui *Gui) contextTree() ContextTree {
 				return nil
 				// TODO: centralise the code here
 				// return gui.refreshPatchBuildingPanel(-1)
+			},
+			OnRender: func() error {
+				return gui.handleRefreshPatchBuildingPanel(-1)
 			},
 			Kind:     MAIN_CONTEXT,
 			ViewName: "main",

--- a/pkg/gui/context_config.go
+++ b/pkg/gui/context_config.go
@@ -110,10 +110,10 @@ func (gui *Gui) allContexts() []Context {
 func (gui *Gui) contextTree() ContextTree {
 	return ContextTree{
 		Status: &BasicContext{
-			OnFocus:  gui.handleStatusSelect,
-			Kind:     SIDE_CONTEXT,
-			ViewName: "status",
-			Key:      STATUS_CONTEXT_KEY,
+			OnRenderToMain: OnFocusWrapper(gui.statusRenderToMain),
+			Kind:           SIDE_CONTEXT,
+			ViewName:       "status",
+			Key:            STATUS_CONTEXT_KEY,
 		},
 		Files:          gui.filesListContext(),
 		Submodules:     gui.submodulesListContext(),
@@ -128,7 +128,7 @@ func (gui *Gui) contextTree() ContextTree {
 		Tags:           gui.tagsListContext(),
 		Stash:          gui.stashListContext(),
 		Normal: &BasicContext{
-			OnFocus: func() error {
+			OnFocus: func(opts ...OnFocusOpts) error {
 				return nil // TODO: should we do something here? We should allow for scrolling the panel
 			},
 			Kind:     MAIN_CONTEXT,
@@ -136,65 +136,67 @@ func (gui *Gui) contextTree() ContextTree {
 			Key:      MAIN_NORMAL_CONTEXT_KEY,
 		},
 		Staging: &BasicContext{
-			OnFocus: func() error {
-				return nil
-				// TODO: centralise the code here
-				// return gui.refreshStagingPanel(false, -1)
-			},
-			OnRender: func() error {
-				return gui.handleRefreshStagingPanel(false, -1)
+			OnRenderToMain: func(opts ...OnFocusOpts) error {
+				forceSecondaryFocused := false
+				selectedLineIdx := -1
+				if len(opts) > 0 && opts[0].ClickedViewName != "" {
+					if opts[0].ClickedViewName == "main" || opts[0].ClickedViewName == "secondary" {
+						selectedLineIdx = opts[0].ClickedViewLineIdx
+					}
+					if opts[0].ClickedViewName == "secondary" {
+						forceSecondaryFocused = true
+					}
+				}
+				return gui.handleRefreshStagingPanel(forceSecondaryFocused, selectedLineIdx)
 			},
 			Kind:     MAIN_CONTEXT,
 			ViewName: "main",
 			Key:      MAIN_STAGING_CONTEXT_KEY,
 		},
 		PatchBuilding: &BasicContext{
-			OnFocus: func() error {
-				return nil
-				// TODO: centralise the code here
-				// return gui.refreshPatchBuildingPanel(-1)
-			},
-			OnRender: func() error {
-				return gui.handleRefreshPatchBuildingPanel(-1)
+			OnRenderToMain: func(opts ...OnFocusOpts) error {
+				selectedLineIdx := -1
+				if len(opts) > 0 && (opts[0].ClickedViewName == "main" || opts[0].ClickedViewName == "secondary") {
+					selectedLineIdx = opts[0].ClickedViewLineIdx
+				}
+
+				return gui.handleRefreshPatchBuildingPanel(selectedLineIdx)
 			},
 			Kind:     MAIN_CONTEXT,
 			ViewName: "main",
 			Key:      MAIN_PATCH_BUILDING_CONTEXT_KEY,
 		},
 		Merging: &BasicContext{
-			OnFocus:         gui.refreshMergePanelWithLock,
+			OnFocus:         OnFocusWrapper(gui.refreshMergePanelWithLock),
 			Kind:            MAIN_CONTEXT,
 			ViewName:        "main",
 			Key:             MAIN_MERGING_CONTEXT_KEY,
 			OnGetOptionsMap: gui.getMergingOptions,
 		},
 		Credentials: &BasicContext{
-			OnFocus:  gui.handleCredentialsViewFocused,
+			OnFocus:  OnFocusWrapper(gui.handleCredentialsViewFocused),
 			Kind:     PERSISTENT_POPUP,
 			ViewName: "credentials",
 			Key:      CREDENTIALS_CONTEXT_KEY,
 		},
 		Confirmation: &BasicContext{
-			OnFocus:  func() error { return nil },
 			Kind:     TEMPORARY_POPUP,
 			ViewName: "confirmation",
 			Key:      CONFIRMATION_CONTEXT_KEY,
 		},
 		Suggestions: gui.suggestionsListContext(),
 		CommitMessage: &BasicContext{
-			OnFocus:  gui.handleCommitMessageFocused,
+			OnFocus:  OnFocusWrapper(gui.handleCommitMessageFocused),
 			Kind:     PERSISTENT_POPUP,
 			ViewName: "commitMessage",
 			Key:      COMMIT_MESSAGE_CONTEXT_KEY,
 		},
 		Search: &BasicContext{
-			OnFocus:  func() error { return nil },
 			Kind:     PERSISTENT_POPUP,
 			ViewName: "search",
 			Key:      SEARCH_CONTEXT_KEY,
 		},
 		CommandLog: &BasicContext{
-			OnFocus:         func() error { return nil },
 			Kind:            EXTRAS_CONTEXT,
 			ViewName:        "extras",
 			Key:             COMMAND_LOG_CONTEXT_KEY,
@@ -204,6 +206,14 @@ func (gui *Gui) contextTree() ContextTree {
 				return nil
 			},
 		},
+	}
+}
+
+// using this wrapper for when an onFocus function doesn't care about any potential
+// props that could be passed
+func OnFocusWrapper(f func() error) func(opts ...OnFocusOpts) error {
+	return func(opts ...OnFocusOpts) error {
+		return f()
 	}
 }
 

--- a/pkg/gui/context_test.go
+++ b/pkg/gui/context_test.go
@@ -1,0 +1,40 @@
+package gui
+
+import (
+	"testing"
+
+	"github.com/jesseduffield/gocui"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCanDeactivatePopupContextsWithoutViews(t *testing.T) {
+	contexts := []func(gui *Gui) Context {
+		func(gui *Gui) Context { return gui.State.Contexts.Credentials },
+		func(gui *Gui) Context { return gui.State.Contexts.Confirmation },
+		func(gui *Gui) Context { return gui.State.Contexts.CommitMessage },
+		func(gui *Gui) Context { return gui.State.Contexts.Search },
+	}
+
+	for _, c := range contexts {
+		gui := NewDummyGui()
+		context := c(gui)
+		gui.g = &gocui.Gui{}
+
+		gui.deactivateContext(context)
+
+		// This really only checks a prerequisit, not the effect of deactivateContext
+		view, _ := gui.g.View(context.GetViewName())
+		assert.Nil(t, view, string(context.GetKey()))
+	}
+}
+
+func TestCanDeactivateCommitFilesContextsWithoutViews(t *testing.T) {
+	gui := NewDummyGui()
+	gui.g = &gocui.Gui{}
+
+	gui.deactivateContext(gui.State.Contexts.CommitFiles)
+
+	// This really only checks a prerequisite, not the effect of deactivateContext
+	view, _ := gui.g.View(gui.State.Contexts.CommitFiles.GetViewName())
+	assert.Nil(t, view)
+}

--- a/pkg/gui/context_test.go
+++ b/pkg/gui/context_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCanDeactivatePopupContextsWithoutViews(t *testing.T) {
-	contexts := []func(gui *Gui) Context {
+	contexts := []func(gui *Gui) Context{
 		func(gui *Gui) Context { return gui.State.Contexts.Credentials },
 		func(gui *Gui) Context { return gui.State.Contexts.Confirmation },
 		func(gui *Gui) Context { return gui.State.Contexts.CommitMessage },
@@ -20,7 +20,7 @@ func TestCanDeactivatePopupContextsWithoutViews(t *testing.T) {
 		context := c(gui)
 		gui.g = &gocui.Gui{}
 
-		gui.deactivateContext(context)
+		_ = gui.deactivateContext(context)
 
 		// This really only checks a prerequisit, not the effect of deactivateContext
 		view, _ := gui.g.View(context.GetViewName())
@@ -32,7 +32,7 @@ func TestCanDeactivateCommitFilesContextsWithoutViews(t *testing.T) {
 	gui := NewDummyGui()
 	gui.g = &gocui.Gui{}
 
-	gui.deactivateContext(gui.State.Contexts.CommitFiles)
+	_ = gui.deactivateContext(gui.State.Contexts.CommitFiles)
 
 	// This really only checks a prerequisite, not the effect of deactivateContext
 	view, _ := gui.g.View(gui.State.Contexts.CommitFiles.GetViewName())

--- a/pkg/gui/diff_context_size.go
+++ b/pkg/gui/diff_context_size.go
@@ -14,3 +14,14 @@ func (gui *Gui) IncreaseContextInDiffView() error {
 
 	return nil
 }
+
+func (gui *Gui) DecreaseContextInDiffView() error {
+	old_size := gui.Config.GetUserConfig().Git.DiffContextSize
+
+	if isShowingDiff(gui) && old_size > 1 {
+		gui.Config.GetUserConfig().Git.DiffContextSize = old_size - 1
+		return gui.postRefreshUpdate(gui.currentStaticContext())
+	}
+
+	return nil
+}

--- a/pkg/gui/diff_context_size.go
+++ b/pkg/gui/diff_context_size.go
@@ -1,0 +1,16 @@
+package gui
+
+func isShowingDiff(gui *Gui) bool {
+	key := gui.currentStaticContext().GetKey()
+
+	return key == FILES_CONTEXT_KEY || key == COMMIT_FILES_CONTEXT_KEY || key == STASH_CONTEXT_KEY || key == BRANCH_COMMITS_CONTEXT_KEY || key == SUB_COMMITS_CONTEXT_KEY || key == MAIN_STAGING_CONTEXT_KEY || key == MAIN_PATCH_BUILDING_CONTEXT_KEY
+}
+
+func (gui *Gui) IncreaseContextInDiffView() error {
+	if isShowingDiff(gui) {
+		gui.Config.GetUserConfig().Git.DiffContextSize = gui.Config.GetUserConfig().Git.DiffContextSize + 1
+		return gui.postRefreshUpdate(gui.currentStaticContext())
+	}
+
+	return nil
+}

--- a/pkg/gui/diff_context_size_test.go
+++ b/pkg/gui/diff_context_size_test.go
@@ -28,11 +28,11 @@ func setupGuiForTest(gui *Gui) {
 	gui.Views.Main, _ = gui.prepareView("main")
 	gui.Views.Secondary, _ = gui.prepareView("secondary")
 	gui.GitCommand.PatchManager = &patch.PatchManager{}
-  gui.refreshLineByLinePanel(diffForTest, "", false, 11)
+	gui.refreshLineByLinePanel(diffForTest, "", false, 11)
 }
 
 func TestIncreasesContextInDiffViewByOneInContextWithDiff(t *testing.T) {
-	contexts := []func(gui *Gui) Context {
+	contexts := []func(gui *Gui) Context{
 		func(gui *Gui) Context { return gui.State.Contexts.Files },
 		func(gui *Gui) Context { return gui.State.Contexts.BranchCommits },
 		func(gui *Gui) Context { return gui.State.Contexts.CommitFiles },
@@ -56,7 +56,7 @@ func TestIncreasesContextInDiffViewByOneInContextWithDiff(t *testing.T) {
 }
 
 func TestDoesntIncreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
-	contexts := []func(gui *Gui) Context {
+	contexts := []func(gui *Gui) Context{
 		func(gui *Gui) Context { return gui.State.Contexts.Status },
 		func(gui *Gui) Context { return gui.State.Contexts.Submodules },
 		func(gui *Gui) Context { return gui.State.Contexts.Remotes },
@@ -82,7 +82,7 @@ func TestDoesntIncreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
 }
 
 func TestDecreasesContextInDiffViewByOneInContextWithDiff(t *testing.T) {
-	contexts := []func(gui *Gui) Context {
+	contexts := []func(gui *Gui) Context{
 		func(gui *Gui) Context { return gui.State.Contexts.Files },
 		func(gui *Gui) Context { return gui.State.Contexts.BranchCommits },
 		func(gui *Gui) Context { return gui.State.Contexts.CommitFiles },
@@ -106,7 +106,7 @@ func TestDecreasesContextInDiffViewByOneInContextWithDiff(t *testing.T) {
 }
 
 func TestDoesntDecreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
-	contexts := []func(gui *Gui) Context {
+	contexts := []func(gui *Gui) Context{
 		func(gui *Gui) Context { return gui.State.Contexts.Status },
 		func(gui *Gui) Context { return gui.State.Contexts.Submodules },
 		func(gui *Gui) Context { return gui.State.Contexts.Remotes },
@@ -119,7 +119,7 @@ func TestDoesntDecreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
 	}
 
 	for _, c := range contexts {
-    gui := NewDummyGui()
+		gui := NewDummyGui()
 		context := c(gui)
 		setupGuiForTest(gui)
 		gui.Config.GetUserConfig().Git.DiffContextSize = 2
@@ -129,6 +129,30 @@ func TestDoesntDecreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
 
 		assert.Equal(t, 2, gui.Config.GetUserConfig().Git.DiffContextSize, string(context.GetKey()))
 	}
+}
+
+func TestDoesntIncreaseContextInDiffViewInContextWhenInPatchBuildingMode(t *testing.T) {
+	gui := NewDummyGui()
+	setupGuiForTest(gui)
+	gui.Config.GetUserConfig().Git.DiffContextSize = 2
+	gui.pushContextDirect(gui.State.Contexts.CommitFiles)
+	gui.GitCommand.PatchManager.Start("from", "to", false, false)
+
+	gui.IncreaseContextInDiffView()
+
+	assert.Equal(t, 2, gui.Config.GetUserConfig().Git.DiffContextSize)
+}
+
+func TestDoesntDecreaseContextInDiffViewInContextWhenInPatchBuildingMode(t *testing.T) {
+	gui := NewDummyGui()
+	setupGuiForTest(gui)
+	gui.Config.GetUserConfig().Git.DiffContextSize = 2
+	gui.pushContextDirect(gui.State.Contexts.CommitFiles)
+	gui.GitCommand.PatchManager.Start("from", "to", false, false)
+
+	gui.DecreaseContextInDiffView()
+
+	assert.Equal(t, 2, gui.Config.GetUserConfig().Git.DiffContextSize)
 }
 
 func TestDecreasesContextInDiffViewNoFurtherThanOne(t *testing.T) {

--- a/pkg/gui/diff_context_size_test.go
+++ b/pkg/gui/diff_context_size_test.go
@@ -80,3 +80,63 @@ func TestDoesntIncreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
 		assert.Equal(t, 1, gui.Config.GetUserConfig().Git.DiffContextSize, string(context.GetKey()))
 	}
 }
+
+func TestDecreasesContextInDiffViewByOneInContextWithDiff(t *testing.T) {
+	contexts := []func(gui *Gui) Context {
+		func(gui *Gui) Context { return gui.State.Contexts.Files },
+		func(gui *Gui) Context { return gui.State.Contexts.BranchCommits },
+		func(gui *Gui) Context { return gui.State.Contexts.CommitFiles },
+		func(gui *Gui) Context { return gui.State.Contexts.Stash },
+		func(gui *Gui) Context { return gui.State.Contexts.Staging },
+		func(gui *Gui) Context { return gui.State.Contexts.PatchBuilding },
+		func(gui *Gui) Context { return gui.State.Contexts.SubCommits },
+	}
+
+	for _, c := range contexts {
+		gui := NewDummyGui()
+		context := c(gui)
+		setupGuiForTest(gui)
+		gui.Config.GetUserConfig().Git.DiffContextSize = 2
+		gui.pushContextDirect(context)
+
+		gui.DecreaseContextInDiffView()
+
+		assert.Equal(t, 1, gui.Config.GetUserConfig().Git.DiffContextSize, string(context.GetKey()))
+	}
+}
+
+func TestDoesntDecreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
+	contexts := []func(gui *Gui) Context {
+		func(gui *Gui) Context { return gui.State.Contexts.Status },
+		func(gui *Gui) Context { return gui.State.Contexts.Submodules },
+		func(gui *Gui) Context { return gui.State.Contexts.Remotes },
+		func(gui *Gui) Context { return gui.State.Contexts.Normal },
+		func(gui *Gui) Context { return gui.State.Contexts.ReflogCommits },
+		func(gui *Gui) Context { return gui.State.Contexts.RemoteBranches },
+		func(gui *Gui) Context { return gui.State.Contexts.Tags },
+		func(gui *Gui) Context { return gui.State.Contexts.Merging },
+		func(gui *Gui) Context { return gui.State.Contexts.CommandLog },
+	}
+
+	for _, c := range contexts {
+    gui := NewDummyGui()
+		context := c(gui)
+		setupGuiForTest(gui)
+		gui.Config.GetUserConfig().Git.DiffContextSize = 2
+		gui.pushContextDirect(context)
+
+		gui.DecreaseContextInDiffView()
+
+		assert.Equal(t, 2, gui.Config.GetUserConfig().Git.DiffContextSize, string(context.GetKey()))
+	}
+}
+
+func TestDecreasesContextInDiffViewNoFurtherThanOne(t *testing.T) {
+	gui := NewDummyGui()
+	setupGuiForTest(gui)
+	gui.Config.GetUserConfig().Git.DiffContextSize = 1
+
+	gui.DecreaseContextInDiffView()
+
+	assert.Equal(t, 1, gui.Config.GetUserConfig().Git.DiffContextSize)
+}

--- a/pkg/gui/diff_context_size_test.go
+++ b/pkg/gui/diff_context_size_test.go
@@ -28,7 +28,7 @@ func setupGuiForTest(gui *Gui) {
 	gui.Views.Main, _ = gui.prepareView("main")
 	gui.Views.Secondary, _ = gui.prepareView("secondary")
 	gui.GitCommand.PatchManager = &patch.PatchManager{}
-	gui.refreshLineByLinePanel(diffForTest, "", false, 11)
+	_, _ = gui.refreshLineByLinePanel(diffForTest, "", false, 11)
 }
 
 func TestIncreasesContextInDiffViewByOneInContextWithDiff(t *testing.T) {
@@ -47,9 +47,9 @@ func TestIncreasesContextInDiffViewByOneInContextWithDiff(t *testing.T) {
 		context := c(gui)
 		setupGuiForTest(gui)
 		gui.Config.GetUserConfig().Git.DiffContextSize = 1
-		gui.pushContextDirect(context)
+		_ = gui.pushContextDirect(context)
 
-		gui.IncreaseContextInDiffView()
+		_ = gui.IncreaseContextInDiffView()
 
 		assert.Equal(t, 2, gui.Config.GetUserConfig().Git.DiffContextSize, string(context.GetKey()))
 	}
@@ -73,9 +73,9 @@ func TestDoesntIncreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
 		context := c(gui)
 		setupGuiForTest(gui)
 		gui.Config.GetUserConfig().Git.DiffContextSize = 1
-		gui.pushContextDirect(context)
+		_ = gui.pushContextDirect(context)
 
-		gui.IncreaseContextInDiffView()
+		_ = gui.IncreaseContextInDiffView()
 
 		assert.Equal(t, 1, gui.Config.GetUserConfig().Git.DiffContextSize, string(context.GetKey()))
 	}
@@ -97,9 +97,9 @@ func TestDecreasesContextInDiffViewByOneInContextWithDiff(t *testing.T) {
 		context := c(gui)
 		setupGuiForTest(gui)
 		gui.Config.GetUserConfig().Git.DiffContextSize = 2
-		gui.pushContextDirect(context)
+		_ = gui.pushContextDirect(context)
 
-		gui.DecreaseContextInDiffView()
+		_ = gui.DecreaseContextInDiffView()
 
 		assert.Equal(t, 1, gui.Config.GetUserConfig().Git.DiffContextSize, string(context.GetKey()))
 	}
@@ -123,9 +123,9 @@ func TestDoesntDecreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
 		context := c(gui)
 		setupGuiForTest(gui)
 		gui.Config.GetUserConfig().Git.DiffContextSize = 2
-		gui.pushContextDirect(context)
+		_ = gui.pushContextDirect(context)
 
-		gui.DecreaseContextInDiffView()
+		_ = gui.DecreaseContextInDiffView()
 
 		assert.Equal(t, 2, gui.Config.GetUserConfig().Git.DiffContextSize, string(context.GetKey()))
 	}
@@ -135,11 +135,21 @@ func TestDoesntIncreaseContextInDiffViewInContextWhenInPatchBuildingMode(t *test
 	gui := NewDummyGui()
 	setupGuiForTest(gui)
 	gui.Config.GetUserConfig().Git.DiffContextSize = 2
-	gui.pushContextDirect(gui.State.Contexts.CommitFiles)
+	_ = gui.pushContextDirect(gui.State.Contexts.CommitFiles)
 	gui.GitCommand.PatchManager.Start("from", "to", false, false)
 
-	gui.IncreaseContextInDiffView()
+	errorCount := 0
+	gui.PopupHandler = &TestPopupHandler{
+		onError: func(message string) error {
+			assert.Equal(t, gui.Tr.CantChangeContextSizeError, message)
+			errorCount += 1
+			return nil
+		},
+	}
 
+	_ = gui.IncreaseContextInDiffView()
+
+	assert.Equal(t, 1, errorCount)
 	assert.Equal(t, 2, gui.Config.GetUserConfig().Git.DiffContextSize)
 }
 
@@ -147,10 +157,19 @@ func TestDoesntDecreaseContextInDiffViewInContextWhenInPatchBuildingMode(t *test
 	gui := NewDummyGui()
 	setupGuiForTest(gui)
 	gui.Config.GetUserConfig().Git.DiffContextSize = 2
-	gui.pushContextDirect(gui.State.Contexts.CommitFiles)
+	_ = gui.pushContextDirect(gui.State.Contexts.CommitFiles)
 	gui.GitCommand.PatchManager.Start("from", "to", false, false)
 
-	gui.DecreaseContextInDiffView()
+	errorCount := 0
+	gui.PopupHandler = &TestPopupHandler{
+		onError: func(message string) error {
+			assert.Equal(t, gui.Tr.CantChangeContextSizeError, message)
+			errorCount += 1
+			return nil
+		},
+	}
+
+	_ = gui.DecreaseContextInDiffView()
 
 	assert.Equal(t, 2, gui.Config.GetUserConfig().Git.DiffContextSize)
 }
@@ -160,7 +179,7 @@ func TestDecreasesContextInDiffViewNoFurtherThanOne(t *testing.T) {
 	setupGuiForTest(gui)
 	gui.Config.GetUserConfig().Git.DiffContextSize = 1
 
-	gui.DecreaseContextInDiffView()
+	_ = gui.DecreaseContextInDiffView()
 
 	assert.Equal(t, 1, gui.Config.GetUserConfig().Git.DiffContextSize)
 }

--- a/pkg/gui/diff_context_size_test.go
+++ b/pkg/gui/diff_context_size_test.go
@@ -1,0 +1,82 @@
+package gui
+
+import (
+	"testing"
+
+	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazygit/pkg/commands/patch"
+	"github.com/stretchr/testify/assert"
+)
+
+const diffForTest = `diff --git a/pkg/gui/diff_context_size.go b/pkg/gui/diff_context_size.go
+index 0da0a982..742b7dcf 100644
+--- a/pkg/gui/diff_context_size.go
++++ b/pkg/gui/diff_context_size.go
+@@ -9,12 +9,12 @@ func getRefreshFunction(gui *Gui) func()error {
+                }
+        } else if key == MAIN_STAGING_CONTEXT_KEY {
+                return func() error {
+-                       selectedLine := gui.Views.Secondary.SelectedLineIdx()
++                       selectedLine := gui.State.Panels.LineByLine.GetSelectedLineIdx()
+                        return gui.handleRefreshStagingPanel(false, selectedLine)
+                }
+        } else if key == MAIN_PATCH_BUILDING_CONTEXT_KEY {
+`
+
+func setupGuiForTest(gui *Gui) {
+	gui.g = &gocui.Gui{}
+	gui.Views.Main, _ = gui.prepareView("main")
+	gui.Views.Secondary, _ = gui.prepareView("secondary")
+	gui.GitCommand.PatchManager = &patch.PatchManager{}
+  gui.refreshLineByLinePanel(diffForTest, "", false, 11)
+}
+
+func TestIncreasesContextInDiffViewByOneInContextWithDiff(t *testing.T) {
+	contexts := []func(gui *Gui) Context {
+		func(gui *Gui) Context { return gui.State.Contexts.Files },
+		func(gui *Gui) Context { return gui.State.Contexts.BranchCommits },
+		func(gui *Gui) Context { return gui.State.Contexts.CommitFiles },
+		func(gui *Gui) Context { return gui.State.Contexts.Stash },
+		func(gui *Gui) Context { return gui.State.Contexts.Staging },
+		func(gui *Gui) Context { return gui.State.Contexts.PatchBuilding },
+		func(gui *Gui) Context { return gui.State.Contexts.SubCommits },
+	}
+
+	for _, c := range contexts {
+		gui := NewDummyGui()
+		context := c(gui)
+		setupGuiForTest(gui)
+		gui.Config.GetUserConfig().Git.DiffContextSize = 1
+		gui.pushContextDirect(context)
+
+		gui.IncreaseContextInDiffView()
+
+		assert.Equal(t, 2, gui.Config.GetUserConfig().Git.DiffContextSize, string(context.GetKey()))
+	}
+}
+
+func TestDoesntIncreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
+	contexts := []func(gui *Gui) Context {
+		func(gui *Gui) Context { return gui.State.Contexts.Status },
+		func(gui *Gui) Context { return gui.State.Contexts.Submodules },
+		func(gui *Gui) Context { return gui.State.Contexts.Remotes },
+		func(gui *Gui) Context { return gui.State.Contexts.Normal },
+		func(gui *Gui) Context { return gui.State.Contexts.ReflogCommits },
+		func(gui *Gui) Context { return gui.State.Contexts.RemoteBranches },
+		func(gui *Gui) Context { return gui.State.Contexts.Tags },
+		func(gui *Gui) Context { return gui.State.Contexts.Merging },
+		func(gui *Gui) Context { return gui.State.Contexts.CommandLog },
+	}
+
+	for _, c := range contexts {
+		gui := NewDummyGui()
+		context := c(gui)
+		setupGuiForTest(gui)
+		gui.Config.GetUserConfig().Git.DiffContextSize = 1
+		gui.pushContextDirect(context)
+
+		gui.IncreaseContextInDiffView()
+
+		assert.Equal(t, 1, gui.Config.GetUserConfig().Git.DiffContextSize, string(context.GetKey()))
+	}
+}

--- a/pkg/gui/dummies.go
+++ b/pkg/gui/dummies.go
@@ -12,12 +12,12 @@ import (
 // NewDummyGui creates a new dummy GUI for testing
 func NewDummyUpdater() *updates.Updater {
 	newAppConfig := config.NewDummyAppConfig()
-	DummyUpdater, _ := updates.NewUpdater(utils.NewDummyLog(), newAppConfig, oscommands.NewDummyOSCommand(), i18n.NewTranslationSet(utils.NewDummyLog(), newAppConfig.GetUserConfig().Gui.Language))
-	return DummyUpdater
+	dummyUpdater, _ := updates.NewUpdater(utils.NewDummyLog(), newAppConfig, oscommands.NewDummyOSCommand(), i18n.NewTranslationSet(utils.NewDummyLog(), newAppConfig.GetUserConfig().Gui.Language))
+	return dummyUpdater
 }
 
 func NewDummyGui() *Gui {
 	newAppConfig := config.NewDummyAppConfig()
-	DummyGui, _ := NewGui(utils.NewDummyLog(), commands.NewDummyGitCommand(), oscommands.NewDummyOSCommand(), i18n.NewTranslationSet(utils.NewDummyLog(), newAppConfig.GetUserConfig().Gui.Language), newAppConfig, NewDummyUpdater(), "", false)
-	return DummyGui
+	dummyGui, _ := NewGui(utils.NewDummyLog(), commands.NewDummyGitCommand(), oscommands.NewDummyOSCommand(), i18n.NewTranslationSet(utils.NewDummyLog(), newAppConfig.GetUserConfig().Gui.Language), newAppConfig, NewDummyUpdater(), "", false)
+	return dummyGui
 }

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -189,9 +189,9 @@ func (gui *Gui) handleMouseDownMain() error {
 		// set filename, set primary/secondary selected, set line number, then switch context
 		// I'll need to know it was changed though.
 		// Could I pass something along to the context change?
-		return gui.enterFile(false, gui.Views.Main.SelectedLineIdx())
+		return gui.enterFile(OnFocusOpts{ClickedViewName: "main", ClickedViewLineIdx: gui.Views.Main.SelectedLineIdx()})
 	case gui.State.Contexts.CommitFiles:
-		return gui.enterCommitFile(gui.Views.Main.SelectedLineIdx())
+		return gui.enterCommitFile(OnFocusOpts{ClickedViewName: "main", ClickedViewLineIdx: gui.Views.Main.SelectedLineIdx()})
 	}
 
 	return nil
@@ -204,7 +204,7 @@ func (gui *Gui) handleMouseDownSecondary() error {
 
 	switch gui.g.CurrentView() {
 	case gui.Views.Files:
-		return gui.enterFile(true, gui.Views.Secondary.SelectedLineIdx())
+		return gui.enterFile(OnFocusOpts{ClickedViewName: "secondary", ClickedViewLineIdx: gui.Views.Secondary.SelectedLineIdx()})
 	}
 
 	return nil

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -121,6 +121,8 @@ type Gui struct {
 	ShowExtrasWindow bool
 
 	suggestionsAsyncHandler *tasks.AsyncHandler
+
+	PopupHandler PopupHandler
 }
 
 type listPanelState struct {
@@ -455,6 +457,7 @@ func NewGui(log *logrus.Entry, gitCommand *commands.GitCommand, oSCommand *oscom
 	onRunCommand := gui.GetOnRunCommand()
 	oSCommand.SetOnRunCommand(onRunCommand)
 	gui.OnRunCommand = onRunCommand
+	gui.PopupHandler = &RealPopupHandler{gui: gui}
 
 	authors.SetCustomAuthors(gui.Config.GetUserConfig().Gui.AuthorColors)
 

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1771,6 +1771,12 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Description: gui.Tr.ToggleWhitespaceInDiffView,
 		},
 		{
+			ViewName:    "",
+			Key:         gui.getKey(config.Universal.IncreaseContextInDiffView),
+			Handler:     gui.IncreaseContextInDiffView,
+			Description: gui.Tr.IncreaseContextInDiffView,
+		},
+		{
 			ViewName: "extras",
 			Key:      gocui.MouseWheelUp,
 			Handler:  gui.scrollUpExtra,

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1777,6 +1777,12 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Description: gui.Tr.IncreaseContextInDiffView,
 		},
 		{
+			ViewName:    "",
+			Key:         gui.getKey(config.Universal.DecreaseContextInDiffView),
+			Handler:     gui.DecreaseContextInDiffView,
+			Description: gui.Tr.DecreaseContextInDiffView,
+		},
+		{
 			ViewName: "extras",
 			Key:      gocui.MouseWheelUp,
 			Handler:  gui.scrollUpExtra,

--- a/pkg/gui/list_context.go
+++ b/pkg/gui/list_context.go
@@ -9,7 +9,8 @@ import (
 type ListContext struct {
 	GetItemsLength      func() int
 	GetDisplayStrings   func(startIdx int, length int) [][]string
-	OnFocus             func() error
+	OnFocus             func(...OnFocusOpts) error
+	OnRenderToMain      func(...OnFocusOpts) error
 	OnFocusLost         func() error
 	OnClickSelectedItem func() error
 
@@ -29,7 +30,6 @@ type ListContext struct {
 type IListContext interface {
 	GetSelectedItem() (ListItem, bool)
 	GetSelectedItemId() string
-	OnRender() error
 	handlePrevLine() error
 	handleNextLine() error
 	handleScrollLeft() error
@@ -42,6 +42,7 @@ type IListContext interface {
 	handleClick() error
 	onSearchSelect(selectedLineIdx int) error
 	FocusLine()
+	HandleRenderToMain() error
 
 	GetPanelState() IListPanelState
 
@@ -101,7 +102,7 @@ func (self *ListContext) GetSelectedItemId() string {
 }
 
 // OnFocus assumes that the content of the context has already been rendered to the view. OnRender is the function which actually renders the content to the view
-func (self *ListContext) OnRender() error {
+func (self *ListContext) HandleRender() error {
 	view, err := self.Gui.g.View(self.ViewName)
 	if err != nil {
 		return nil
@@ -131,7 +132,7 @@ func (self *ListContext) HandleFocusLost() error {
 	return nil
 }
 
-func (self *ListContext) HandleFocus() error {
+func (self *ListContext) HandleFocus(opts ...OnFocusOpts) error {
 	if self.Gui.popupPanelFocused() {
 		return nil
 	}
@@ -143,14 +144,18 @@ func (self *ListContext) HandleFocus() error {
 	}
 
 	if self.OnFocus != nil {
-		return self.OnFocus()
+		if err := self.OnFocus(opts...); err != nil {
+			return err
+		}
+	}
+
+	if self.OnRenderToMain != nil {
+		if err := self.OnRenderToMain(opts...); err != nil {
+			return err
+		}
 	}
 
 	return nil
-}
-
-func (self *ListContext) HandleRender() error {
-	return self.OnRender()
 }
 
 func (self *ListContext) handlePrevLine() error {
@@ -267,4 +272,12 @@ func (self *ListContext) handleClick() error {
 func (self *ListContext) onSearchSelect(selectedLineIdx int) error {
 	self.GetPanelState().SetSelectedLineIdx(selectedLineIdx)
 	return self.HandleFocus()
+}
+
+func (self *ListContext) HandleRenderToMain() error {
+	if self.OnRenderToMain != nil {
+		return self.OnRenderToMain()
+	}
+
+	return nil
 }

--- a/pkg/gui/list_context_config.go
+++ b/pkg/gui/list_context_config.go
@@ -18,7 +18,6 @@ func (gui *Gui) menuListContext() IListContext {
 		},
 		GetItemsLength:      func() int { return gui.Views.Menu.LinesHeight() },
 		OnGetPanelState:     func() IListPanelState { return gui.State.Panels.Menu },
-		OnFocus:             gui.handleMenuSelect,
 		OnClickSelectedItem: gui.onMenuPress,
 		Gui:                 gui,
 
@@ -36,7 +35,8 @@ func (gui *Gui) filesListContext() IListContext {
 		},
 		GetItemsLength:      func() int { return gui.State.FileManager.GetItemsLength() },
 		OnGetPanelState:     func() IListPanelState { return gui.State.Panels.Files },
-		OnFocus:             gui.focusAndSelectFile,
+		OnFocus:             OnFocusWrapper(gui.onFocusFile),
+		OnRenderToMain:      OnFocusWrapper(gui.filesRenderToMain),
 		OnClickSelectedItem: gui.handleFilePress,
 		Gui:                 gui,
 		GetDisplayStrings: func(startIdx int, length int) [][]string {
@@ -65,7 +65,7 @@ func (gui *Gui) branchesListContext() IListContext {
 		},
 		GetItemsLength:  func() int { return len(gui.State.Branches) },
 		OnGetPanelState: func() IListPanelState { return gui.State.Panels.Branches },
-		OnFocus:         gui.handleBranchSelect,
+		OnRenderToMain:  OnFocusWrapper(gui.branchesRenderToMain),
 		Gui:             gui,
 		GetDisplayStrings: func(startIdx int, length int) [][]string {
 			return presentation.GetBranchListDisplayStrings(gui.State.Branches, gui.State.ScreenMode != SCREEN_NORMAL, gui.State.Modes.Diffing.Ref)
@@ -87,7 +87,7 @@ func (gui *Gui) remotesListContext() IListContext {
 		},
 		GetItemsLength:      func() int { return len(gui.State.Remotes) },
 		OnGetPanelState:     func() IListPanelState { return gui.State.Panels.Remotes },
-		OnFocus:             gui.handleRemoteSelect,
+		OnRenderToMain:      OnFocusWrapper(gui.remotesRenderToMain),
 		OnClickSelectedItem: gui.handleRemoteEnter,
 		Gui:                 gui,
 		GetDisplayStrings: func(startIdx int, length int) [][]string {
@@ -110,7 +110,7 @@ func (gui *Gui) remoteBranchesListContext() IListContext {
 		},
 		GetItemsLength:  func() int { return len(gui.State.RemoteBranches) },
 		OnGetPanelState: func() IListPanelState { return gui.State.Panels.RemoteBranches },
-		OnFocus:         gui.handleRemoteBranchSelect,
+		OnRenderToMain:  OnFocusWrapper(gui.remoteBranchesRenderToMain),
 		Gui:             gui,
 		GetDisplayStrings: func(startIdx int, length int) [][]string {
 			return presentation.GetRemoteBranchListDisplayStrings(gui.State.RemoteBranches, gui.State.Modes.Diffing.Ref)
@@ -132,7 +132,7 @@ func (gui *Gui) tagsListContext() IListContext {
 		},
 		GetItemsLength:  func() int { return len(gui.State.Tags) },
 		OnGetPanelState: func() IListPanelState { return gui.State.Panels.Tags },
-		OnFocus:         gui.handleTagSelect,
+		OnRenderToMain:  OnFocusWrapper(gui.tagsRenderToMain),
 		Gui:             gui,
 		GetDisplayStrings: func(startIdx int, length int) [][]string {
 			return presentation.GetTagListDisplayStrings(gui.State.Tags, gui.State.Modes.Diffing.Ref)
@@ -155,7 +155,8 @@ func (gui *Gui) branchCommitsListContext() IListContext {
 		},
 		GetItemsLength:      func() int { return len(gui.State.Commits) },
 		OnGetPanelState:     func() IListPanelState { return gui.State.Panels.Commits },
-		OnFocus:             gui.handleCommitSelect,
+		OnFocus:             OnFocusWrapper(gui.onCommitFocus),
+		OnRenderToMain:      OnFocusWrapper(gui.branchCommitsRenderToMain),
 		OnClickSelectedItem: gui.handleViewCommitFiles,
 		Gui:                 gui,
 		GetDisplayStrings: func(startIdx int, length int) [][]string {
@@ -197,7 +198,7 @@ func (gui *Gui) subCommitsListContext() IListContext {
 		},
 		GetItemsLength:  func() int { return len(gui.State.SubCommits) },
 		OnGetPanelState: func() IListPanelState { return gui.State.Panels.SubCommits },
-		OnFocus:         gui.handleSubCommitSelect,
+		OnRenderToMain:  OnFocusWrapper(gui.subCommitsRenderToMain),
 		Gui:             gui,
 		GetDisplayStrings: func(startIdx int, length int) [][]string {
 			selectedCommitSha := ""
@@ -253,7 +254,7 @@ func (gui *Gui) reflogCommitsListContext() IListContext {
 		},
 		GetItemsLength:  func() int { return len(gui.State.FilteredReflogCommits) },
 		OnGetPanelState: func() IListPanelState { return gui.State.Panels.ReflogCommits },
-		OnFocus:         gui.handleReflogCommitSelect,
+		OnRenderToMain:  OnFocusWrapper(gui.reflogCommitsRenderToMain),
 		Gui:             gui,
 		GetDisplayStrings: func(startIdx int, length int) [][]string {
 			return presentation.GetReflogCommitListDisplayStrings(
@@ -281,7 +282,7 @@ func (gui *Gui) stashListContext() IListContext {
 		},
 		GetItemsLength:  func() int { return len(gui.State.StashEntries) },
 		OnGetPanelState: func() IListPanelState { return gui.State.Panels.Stash },
-		OnFocus:         gui.handleStashEntrySelect,
+		OnRenderToMain:  OnFocusWrapper(gui.stashRenderToMain),
 		Gui:             gui,
 		GetDisplayStrings: func(startIdx int, length int) [][]string {
 			return presentation.GetStashEntryListDisplayStrings(gui.State.StashEntries, gui.State.Modes.Diffing.Ref)
@@ -303,7 +304,8 @@ func (gui *Gui) commitFilesListContext() IListContext {
 		},
 		GetItemsLength:  func() int { return gui.State.CommitFileManager.GetItemsLength() },
 		OnGetPanelState: func() IListPanelState { return gui.State.Panels.CommitFiles },
-		OnFocus:         gui.handleCommitFileSelect,
+		OnFocus:         OnFocusWrapper(gui.onCommitFileFocus),
+		OnRenderToMain:  OnFocusWrapper(gui.commitFilesRenderToMain),
 		Gui:             gui,
 		GetDisplayStrings: func(startIdx int, length int) [][]string {
 			if gui.State.CommitFileManager.GetItemsLength() == 0 {
@@ -335,7 +337,7 @@ func (gui *Gui) submodulesListContext() IListContext {
 		},
 		GetItemsLength:  func() int { return len(gui.State.Submodules) },
 		OnGetPanelState: func() IListPanelState { return gui.State.Panels.Submodules },
-		OnFocus:         gui.handleSubmoduleSelect,
+		OnRenderToMain:  OnFocusWrapper(gui.submodulesRenderToMain),
 		Gui:             gui,
 		GetDisplayStrings: func(startIdx int, length int) [][]string {
 			return presentation.GetSubmoduleListDisplayStrings(gui.State.Submodules)
@@ -357,7 +359,6 @@ func (gui *Gui) suggestionsListContext() IListContext {
 		},
 		GetItemsLength:  func() int { return len(gui.State.Suggestions) },
 		OnGetPanelState: func() IListPanelState { return gui.State.Panels.Suggestions },
-		OnFocus:         func() error { return nil },
 		Gui:             gui,
 		GetDisplayStrings: func(startIdx int, length int) [][]string {
 			return presentation.GetSuggestionListDisplayStrings(gui.State.Suggestions)

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/theme"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
@@ -25,12 +24,6 @@ func (i *menuItem) ID() string {
 	}
 
 	return strings.Join(i.displayStrings, "-")
-}
-
-// list panel functions
-
-func (gui *Gui) handleMenuSelect() error {
-	return nil
 }
 
 // specific functions
@@ -95,10 +88,7 @@ func (gui *Gui) createMenu(title string, items []*menuItem, createMenuOptions cr
 	menuView.SetContent(list)
 	gui.State.Panels.Menu.SelectedLineIdx = 0
 
-	gui.g.Update(func(g *gocui.Gui) error {
-		return gui.pushContext(gui.State.Contexts.Menu)
-	})
-	return nil
+	return gui.pushContext(gui.State.Contexts.Menu)
 }
 
 func (gui *Gui) onMenuPress() error {

--- a/pkg/gui/popup_handler.go
+++ b/pkg/gui/popup_handler.go
@@ -1,0 +1,87 @@
+package gui
+
+import (
+	"strings"
+
+	"github.com/jesseduffield/lazygit/pkg/gui/style"
+)
+
+type PopupHandler interface {
+	Error(message string) error
+	Ask(opts askOpts) error
+	Prompt(opts promptOpts) error
+	Loader(message string) error
+}
+
+type RealPopupHandler struct {
+	gui *Gui
+}
+
+func (self *RealPopupHandler) Error(message string) error {
+	gui := self.gui
+
+	coloredMessage := style.FgRed.Sprint(strings.TrimSpace(message))
+	if err := gui.refreshSidePanels(refreshOptions{mode: ASYNC}); err != nil {
+		return err
+	}
+
+	return self.Ask(askOpts{
+		title:  gui.Tr.Error,
+		prompt: coloredMessage,
+	})
+}
+
+func (self *RealPopupHandler) Ask(opts askOpts) error {
+	gui := self.gui
+
+	return gui.createPopupPanel(createPopupPanelOpts{
+		title:               opts.title,
+		prompt:              opts.prompt,
+		handleConfirm:       opts.handleConfirm,
+		handleClose:         opts.handleClose,
+		handlersManageFocus: opts.handlersManageFocus,
+	})
+}
+
+func (self *RealPopupHandler) Prompt(opts promptOpts) error {
+	gui := self.gui
+
+	return gui.createPopupPanel(createPopupPanelOpts{
+		title:               opts.title,
+		prompt:              opts.initialContent,
+		editable:            true,
+		handleConfirmPrompt: opts.handleConfirm,
+		findSuggestionsFunc: opts.findSuggestionsFunc,
+	})
+}
+
+func (self *RealPopupHandler) Loader(message string) error {
+	gui := self.gui
+
+	return gui.createPopupPanel(createPopupPanelOpts{
+		prompt:    message,
+		hasLoader: true,
+	})
+}
+
+type TestPopupHandler struct {
+	onError  func(message string) error
+	onAsk    func(opts askOpts) error
+	onPrompt func(opts promptOpts) error
+}
+
+func (self *TestPopupHandler) Error(message string) error {
+	return self.onError(message)
+}
+
+func (self *TestPopupHandler) Ask(opts askOpts) error {
+	return self.onAsk(opts)
+}
+
+func (self *TestPopupHandler) Prompt(opts promptOpts) error {
+	return self.onPrompt(opts)
+}
+
+func (self *TestPopupHandler) Loader(message string) error {
+	return nil
+}

--- a/pkg/gui/reflog_panel.go
+++ b/pkg/gui/reflog_panel.go
@@ -16,7 +16,7 @@ func (gui *Gui) getSelectedReflogCommit() *models.Commit {
 	return reflogComits[selectedLine]
 }
 
-func (gui *Gui) handleReflogCommitSelect() error {
+func (gui *Gui) reflogCommitsRenderToMain() error {
 	commit := gui.getSelectedReflogCommit()
 	var task updateTask
 	if commit == nil {

--- a/pkg/gui/remote_branches_panel.go
+++ b/pkg/gui/remote_branches_panel.go
@@ -18,7 +18,7 @@ func (gui *Gui) getSelectedRemoteBranch() *models.RemoteBranch {
 	return gui.State.RemoteBranches[selectedLine]
 }
 
-func (gui *Gui) handleRemoteBranchSelect() error {
+func (gui *Gui) remoteBranchesRenderToMain() error {
 	var task updateTask
 	remoteBranch := gui.getSelectedRemoteBranch()
 	if remoteBranch == nil {

--- a/pkg/gui/remotes_panel.go
+++ b/pkg/gui/remotes_panel.go
@@ -20,7 +20,7 @@ func (gui *Gui) getSelectedRemote() *models.Remote {
 	return gui.State.Remotes[selectedLine]
 }
 
-func (gui *Gui) handleRemoteSelect() error {
+func (gui *Gui) remotesRenderToMain() error {
 	var task updateTask
 	remote := gui.getSelectedRemote()
 	if remote == nil {

--- a/pkg/gui/stash_panel.go
+++ b/pkg/gui/stash_panel.go
@@ -16,7 +16,7 @@ func (gui *Gui) getSelectedStashEntry() *models.StashEntry {
 	return gui.State.StashEntries[selectedLine]
 }
 
-func (gui *Gui) handleStashEntrySelect() error {
+func (gui *Gui) stashRenderToMain() error {
 	var task updateTask
 	stashEntry := gui.getSelectedStashEntry()
 	if stashEntry == nil {

--- a/pkg/gui/status_panel.go
+++ b/pkg/gui/status_panel.go
@@ -86,10 +86,10 @@ func (gui *Gui) handleStatusClick() error {
 		}
 	}
 
-	return gui.handleStatusSelect()
+	return nil
 }
 
-func (gui *Gui) handleStatusSelect() error {
+func (gui *Gui) statusRenderToMain() error {
 	// TODO: move into some abstraction (status is currently not a listViewContext where a lot of this code lives)
 	if gui.popupPanelFocused() {
 		return nil

--- a/pkg/gui/sub_commits_panel.go
+++ b/pkg/gui/sub_commits_panel.go
@@ -17,7 +17,7 @@ func (gui *Gui) getSelectedSubCommit() *models.Commit {
 	return commits[selectedLine]
 }
 
-func (gui *Gui) handleSubCommitSelect() error {
+func (gui *Gui) subCommitsRenderToMain() error {
 	commit := gui.getSelectedSubCommit()
 	var task updateTask
 	if commit == nil {

--- a/pkg/gui/submodules_panel.go
+++ b/pkg/gui/submodules_panel.go
@@ -19,7 +19,7 @@ func (gui *Gui) getSelectedSubmodule() *models.SubmoduleConfig {
 	return gui.State.Submodules[selectedLine]
 }
 
-func (gui *Gui) handleSubmoduleSelect() error {
+func (gui *Gui) submodulesRenderToMain() error {
 	var task updateTask
 	submodule := gui.getSelectedSubmodule()
 	if submodule == nil {

--- a/pkg/gui/tags_panel.go
+++ b/pkg/gui/tags_panel.go
@@ -40,9 +40,7 @@ func (gui *Gui) handleCreateTag() error {
 	})
 }
 
-// tag-specific handlers
-// view model would need to raise an event called 'tag selected', perhaps containing a tag. The listener would _be_ the main view, or the main context, and it would be able to render to itself.
-func (gui *Gui) handleTagSelect() error {
+func (gui *Gui) tagsRenderToMain() error {
 	var task updateTask
 	tag := gui.getSelectedTag()
 	if tag == nil {
@@ -84,6 +82,8 @@ func (gui *Gui) withSelectedTag(f func(tag *models.Tag) error) func() error {
 		return f(tag)
 	}
 }
+
+// tag-specific handlers
 
 func (gui *Gui) handleCheckoutTag(tag *models.Tag) error {
 	if err := gui.handleCheckoutRef(tag.Name, handleCheckoutRefOptions{span: gui.Tr.Spans.CheckoutTag}); err != nil {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -427,6 +427,7 @@ type TranslationSet struct {
 	ToggleWhitespaceInDiffView          string
 	IgnoringWhitespaceInDiffView        string
 	ShowingWhitespaceInDiffView         string
+	IncreaseContextInDiffView           string
 	CreatePullRequestOptions            string
 	LcCreatePullRequestOptions          string
 	LcDefaultBranch                     string
@@ -967,6 +968,7 @@ func englishTranslationSet() TranslationSet {
 		ToggleWhitespaceInDiffView:          "Toggle whether or not whitespace changes are shown in the diff view",
 		IgnoringWhitespaceInDiffView:        "Whitespace will be ignored in the diff view",
 		ShowingWhitespaceInDiffView:         "Whitespace will be shown in the diff view",
+		IncreaseContextInDiffView:           "Increase the size of the context shown around changes in the diff view",
 		CreatePullRequest:                   "Create pull request",
 		CreatePullRequestOptions:            "Create pull request options",
 		LcCreatePullRequestOptions:          "create pull request options",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -449,6 +449,7 @@ type TranslationSet struct {
 	ToggleShowGitGraphAll               string
 	ShowGitGraph                        string
 	SortCommits                         string
+	CantChangeContextSizeError          string
 	Spans                               Spans
 }
 
@@ -991,6 +992,7 @@ func englishTranslationSet() TranslationSet {
 		ToggleShowGitGraphAll:               "toggle show whole git graph (pass the `--all` flag to `git log`)",
 		ShowGitGraph:                        "show git graph",
 		SortCommits:                         "commit sort order",
+		CantChangeContextSizeError:          "Cannot change context while in patch building mode because we were too lazy to support it when releasing the feature. If you really want it, please let us know!",
 		Spans: Spans{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)
 			CheckoutCommit:                    "Checkout commit",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -428,6 +428,7 @@ type TranslationSet struct {
 	IgnoringWhitespaceInDiffView        string
 	ShowingWhitespaceInDiffView         string
 	IncreaseContextInDiffView           string
+	DecreaseContextInDiffView           string
 	CreatePullRequestOptions            string
 	LcCreatePullRequestOptions          string
 	LcDefaultBranch                     string
@@ -969,6 +970,7 @@ func englishTranslationSet() TranslationSet {
 		IgnoringWhitespaceInDiffView:        "Whitespace will be ignored in the diff view",
 		ShowingWhitespaceInDiffView:         "Whitespace will be shown in the diff view",
 		IncreaseContextInDiffView:           "Increase the size of the context shown around changes in the diff view",
+		DecreaseContextInDiffView:           "Decrease the size of the context shown around changes in the diff view",
 		CreatePullRequest:                   "Create pull request",
 		CreatePullRequestOptions:            "Create pull request options",
 		LcCreatePullRequestOptions:          "create pull request options",


### PR DESCRIPTION
### What
This PR adds the ability to increase (`}`) or decrease (`{`) the context shown around changes in diffs.

### Why
I've found that it's often helpful to see a little more than the standard 3 lines above and below the actual changes in a diff.
At times, for example, I'd like to see where a variable used in the changed lines comes from.

### Notes
- I have tried to write more unit tests for verifying that the right refresh function is called in the given context but failed. It seems not to be that easy to mock these functions for the tests. Any input here would be welcome!
- According to the git documentation, the `--unified` argument in `diff` implies the `--patch` argument. The latter wasn't used in most of the calls to `git diff`, but I couldn't see any changes in the output in the staging- or patch building panel.