### PR TITLE
change branch regex to only grab the first remote on each line of branch command

### DIFF
--- a/pkg/commands/loading_remotes.go
+++ b/pkg/commands/loading_remotes.go
@@ -27,7 +27,7 @@ func (c *GitCommand) GetRemotes() ([]*models.Remote, error) {
 	for i, goGitRemote := range goGitRemotes {
 		remoteName := goGitRemote.Config().Name
 
-		re := regexp.MustCompile(fmt.Sprintf(`%s\/([\S]+)`, remoteName))
+		re := regexp.MustCompile(fmt.Sprintf(`(?m)^\s*%s\/([\S]+)`, remoteName))
 		matches := re.FindAllStringSubmatch(remoteBranchesStr, -1)
 		branches := make([]*models.RemoteBranch, len(matches))
 		for j, match := range matches {


### PR DESCRIPTION
I noticed I was sometimes getting dupe branch names in my branches list - it ended up being whatever HEAD happened to be pointed to. The regex was matching both remotes listed on lines that looked like `  origin/HEAD -> origin/master` instead of just the first.