### PR TITLE
WIP: 1489: added demonstration for using an Editor implementation for menu…

### DIFF
--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -50,7 +50,8 @@ func (gui *Gui) handleMenuClose() error {
 }
 
 type createMenuOptions struct {
-	showCancel bool
+	showCancel     bool
+	allowFiltering bool
 }
 
 func (gui *Gui) createMenu(title string, items []*menuItem, createMenuOptions createMenuOptions) error {
@@ -64,12 +65,70 @@ func (gui *Gui) createMenu(title string, items []*menuItem, createMenuOptions cr
 		})
 	}
 
-	gui.State.MenuItems = items
+	menuView, renderError := gui.buildMenuView(title, items)
+	if renderError != nil {
+		return renderError
+	}
 
+	if createMenuOptions.allowFiltering {
+		filter := MenuPanelFilter{
+			menuView:  menuView,
+			menuItems: items,
+			updateMenu: func(needle string, filteredItems []*menuItem) {
+				menuView, _ := gui.buildMenuView(title, filteredItems)
+				menuView.Search(needle)
+			},
+		}
+
+		menuView.Editable = true
+
+		menuView.Editor = gocui.EditorFunc(func(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) bool {
+			switch key {
+			case gocui.KeyBackspace:
+			case gocui.KeyBackspace2:
+				filter.HandleSearchBackspace()
+			case gocui.KeyDelete:
+				filter.HandleResetSearch()
+			default:
+				char := string(ch)
+				filter.HandleSearchKeystroke(char)
+			}
+			return false
+		})
+	}
+
+	gui.g.Update(func(g *gocui.Gui) error {
+		return gui.pushContext(gui.State.Contexts.Menu)
+	})
+	return nil
+}
+
+// buildMenuView formats a given set of menuItems and creates a menuView
+func (gui *Gui) buildMenuView(title string, items []*menuItem) (*gocui.View, error) {
+	list, err := formatListItems(items)
+	if err != nil {
+		return nil, err
+	}
+
+	x0, y0, x1, y1 := gui.getConfirmationPanelDimensions(false, list)
+	menuView, _ := gui.g.SetView("menu", x0, y0, x1, y1, 0)
+	menuView.Title = title
+	menuView.FgColor = theme.GocuiDefaultTextColor
+	menuView.SetOnSelectItem(gui.onSelectItemWrapper(func(selectedLine int) error {
+		return nil
+	}))
+	menuView.SetContent(list)
+	gui.State.MenuItems = items
+	gui.State.Panels.Menu.SelectedLineIdx = 0
+	return menuView, nil
+}
+
+// formatListItems formats a set of menuItems to a format string suitable for a menu
+func formatListItems(items []*menuItem) (string, error) {
 	stringArrays := make([][]string, len(items))
 	for i, item := range items {
 		if item.opensMenu && item.displayStrings != nil {
-			return errors.New("Message for the developer of this app: you've set opensMenu with displaystrings on the menu panel. Bad developer!. Apologies, user")
+			return "", errors.New("Message for the developer of this app: you've set opensMenu with displaystrings on the menu panel. Bad developer!. Apologies, user")
 		}
 
 		if item.displayStrings == nil {
@@ -84,21 +143,7 @@ func (gui *Gui) createMenu(title string, items []*menuItem, createMenuOptions cr
 	}
 
 	list := utils.RenderDisplayStrings(stringArrays)
-
-	x0, y0, x1, y1 := gui.getConfirmationPanelDimensions(false, list)
-	menuView, _ := gui.g.SetView("menu", x0, y0, x1, y1, 0)
-	menuView.Title = title
-	menuView.FgColor = theme.GocuiDefaultTextColor
-	menuView.SetOnSelectItem(gui.onSelectItemWrapper(func(selectedLine int) error {
-		return nil
-	}))
-	menuView.SetContent(list)
-	gui.State.Panels.Menu.SelectedLineIdx = 0
-
-	gui.g.Update(func(g *gocui.Gui) error {
-		return gui.pushContext(gui.State.Contexts.Menu)
-	})
-	return nil
+	return list, nil
 }
 
 func (gui *Gui) onMenuPress() error {

--- a/pkg/gui/menu_panel_filter.go
+++ b/pkg/gui/menu_panel_filter.go
@@ -1,0 +1,61 @@
+package gui
+
+import (
+	"github.com/jesseduffield/gocui"
+	"regexp"
+	"strings"
+)
+
+type MenuPanelFilter struct {
+	needle     string
+	menuView   *gocui.View
+	menuItems  []*menuItem
+	updateMenu func(string, []*menuItem)
+}
+
+func (m *MenuPanelFilter) applyFilterIfMatching(needle string) (newNeedle string) {
+	filteredItems, _ := filterListItems(m.menuItems, needle)
+
+	if len(filteredItems) > 0 {
+		m.needle = needle
+		m.updateMenu(needle, filteredItems)
+	}
+
+	newNeedle = m.needle
+	return
+}
+
+func (m *MenuPanelFilter) HandleSearchKeystroke(key string) {
+	isPrintableCharacter, _ := regexp.MatchString("[a-zA-Z]", key)
+
+	if isPrintableCharacter {
+		needle := m.needle + key
+		m.applyFilterIfMatching(needle)
+	}
+}
+
+func (m *MenuPanelFilter) HandleSearchBackspace() {
+	if len(m.needle) > 0 {
+		needle := m.needle[:len(m.needle)-1]
+		m.applyFilterIfMatching(needle)
+	}
+}
+
+func (m *MenuPanelFilter) HandleResetSearch() {
+	m.needle = ""
+	m.applyFilterIfMatching("")
+}
+
+func filterListItems(menuItems []*menuItem, filter string) ([]*menuItem, error) {
+	var filteredItems []*menuItem
+	for _, menuItem := range menuItems {
+		for _, displayString := range menuItem.displayStrings {
+			if strings.Contains(strings.ToUpper(displayString), strings.ToUpper(filter)) || len(filter) == 0 {
+				filteredItems = append(filteredItems, menuItem)
+				break
+			}
+		}
+	}
+
+	return filteredItems, nil
+}

--- a/pkg/gui/menu_panel_filter_test.go
+++ b/pkg/gui/menu_panel_filter_test.go
@@ -1,0 +1,63 @@
+package gui
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMenuPanelFilter(t *testing.T) {
+
+	fakeMenuItems :=
+		[]*menuItem{
+			{
+				displayStrings: []string{"a", "FAKE_DISPLAY_STRING_ONE"},
+			}, {
+				displayStrings: []string{"a", "FAKE_DISPLAY_STRING_TWO"},
+			}, {
+				displayStrings: []string{"a", "FAKE_DISPLAY_STRING_THREE"},
+			},
+		}
+
+	t.Run("filterListItems", func(t *testing.T) {
+		type scenario struct {
+			testName  string
+			menuItems []*menuItem
+			filter    string
+			assert    func(filteredItems []*menuItem, err error)
+		}
+
+		scenarios := []scenario{
+			{
+				testName:  "should return input data when no filter provided",
+				menuItems: fakeMenuItems,
+				filter:    "",
+				assert: func(filteredItems []*menuItem, err error) {
+					assert.Equal(t, fakeMenuItems, filteredItems)
+				},
+			}, {
+				testName:  "should return no data when filter matches no elements",
+				menuItems: fakeMenuItems,
+				filter:    "NOT_IN_THAT_HAYSTACK",
+				assert: func(filteredItems []*menuItem, err error) {
+					assert.Empty(t, filteredItems)
+				},
+			}, {
+				testName:  "should return item when single match",
+				menuItems: fakeMenuItems,
+				filter:    "ONE",
+				assert: func(filteredItems []*menuItem, err error) {
+					assert.Len(t, filteredItems, 1)
+					assert.Equal(t, filteredItems[0], fakeMenuItems[0])
+				},
+			},
+		}
+
+		for _, scenario := range scenarios {
+			t.Run(scenario.testName, func(t *testing.T) {
+				result, err := filterListItems(scenario.menuItems, scenario.filter)
+				scenario.assert(result, err)
+			})
+		}
+
+	})
+}

--- a/pkg/gui/menu_panel_test.go
+++ b/pkg/gui/menu_panel_test.go
@@ -1,0 +1,66 @@
+package gui
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMenuItemHandling(t *testing.T) {
+
+	fakeMenuItems :=
+		[]*menuItem{
+			{
+				displayStrings: []string{"a", "FAKE_DISPLAY_STRING_ONE"},
+			}, {
+				displayStrings: []string{"a", "FAKE_DISPLAY_STRING_TWO"},
+			}, {
+				displayStrings: []string{"a", "FAKE_DISPLAY_STRING_THREE"},
+			},
+		}
+
+	t.Run("formatListItems", func(t *testing.T) {
+
+		type scenario struct {
+			testName  string
+			menuItems []*menuItem
+			assert    func(data string, err error)
+		}
+
+		scenarios := []scenario{
+			{
+				testName:  "should return empty formatted result on empty input",
+				menuItems: []*menuItem{},
+				assert: func(data string, err error) {
+					assert.Nil(t, err)
+					assert.Equal(t, "", data)
+				},
+			},
+			{
+				testName: "should return formatted version of single item",
+				menuItems: []*menuItem{
+					{
+						displayString: "FAKE_DISPLAY_STRING",
+					}},
+				assert: func(data string, err error) {
+					assert.Nil(t, err)
+					assert.Equal(t, "FAKE_DISPLAY_STRING", data)
+				},
+			}, {
+				testName:  "should return formatted version of multiple items",
+				menuItems: fakeMenuItems,
+				assert: func(data string, err error) {
+					assert.Nil(t, err)
+					assert.Equal(t, "FAKE_DISPLAY_STRING_ONE\nFAKE_DISPLAY_STRING_TWO\nFAKE_DISPLAY_STRING_THREE", data)
+				},
+			},
+		}
+
+		for _, scenario := range scenarios {
+			t.Run(scenario.testName, func(t *testing.T) {
+				result, err := formatListItems(scenario.menuItems)
+				scenario.assert(result, err)
+			})
+		}
+
+	})
+}

--- a/pkg/gui/options_menu_panel.go
+++ b/pkg/gui/options_menu_panel.go
@@ -1,11 +1,10 @@
 package gui
 
 import (
-	"strings"
-
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/utils"
+	"strings"
 )
 
 func (gui *Gui) getBindings(v *gocui.View) []*Binding {
@@ -72,5 +71,7 @@ func (gui *Gui) handleCreateOptionsMenu() error {
 		}
 	}
 
-	return gui.createMenu(strings.Title(gui.Tr.LcMenu), menuItems, createMenuOptions{})
+	return gui.createMenu(strings.Title(gui.Tr.LcMenu), menuItems, createMenuOptions{
+		allowFiltering: true,
+	})
 }


### PR DESCRIPTION
**WORK IN PROGRESS**

Pull-Request for enabling filtering in menus.

Open issues:
- A keypress on ESC is not caught properly and forwarded to the editor. So, the first keypress on ESC just resets the search highlighting, the second closes the menu. If there would be a way to catch the keypress, it would be fine.
- I am not aware of any event thrown when a submenu is opened, so the state of the filter is not cleaned up properly when i.E. one filters the "x" menu by "filter" and opens the "Filter" submenu.

