### PR TITLE
Implement ERASE_IN_LINE terminal instruction

### DIFF
--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -604,11 +604,17 @@ func (v *View) parseInput(ch rune) []cell {
 		}
 		v.ei.reset()
 	} else {
-		if isEscape {
-			return nil
-		}
 		repeatCount := 1
-		if ch == '\t' {
+		if v.ei.instruction.kind == ERASE_IN_LINE && v.ei.instruction.param1 == 0 {
+			// fill rest of line
+			v.ei.instructionRead()
+			repeatCount = v.x1 - v.x0 - v.wx - 1
+			ch = ' '
+		} else if isEscape {
+			// do not output anything
+			return nil
+		} else if ch == '\t' {
+			// fill tab-sized space
 			ch = ' '
 			repeatCount = 4
 		}


### PR DESCRIPTION
This is a very rough patch and is completely superseded by the code in gocui master.

However, it does fix the "line not colored to end" issue just fine.

Fixes #1386