### PR TITLE
Improve backward compatibility

### DIFF
--- a/pkg/commands/loading_commits.go
+++ b/pkg/commands/loading_commits.go
@@ -361,7 +361,7 @@ func (c *CommitListBuilder) getLogCmd(opts GetCommitsOptions) *exec.Cmd {
 
 	return c.OSCommand.ExecutableFromString(
 		fmt.Sprintf(
-			"git log %s --oneline --pretty=format:\"%%H%s%%at%s%%aN%s%%d%s%%p%s%%s\" %s --abbrev=%d --date=unix %s",
+			"git log %s --oneline --pretty=format:\"%%H%s%%at%s%%aN%s%%d%s%%p%s%%s\" %s --abbrev=%d %s",
 			c.OSCommand.Quote(opts.RefName),
 			SEPARATION_CHAR,
 			SEPARATION_CHAR,


### PR DESCRIPTION
`--date=unix` is only available in Git 2.9.4 or later. #1441

<table>
<tr>
<td>Lazygit 0.29 + Git 2.9.0
<td>PR + Git 2.7.0
<tr>
<td>
<img width="848" alt="スクリーンショット 2021-10-18 22 42 46" src="https://user-images.githubusercontent.com/10097437/137743973-9d1fa679-845a-4cf0-8f4a-ea4808137c67.png">
<td>
<img width="757" alt="スクリーンショット 2021-10-18 22 43 31" src="https://user-images.githubusercontent.com/10097437/137743934-af210035-3d4c-48fa-86f4-944116744bb3.png">
</table>