### PR TITLE
Improved command execution

### DIFF
--- a/pkg/commands/files.go
+++ b/pkg/commands/files.go
@@ -123,14 +123,14 @@ func (c *GitCommand) DiscardAllFileChanges(file *models.File) error {
 		if err := c.RunCommand("git checkout --ours --  %s", quotedFileName); err != nil {
 			return err
 		}
-		if err := c.RunCommand("git add %s", quotedFileName); err != nil {
+		if err := c.RunCommand("git add -- %s", quotedFileName); err != nil {
 			return err
 		}
 		return nil
 	}
 
 	if file.ShortStatus == "DU" {
-		return c.RunCommand("git rm %s", quotedFileName)
+		return c.RunCommand("git rm -- %s", quotedFileName)
 	}
 
 	// if the file isn't tracked, we assume you want to delete it
@@ -299,7 +299,7 @@ func (c *GitCommand) DiscardAnyUnstagedFileChanges() error {
 
 // RemoveTrackedFiles will delete the given file(s) even if they are currently tracked
 func (c *GitCommand) RemoveTrackedFiles(name string) error {
-	return c.RunCommand("git rm -r --cached %s", c.OSCommand.Quote(name))
+	return c.RunCommand("git rm -r --cached -- %s", c.OSCommand.Quote(name))
 }
 
 // RemoveUntrackedFiles runs `git clean -fd`

--- a/pkg/commands/submodules.go
+++ b/pkg/commands/submodules.go
@@ -119,7 +119,7 @@ func (c *GitCommand) SubmoduleAdd(name string, path string, url string) error {
 
 func (c *GitCommand) SubmoduleUpdateUrl(name string, path string, newUrl string) error {
 	// the set-url command is only for later git versions so we're doing it manually here
-	if err := c.RunCommand("git config --file .gitmodules submodule.%s.url %s", c.OSCommand.Quote(name), newUrl); err != nil {
+	if err := c.RunCommand("git config --file .gitmodules submodule.%s.url %s", c.OSCommand.Quote(name), c.OSCommand.Quote(newUrl)); err != nil {
 		return err
 	}
 

--- a/pkg/commands/tags.go
+++ b/pkg/commands/tags.go
@@ -3,7 +3,7 @@ package commands
 import "fmt"
 
 func (c *GitCommand) CreateLightweightTag(tagName string, commitSha string) error {
-	return c.RunCommand("git tag %s %s", tagName, commitSha)
+	return c.RunCommand("git tag -- %s %s", tagName, commitSha)
 }
 
 func (c *GitCommand) DeleteTag(tagName string) error {


### PR DESCRIPTION
## 1. Fix crash when try to ignore tracked files


<img width="703" alt="スクリーンショット 2021-10-06 23 02 23" src="https://user-images.githubusercontent.com/10097437/136218372-d1f922c5-9fc2-4f0f-a26c-42bef9d32210.png">

```log
2021/10/06 23:02:26 An error occurred! Please create an issue at: https://github.com/jesseduffield/lazygit/issues

*errors.errorString error: unknown option `a'
usage: git rm [<options>] [--] <file>...

    -n, --dry-run         dry run
    -q, --quiet           do not list removed files
    --cached              only remove from the index
    -f, --force           override the up-to-date check
    -r                    allow recursive removal
    --ignore-unmatch      exit with a zero status even if nothing matched
    --pathspec-from-file <file>
                          read pathspec from file
    --pathspec-file-nul   with --pathspec-from-file, pathspec elements are separated with NUL character


/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/commands/oscommands/os.go:283 (0x124eb1b)
        sanitisedCommandOutput: return outputString, errors.New(outputString)
/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/commands/oscommands/os.go:172 (0x124de1b)
        (*OSCommand).RunCommandWithOutput: output, err := sanitisedCommandOutput(cmd.CombinedOutput())
/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/commands/git.go:233 (0x14ed11e)
        (*GitCommand).RunCommandWithOutput: output, err := c.OSCommand.RunCommandWithOutput(formatString, formatArgs...)
/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/commands/git.go:222 (0x14ebf29)
        (*GitCommand).RemoveTrackedFiles: _, err := c.RunCommandWithOutput(formatString, formatArgs...)
/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/commands/files.go:302 (0x14ebedf)
        (*GitCommand).RemoveTrackedFiles: return c.RunCommand("git rm -r --cached -- %s", c.OSCommand.Quote(name))
/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/gui/files_panel.go:321 (0x1525c85)
        (*Gui).handleIgnoreFile.func2: if err := gitCommand.RemoveTrackedFiles(node.GetPath()); err != nil {
/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/gui/confirmation_panel.go:81 (0x1517573)
        (*Gui).wrappedConfirmationFunction.func1: if err := function(); err != nil {
/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/gui/confirmation_panel.go:314 (0x151891b)
        (*Gui).setKeyBindings.func5: return f()
/Users/tamate/repos/github.com/jesseduffield/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:1161 (0x1241b8e)
        (*Gui).execKeybinding: if err := kb.handler(g, v); err != nil {
/Users/tamate/repos/github.com/jesseduffield/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:1129 (0x1241a33)
        (*Gui).execKeybindings: return g.execKeybinding(v, kb)
/Users/tamate/repos/github.com/jesseduffield/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:1054 (0x12415be)
        (*Gui).onKey: _, err := g.execKeybindings(g.currentView, ev)
/Users/tamate/repos/github.com/jesseduffield/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:650 (0x123fe05)
        (*Gui).handleEvent: return g.onKey(ev)
/Users/tamate/repos/github.com/jesseduffield/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:610 (0x123fa25)
        (*Gui).MainLoop: if err := g.handleEvent(&ev); err != nil {
/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/gui/gui.go:515 (0x15302d7)
        (*Gui).Run: err = g.MainLoop()
/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/gui/gui.go:523 (0x1530614)
        (*Gui).RunAndHandleError.func1: if err := gui.Run(); err != nil {
/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/utils/utils.go:126 (0x124b287)
        SafeWithError: err := f()
/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/gui/gui.go:522 (0x15305af)
        (*Gui).RunAndHandleError: return utils.SafeWithError(func() error {
/Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/app/app.go:243 (0x157dba5)
        (*App).Run: err := app.Gui.RunAndHandleError()
/Users/tamate/repos/github.com/jesseduffield/lazygit/main.go:127 (0x157f19d)
        main: err = app.Run()
/usr/local/Cellar/go/1.17/libexec/src/runtime/proc.go:255 (0x1036e27)
        main: fn()
/usr/local/Cellar/go/1.17/libexec/src/runtime/asm_amd64.s:1581 (0x10651c1)
        goexit: BYTE    $0x90   // NOP
```

## 2. Fix crash when new submodule url contains double quotes

<img width="366" alt="スクリーンショット 2021-10-06 22 59 39" src="https://user-images.githubusercontent.com/10097437/136217864-bec2707a-5fad-4784-8e4b-ba508bd6151a.png">


```log
panic: Starting quote has no ending quote.

goroutine 138 [running]:
github.com/mgutz/str.ToArgv({0xc000126040, 0x33})
        /Users/tamate/repos/github.com/jesseduffield/lazygit/vendor/github.com/mgutz/str/funcsPZ.go:377 +0x4be
github.com/jesseduffield/lazygit/pkg/commands/oscommands.(*OSCommand).ExecutableFromString(0xc0006aa060, {0xc000126040, 0xc000227df8})
        /Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/commands/oscommands/os.go:194 +0x2d
github.com/jesseduffield/lazygit/pkg/commands/oscommands.(*OSCommand).RunCommandWithOutput(0xc0006aa060, {0x16e06dc, 0x5c52108}, {0xc000227df8, 0x10, 0x1d335b8})
        /Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/commands/oscommands/os.go:170 +0x77
github.com/jesseduffield/lazygit/pkg/commands.(*GitCommand).RunCommandWithOutput(0xc0006aa000, {0x16e06dc, 0x31}, {0xc000227df8, 0x2, 0x2})
        /Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/commands/git.go:233 +0x9e
github.com/jesseduffield/lazygit/pkg/commands.(*GitCommand).RunCommand(...)
        /Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/commands/git.go:222
github.com/jesseduffield/lazygit/pkg/commands.(*GitCommand).SubmoduleUpdateUrl(0xc0006aa000, {0xc0000d0024, 0x5c52108}, {0xc00002e208, 0x3}, {0xc00030a188, 0x1})
        /Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/commands/submodules.go:122 +0xc5
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).handleEditSubmoduleUrl.func1.1()
        /Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/gui/submodules_panel.go:164 +0x1f5
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).WithWaitingStatus.func1()
        /Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/gui/app_status_manager.go:119 +0x97
github.com/jesseduffield/lazygit/pkg/utils.Safe.func1()
        /Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/utils/utils.go:115 +0x1b
github.com/jesseduffield/lazygit/pkg/utils.SafeWithError(0x103e165)
        /Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/utils/utils.go:126 +0x67
github.com/jesseduffield/lazygit/pkg/utils.Safe(0x0)
        /Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/utils/utils.go:115 +0x35
created by github.com/jesseduffield/lazygit/pkg/gui.(*Gui).WithWaitingStatus
        /Users/tamate/repos/github.com/jesseduffield/lazygit/pkg/gui/app_status_manager.go:110 +0xef
```

## 3. Fix error prompt when new tag name starts with '--'

<img width="404" alt="スクリーンショット 2021-10-06 22 58 38" src="https://user-images.githubusercontent.com/10097437/136218489-8a2aef77-352c-4e3a-9d15-e777ec51901c.png">

<img width="968" alt="スクリーンショット 2021-10-06 22 58 45" src="https://user-images.githubusercontent.com/10097437/136218560-7286bc14-69cc-470d-b29f-ad8ae0998dd7.png">

