### PR TITLE
use regex to match against git service URL

### DIFF
--- a/pkg/commands/pull_request_test.go
+++ b/pkg/commands/pull_request_test.go
@@ -9,6 +9,7 @@ import (
 // TestGetRepoInfoFromURL is a function.
 func TestGetRepoInfoFromURL(t *testing.T) {
 	type scenario struct {
+		service  *Service
 		testName string
 		repoURL  string
 		test     func(*RepoInformation)
@@ -16,6 +17,7 @@ func TestGetRepoInfoFromURL(t *testing.T) {
 
 	scenarios := []scenario{
 		{
+			NewGithubService("github.com", "github.com"),
 			"Returns repository information for git remote url",
 			"git@github.com:petersmith/super_calculator",
 			func(repoInfo *RepoInformation) {
@@ -24,6 +26,16 @@ func TestGetRepoInfoFromURL(t *testing.T) {
 			},
 		},
 		{
+			NewGithubService("github.com", "github.com"),
+			"Returns repository information for git remote url, trimming trailing '.git'",
+			"git@github.com:petersmith/super_calculator.git",
+			func(repoInfo *RepoInformation) {
+				assert.EqualValues(t, repoInfo.Owner, "petersmith")
+				assert.EqualValues(t, repoInfo.Repository, "super_calculator")
+			},
+		},
+		{
+			NewGithubService("github.com", "github.com"),
 			"Returns repository information for http remote url",
 			"https://my_username@bitbucket.org/johndoe/social_network.git",
 			func(repoInfo *RepoInformation) {
@@ -35,7 +47,7 @@ func TestGetRepoInfoFromURL(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.testName, func(t *testing.T) {
-			s.test(getRepoInfoFromURL(s.repoURL))
+			s.test(s.service.getRepoInfoFromURL(s.repoURL))
 		})
 	}
 }

--- a/pkg/utils/regexp.go
+++ b/pkg/utils/regexp.go
@@ -1,0 +1,17 @@
+package utils
+
+import "regexp"
+
+func FindNamedMatches(regex *regexp.Regexp, str string) map[string]string {
+	match := regex.FindStringSubmatch(str)
+
+	if len(match) == 0 {
+		return nil
+	}
+
+	results := map[string]string{}
+	for i, value := range match[1:] {
+		results[regex.SubexpNames()[i+1]] = value
+	}
+	return results
+}

--- a/pkg/utils/regexp_test.go
+++ b/pkg/utils/regexp_test.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func TestFindNamedMatches(t *testing.T) {
+	scenarios := []struct {
+		regex    *regexp.Regexp
+		input    string
+		expected map[string]string
+	}{
+		{
+			regexp.MustCompile(`^(?P<name>\w+)`),
+			"hello world",
+			map[string]string{
+				"name": "hello",
+			},
+		},
+		{
+			regexp.MustCompile(`^https?://.*/(?P<owner>.*)/(?P<repo>.*?)(\.git)?$`),
+			"https://my_username@bitbucket.org/johndoe/social_network.git",
+			map[string]string{
+				"owner": "johndoe",
+				"repo":  "social_network",
+				"":      ".git", // unnamed capture group
+			},
+		},
+		{
+			regexp.MustCompile(`(?P<owner>hello) world`),
+			"yo world",
+			nil,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		actual := FindNamedMatches(scenario.regex, scenario.input)
+		if !reflect.DeepEqual(actual, scenario.expected) {
+			t.Errorf("FindNamedMatches(%s, %s) == %s, expected %s", scenario.regex, scenario.input, actual, scenario.expected)
+		}
+	}
+}


### PR DESCRIPTION
So that we don't need to write a bunch of custom code for each new git service, I'm having each service define some URL regexes to match against so we can extract the owner and repo name from the URL.

Currently we're determining which git service to use based on whether say 'github' is in the name of the url, which I can foresee causing issues in some cases. We may at some point decide to instead have each service with more specific regexes and the first service with a matching regex gets is the one that gets picked.