### PR TITLE
Add sign-off feature to git commit

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -56,6 +56,8 @@ git:
   paging:
     colorArg: always
     useConfig: false
+  commit:
+    signOff: false
   merging:
     # only applicable to unix users
     manualCommit: false

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -61,6 +61,7 @@ type CommitLengthConfig struct {
 
 type GitConfig struct {
 	Paging              PagingConfig                  `yaml:"paging"`
+	Commit              CommitConfig                  `yaml:"commit"`
 	Merging             MergingConfig                 `yaml:"merging"`
 	SkipHookPrefix      string                        `yaml:"skipHookPrefix"`
 	AutoFetch           bool                          `yaml:"autoFetch"`
@@ -78,6 +79,10 @@ type PagingConfig struct {
 	ColorArg  string `yaml:"colorArg"`
 	Pager     string `yaml:"pager"`
 	UseConfig bool   `yaml:"useConfig"`
+}
+
+type CommitConfig struct {
+	SignOff bool `yaml:"signOff"`
 }
 
 type MergingConfig struct {
@@ -344,6 +349,9 @@ func GetDefaultConfig() *UserConfig {
 				ColorArg:  "always",
 				Pager:     "",
 				UseConfig: false},
+			Commit: CommitConfig{
+				SignOff: false,
+			},
 			Merging: MergingConfig{
 				ManualCommit: false,
 				Args:         "",

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -14,13 +14,17 @@ func (gui *Gui) handleCommitConfirm() error {
 	if message == "" {
 		return gui.createErrorPanel(gui.Tr.CommitWithoutMessageErr)
 	}
-	flags := ""
+	flags := []string{}
 	skipHookPrefix := gui.Config.GetUserConfig().Git.SkipHookPrefix
 	if skipHookPrefix != "" && strings.HasPrefix(message, skipHookPrefix) {
-		flags = "--no-verify"
+		flags = append(flags, "--no-verify")
 	}
 
-	cmdStr := gui.GitCommand.CommitCmdStr(message, flags)
+	if gui.Config.GetUserConfig().Git.Commit.SignOff {
+		flags = append(flags, "--signoff")
+	}
+
+	cmdStr := gui.GitCommand.CommitCmdStr(message, strings.Join(flags, " "))
 	gui.OnRunCommand(oscommands.NewCmdLogEntry(cmdStr, gui.Tr.Spans.Commit, true))
 	_ = gui.returnFromContext()
 	return gui.withGpgHandling(cmdStr, gui.Tr.CommittingStatus, func() error {

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -461,8 +461,14 @@ func (gui *Gui) handleCommitEditorPress() error {
 		return gui.promptToStageAllAndRetry(gui.handleCommitEditorPress)
 	}
 
+	args := []string{"commit"}
+
+	if gui.Config.GetUserConfig().Git.Commit.SignOff {
+		args = append(args, "--signoff")
+	}
+
 	return gui.runSubprocessWithSuspenseAndRefresh(
-		gui.OSCommand.WithSpan(gui.Tr.Spans.Commit).PrepareSubProcess("git", "commit"),
+		gui.OSCommand.WithSpan(gui.Tr.Spans.Commit).PrepareSubProcess("git", args...),
 	)
 }
 


### PR DESCRIPTION
Enable via configuration:

```yaml
git:
  commit:
    signOff: true
```

Resubmission of #1031
Fixes #505

To answer the question that came up previously: no, signing-off does not require password entry.

The implementation in this PR is similar to #1031, but I wonder if it would be better to move the signoff flag directly to `GitCommand.CommitCmdStr`: it has access to the configuration and the signoff flag should probably always be passed to the git commit command. Let me know what you think and I rework the PR if necessary.