### PR TITLE
support config unified color for commit authors

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -50,8 +50,6 @@ gui:
   showRandomTip: true
   showCommandLog: true
   commandLogSize: 8
-  authorColors: # in case you're not happy with the randomly assigned colour
-    'John Smith': '#ff0000'
 git:
   paging:
     colorArg: always
@@ -375,6 +373,28 @@ gui:
 Alternatively you may have bold fonts disabled in your terminal, in which case enabling bold fonts should solve the problem.
 
 If you're still having trouble please raise an issue.
+
+## Custom Author Color
+
+Lazygit will assgin a random color for every commit author in the commits pane by default.
+
+You can customize the color in case you're not happy with the randomly assigned one:
+
+```yaml
+gui:
+  authorColors:
+    'John Smith': '#ff0000 # use red for John Smith
+```
+
+You can use wildcard to set a unified color in case your are lazy to customize the color for every author or you are just want a single color for all/other authors:
+```yaml
+gui:
+  authorColors:
+    # use red for John Smith
+    'John Smith': '#ff0000
+    # use blue for other authors
+    '*': '#0000ff'
+```
 
 ## Example Coloring
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -376,22 +376,22 @@ If you're still having trouble please raise an issue.
 
 ## Custom Author Color
 
-Lazygit will assgin a random color for every commit author in the commits pane by default.
+Lazygit will assign a random color for every commit author in the commits pane by default.
 
 You can customize the color in case you're not happy with the randomly assigned one:
 
 ```yaml
 gui:
   authorColors:
-    'John Smith': '#ff0000 # use red for John Smith
+    'John Smith': '#ff0000' # use red for John Smith
 ```
 
-You can use wildcard to set a unified color in case your are lazy to customize the color for every author or you are just want a single color for all/other authors:
+You can use wildcard to set a unified color in case your are lazy to customize the color for every author or you just want a single color for all/other authors:
 ```yaml
 gui:
   authorColors:
     # use red for John Smith
-    'John Smith': '#ff0000
+    'John Smith': '#ff0000'
     # use blue for other authors
     '*': '#0000ff'
 ```

--- a/pkg/gui/presentation/authors/authors.go
+++ b/pkg/gui/presentation/authors/authors.go
@@ -13,9 +13,13 @@ import (
 
 // if these being global variables causes trouble we can wrap them in a struct
 // attached to the gui state.
-var authorInitialCache = make(map[string]string)
-var authorNameCache = make(map[string]string)
-var authorStyleCache = make(map[string]style.TextStyle)
+var (
+	authorInitialCache = make(map[string]string)
+	authorNameCache    = make(map[string]string)
+	authorStyleCache   = make(map[string]style.TextStyle)
+)
+
+const authorNameWildcard = "*"
 
 func ShortAuthor(authorName string) string {
 	if value, ok := authorInitialCache[authorName]; ok {
@@ -48,6 +52,11 @@ func LongAuthor(authorName string) string {
 
 func AuthorStyle(authorName string) style.TextStyle {
 	if value, ok := authorStyleCache[authorName]; ok {
+		return value
+	}
+
+	// use the unified style whatever the autor name is
+	if value, ok := authorStyleCache[authorNameWildcard]; ok {
 		return value
 	}
 

--- a/pkg/gui/presentation/authors/authors.go
+++ b/pkg/gui/presentation/authors/authors.go
@@ -55,7 +55,7 @@ func AuthorStyle(authorName string) style.TextStyle {
 		return value
 	}
 
-	// use the unified style whatever the autor name is
+	// use the unified style whatever the author name is
 	if value, ok := authorStyleCache[authorNameWildcard]; ok {
 		return value
 	}


### PR DESCRIPTION
It's nice to assign a unique color for each commit author. But the randomly generated color may not suitable for everyone's terminal:
![image](https://user-images.githubusercontent.com/8230448/145013835-eadda288-94d5-400d-9802-a749588d0ec8.png)

The high color contrast would make it hard to read in some color scheme.

Users do can customize the colors by configuring `authorColors`. But the problem is you need to config the color for every author. I think it's not practical since people may have multiple repos and there are multiple (many) authors in each repo. This PR add support to assign a unified color for commit authors.

This solution may not be the best one but I think it do address some use cases.