### PR TITLE
copy selected text to clipboard

### DIFF
--- a/pkg/commands/patch/patch_parser.go
+++ b/pkg/commands/patch/patch_parser.go
@@ -194,6 +194,22 @@ func (p *PatchParser) Render(firstLineIndex int, lastLineIndex int, incLineIndic
 	return result
 }
 
+// RenderLines returns the coloured string of diff part from firstLineIndex to
+// lastLineIndex
+func (p *PatchParser) RenderLines(firstLineIndex, lastLineIndex int) string {
+	renderedLines := make([]string, lastLineIndex-firstLineIndex+1)
+	for index := firstLineIndex; index <= lastLineIndex; index++ {
+		renderedLines[index-firstLineIndex] = p.PatchLines[index].render(
+			false, false,
+		)
+	}
+	result := strings.Join(renderedLines, "\n")
+	if strings.TrimSpace(utils.Decolorise(result)) == "" {
+		return ""
+	}
+	return result
+}
+
 // GetNextStageableLineIndex takes a line index and returns the line index of the next stageable line
 // note this will actually include the current index if it is stageable
 func (p *PatchParser) GetNextStageableLineIndex(currentIndex int) int {

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1304,6 +1304,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Handler:  gui.handleSelectNextHunk,
 		},
 		{
+			ViewName: "main",
+			Contexts: []string{string(MAIN_PATCH_BUILDING_CONTEXT_KEY), string(MAIN_STAGING_CONTEXT_KEY)},
+			Key:      gui.getKey(config.Universal.CopyToClipboard),
+			Modifier: gocui.ModNone,
+			Handler:  gui.copySelectedToClipboard,
+		},
+		{
 			ViewName:    "main",
 			Contexts:    []string{string(MAIN_STAGING_CONTEXT_KEY)},
 			Key:         gui.getKey(config.Universal.Edit),

--- a/pkg/gui/lbl/state.go
+++ b/pkg/gui/lbl/state.go
@@ -180,6 +180,11 @@ func (s *State) RenderForLineIndices(includedLineIndices []int) string {
 	return s.patchParser.Render(firstLineIdx, lastLineIdx, includedLineIndices)
 }
 
+func (s *State) RenderSelected() string {
+	firstLineIdx, lastLineIdx := s.SelectedRange()
+	return s.patchParser.RenderLines(firstLineIdx, lastLineIdx)
+}
+
 func (s *State) SelectBottom() {
 	s.SetLineSelectMode()
 	s.SelectLine(len(s.patchParser.PatchLines) - 1)

--- a/pkg/gui/line_by_line_panel.go
+++ b/pkg/gui/line_by_line_panel.go
@@ -2,11 +2,13 @@ package gui
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-errors/errors"
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/patch"
 	"github.com/jesseduffield/lazygit/pkg/gui/lbl"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 // Currently there are two 'pseudo-panels' that make use of this 'pseudo-panel'.
@@ -83,6 +85,22 @@ func (gui *Gui) handleSelectNextHunk() error {
 		state.CycleHunk(true)
 
 		return gui.refreshAndFocusLblPanel(state)
+	})
+}
+
+func (gui *Gui) copySelectedToClipboard() error {
+	return gui.withLBLActiveCheck(func(state *LblPanelState) error {
+
+		colorSelected := state.RenderSelected()
+		selected := strings.TrimSpace(utils.Decolorise(colorSelected))
+
+		if err := gui.OSCommand.WithSpan(
+			gui.Tr.Spans.CopySelectedTextToClipboard,
+		).CopyToClipboard(selected); err != nil {
+			return gui.surfaceError(err)
+		}
+
+		return nil
 	})
 }
 

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -477,6 +477,7 @@ type Spans struct {
 	GitFlowFinish                     string
 	GitFlowStart                      string
 	CopyToClipboard                   string
+	CopySelectedTextToClipboard       string
 	RemovePatchFromCommit             string
 	MovePatchToSelectedCommit         string
 	MovePatchIntoIndex                string
@@ -995,6 +996,7 @@ func englishTranslationSet() TranslationSet {
 			GitFlowFinish:                     "Git flow finish",
 			GitFlowStart:                      "Git Flow start",
 			CopyToClipboard:                   "Copy to clipboard",
+			CopySelectedTextToClipboard:       "Copy Selected Text to clipboard",
 			RemovePatchFromCommit:             "Remove patch from commit",
 			MovePatchToSelectedCommit:         "Move patch to selected commit",
 			MovePatchIntoIndex:                "Move patch into index",


### PR DESCRIPTION
This commit allows selected text from staging or patch building view to be copied to clipboard via `config.Universal.CopyToClipboard` keybinding.

Fixes: #1482 