### PR TITLE
Fix `showFileTree` default value in docs

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -45,7 +45,7 @@ gui:
   mouseEvents: true
   skipUnstageLineWarning: false
   skipStashWarning: true
-  showFileTree: false # for rendering changes files in a tree format
+  showFileTree: true # for rendering changes files in a tree format
   showListFooter: true # for seeing the '5 of 20' message in list panels
   showRandomTip: true
   showCommandLog: true


### PR DESCRIPTION
This PR changes the docs default value for the `gui.showFileTree` option from false to true. The default value has already changed from false to true in this PR but the change wasn't reflected in the docs: https://github.com/jesseduffield/lazygit/pull/1535

Current master link: https://github.com/jesseduffield/lazygit/blob/18283ad41bbb2ac17c8482ddaaf0f31ea9d38a26/pkg/config/user_config.go#L341

