### PR TITLE
Use "reword" for amending a commit message everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ See the [docs](docs/Custom_Command_Keybindings.md)
 - Easily check out recent branches
 - Scroll through logs/diffs of branches/commits/stash
 - Quick pushing/pulling
-- Squash down and rename commits
+- Squash down and reword commits
 
 ### Resolving merge conflicts
 

--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -121,7 +121,7 @@
 <pre>
   <kbd>s</kbd>: squash down
   <kbd>r</kbd>: reword commit
-  <kbd>R</kbd>: rename commit with editor
+  <kbd>R</kbd>: reword commit with editor
   <kbd>g</kbd>: reset to this commit
   <kbd>f</kbd>: fixup commit
   <kbd>F</kbd>: create fixup commit for this commit

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -643,7 +643,7 @@ func englishTranslationSet() TranslationSet {
 		LcMoveUpCommit:                      "move commit up one",
 		LcEditCommit:                        "edit commit",
 		LcAmendToCommit:                     "amend commit with staged changes",
-		LcRenameCommitEditor:                "rename commit with editor",
+		LcRenameCommitEditor:                "reword commit with editor",
 		Error:                               "Error",
 		LcSelectHunk:                        "select hunk",
 		LcNavigateConflicts:                 "navigate conflicts",


### PR DESCRIPTION
We were inconsistent about "rename" vs "reword" for commits.  reword
is the term used in git itself (for example, in rebase).