### PR TITLE
fix: read one line before resuming TUI to prevent unintentional operations

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -662,7 +662,10 @@ func (gui *Gui) runSubprocess(cmdObj oscommands.ICmdObj) error { //nolint:unpara
 
 	if gui.Config.GetUserConfig().PromptToReturnFromSubprocess {
 		fmt.Fprintf(os.Stdout, "\n%s", style.FgGreen.Sprint(gui.Tr.PressEnterToReturn))
-		fmt.Scanln() // wait for enter press
+
+		// scan to buffer to prevent run unintentional operations when TUI resumes.
+		var buffer string
+		fmt.Scanln(&buffer) // wait for enter press
 	}
 
 	return err


### PR DESCRIPTION
Partially fixes #1629.

I can't find any way to empty stdin buffer, so this PR fixes only inputs with no extra newlines.
e.g: typing `zzzzzP<Enter>` while processing commit is safe, but `<Enter>zzzzzP<Enter><Enter>` may cause big disaster.