### PR TITLE
Work with absolute paths when invoked with `--path`

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,8 +71,12 @@ func main() {
 			log.Fatal("--path option is incompatible with the --work-tree and --git-dir options")
 		}
 
-		workTree = repoPath
-		gitDir = filepath.Join(repoPath, ".git")
+		absRepoPath, err := filepath.Abs(repoPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		workTree = absRepoPath
+		gitDir = filepath.Join(absRepoPath, ".git")
 	}
 
 	if customConfig != "" {


### PR DESCRIPTION
this change aims to fix situations when ~~I want~~ a user wants to run `lazygit` with `--path` set to a relative path (this happens both on v0.31.4 published for macOS and fresh `lazygit` build from https://github.com/jesseduffield/lazygit/commit/e524e398423f8aea2961302287123085dcc5a524). at the same time, supplying `--work-tree` instead of `--path` does the trick.

poking around with `dlv` reveals that:

- using `--path` results in `GIT_DIR` being set to whatever was passed, which is then read by `navigateToRepoRootDirectory()` from `pkg.commands.git.NewGitCommand()`
- when `--work-tree` is used, we jump to the passed directory immediately (there's a `os.Chdir()` call in `main.go`)

<details>
<summary>stacktrace w/o the patch</summary>

```
blah ~/development % ./lazygit/lazygit --path lazygit
2022/01/06 00:29:39 An error occurred! Please create an issue at: https://github.com/jesseduffield/lazygit/issues

*fs.PathError stat lazygit/.git: not a directory
/Users/whatever/development/lazygit/pkg/utils/errors.go:13 (0x150a4fa)
	navigateToRepoRootDirectory: return errors.Wrap(err, 0)
/Users/whatever/development/lazygit/pkg/commands/git.go:143 (0x150a4fb)
	navigateToRepoRootDirectory: return utils.WrapError(err)
/Users/whatever/development/lazygit/pkg/commands/git.go:71 (0x1509938)
	NewGitCommand: if err := navigateToRepoRootDirectory(os.Stat, os.Chdir); err != nil {
/Users/whatever/development/lazygit/pkg/app/app.go:137 (0x15ab9b3)
	NewApp: app.GitCommand, err = commands.NewGitCommand(
/Users/whatever/development/lazygit/main.go:137 (0x15ad86b)
	main: app, err := app.NewApp(appConfig, filterPath)
/usr/local/go/src/runtime/proc.go:255 (0x1036e27)
	main: fn()
/usr/local/go/src/runtime/asm_amd64.s:1581 (0x1065281)
	goexit: BYTE	$0x90	// NOP
```

</details>

I have tested the patch manually, but didn't add any tests because this is related more to flag handling than anything, and you don't seem to have any tests for that ¯\\\_(ツ)\_/¯