### PR TITLE
remember commit message if commit fails

### DIFF
--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -11,6 +11,7 @@ import (
 
 func (gui *Gui) handleCommitConfirm() error {
 	message := strings.TrimSpace(gui.Views.CommitMessage.TextArea.GetContent())
+	gui.State.messageFailedCommit = message
 	if message == "" {
 		return gui.createErrorPanel(gui.Tr.CommitWithoutMessageErr)
 	}
@@ -25,6 +26,7 @@ func (gui *Gui) handleCommitConfirm() error {
 	_ = gui.returnFromContext()
 	return gui.withGpgHandling(cmdStr, gui.Tr.CommittingStatus, func() error {
 		gui.Views.CommitMessage.ClearTextArea()
+		gui.State.messageFailedCommit = ""
 		return nil
 	})
 }

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -384,18 +384,24 @@ func (gui *Gui) handleCommitPress() error {
 		return gui.promptToStageAllAndRetry(gui.handleCommitPress)
 	}
 
-	commitPrefixConfig := gui.commitPrefixConfigForRepo()
-	if commitPrefixConfig != nil {
-		prefixPattern := commitPrefixConfig.Pattern
-		prefixReplace := commitPrefixConfig.Replace
-		rgx, err := regexp.Compile(prefixPattern)
-		if err != nil {
-			return gui.createErrorPanel(fmt.Sprintf("%s: %s", gui.Tr.LcCommitPrefixPatternError, err.Error()))
-		}
-		prefix := rgx.ReplaceAllString(gui.getCheckedOutBranch().Name, prefixReplace)
+	if len(gui.State.messageFailedCommit) > 0 {
 		gui.Views.CommitMessage.ClearTextArea()
-		gui.Views.CommitMessage.TextArea.TypeString(prefix)
-		gui.render()
+		gui.Views.CommitMessage.TextArea.TypeString(gui.State.messageFailedCommit)
+		gui.Views.CommitMessage.RenderTextArea()
+	} else {
+		commitPrefixConfig := gui.commitPrefixConfigForRepo()
+		if commitPrefixConfig != nil {
+			prefixPattern := commitPrefixConfig.Pattern
+			prefixReplace := commitPrefixConfig.Replace
+			rgx, err := regexp.Compile(prefixPattern)
+			if err != nil {
+				return gui.createErrorPanel(fmt.Sprintf("%s: %s", gui.Tr.LcCommitPrefixPatternError, err.Error()))
+			}
+			prefix := rgx.ReplaceAllString(gui.getCheckedOutBranch().Name, prefixReplace)
+			gui.Views.CommitMessage.ClearTextArea()
+			gui.Views.CommitMessage.TextArea.TypeString(prefix)
+			gui.Views.CommitMessage.RenderTextArea()
+		}
 	}
 
 	gui.g.Update(func(g *gocui.Gui) error {

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -346,6 +346,9 @@ type guiState struct {
 
 	// for displaying suggestions while typing in a file name
 	FilesTrie *patricia.Trie
+
+	// this is the message of the last failed commit attempt
+	messageFailedCommit string
 }
 
 // reuseState determines if we pull the repo state from our repo state map or

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -628,7 +628,8 @@ func (gui *Gui) runSubprocess(subprocess *exec.Cmd) error {
 
 	fmt.Fprintf(os.Stdout, "\n%s\n\n", style.FgBlue.Sprint("+ "+strings.Join(subprocess.Args, " ")))
 
-	if err := subprocess.Run(); err != nil {
+	err := subprocess.Run()
+	if err != nil {
 		// not handling the error explicitly because usually we're going to see it
 		// in the output anyway
 		gui.Log.Error(err)
@@ -641,7 +642,7 @@ func (gui *Gui) runSubprocess(subprocess *exec.Cmd) error {
 	fmt.Fprintf(os.Stdout, "\n%s", style.FgGreen.Sprint(gui.Tr.PressEnterToReturn))
 	fmt.Scanln() // wait for enter press
 
-	return nil
+	return err
 }
 
 func (gui *Gui) loadNewRepo() error {


### PR DESCRIPTION
With this PR lazygit will remember the commit message, if a creating a commit fails (e.g. by a failing pre-commit hook).

Additionally I realized, that a pre-commit error is actually completely ignored, if it happens in a subprocess because of gpg signing.
So I also fixed that problem, in order that the error detection will work.

Fixes #854
and probably also fixes #1360 (untested)

--- 

In case you want any tests, I can probably write one in the next days. You can force a failing git commit by pasting `#!/bin/sh exit 1` into `.git/hooks/pre-commit` and give it executable permissions `chmod +x .git/hooks/pre-commit`.

But I already spend quite a lot of hours debugging, figuring out the codebase and writing the solution (my first ever written Go code :smiley:), so I'm definitely not doing it today.