### PR TITLE
Suggest existing remote for non-tracking branch

### DIFF
--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -657,9 +657,11 @@ func (gui *Gui) handlePullFiles() error {
 			}
 		}
 
+		suggestedRemote := getSuggestedRemote(gui.State.Remotes)
+
 		return gui.prompt(promptOpts{
 			title:               gui.Tr.EnterUpstream,
-			initialContent:      "origin/" + currentBranch.Name,
+			initialContent:      suggestedRemote + "/" + currentBranch.Name,
 			findSuggestionsFunc: gui.getRemoteBranchesSuggestionsFunc("/"),
 			handleConfirm: func(upstream string) error {
 				if err := gui.GitCommand.SetUpstreamBranch(upstream); err != nil {
@@ -794,12 +796,14 @@ func (gui *Gui) pushFiles() error {
 			)
 		}
 
+		suggestedRemote := getSuggestedRemote(gui.State.Remotes)
+
 		if gui.GitCommand.PushToCurrent {
 			return gui.push(pushOpts{setUpstream: true})
 		} else {
 			return gui.prompt(promptOpts{
 				title:               gui.Tr.EnterUpstream,
-				initialContent:      "origin " + currentBranch.Name,
+				initialContent:      suggestedRemote + " " + currentBranch.Name,
 				findSuggestionsFunc: gui.getRemoteBranchesSuggestionsFunc(" "),
 				handleConfirm: func(upstream string) error {
 					var upstreamBranch, upstreamRemote string
@@ -822,6 +826,20 @@ func (gui *Gui) pushFiles() error {
 			})
 		}
 	}
+}
+
+func getSuggestedRemote(remotes []*models.Remote) string {
+	if len(remotes) == 0 {
+		return "origin"
+	}
+
+	for _, remote := range remotes {
+		if remote.Name == "origin" {
+			return remote.Name
+		}
+	}
+
+	return remotes[0].Name
 }
 
 func (gui *Gui) requestToForcePush() error {

--- a/pkg/gui/files_panel_test.go
+++ b/pkg/gui/files_panel_test.go
@@ -1,0 +1,34 @@
+package gui
+
+import (
+	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSuggestedRemote(t *testing.T) {
+	cases := []struct {
+		remotes  []*models.Remote
+		expected string
+	}{
+		{mkRemoteList(), "origin"},
+		{mkRemoteList("upstream", "origin", "foo"), "origin"},
+		{mkRemoteList("upstream", "foo", "bar"), "upstream"},
+	}
+
+	for _, c := range cases {
+		result := getSuggestedRemote(c.remotes)
+		assert.EqualValues(t, c.expected, result)
+	}
+}
+
+func mkRemoteList(names ...string) []*models.Remote {
+	var result []*models.Remote
+
+	for _, name := range names {
+		result = append(result, &models.Remote{Name: name})
+	}
+
+	return result
+}


### PR DESCRIPTION
Currently, when pushing or pulling a branch that has no tracking remote,
lazygit suggests the (hard-coded) remote named 'origin'. However, a
repository might not have a remote with this name, in which case the
suggestion makes no sense. This happens to me quite regularly when I
choose a more meaningful name than 'origin' for a remote.

This change keeps the current behavior by suggesting 'origin' when there
is either a remote with that name or no remote at all. However, when
'origin' does not exist, the name of the first existing remote is
suggested.