### PR TITLE
move toplevel keybindings out of global view space

### DIFF
--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1684,51 +1684,50 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			{ViewName: viewName, Key: gui.getKey(config.Universal.PrevBlockAlt2), Modifier: gocui.ModNone, Handler: gui.previousSideWindow},
 			{ViewName: viewName, Key: gui.getKey(config.Universal.NextBlockAlt2), Modifier: gocui.ModNone, Handler: gui.nextSideWindow},
 
-            // all the previously "global" keystrokes that aren't quit-ish: anything that wouldn't make sense in a popup, and are actually only toplevel window commands
+			// all the previously "global" keystrokes that aren't quit-ish: anything that wouldn't make sense in a popup, and are actually only toplevel window commands
 			{ViewName: viewName, Key: gui.getKey(config.Universal.Return), Modifier: gocui.ModNone, Handler: gui.handleTopLevelReturn},
-            {ViewName: viewName, Key: gui.getKey(config.Universal.OpenRecentRepos), Handler: gui.handleCreateRecentReposMenu, Alternative: "<c-r>", Description: gui.Tr.SwitchRepo},
-            {ViewName: viewName, Key: gui.getKey(config.Universal.ScrollUpMain), Handler: gui.scrollUpMain, Alternative: "fn+up", Description: gui.Tr.LcScrollUpMainPanel},
-            {ViewName: viewName, Key: gui.getKey(config.Universal.ScrollDownMain), Handler: gui.scrollDownMain, Alternative: "fn+down", Description: gui.Tr.LcScrollDownMainPanel},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.OpenRecentRepos), Handler: gui.handleCreateRecentReposMenu, Alternative: "<c-r>", Description: gui.Tr.SwitchRepo},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.ScrollUpMain), Handler: gui.scrollUpMain, Alternative: "fn+up", Description: gui.Tr.LcScrollUpMainPanel},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.ScrollDownMain), Handler: gui.scrollDownMain, Alternative: "fn+down", Description: gui.Tr.LcScrollDownMainPanel},
 			{ViewName: viewName, Key: gui.getKey(config.Universal.ScrollUpMainAlt1), Modifier: gocui.ModNone, Handler: gui.scrollUpMain},
 			{ViewName: viewName, Key: gui.getKey(config.Universal.ScrollDownMainAlt1), Modifier: gocui.ModNone, Handler: gui.scrollDownMain},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.ScrollUpMainAlt2), Modifier: gocui.ModNone, Handler: gui.scrollUpMain},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.ScrollDownMainAlt2), Modifier: gocui.ModNone, Handler:  gui.scrollDownMain},
-    		{ViewName: viewName, Key: gui.getKey(config.Universal.CreateRebaseOptionsMenu), Handler: gui.handleCreateRebaseOptionsMenu, Description: gui.Tr.ViewMergeRebaseOptions, OpensMenu: true},
-    		{ViewName: viewName, Key: gui.getKey(config.Universal.CreatePatchOptionsMenu), Handler: gui.handleCreatePatchOptionsMenu, Description: gui.Tr.ViewPatchOptions, OpensMenu: true},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.PushFiles), Handler: gui.pushFiles, Description: gui.Tr.LcPush},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.PullFiles), Handler: gui.handlePullFiles, Description: gui.Tr.LcPull},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.Refresh), Handler: gui.handleRefresh, Description: gui.Tr.LcRefresh},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.OptionMenu), Handler: gui.handleCreateOptionsMenu, Description: gui.Tr.LcOpenMenu, OpensMenu: true},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.OptionMenuAlt1), Modifier: gocui.ModNone, Handler: gui.handleCreateOptionsMenu},
-		    {ViewName: viewName, Key: gocui.MouseMiddle, Modifier: gocui.ModNone, Handler:  gui.handleCreateOptionsMenu},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.Undo), Handler: gui.reflogUndo, Description: gui.Tr.LcUndoReflog},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.Redo), Handler: gui.reflogRedo, Description: gui.Tr.LcRedoReflog},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.NextScreenMode), Handler: gui.nextScreenMode, Description: gui.Tr.LcNextScreenMode},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.PrevScreenMode), Handler: gui.prevScreenMode, Description: gui.Tr.LcPrevScreenMode},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.ExecuteCustomCommand), Handler: gui.handleCustomCommand, Description: gui.Tr.LcExecuteCustomCommand},
-    		{ViewName: viewName, Key: gui.getKey(config.Universal.FilteringMenu), Handler: gui.handleCreateFilteringMenuPanel, Description: gui.Tr.LcOpenFilteringMenu, OpensMenu: true},
-    		{ViewName: viewName, Key: gui.getKey(config.Universal.DiffingMenu), Handler: gui.handleCreateDiffingMenuPanel, Description: gui.Tr.LcOpenDiffingMenu, OpensMenu: true},
-    		{ViewName: viewName, Key: gui.getKey(config.Universal.DiffingMenuAlt), Handler: gui.handleCreateDiffingMenuPanel, Description: gui.Tr.LcOpenDiffingMenu, OpensMenu: true},
-    		{ViewName: viewName, Key: gui.getKey(config.Universal.ExtrasMenu), Handler: gui.handleCreateExtrasMenuPanel, Description: gui.Tr.LcOpenExtrasMenu, OpensMenu: true},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.IncreaseContextInDiffView), Handler: gui.IncreaseContextInDiffView, Description: gui.Tr.IncreaseContextInDiffView},
-		    {ViewName: viewName, Key: gui.getKey(config.Universal.DecreaseContextInDiffView), Handler: gui.DecreaseContextInDiffView, Description: gui.Tr.DecreaseContextInDiffView},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.ScrollUpMainAlt2), Modifier: gocui.ModNone, Handler: gui.scrollUpMain},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.ScrollDownMainAlt2), Modifier: gocui.ModNone, Handler: gui.scrollDownMain},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.CreateRebaseOptionsMenu), Handler: gui.handleCreateRebaseOptionsMenu, Description: gui.Tr.ViewMergeRebaseOptions, OpensMenu: true},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.CreatePatchOptionsMenu), Handler: gui.handleCreatePatchOptionsMenu, Description: gui.Tr.ViewPatchOptions, OpensMenu: true},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.PushFiles), Handler: gui.pushFiles, Description: gui.Tr.LcPush},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.PullFiles), Handler: gui.handlePullFiles, Description: gui.Tr.LcPull},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.Refresh), Handler: gui.handleRefresh, Description: gui.Tr.LcRefresh},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.OptionMenu), Handler: gui.handleCreateOptionsMenu, Description: gui.Tr.LcOpenMenu, OpensMenu: true},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.OptionMenuAlt1), Modifier: gocui.ModNone, Handler: gui.handleCreateOptionsMenu},
+			{ViewName: viewName, Key: gocui.MouseMiddle, Modifier: gocui.ModNone, Handler: gui.handleCreateOptionsMenu},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.Undo), Handler: gui.reflogUndo, Description: gui.Tr.LcUndoReflog},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.Redo), Handler: gui.reflogRedo, Description: gui.Tr.LcRedoReflog},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.NextScreenMode), Handler: gui.nextScreenMode, Description: gui.Tr.LcNextScreenMode},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.PrevScreenMode), Handler: gui.prevScreenMode, Description: gui.Tr.LcPrevScreenMode},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.ExecuteCustomCommand), Handler: gui.handleCustomCommand, Description: gui.Tr.LcExecuteCustomCommand},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.FilteringMenu), Handler: gui.handleCreateFilteringMenuPanel, Description: gui.Tr.LcOpenFilteringMenu, OpensMenu: true},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.DiffingMenu), Handler: gui.handleCreateDiffingMenuPanel, Description: gui.Tr.LcOpenDiffingMenu, OpensMenu: true},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.DiffingMenuAlt), Handler: gui.handleCreateDiffingMenuPanel, Description: gui.Tr.LcOpenDiffingMenu, OpensMenu: true},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.ExtrasMenu), Handler: gui.handleCreateExtrasMenuPanel, Description: gui.Tr.LcOpenExtrasMenu, OpensMenu: true},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.IncreaseContextInDiffView), Handler: gui.IncreaseContextInDiffView, Description: gui.Tr.IncreaseContextInDiffView},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.DecreaseContextInDiffView), Handler: gui.DecreaseContextInDiffView, Description: gui.Tr.DecreaseContextInDiffView},
 		}...)
-    	// Appends keybindings to jump to a particular sideView using numbers
-    	windows := []string{"status", "files", "branches", "commits", "stash"}
-    
-    	if len(config.Universal.JumpToBlock) != len(windows) {
-    		log.Fatal("Jump to block keybindings cannot be set. Exactly 5 keybindings must be supplied.")
-    	} else {
-    		for i, window := range windows {
-    			bindings = append(bindings, &Binding{
-    				ViewName: viewName,
-    				Key:      gui.getKey(config.Universal.JumpToBlock[i]),
-    				Modifier: gocui.ModNone,
-    				Handler:  gui.goToSideWindow(window)})
-    		}
-    	}
-	}
+		// Appends keybindings to jump to a particular sideView using numbers
+		windows := []string{"status", "files", "branches", "commits", "stash"}
 
+		if len(config.Universal.JumpToBlock) != len(windows) {
+			log.Fatal("Jump to block keybindings cannot be set. Exactly 5 keybindings must be supplied.")
+		} else {
+			for i, window := range windows {
+				bindings = append(bindings, &Binding{
+					ViewName: viewName,
+					Key:      gui.getKey(config.Universal.JumpToBlock[i]),
+					Modifier: gocui.ModNone,
+					Handler:  gui.goToSideWindow(window)})
+			}
+		}
+	}
 
 	for viewName := range gui.State.Contexts.initialViewTabContextMap() {
 		bindings = append(bindings, []*Binding{

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1675,7 +1675,7 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		},
 	}
 
-	for _, viewName := range []string{"status", "branches", "files", "commits", "commitFiles", "stash"} {
+	for _, viewName := range []string{"status", "branches", "files", "commits", "commitFiles", "stash", "menu", "main", "secondary", "extras"} {
 		bindings = append(bindings, []*Binding{
 			{ViewName: viewName, Key: gui.getKey(config.Universal.PrevBlock), Modifier: gocui.ModNone, Handler: gui.previousSideWindow},
 			{ViewName: viewName, Key: gui.getKey(config.Universal.NextBlock), Modifier: gocui.ModNone, Handler: gui.nextSideWindow},

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -944,6 +944,18 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Description: gui.Tr.LcCloseMenu,
 		},
 		{
+			ViewName:    "menu",
+			Key:         gui.getKey(config.Universal.OptionMenu),
+			Handler:     gui.handleMenuClose,
+			Description: gui.Tr.LcCloseMenu,
+		},
+		{
+			ViewName:    "menu",
+			Key:         gui.getKey(config.Universal.OptionMenuAlt1),
+			Handler:     gui.handleMenuClose,
+			Description: gui.Tr.LcCloseMenu,
+		},
+		{
 			ViewName: "information",
 			Key:      gocui.MouseLeft,
 			Modifier: gocui.ModNone,
@@ -1675,7 +1687,7 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		},
 	}
 
-	for _, viewName := range []string{"status", "branches", "files", "commits", "commitFiles", "stash", "menu", "main", "secondary", "extras"} {
+	for _, viewName := range []string{"status", "branches", "files", "commits", "commitFiles", "stash", "main", "secondary", "extras"} {
 		bindings = append(bindings, []*Binding{
 			{ViewName: viewName, Key: gui.getKey(config.Universal.PrevBlock), Modifier: gocui.ModNone, Handler: gui.previousSideWindow},
 			{ViewName: viewName, Key: gui.getKey(config.Universal.NextBlock), Modifier: gocui.ModNone, Handler: gui.nextSideWindow},

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -226,136 +226,10 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Handler:  gui.handleQuit,
 		},
 		{
-			ViewName: "",
-			Key:      gui.getKey(config.Universal.Return),
-			Modifier: gocui.ModNone,
-			Handler:  gui.handleTopLevelReturn,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.OpenRecentRepos),
-			Handler:     gui.handleCreateRecentReposMenu,
-			Alternative: "<c-r>",
-			Description: gui.Tr.SwitchRepo,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.ScrollUpMain),
-			Handler:     gui.scrollUpMain,
-			Alternative: "fn+up",
-			Description: gui.Tr.LcScrollUpMainPanel,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.ScrollDownMain),
-			Handler:     gui.scrollDownMain,
-			Alternative: "fn+down",
-			Description: gui.Tr.LcScrollDownMainPanel,
-		},
-		{
-			ViewName: "",
-			Key:      gui.getKey(config.Universal.ScrollUpMainAlt1),
-			Modifier: gocui.ModNone,
-			Handler:  gui.scrollUpMain,
-		},
-		{
-			ViewName: "",
-			Key:      gui.getKey(config.Universal.ScrollDownMainAlt1),
-			Modifier: gocui.ModNone,
-			Handler:  gui.scrollDownMain,
-		},
-		{
-			ViewName: "",
-			Key:      gui.getKey(config.Universal.ScrollUpMainAlt2),
-			Modifier: gocui.ModNone,
-			Handler:  gui.scrollUpMain,
-		},
-		{
-			ViewName: "",
-			Key:      gui.getKey(config.Universal.ScrollDownMainAlt2),
-			Modifier: gocui.ModNone,
-			Handler:  gui.scrollDownMain,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.CreateRebaseOptionsMenu),
-			Handler:     gui.handleCreateRebaseOptionsMenu,
-			Description: gui.Tr.ViewMergeRebaseOptions,
-			OpensMenu:   true,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.CreatePatchOptionsMenu),
-			Handler:     gui.handleCreatePatchOptionsMenu,
-			Description: gui.Tr.ViewPatchOptions,
-			OpensMenu:   true,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.PushFiles),
-			Handler:     gui.pushFiles,
-			Description: gui.Tr.LcPush,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.PullFiles),
-			Handler:     gui.handlePullFiles,
-			Description: gui.Tr.LcPull,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.Refresh),
-			Handler:     gui.handleRefresh,
-			Description: gui.Tr.LcRefresh,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.OptionMenu),
-			Handler:     gui.handleCreateOptionsMenu,
-			Description: gui.Tr.LcOpenMenu,
-			OpensMenu:   true,
-		},
-		{
-			ViewName: "",
-			Key:      gui.getKey(config.Universal.OptionMenuAlt1),
-			Modifier: gocui.ModNone,
-			Handler:  gui.handleCreateOptionsMenu,
-		},
-		{
-			ViewName: "",
-			Key:      gocui.MouseMiddle,
-			Modifier: gocui.ModNone,
-			Handler:  gui.handleCreateOptionsMenu,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.Undo),
-			Handler:     gui.reflogUndo,
-			Description: gui.Tr.LcUndoReflog,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.Redo),
-			Handler:     gui.reflogRedo,
-			Description: gui.Tr.LcRedoReflog,
-		},
-		{
 			ViewName:    "status",
 			Key:         gui.getKey(config.Universal.Edit),
 			Handler:     gui.handleEditConfig,
 			Description: gui.Tr.EditConfig,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.NextScreenMode),
-			Handler:     gui.nextScreenMode,
-			Description: gui.Tr.LcNextScreenMode,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.PrevScreenMode),
-			Handler:     gui.prevScreenMode,
-			Description: gui.Tr.LcPrevScreenMode,
 		},
 		{
 			ViewName:    "status",
@@ -508,12 +382,6 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Key:         gui.getKey(config.Universal.CopyToClipboard),
 			Handler:     gui.handleCopySelectedSideContextItemToClipboard,
 			Description: gui.Tr.LcCopyFileNameToClipboard,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.ExecuteCustomCommand),
-			Handler:     gui.handleCustomCommand,
-			Description: gui.Tr.LcExecuteCustomCommand,
 		},
 		{
 			ViewName:    "files",
@@ -1128,34 +996,6 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Key:         gui.getKey(config.Files.ToggleTreeView),
 			Handler:     gui.handleToggleCommitFileTreeView,
 			Description: gui.Tr.LcToggleTreeView,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.FilteringMenu),
-			Handler:     gui.handleCreateFilteringMenuPanel,
-			Description: gui.Tr.LcOpenFilteringMenu,
-			OpensMenu:   true,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.DiffingMenu),
-			Handler:     gui.handleCreateDiffingMenuPanel,
-			Description: gui.Tr.LcOpenDiffingMenu,
-			OpensMenu:   true,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.DiffingMenuAlt),
-			Handler:     gui.handleCreateDiffingMenuPanel,
-			Description: gui.Tr.LcOpenDiffingMenu,
-			OpensMenu:   true,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.ExtrasMenu),
-			Handler:     gui.handleCreateExtrasMenuPanel,
-			Description: gui.Tr.LcOpenExtrasMenu,
-			OpensMenu:   true,
 		},
 		{
 			ViewName: "secondary",
@@ -1778,18 +1618,6 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Description: gui.Tr.ToggleWhitespaceInDiffView,
 		},
 		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.IncreaseContextInDiffView),
-			Handler:     gui.IncreaseContextInDiffView,
-			Description: gui.Tr.IncreaseContextInDiffView,
-		},
-		{
-			ViewName:    "",
-			Key:         gui.getKey(config.Universal.DecreaseContextInDiffView),
-			Handler:     gui.DecreaseContextInDiffView,
-			Description: gui.Tr.DecreaseContextInDiffView,
-		},
-		{
 			ViewName: "extras",
 			Key:      gocui.MouseWheelUp,
 			Handler:  gui.scrollUpExtra,
@@ -1847,7 +1675,7 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		},
 	}
 
-	for _, viewName := range []string{"status", "branches", "files", "commits", "commitFiles", "stash", "menu"} {
+	for _, viewName := range []string{"status", "branches", "files", "commits", "commitFiles", "stash"} {
 		bindings = append(bindings, []*Binding{
 			{ViewName: viewName, Key: gui.getKey(config.Universal.PrevBlock), Modifier: gocui.ModNone, Handler: gui.previousSideWindow},
 			{ViewName: viewName, Key: gui.getKey(config.Universal.NextBlock), Modifier: gocui.ModNone, Handler: gui.nextSideWindow},
@@ -1855,23 +1683,52 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			{ViewName: viewName, Key: gui.getKey(config.Universal.NextBlockAlt), Modifier: gocui.ModNone, Handler: gui.nextSideWindow},
 			{ViewName: viewName, Key: gui.getKey(config.Universal.PrevBlockAlt2), Modifier: gocui.ModNone, Handler: gui.previousSideWindow},
 			{ViewName: viewName, Key: gui.getKey(config.Universal.NextBlockAlt2), Modifier: gocui.ModNone, Handler: gui.nextSideWindow},
+
+            // all the previously "global" keystrokes that aren't quit-ish: anything that wouldn't make sense in a popup, and are actually only toplevel window commands
+			{ViewName: viewName, Key: gui.getKey(config.Universal.Return), Modifier: gocui.ModNone, Handler: gui.handleTopLevelReturn},
+            {ViewName: viewName, Key: gui.getKey(config.Universal.OpenRecentRepos), Handler: gui.handleCreateRecentReposMenu, Alternative: "<c-r>", Description: gui.Tr.SwitchRepo},
+            {ViewName: viewName, Key: gui.getKey(config.Universal.ScrollUpMain), Handler: gui.scrollUpMain, Alternative: "fn+up", Description: gui.Tr.LcScrollUpMainPanel},
+            {ViewName: viewName, Key: gui.getKey(config.Universal.ScrollDownMain), Handler: gui.scrollDownMain, Alternative: "fn+down", Description: gui.Tr.LcScrollDownMainPanel},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.ScrollUpMainAlt1), Modifier: gocui.ModNone, Handler: gui.scrollUpMain},
+			{ViewName: viewName, Key: gui.getKey(config.Universal.ScrollDownMainAlt1), Modifier: gocui.ModNone, Handler: gui.scrollDownMain},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.ScrollUpMainAlt2), Modifier: gocui.ModNone, Handler: gui.scrollUpMain},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.ScrollDownMainAlt2), Modifier: gocui.ModNone, Handler:  gui.scrollDownMain},
+    		{ViewName: viewName, Key: gui.getKey(config.Universal.CreateRebaseOptionsMenu), Handler: gui.handleCreateRebaseOptionsMenu, Description: gui.Tr.ViewMergeRebaseOptions, OpensMenu: true},
+    		{ViewName: viewName, Key: gui.getKey(config.Universal.CreatePatchOptionsMenu), Handler: gui.handleCreatePatchOptionsMenu, Description: gui.Tr.ViewPatchOptions, OpensMenu: true},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.PushFiles), Handler: gui.pushFiles, Description: gui.Tr.LcPush},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.PullFiles), Handler: gui.handlePullFiles, Description: gui.Tr.LcPull},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.Refresh), Handler: gui.handleRefresh, Description: gui.Tr.LcRefresh},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.OptionMenu), Handler: gui.handleCreateOptionsMenu, Description: gui.Tr.LcOpenMenu, OpensMenu: true},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.OptionMenuAlt1), Modifier: gocui.ModNone, Handler: gui.handleCreateOptionsMenu},
+		    {ViewName: viewName, Key: gocui.MouseMiddle, Modifier: gocui.ModNone, Handler:  gui.handleCreateOptionsMenu},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.Undo), Handler: gui.reflogUndo, Description: gui.Tr.LcUndoReflog},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.Redo), Handler: gui.reflogRedo, Description: gui.Tr.LcRedoReflog},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.NextScreenMode), Handler: gui.nextScreenMode, Description: gui.Tr.LcNextScreenMode},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.PrevScreenMode), Handler: gui.prevScreenMode, Description: gui.Tr.LcPrevScreenMode},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.ExecuteCustomCommand), Handler: gui.handleCustomCommand, Description: gui.Tr.LcExecuteCustomCommand},
+    		{ViewName: viewName, Key: gui.getKey(config.Universal.FilteringMenu), Handler: gui.handleCreateFilteringMenuPanel, Description: gui.Tr.LcOpenFilteringMenu, OpensMenu: true},
+    		{ViewName: viewName, Key: gui.getKey(config.Universal.DiffingMenu), Handler: gui.handleCreateDiffingMenuPanel, Description: gui.Tr.LcOpenDiffingMenu, OpensMenu: true},
+    		{ViewName: viewName, Key: gui.getKey(config.Universal.DiffingMenuAlt), Handler: gui.handleCreateDiffingMenuPanel, Description: gui.Tr.LcOpenDiffingMenu, OpensMenu: true},
+    		{ViewName: viewName, Key: gui.getKey(config.Universal.ExtrasMenu), Handler: gui.handleCreateExtrasMenuPanel, Description: gui.Tr.LcOpenExtrasMenu, OpensMenu: true},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.IncreaseContextInDiffView), Handler: gui.IncreaseContextInDiffView, Description: gui.Tr.IncreaseContextInDiffView},
+		    {ViewName: viewName, Key: gui.getKey(config.Universal.DecreaseContextInDiffView), Handler: gui.DecreaseContextInDiffView, Description: gui.Tr.DecreaseContextInDiffView},
 		}...)
+    	// Appends keybindings to jump to a particular sideView using numbers
+    	windows := []string{"status", "files", "branches", "commits", "stash"}
+    
+    	if len(config.Universal.JumpToBlock) != len(windows) {
+    		log.Fatal("Jump to block keybindings cannot be set. Exactly 5 keybindings must be supplied.")
+    	} else {
+    		for i, window := range windows {
+    			bindings = append(bindings, &Binding{
+    				ViewName: viewName,
+    				Key:      gui.getKey(config.Universal.JumpToBlock[i]),
+    				Modifier: gocui.ModNone,
+    				Handler:  gui.goToSideWindow(window)})
+    		}
+    	}
 	}
 
-	// Appends keybindings to jump to a particular sideView using numbers
-	windows := []string{"status", "files", "branches", "commits", "stash"}
-
-	if len(config.Universal.JumpToBlock) != len(windows) {
-		log.Fatal("Jump to block keybindings cannot be set. Exactly 5 keybindings must be supplied.")
-	} else {
-		for i, window := range windows {
-			bindings = append(bindings, &Binding{
-				ViewName: "",
-				Key:      gui.getKey(config.Universal.JumpToBlock[i]),
-				Modifier: gocui.ModNone,
-				Handler:  gui.goToSideWindow(window)})
-		}
-	}
 
 	for viewName := range gui.State.Contexts.initialViewTabContextMap() {
 		bindings = append(bindings, []*Binding{


### PR DESCRIPTION
fixes #1628 and part of #1507 ... There were a couple ways to go about solving the key binding vs top view problem, this seemed the most "correct" based on keybindings being attached to views. let me know if you would rather this be solved a different way. also... there was a lot of moving bindings around and reformatting them - hopefully I didn't accidentally break one.