### PR TITLE
Add escape handling for & character in Windows

### DIFF
--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -336,6 +336,7 @@ func (c *OSCommand) Quote(message string) string {
 	if c.Platform.OS == "windows" {
 		message = strings.Replace(message, `"`, `"'"'"`, -1)
 		message = strings.Replace(message, `\"`, `\\"`, -1)
+		message = strings.Replace(message, `&`, `^&`, -1)
 	} else {
 		message = strings.Replace(message, `\`, `\\`, -1)
 		message = strings.Replace(message, `"`, `\"`, -1)

--- a/pkg/commands/oscommands/os_test.go
+++ b/pkg/commands/oscommands/os_test.go
@@ -185,7 +185,7 @@ func TestOSCommandOpenFileLinux(t *testing.T) {
 	}
 }
 
-// TestOSCommandQuote is a function.
+// TestOSCommandQuote tests the quote function with ` character explicitly for Linux
 func TestOSCommandQuote(t *testing.T) {
 	osCommand := NewDummyOSCommand()
 
@@ -224,8 +224,8 @@ func TestOSCommandQuoteDoubleQuote(t *testing.T) {
 	assert.EqualValues(t, expected, actual)
 }
 
-// TestOSCommandQuoteWindows tests the quote function for Windows
-func TestOSCommandQuoteWindows(t *testing.T) {
+// TestOSCommandQuoteWindows tests the quote function with " quotes explicitly for Windows
+func TestOSCommandQuoteWindowsDoubleQuote(t *testing.T) {
 	osCommand := NewDummyOSCommand()
 
 	osCommand.Platform.OS = "windows"
@@ -233,6 +233,19 @@ func TestOSCommandQuoteWindows(t *testing.T) {
 	actual := osCommand.Quote(`hello "test"`)
 
 	expected := osCommand.Platform.EscapedQuote + `hello "'"'"test"'"'"` + osCommand.Platform.EscapedQuote
+
+	assert.EqualValues(t, expected, actual)
+}
+
+// TestOSCommandQuoteWindows tests the quote function with & character explicitly for Windows
+func TestOSCommandQuoteWindowsAndCharacter(t *testing.T) {
+	osCommand := NewDummyOSCommand()
+
+	osCommand.Platform.OS = "windows"
+
+	actual := osCommand.Quote("hello & test")
+
+	expected := osCommand.Platform.EscapedQuote + "hello ^& test" + osCommand.Platform.EscapedQuote
 
 	assert.EqualValues(t, expected, actual)
 }


### PR DESCRIPTION
This should solve the issue that some links, notably Bitbucket open PRs, can contain & which needs to be escaped in
Windows.

Hope this is OK as a PR in itself. I'm not that experienced in go - so haven't made much of a change.
Maybe some of those tests in os_test.go could be put in scenarios. But I think this change is ok without doing that.

This solves #470 
Have tried out locally using go install and then opening a pr in a bitbucket repo.
After the change, the error no longer appears.