### PR TITLE
fix: ssh scheme prefix handling on making pull request

### DIFF
--- a/pkg/commands/pull_request.go
+++ b/pkg/commands/pull_request.go
@@ -161,9 +161,10 @@ func (pr *PullRequest) getPullRequestURL(from string, to string) (string, error)
 }
 
 func getRepoInfoFromURL(url string) *RepoInformation {
-	isHTTP := strings.HasPrefix(url, "http")
+	hasHTTPScheme := strings.HasPrefix(url, "http")
+	hasSSHScheme := strings.HasPrefix(url, "ssh")
 
-	if isHTTP {
+	if hasHTTPScheme || hasSSHScheme {
 		splits := strings.Split(url, "/")
 		owner := strings.Join(splits[3:len(splits)-1], "/")
 		repo := strings.TrimSuffix(splits[len(splits)-1], ".git")

--- a/pkg/commands/pull_request_test.go
+++ b/pkg/commands/pull_request_test.go
@@ -24,6 +24,14 @@ func TestGetRepoInfoFromURL(t *testing.T) {
 			},
 		},
 		{
+			"Returns repository information for ssh remote url",
+			"ssh://git@github.com/petersmith/super_calculator",
+			func(repoInfo *RepoInformation) {
+				assert.EqualValues(t, repoInfo.Owner, "petersmith")
+				assert.EqualValues(t, repoInfo.Repository, "super_calculator")
+			},
+		},
+		{
 			"Returns repository information for http remote url",
 			"https://my_username@bitbucket.org/johndoe/social_network.git",
 			func(repoInfo *RepoInformation) {


### PR DESCRIPTION
When a remote url uses ssh and has scheme prefix (like `ssh://git@github.com/kawaemon/lazygit.git`), lazygit generates invalid pull request URL like this: `https://github.com///git@github.com/kawaemon/lazygit/compare/fix-ssh-scheme?expand=1`

This pull request fixes this issue, and adds a test for it.