### PR TITLE
fix delta again

### DIFF
--- a/pkg/gui/pty.go
+++ b/pkg/gui/pty.go
@@ -12,17 +12,23 @@ import (
 	"github.com/jesseduffield/gocui"
 )
 
+func (gui *Gui) desiredPtySize() *pty.Winsize {
+	width, height := gui.Views.Main.Size()
+
+	return &pty.Winsize{Cols: uint16(width), Rows: uint16(height)}
+}
+
 func (gui *Gui) onResize() error {
 	if gui.State.Ptmx == nil {
 		return nil
 	}
-	width, height := gui.Views.Main.Size()
 
-	if err := pty.Setsize(gui.State.Ptmx, &pty.Winsize{Cols: uint16(width), Rows: uint16(height)}); err != nil {
+	// TODO: handle resizing properly: we need to actually clear the main view
+	// and re-read the output from our pty. Or we could just re-run the original
+	// command from scratch
+	if err := pty.Setsize(gui.State.Ptmx, gui.desiredPtySize()); err != nil {
 		return err
 	}
-
-	// TODO: handle resizing properly
 
 	return nil
 }
@@ -52,7 +58,7 @@ func (gui *Gui) newPtyTask(view *gocui.View, cmd *exec.Cmd, prefix string) error
 	manager := gui.getManager(view)
 
 	start := func() (*exec.Cmd, io.Reader) {
-		ptmx, err := pty.Start(cmd)
+		ptmx, err := pty.StartWithSize(cmd, gui.desiredPtySize())
 		if err != nil {
 			gui.Log.Error(err)
 		}
@@ -65,10 +71,6 @@ func (gui *Gui) newPtyTask(view *gocui.View, cmd *exec.Cmd, prefix string) error
 	onClose := func() {
 		gui.State.Ptmx.Close()
 		gui.State.Ptmx = nil
-	}
-
-	if err := gui.onResize(); err != nil {
-		return err
 	}
 
 	if err := manager.NewTask(manager.NewCmdTask(start, prefix, height+oy+10, onClose), cmdStr); err != nil {


### PR DESCRIPTION
fixes https://github.com/jesseduffield/lazygit/issues/1582

Not really sure how to write a spec for this to stop it happening again, but alas this part of the code doesn't change very often.

I should have included the onResize call in the start function when I did a recent refactoring, and because it depends on gui.State.Ptmx being defined, it did nothing given that the start function hadn't yet been called. As @blm it's easier to just use `StartWithSize`. This leaves us with an onResize function that only gets called when the layout changes (which itself may happen if the terminal window is resized) and testing that it looks like it doesn't really work, but I'm pretty sure that was already the case. We'll need to look into that one at some point