### PR TITLE
simplify how we log commands

### DIFF
--- a/pkg/commands/branches.go
+++ b/pkg/commands/branches.go
@@ -18,12 +18,12 @@ func (c *GitCommand) NewBranch(name string, base string) error {
 // the first returned string is the name and the second is the displayname
 // e.g. name is 123asdf and displayname is '(HEAD detached at 123asdf)'
 func (c *GitCommand) CurrentBranchName() (string, string, error) {
-	branchName, err := c.Cmd.New("git symbolic-ref --short HEAD").RunWithOutput()
+	branchName, err := c.Cmd.New("git symbolic-ref --short HEAD").DontLog().RunWithOutput()
 	if err == nil && branchName != "HEAD\n" {
 		trimmedBranchName := strings.TrimSpace(branchName)
 		return trimmedBranchName, trimmedBranchName, nil
 	}
-	output, err := c.Cmd.New("git branch --contains").RunWithOutput()
+	output, err := c.Cmd.New("git branch --contains").DontLog().RunWithOutput()
 	if err != nil {
 		return "", "", err
 	}
@@ -74,11 +74,11 @@ func (c *GitCommand) Checkout(branch string, options CheckoutOptions) error {
 // Currently it limits the result to 100 commits, but when we get async stuff
 // working we can do lazy loading
 func (c *GitCommand) GetBranchGraph(branchName string) (string, error) {
-	return c.GetBranchGraphCmdObj(branchName).RunWithOutput()
+	return c.GetBranchGraphCmdObj(branchName).DontLog().RunWithOutput()
 }
 
 func (c *GitCommand) GetUpstreamForBranch(branchName string) (string, error) {
-	output, err := c.Cmd.New(fmt.Sprintf("git rev-parse --abbrev-ref --symbolic-full-name %s@{u}", c.OSCommand.Quote(branchName))).RunWithOutput()
+	output, err := c.Cmd.New(fmt.Sprintf("git rev-parse --abbrev-ref --symbolic-full-name %s@{u}", c.OSCommand.Quote(branchName))).DontLog().RunWithOutput()
 	return strings.TrimSpace(output), err
 }
 
@@ -87,7 +87,7 @@ func (c *GitCommand) GetBranchGraphCmdObj(branchName string) oscommands.ICmdObj 
 	templateValues := map[string]string{
 		"branchName": c.OSCommand.Quote(branchName),
 	}
-	return c.Cmd.New(utils.ResolvePlaceholderString(branchLogCmdTemplate, templateValues))
+	return c.Cmd.New(utils.ResolvePlaceholderString(branchLogCmdTemplate, templateValues)).DontLog()
 }
 
 func (c *GitCommand) SetUpstreamBranch(upstream string) error {
@@ -110,11 +110,11 @@ func (c *GitCommand) GetBranchUpstreamDifferenceCount(branchName string) (string
 // current branch
 func (c *GitCommand) GetCommitDifferences(from, to string) (string, string) {
 	command := "git rev-list %s..%s --count"
-	pushableCount, err := c.Cmd.New(fmt.Sprintf(command, to, from)).RunWithOutput()
+	pushableCount, err := c.Cmd.New(fmt.Sprintf(command, to, from)).DontLog().RunWithOutput()
 	if err != nil {
 		return "?", "?"
 	}
-	pullableCount, err := c.Cmd.New(fmt.Sprintf(command, from, to)).RunWithOutput()
+	pullableCount, err := c.Cmd.New(fmt.Sprintf(command, from, to)).DontLog().RunWithOutput()
 	if err != nil {
 		return "?", "?"
 	}
@@ -146,7 +146,7 @@ func (c *GitCommand) AbortMerge() error {
 }
 
 func (c *GitCommand) IsHeadDetached() bool {
-	err := c.Cmd.New("git symbolic-ref -q HEAD").Run()
+	err := c.Cmd.New("git symbolic-ref -q HEAD").DontLog().Run()
 	return err != nil
 }
 
@@ -169,5 +169,5 @@ func (c *GitCommand) RenameBranch(oldName string, newName string) error {
 }
 
 func (c *GitCommand) GetRawBranches() (string, error) {
-	return c.Cmd.New(`git for-each-ref --sort=-committerdate --format="%(HEAD)|%(refname:short)|%(upstream:short)|%(upstream:track)" refs/heads`).RunWithOutput()
+	return c.Cmd.New(`git for-each-ref --sort=-committerdate --format="%(HEAD)|%(refname:short)|%(upstream:short)|%(upstream:track)" refs/heads`).DontLog().RunWithOutput()
 }

--- a/pkg/commands/commits.go
+++ b/pkg/commands/commits.go
@@ -40,19 +40,19 @@ func (c *GitCommand) CommitCmdObj(message string, flags string) oscommands.ICmdO
 
 // Get the subject of the HEAD commit
 func (c *GitCommand) GetHeadCommitMessage() (string, error) {
-	message, err := c.Cmd.New("git log -1 --pretty=%s").RunWithOutput()
+	message, err := c.Cmd.New("git log -1 --pretty=%s").DontLog().RunWithOutput()
 	return strings.TrimSpace(message), err
 }
 
 func (c *GitCommand) GetCommitMessage(commitSha string) (string, error) {
 	cmdStr := "git rev-list --format=%B --max-count=1 " + commitSha
-	messageWithHeader, err := c.Cmd.New(cmdStr).RunWithOutput()
+	messageWithHeader, err := c.Cmd.New(cmdStr).DontLog().RunWithOutput()
 	message := strings.Join(strings.SplitAfter(messageWithHeader, "\n")[1:], "\n")
 	return strings.TrimSpace(message), err
 }
 
 func (c *GitCommand) GetCommitMessageFirstLine(sha string) (string, error) {
-	return c.Cmd.New(fmt.Sprintf("git show --no-patch --pretty=format:%%s %s", sha)).RunWithOutput()
+	return c.Cmd.New(fmt.Sprintf("git show --no-patch --pretty=format:%%s %s", sha)).DontLog().RunWithOutput()
 }
 
 // AmendHead amends HEAD with whatever is staged in your working tree
@@ -72,7 +72,7 @@ func (c *GitCommand) ShowCmdObj(sha string, filterPath string) oscommands.ICmdOb
 	}
 
 	cmdStr := fmt.Sprintf("git show --submodule --color=%s --unified=%d --no-renames --stat -p %s %s", c.colorArg(), contextSize, sha, filterPathArg)
-	return c.Cmd.New(cmdStr)
+	return c.Cmd.New(cmdStr).DontLog()
 }
 
 // Revert reverts the selected commit by sha

--- a/pkg/commands/files.go
+++ b/pkg/commands/files.go
@@ -229,7 +229,7 @@ func (c *GitCommand) WorktreeFileDiffCmdObj(node models.IFile, plain bool, cache
 
 	cmdStr := fmt.Sprintf("git diff --submodule --no-ext-diff --unified=%d --color=%s %s %s %s %s", contextSize, colorArg, ignoreWhitespaceArg, cachedArg, trackedArg, quotedPath)
 
-	return c.Cmd.New(cmdStr)
+	return c.Cmd.New(cmdStr).DontLog()
 }
 
 func (c *GitCommand) ApplyPatch(patch string, flags ...string) error {
@@ -265,7 +265,7 @@ func (c *GitCommand) ShowFileDiffCmdObj(from string, to string, reverse bool, fi
 		reverseFlag = " -R "
 	}
 
-	return c.Cmd.New(fmt.Sprintf("git diff --submodule --no-ext-diff --unified=%d --no-renames --color=%s %s %s %s -- %s", contextSize, colorArg, from, to, reverseFlag, c.OSCommand.Quote(fileName)))
+	return c.Cmd.New(fmt.Sprintf("git diff --submodule --no-ext-diff --unified=%d --no-renames --color=%s %s %s %s -- %s", contextSize, colorArg, from, to, reverseFlag, c.OSCommand.Quote(fileName))).DontLog()
 }
 
 // CheckoutFile checks out the file for the given commit
@@ -280,7 +280,7 @@ func (c *GitCommand) DiscardOldFileChanges(commits []*models.Commit, commitIndex
 	}
 
 	// check if file exists in previous commit (this command returns an error if the file doesn't exist)
-	if err := c.Cmd.New("git cat-file -e HEAD^:" + c.OSCommand.Quote(fileName)).Run(); err != nil {
+	if err := c.Cmd.New("git cat-file -e HEAD^:" + c.OSCommand.Quote(fileName)).DontLog().Run(); err != nil {
 		if err := c.OSCommand.Remove(fileName); err != nil {
 			return err
 		}
@@ -353,7 +353,7 @@ func (c *GitCommand) EditFileCmdStr(filename string, lineNumber int) (string, er
 		editor = c.OSCommand.Getenv("EDITOR")
 	}
 	if editor == "" {
-		if err := c.OSCommand.Cmd.New("which vi").Run(); err == nil {
+		if err := c.OSCommand.Cmd.New("which vi").DontLog().Run(); err == nil {
 			editor = "vi"
 		}
 	}

--- a/pkg/commands/loaders/commit_files.go
+++ b/pkg/commands/loaders/commit_files.go
@@ -28,7 +28,7 @@ func (self *CommitFileLoader) GetFilesInDiff(from string, to string, reverse boo
 		reverseFlag = " -R "
 	}
 
-	filenames, err := self.cmd.New(fmt.Sprintf("git diff --submodule --no-ext-diff --name-status -z --no-renames %s %s %s", reverseFlag, from, to)).RunWithOutput()
+	filenames, err := self.cmd.New(fmt.Sprintf("git diff --submodule --no-ext-diff --name-status -z --no-renames %s %s %s", reverseFlag, from, to)).DontLog().RunWithOutput()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/loaders/commits.go
+++ b/pkg/commands/loaders/commits.go
@@ -218,7 +218,7 @@ func (self *CommitLoader) getHydratedRebasingCommits(rebaseMode enums.RebaseMode
 			prettyFormat,
 			20,
 		),
-	)
+	).DontLog()
 
 	hydratedCommits := make([]*models.Commit, 0, len(commits))
 	i := 0
@@ -384,7 +384,7 @@ func (self *CommitLoader) getMergeBase(refName string) (string, error) {
 	}
 
 	// swallowing error because it's not a big deal; probably because there are no commits yet
-	output, _ := self.cmd.New(fmt.Sprintf("git merge-base %s %s", self.cmd.Quote(refName), self.cmd.Quote(baseBranch))).RunWithOutput()
+	output, _ := self.cmd.New(fmt.Sprintf("git merge-base %s %s", self.cmd.Quote(refName), self.cmd.Quote(baseBranch))).DontLog().RunWithOutput()
 	return ignoringWarnings(output), nil
 }
 
@@ -405,6 +405,7 @@ func (self *CommitLoader) getFirstPushedCommit(refName string) (string, error) {
 		New(
 			fmt.Sprintf("git merge-base %s %s@{u}", self.cmd.Quote(refName), self.cmd.Quote(refName)),
 		).
+		DontLog().
 		RunWithOutput()
 	if err != nil {
 		return "", err
@@ -444,7 +445,7 @@ func (self *CommitLoader) getLogCmd(opts GetCommitsOptions) oscommands.ICmdObj {
 			20,
 			filterFlag,
 		),
-	)
+	).DontLog()
 }
 
 var prettyFormat = fmt.Sprintf(

--- a/pkg/commands/loaders/files.go
+++ b/pkg/commands/loaders/files.go
@@ -98,7 +98,7 @@ func (c *FileLoader) GitStatus(opts GitStatusOptions) ([]FileStatus, error) {
 		noRenamesFlag = " --no-renames"
 	}
 
-	statusLines, err := c.cmd.New(fmt.Sprintf("git status %s --porcelain -z%s", opts.UntrackedFilesArg, noRenamesFlag)).RunWithOutput()
+	statusLines, err := c.cmd.New(fmt.Sprintf("git status %s --porcelain -z%s", opts.UntrackedFilesArg, noRenamesFlag)).DontLog().RunWithOutput()
 	if err != nil {
 		return []FileStatus{}, err
 	}

--- a/pkg/commands/loaders/reflog_commits.go
+++ b/pkg/commands/loaders/reflog_commits.go
@@ -32,7 +32,7 @@ func (self *ReflogCommitLoader) GetReflogCommits(lastReflogCommit *models.Commit
 		filterPathArg = fmt.Sprintf(" --follow -- %s", self.cmd.Quote(filterPath))
 	}
 
-	cmdObj := self.cmd.New(fmt.Sprintf(`git log -g --abbrev=20 --format="%%h %%ct %%gs" %s`, filterPathArg))
+	cmdObj := self.cmd.New(fmt.Sprintf(`git log -g --abbrev=20 --format="%%h %%ct %%gs" %s`, filterPathArg)).DontLog()
 	onlyObtainedNewReflogCommits := false
 	err := cmdObj.RunAndProcessLines(func(line string) (bool, error) {
 		fields := strings.SplitN(line, " ", 3)

--- a/pkg/commands/loaders/remotes.go
+++ b/pkg/commands/loaders/remotes.go
@@ -31,7 +31,7 @@ func NewRemoteLoader(
 }
 
 func (self *RemoteLoader) GetRemotes() ([]*models.Remote, error) {
-	remoteBranchesStr, err := self.cmd.New("git branch -r").RunWithOutput()
+	remoteBranchesStr, err := self.cmd.New("git branch -r").DontLog().RunWithOutput()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/loaders/stash.go
+++ b/pkg/commands/loaders/stash.go
@@ -31,7 +31,7 @@ func (self *StashLoader) GetStashEntries(filterPath string) []*models.StashEntry
 		return self.getUnfilteredStashEntries()
 	}
 
-	rawString, err := self.cmd.New("git stash list --name-only").RunWithOutput()
+	rawString, err := self.cmd.New("git stash list --name-only").DontLog().RunWithOutput()
 	if err != nil {
 		return self.getUnfilteredStashEntries()
 	}
@@ -64,7 +64,7 @@ outer:
 }
 
 func (self *StashLoader) getUnfilteredStashEntries() []*models.StashEntry {
-	rawString, _ := self.cmd.New("git stash list --pretty='%gs'").RunWithOutput()
+	rawString, _ := self.cmd.New("git stash list --pretty='%gs'").DontLog().RunWithOutput()
 	stashEntries := []*models.StashEntry{}
 	for i, line := range utils.SplitLines(rawString) {
 		stashEntries = append(stashEntries, self.stashEntryFromLine(line, i))

--- a/pkg/commands/loaders/tags.go
+++ b/pkg/commands/loaders/tags.go
@@ -27,7 +27,7 @@ func NewTagLoader(
 func (self *TagLoader) GetTags() ([]*models.Tag, error) {
 	// get remote branches, sorted  by creation date (descending)
 	// see: https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---sortltkeygt
-	remoteBranchesStr, err := self.cmd.New(`git tag --list --sort=-creatordate`).RunWithOutput()
+	remoteBranchesStr, err := self.cmd.New(`git tag --list --sort=-creatordate`).DontLog().RunWithOutput()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/oscommands/cmd_obj.go
+++ b/pkg/commands/oscommands/cmd_obj.go
@@ -12,6 +12,7 @@ type ICmdObj interface {
 	// using NewFromArgs, the output won't be quite the same as what you would type
 	// into a terminal e.g. 'sh -c git commit' as opposed to 'sh -c "git commit"'
 	ToString() string
+
 	AddEnvVars(...string) ICmdObj
 	GetEnvVars() []string
 
@@ -22,9 +23,16 @@ type ICmdObj interface {
 	// runs the command and runs a callback function on each line of the output. If the callback returns true for the boolean value, we kill the process and return.
 	RunAndProcessLines(onLine func(line string) (bool, error)) error
 
-	// Marks the command object as readonly, so that when it is run, we don't log it to the user.
-	// We only want to log commands to the user which change state in some way.
+	// Be calling DontLog(), we're saying that once we call Run(), we don't want to
+	// log the command in the UI (it'll still be logged in the log file). The general rule
+	// is that if a command doesn't change the git state (e.g. read commands like `git diff`)
+	// then we don't want to log it. If we are changing something (e.g. `git add .`) then
+	// we do. The only exception is if we're running a command in the background periodically
+	// like `git fetch`, which technically does mutate stuff but isn't something we need
+	// to notify the user about.
 	DontLog() ICmdObj
+
+	// This returns false if DontLog() was called
 	ShouldLog() bool
 }
 

--- a/pkg/commands/oscommands/cmd_obj_builder.go
+++ b/pkg/commands/oscommands/cmd_obj_builder.go
@@ -35,10 +35,9 @@ func (self *CmdObjBuilder) New(cmdStr string) ICmdObj {
 	cmd.Env = os.Environ()
 
 	return &CmdObj{
-		cmdStr:     cmdStr,
-		cmd:        cmd,
-		runner:     self.runner,
-		logCommand: self.logCmdObj,
+		cmdStr: cmdStr,
+		cmd:    cmd,
+		runner: self.runner,
 	}
 }
 
@@ -47,10 +46,9 @@ func (self *CmdObjBuilder) NewFromArgs(args []string) ICmdObj {
 	cmd.Env = os.Environ()
 
 	return &CmdObj{
-		cmdStr:     strings.Join(args, " "),
-		cmd:        cmd,
-		runner:     self.runner,
-		logCommand: self.logCmdObj,
+		cmdStr: strings.Join(args, " "),
+		cmd:    cmd,
+		runner: self.runner,
 	}
 }
 

--- a/pkg/commands/oscommands/cmd_obj_builder.go
+++ b/pkg/commands/oscommands/cmd_obj_builder.go
@@ -21,9 +21,8 @@ type ICmdObjBuilder interface {
 }
 
 type CmdObjBuilder struct {
-	runner    ICmdObjRunner
-	logCmdObj func(ICmdObj)
-	platform  *Platform
+	runner   ICmdObjRunner
+	platform *Platform
 }
 
 // poor man's version of explicitly saying that struct X implements interface Y
@@ -76,8 +75,27 @@ func (self *CmdObjBuilder) CloneWithNewRunner(decorate func(ICmdObjRunner) ICmdO
 	decoratedRunner := decorate(self.runner)
 
 	return &CmdObjBuilder{
-		runner:    decoratedRunner,
-		logCmdObj: self.logCmdObj,
-		platform:  self.platform,
+		runner:   decoratedRunner,
+		platform: self.platform,
 	}
+}
+
+func (self *CmdObjBuilder) Quote(message string) string {
+	var quote string
+	if self.platform.OS == "windows" {
+		quote = `\"`
+		message = strings.NewReplacer(
+			`"`, `"'"'"`,
+			`\"`, `\\"`,
+		).Replace(message)
+	} else {
+		quote = `"`
+		message = strings.NewReplacer(
+			`\`, `\\`,
+			`"`, `\"`,
+			`$`, `\$`,
+			"`", "\\`",
+		).Replace(message)
+	}
+	return quote + message + quote
 }

--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -22,10 +22,6 @@ type cmdObjRunner struct {
 var _ ICmdObjRunner = &cmdObjRunner{}
 
 func (self *cmdObjRunner) Run(cmdObj ICmdObj) error {
-	if cmdObj.ShouldLog() {
-		self.logCmdObj(cmdObj)
-	}
-
 	_, err := self.RunWithOutput(cmdObj)
 	return err
 }

--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -22,12 +22,19 @@ type cmdObjRunner struct {
 var _ ICmdObjRunner = &cmdObjRunner{}
 
 func (self *cmdObjRunner) Run(cmdObj ICmdObj) error {
+	if cmdObj.ShouldLog() {
+		self.logCmdObj(cmdObj)
+	}
+
 	_, err := self.RunWithOutput(cmdObj)
 	return err
 }
 
 func (self *cmdObjRunner) RunWithOutput(cmdObj ICmdObj) (string, error) {
-	self.logCmdObj(cmdObj)
+	if cmdObj.ShouldLog() {
+		self.logCmdObj(cmdObj)
+	}
+
 	output, err := sanitisedCommandOutput(cmdObj.GetCmd().CombinedOutput())
 	if err != nil {
 		self.log.WithField("command", cmdObj.ToString()).Error(output)
@@ -36,6 +43,10 @@ func (self *cmdObjRunner) RunWithOutput(cmdObj ICmdObj) (string, error) {
 }
 
 func (self *cmdObjRunner) RunAndProcessLines(cmdObj ICmdObj, onLine func(line string) (bool, error)) error {
+	if cmdObj.ShouldLog() {
+		self.logCmdObj(cmdObj)
+	}
+
 	cmd := cmdObj.GetCmd()
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {

--- a/pkg/commands/oscommands/dummies.go
+++ b/pkg/commands/oscommands/dummies.go
@@ -13,9 +13,8 @@ func NewDummyOSCommand() *OSCommand {
 
 func NewDummyCmdObjBuilder(runner ICmdObjRunner) *CmdObjBuilder {
 	return &CmdObjBuilder{
-		runner:    runner,
-		logCmdObj: func(ICmdObj) {},
-		platform:  dummyPlatform,
+		runner:   runner,
+		platform: dummyPlatform,
 	}
 }
 

--- a/pkg/commands/oscommands/exec_live.go
+++ b/pkg/commands/oscommands/exec_live.go
@@ -66,7 +66,9 @@ func RunCommandWithOutputLiveAux(
 	startCmd func(cmd *exec.Cmd) (*cmdHandler, error),
 ) error {
 	c.Log.WithField("command", cmdObj.ToString()).Info("RunCommand")
-	c.LogCommand(cmdObj.ToString(), true)
+	if cmdObj.ShouldLog() {
+		c.LogCommand(cmdObj.ToString(), true)
+	}
 	cmd := cmdObj.AddEnvVars("LANG=en_US.UTF-8", "LC_ALL=en_US.UTF-8").GetCmd()
 
 	var stderr bytes.Buffer

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -87,22 +87,6 @@ func NewOSCommand(common *common.Common, platform *Platform) *OSCommand {
 	return c
 }
 
-func (c *OSCommand) WithSpan(span string) *OSCommand {
-	// sometimes .WithSpan(span) will be called where span actually is empty, in
-	// which case we don't need to log anything so we can just return early here
-	// with the original struct
-	if span == "" {
-		return c
-	}
-
-	newOSCommand := &OSCommand{}
-	*newOSCommand = *c
-	newOSCommand.CmdLogSpan = span
-	newOSCommand.Cmd.logCmdObj = newOSCommand.LogCmdObj
-	newOSCommand.Cmd.runner = &cmdObjRunner{log: c.Log, logCmdObj: newOSCommand.LogCmdObj}
-	return newOSCommand
-}
-
 func (c *OSCommand) LogCmdObj(cmdObj ICmdObj) {
 	c.LogCommand(cmdObj.ToString(), true)
 }
@@ -110,7 +94,7 @@ func (c *OSCommand) LogCmdObj(cmdObj ICmdObj) {
 func (c *OSCommand) LogCommand(cmdStr string, commandLine bool) {
 	c.Log.WithField("command", cmdStr).Info("RunCommand")
 
-	if c.onRunCommand != nil && c.CmdLogSpan != "" {
+	if c.onRunCommand != nil {
 		c.onRunCommand(NewCmdLogEntry(cmdStr, c.CmdLogSpan, commandLine))
 	}
 }

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -100,7 +100,6 @@ func (c *OSCommand) OpenFile(filename string) error {
 }
 
 func (c *OSCommand) OpenLink(link string) error {
-	c.LogCommand(fmt.Sprintf("Opening link '%s'", link), false)
 	commandTemplate := c.UserConfig.OS.OpenLinkCommand
 	templateValues := map[string]string{
 		"link": c.Quote(link),

--- a/pkg/commands/patch/patch_manager.go
+++ b/pkg/commands/patch/patch_manager.go
@@ -34,7 +34,7 @@ type PatchManager struct {
 	// To is the commit sha if we're dealing with files of a commit, or a stash ref for a stash
 	To      string
 	From    string
-	Reverse bool
+	reverse bool
 
 	// CanRebase tells us whether we're allowed to modify our commits. CanRebase should be true for commits of the currently checked out branch and false for everything else
 	// TODO: move this out into a proper mode struct in the gui package: it doesn't really belong here
@@ -43,18 +43,18 @@ type PatchManager struct {
 	// fileInfoMap starts empty but you add files to it as you go along
 	fileInfoMap map[string]*fileInfo
 	Log         *logrus.Entry
-	ApplyPatch  applyPatchFunc
+	applyPatch  applyPatchFunc
 
-	// LoadFileDiff loads the diff of a file, for a given to (typically a commit SHA)
-	LoadFileDiff loadFileDiffFunc
+	// loadFileDiff loads the diff of a file, for a given to (typically a commit SHA)
+	loadFileDiff loadFileDiffFunc
 }
 
 // NewPatchManager returns a new PatchManager
 func NewPatchManager(log *logrus.Entry, applyPatch applyPatchFunc, loadFileDiff loadFileDiffFunc) *PatchManager {
 	return &PatchManager{
 		Log:          log,
-		ApplyPatch:   applyPatch,
-		LoadFileDiff: loadFileDiff,
+		applyPatch:   applyPatch,
+		loadFileDiff: loadFileDiff,
 	}
 }
 
@@ -62,7 +62,7 @@ func NewPatchManager(log *logrus.Entry, applyPatch applyPatchFunc, loadFileDiff 
 func (p *PatchManager) Start(from, to string, reverse bool, canRebase bool) {
 	p.To = to
 	p.From = from
-	p.Reverse = reverse
+	p.reverse = reverse
 	p.CanRebase = canRebase
 	p.fileInfoMap = map[string]*fileInfo{}
 }
@@ -118,7 +118,7 @@ func (p *PatchManager) getFileInfo(filename string) (*fileInfo, error) {
 		return info, nil
 	}
 
-	diff, err := p.LoadFileDiff(p.From, p.To, p.Reverse, filename, true)
+	diff, err := p.loadFileDiff(p.From, p.To, p.reverse, filename, true)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +265,7 @@ func (p *PatchManager) ApplyPatches(reverse bool) error {
 			if patch == "" {
 				continue
 			}
-			if err = p.ApplyPatch(patch, applyFlags...); err != nil {
+			if err = p.applyPatch(patch, applyFlags...); err != nil {
 				continue
 			}
 			break
@@ -301,5 +301,5 @@ func (p *PatchManager) IsEmpty() bool {
 
 // if any of these things change we'll need to reset and start a new patch
 func (p *PatchManager) NewPatchRequired(from string, to string, reverse bool) bool {
-	return from != p.From || to != p.To || reverse != p.Reverse
+	return from != p.From || to != p.To || reverse != p.reverse
 }

--- a/pkg/commands/rebasing.go
+++ b/pkg/commands/rebasing.go
@@ -59,7 +59,7 @@ func (c *GitCommand) InteractiveRebase(commits []*models.Commit, index int, acti
 // we tell git to run lazygit to edit the todo list, and we pass the client
 // lazygit a todo string to write to the todo file
 func (c *GitCommand) PrepareInteractiveRebaseCommand(baseSha string, todo string, overrideEditor bool) (oscommands.ICmdObj, error) {
-	ex := c.OSCommand.GetLazygitPath()
+	ex := oscommands.GetLazygitPath()
 
 	debug := "FALSE"
 	if c.Debug {
@@ -267,8 +267,8 @@ func (c *GitCommand) GenericMergeOrRebaseAction(commandType string, command stri
 }
 
 func (c *GitCommand) runSkipEditorCommand(command string) error {
-	cmdObj := c.OSCommand.Cmd.New(command)
-	lazyGitPath := c.OSCommand.GetLazygitPath()
+	cmdObj := c.Cmd.New(command)
+	lazyGitPath := oscommands.GetLazygitPath()
 	return cmdObj.
 		AddEnvVars(
 			"LAZYGIT_CLIENT_COMMAND=EXIT_IMMEDIATELY",

--- a/pkg/commands/remotes.go
+++ b/pkg/commands/remotes.go
@@ -47,7 +47,9 @@ func (c *GitCommand) CheckRemoteBranchExists(branchName string) bool {
 		New(
 			fmt.Sprintf("git show-ref --verify -- refs/remotes/origin/%s",
 				c.Cmd.Quote(branchName),
-			)).
+			),
+		).
+		DontLog().
 		RunWithOutput()
 
 	return err == nil

--- a/pkg/commands/stash_entries.go
+++ b/pkg/commands/stash_entries.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jesseduffield/lazygit/pkg/commands/loaders"
+	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 )
 
 // StashDo modify stash
@@ -17,9 +18,10 @@ func (c *GitCommand) StashSave(message string) error {
 	return c.Cmd.New("git stash save " + c.OSCommand.Quote(message)).Run()
 }
 
-// GetStashEntryDiff stash diff
-func (c *GitCommand) ShowStashEntryCmdStr(index int) string {
-	return fmt.Sprintf("git stash show -p --stat --color=%s --unified=%d stash@{%d}", c.colorArg(), c.UserConfig.Git.DiffContextSize, index)
+func (c *GitCommand) ShowStashEntryCmdObj(index int) oscommands.ICmdObj {
+	cmdStr := fmt.Sprintf("git stash show -p --stat --color=%s --unified=%d stash@{%d}", c.colorArg(), c.UserConfig.Git.DiffContextSize, index)
+
+	return c.Cmd.New(cmdStr).DontLog()
 }
 
 // StashSaveStagedChanges stashes only the currently staged changes. This takes a few steps

--- a/pkg/commands/stash_entries_test.go
+++ b/pkg/commands/stash_entries_test.go
@@ -25,7 +25,7 @@ func TestGitCommandStashSave(t *testing.T) {
 	runner.CheckForMissingCalls()
 }
 
-func TestGitCommandShowStashEntryCmdStr(t *testing.T) {
+func TestGitCommandShowStashEntryCmdObj(t *testing.T) {
 	type scenario struct {
 		testName    string
 		index       int
@@ -52,7 +52,7 @@ func TestGitCommandShowStashEntryCmdStr(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			gitCmd := NewDummyGitCommand()
 			gitCmd.UserConfig.Git.DiffContextSize = s.contextSize
-			cmdStr := gitCmd.ShowStashEntryCmdStr(s.index)
+			cmdStr := gitCmd.ShowStashEntryCmdObj(s.index).ToString()
 			assert.Equal(t, s.expected, cmdStr)
 		})
 	}

--- a/pkg/commands/sync.go
+++ b/pkg/commands/sync.go
@@ -68,8 +68,12 @@ func (c *GitCommand) Fetch(opts FetchOptions) error {
 	}
 
 	cmdObj := c.Cmd.New(cmdStr)
+	userInitiated := opts.PromptUserForCredential != nil
+	if !userInitiated {
+		cmdObj.DontLog()
+	}
 	return c.DetectUnamePass(cmdObj, func(question string) string {
-		if opts.PromptUserForCredential != nil {
+		if userInitiated {
 			return opts.PromptUserForCredential(question)
 		}
 		return "\n"

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -127,8 +127,9 @@ func (gui *Gui) handleGitFetch() error {
 	if err := gui.createLoaderPanel(gui.Tr.FetchWait); err != nil {
 		return err
 	}
+
 	go utils.Safe(func() {
-		err := gui.fetch(true, "Fetch")
+		err := gui.fetch()
 		gui.handleCredentialsPopup(err)
 		_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC})
 	})

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -80,7 +80,8 @@ func (gui *Gui) handleBranchPress() error {
 		return gui.createErrorPanel(gui.Tr.AlreadyCheckedOutBranch)
 	}
 	branch := gui.getSelectedBranch()
-	return gui.handleCheckoutRef(branch.Name, handleCheckoutRefOptions{span: gui.Tr.Spans.CheckoutBranch})
+	gui.logSpan(gui.Tr.Spans.CheckoutBranch)
+	return gui.handleCheckoutRef(branch.Name, handleCheckoutRefOptions{})
 }
 
 func (gui *Gui) handleCreatePullRequestPress() error {
@@ -145,7 +146,8 @@ func (gui *Gui) handleForceCheckout() error {
 		title:  title,
 		prompt: message,
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.ForceCheckoutBranch).Checkout(branch.Name, commands.CheckoutOptions{Force: true}); err != nil {
+			gui.logSpan(gui.Tr.Spans.ForceCheckoutBranch)
+			if err := gui.GitCommand.Checkout(branch.Name, commands.CheckoutOptions{Force: true}); err != nil {
 				_ = gui.surfaceError(err)
 			}
 			return gui.refreshSidePanels(refreshOptions{mode: ASYNC})
@@ -157,7 +159,6 @@ type handleCheckoutRefOptions struct {
 	WaitingStatus string
 	EnvVars       []string
 	onRefNotFound func(ref string) error
-	span          string
 }
 
 func (gui *Gui) handleCheckoutRef(ref string, options handleCheckoutRefOptions) error {
@@ -175,10 +176,8 @@ func (gui *Gui) handleCheckoutRef(ref string, options handleCheckoutRefOptions) 
 		gui.State.Panels.Commits.LimitCommits = true
 	}
 
-	gitCommand := gui.GitCommand.WithSpan(options.span)
-
 	return gui.WithWaitingStatus(waitingStatus, func() error {
-		if err := gitCommand.Checkout(ref, cmdOptions); err != nil {
+		if err := gui.GitCommand.Checkout(ref, cmdOptions); err != nil {
 			// note, this will only work for english-language git commands. If we force git to use english, and the error isn't this one, then the user will receive an english command they may not understand. I'm not sure what the best solution to this is. Running the command once in english and a second time in the native language is one option
 
 			if options.onRefNotFound != nil && strings.Contains(err.Error(), "did not match any file(s) known to git") {
@@ -192,15 +191,15 @@ func (gui *Gui) handleCheckoutRef(ref string, options handleCheckoutRefOptions) 
 					title:  gui.Tr.AutoStashTitle,
 					prompt: gui.Tr.AutoStashPrompt,
 					handleConfirm: func() error {
-						if err := gitCommand.StashSave(gui.Tr.StashPrefix + ref); err != nil {
+						if err := gui.GitCommand.StashSave(gui.Tr.StashPrefix + ref); err != nil {
 							return gui.surfaceError(err)
 						}
-						if err := gitCommand.Checkout(ref, cmdOptions); err != nil {
+						if err := gui.GitCommand.Checkout(ref, cmdOptions); err != nil {
 							return gui.surfaceError(err)
 						}
 
 						onSuccess()
-						if err := gitCommand.StashDo(0, "pop"); err != nil {
+						if err := gui.GitCommand.StashDo(0, "pop"); err != nil {
 							if err := gui.refreshSidePanels(refreshOptions{mode: BLOCK_UI}); err != nil {
 								return err
 							}
@@ -226,10 +225,9 @@ func (gui *Gui) handleCheckoutByName() error {
 		title:               gui.Tr.BranchName + ":",
 		findSuggestionsFunc: gui.getRefsSuggestionsFunc(),
 		handleConfirm: func(response string) error {
+			gui.logSpan("Checkout branch")
 			return gui.handleCheckoutRef(response, handleCheckoutRefOptions{
-				span: "Checkout branch",
 				onRefNotFound: func(ref string) error {
-
 					return gui.ask(askOpts{
 						title:  gui.Tr.BranchNotFoundTitle,
 						prompt: fmt.Sprintf("%s %s%s", gui.Tr.BranchNotFoundPrompt, ref, "?"),
@@ -300,7 +298,8 @@ func (gui *Gui) deleteNamedBranch(selectedBranch *models.Branch, force bool) err
 		title:  title,
 		prompt: message,
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DeleteBranch).DeleteBranch(selectedBranch.Name, force); err != nil {
+			gui.logSpan(gui.Tr.Spans.DeleteBranch)
+			if err := gui.GitCommand.DeleteBranch(selectedBranch.Name, force); err != nil {
 				errMessage := err.Error()
 				if !force && strings.Contains(errMessage, "git branch -D ") {
 					return gui.deleteNamedBranch(selectedBranch, true)
@@ -336,7 +335,8 @@ func (gui *Gui) mergeBranchIntoCheckedOutBranch(branchName string) error {
 		title:  gui.Tr.MergingTitle,
 		prompt: prompt,
 		handleConfirm: func() error {
-			err := gui.GitCommand.WithSpan(gui.Tr.Spans.Merge).Merge(branchName, commands.MergeOpts{})
+			gui.logSpan(gui.Tr.Spans.Merge)
+			err := gui.GitCommand.Merge(branchName, commands.MergeOpts{})
 			return gui.handleGenericMergeCommandResult(err)
 		},
 	})
@@ -377,7 +377,8 @@ func (gui *Gui) handleRebaseOntoBranch(selectedBranchName string) error {
 		title:  gui.Tr.RebasingTitle,
 		prompt: prompt,
 		handleConfirm: func() error {
-			err := gui.GitCommand.WithSpan(gui.Tr.Spans.RebaseBranch).RebaseBranch(selectedBranchName)
+			gui.logSpan(gui.Tr.Spans.RebaseBranch)
+			err := gui.GitCommand.RebaseBranch(selectedBranchName)
 			return gui.handleGenericMergeCommandResult(err)
 		},
 	})
@@ -420,7 +421,8 @@ func (gui *Gui) handleFastForward() error {
 		if gui.State.Panels.Branches.SelectedLineIdx == 0 {
 			_ = gui.pullWithLock(PullFilesOptions{span: span, FastForwardOnly: true})
 		} else {
-			err := gui.GitCommand.WithSpan(span).FastForward(branch.Name, remoteName, remoteBranchName, gui.promptUserForCredential)
+			gui.logSpan(span)
+			err := gui.GitCommand.FastForward(branch.Name, remoteName, remoteBranchName, gui.promptUserForCredential)
 			gui.handleCredentialsPopup(err)
 			_ = gui.refreshSidePanels(refreshOptions{mode: ASYNC, scope: []RefreshableView{BRANCHES}})
 		}
@@ -448,7 +450,8 @@ func (gui *Gui) handleRenameBranch() error {
 			title:          gui.Tr.NewBranchNamePrompt + " " + branch.Name + ":",
 			initialContent: branch.Name,
 			handleConfirm: func(newBranchName string) error {
-				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.RenameBranch).RenameBranch(branch.Name, newBranchName); err != nil {
+				gui.logSpan(gui.Tr.Spans.RenameBranch)
+				if err := gui.GitCommand.RenameBranch(branch.Name, newBranchName); err != nil {
 					return gui.surfaceError(err)
 				}
 
@@ -516,7 +519,8 @@ func (gui *Gui) handleNewBranchOffCurrentItem() error {
 		title:          message,
 		initialContent: prefilledName,
 		handleConfirm: func(response string) error {
-			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.CreateBranch).NewBranch(sanitizedBranchName(response), item.ID()); err != nil {
+			gui.logSpan(gui.Tr.Spans.CreateBranch)
+			if err := gui.GitCommand.NewBranch(sanitizedBranchName(response), item.ID()); err != nil {
 				return err
 			}
 

--- a/pkg/gui/cherry_picking.go
+++ b/pkg/gui/cherry_picking.go
@@ -148,7 +148,8 @@ func (gui *Gui) HandlePasteCommits() error {
 		prompt: gui.Tr.SureCherryPick,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.CherryPickingStatus, func() error {
-				err := gui.GitCommand.WithSpan(gui.Tr.Spans.CherryPick).CherryPickCommits(gui.State.Modes.CherryPicking.CherryPickedCommits)
+				gui.logSpan(gui.Tr.Spans.CherryPick)
+				err := gui.GitCommand.CherryPickCommits(gui.State.Modes.CherryPicking.CherryPickedCommits)
 				return gui.handleGenericMergeCommandResult(err)
 			})
 		},

--- a/pkg/gui/cherry_picking.go
+++ b/pkg/gui/cherry_picking.go
@@ -148,7 +148,7 @@ func (gui *Gui) HandlePasteCommits() error {
 		prompt: gui.Tr.SureCherryPick,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.CherryPickingStatus, func() error {
-				gui.logSpan(gui.Tr.Spans.CherryPick)
+				gui.logAction(gui.Tr.Actions.CherryPick)
 				err := gui.GitCommand.CherryPickCommits(gui.State.Modes.CherryPicking.CherryPickedCommits)
 				return gui.handleGenericMergeCommandResult(err)
 			})

--- a/pkg/gui/command_log_panel.go
+++ b/pkg/gui/command_log_panel.go
@@ -13,20 +13,12 @@ import (
 )
 
 func (gui *Gui) GetOnRunCommand() func(entry oscommands.CmdLogEntry) {
-	// closing over this so that nobody else can modify it
-	currentSpan := ""
-
 	return func(entry oscommands.CmdLogEntry) {
 		if gui.Views.Extras == nil {
 			return
 		}
 
 		gui.Views.Extras.Autoscroll = true
-
-		if entry.GetSpan() != currentSpan {
-			fmt.Fprint(gui.Views.Extras, "\n"+style.FgYellow.Sprint(entry.GetSpan()))
-			currentSpan = entry.GetSpan()
-		}
 
 		textStyle := theme.DefaultTextColor
 		if !entry.GetCommandLine() {
@@ -36,6 +28,16 @@ func (gui *Gui) GetOnRunCommand() func(entry oscommands.CmdLogEntry) {
 		indentedCmdStr := "  " + strings.Replace(entry.GetCmdStr(), "\n", "\n  ", -1)
 		fmt.Fprint(gui.Views.Extras, "\n"+textStyle.Sprint(indentedCmdStr))
 	}
+}
+
+func (gui *Gui) logSpan(span string) {
+	if gui.Views.Extras == nil {
+		return
+	}
+
+	gui.Views.Extras.Autoscroll = true
+
+	fmt.Fprint(gui.Views.Extras, "\n"+style.FgYellow.Sprint(span))
 }
 
 func (gui *Gui) printCommandLogHeader() {

--- a/pkg/gui/command_log_panel.go
+++ b/pkg/gui/command_log_panel.go
@@ -6,38 +6,48 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 	"github.com/jesseduffield/lazygit/pkg/constants"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/theme"
 )
 
-func (gui *Gui) GetOnRunCommand() func(entry oscommands.CmdLogEntry) {
-	return func(entry oscommands.CmdLogEntry) {
-		if gui.Views.Extras == nil {
-			return
-		}
-
-		gui.Views.Extras.Autoscroll = true
-
-		textStyle := theme.DefaultTextColor
-		if !entry.GetCommandLine() {
-			textStyle = style.FgMagenta
-		}
-		gui.CmdLog = append(gui.CmdLog, entry.GetCmdStr())
-		indentedCmdStr := "  " + strings.Replace(entry.GetCmdStr(), "\n", "\n  ", -1)
-		fmt.Fprint(gui.Views.Extras, "\n"+textStyle.Sprint(indentedCmdStr))
-	}
-}
-
-func (gui *Gui) logSpan(span string) {
+// our UI command log looks like this:
+// Stage File
+//   git add -- 'filename'
+// Unstage File
+//   git reset HEAD 'filename'
+//
+// The 'Stage File' and 'Unstage File' lines are actions i.e they group up a set
+// of command logs (typically there's only one command under an action but there may be more).
+// So we call logAction to log the 'Stage File' part and then we call logCommand to log the command itself.
+// We pass logCommand to our OSCommand struct so that it can handle logging commands
+// for us.
+func (gui *Gui) logAction(action string) {
 	if gui.Views.Extras == nil {
 		return
 	}
 
 	gui.Views.Extras.Autoscroll = true
 
-	fmt.Fprint(gui.Views.Extras, "\n"+style.FgYellow.Sprint(span))
+	fmt.Fprint(gui.Views.Extras, "\n"+style.FgYellow.Sprint(action))
+}
+
+func (gui *Gui) logCommand(cmdStr string, commandLine bool) {
+	if gui.Views.Extras == nil {
+		return
+	}
+
+	gui.Views.Extras.Autoscroll = true
+
+	textStyle := theme.DefaultTextColor
+	if !commandLine {
+		// if we're not dealing with a direct command that could be run on the command line,
+		// we style it differently to communicate that
+		textStyle = style.FgMagenta
+	}
+	gui.CmdLog = append(gui.CmdLog, cmdStr)
+	indentedCmdStr := "  " + strings.Replace(cmdStr, "\n", "\n  ", -1)
+	fmt.Fprint(gui.Views.Extras, "\n"+textStyle.Sprint(indentedCmdStr))
 }
 
 func (gui *Gui) printCommandLogHeader() {

--- a/pkg/gui/commit_files_panel.go
+++ b/pkg/gui/commit_files_panel.go
@@ -63,7 +63,7 @@ func (gui *Gui) handleCheckoutCommitFile() error {
 		return nil
 	}
 
-	gui.logSpan(gui.Tr.Spans.CheckoutFile)
+	gui.logAction(gui.Tr.Actions.CheckoutFile)
 	if err := gui.GitCommand.CheckoutFile(gui.State.CommitFileManager.GetParent(), node.GetPath()); err != nil {
 		return gui.surfaceError(err)
 	}
@@ -83,7 +83,7 @@ func (gui *Gui) handleDiscardOldFileChange() error {
 		prompt: gui.Tr.DiscardFileChangesPrompt,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
-				gui.logSpan(gui.Tr.Spans.DiscardOldFileChange)
+				gui.logAction(gui.Tr.Actions.DiscardOldFileChange)
 				if err := gui.GitCommand.DiscardOldFileChanges(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, fileName); err != nil {
 					if err := gui.handleGenericMergeCommandResult(err); err != nil {
 						return err

--- a/pkg/gui/commit_files_panel.go
+++ b/pkg/gui/commit_files_panel.go
@@ -63,7 +63,8 @@ func (gui *Gui) handleCheckoutCommitFile() error {
 		return nil
 	}
 
-	if err := gui.GitCommand.WithSpan(gui.Tr.Spans.CheckoutFile).CheckoutFile(gui.State.CommitFileManager.GetParent(), node.GetPath()); err != nil {
+	gui.logSpan(gui.Tr.Spans.CheckoutFile)
+	if err := gui.GitCommand.CheckoutFile(gui.State.CommitFileManager.GetParent(), node.GetPath()); err != nil {
 		return gui.surfaceError(err)
 	}
 
@@ -82,7 +83,8 @@ func (gui *Gui) handleDiscardOldFileChange() error {
 		prompt: gui.Tr.DiscardFileChangesPrompt,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
-				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DiscardOldFileChange).DiscardOldFileChanges(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, fileName); err != nil {
+				gui.logSpan(gui.Tr.Spans.DiscardOldFileChange)
+				if err := gui.GitCommand.DiscardOldFileChanges(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, fileName); err != nil {
 					if err := gui.handleGenericMergeCommandResult(err); err != nil {
 						return err
 					}

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/jesseduffield/gocui"
-	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
@@ -25,7 +24,7 @@ func (gui *Gui) handleCommitConfirm() error {
 	}
 
 	cmdObj := gui.GitCommand.CommitCmdObj(message, strings.Join(flags, " "))
-	gui.OnRunCommand(oscommands.NewCmdLogEntry(cmdObj.ToString(), gui.Tr.Spans.Commit, true))
+	gui.logAction(gui.Tr.Actions.Commit)
 
 	_ = gui.returnFromContext()
 	return gui.withGpgHandling(cmdObj, gui.Tr.CommittingStatus, func() error {

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -173,7 +173,8 @@ func (gui *Gui) handleCommitSquashDown() error {
 		prompt: gui.Tr.SureSquashThisCommit,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.SquashingStatus, func() error {
-				err := gui.GitCommand.WithSpan(gui.Tr.Spans.SquashCommitDown).InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "squash")
+				gui.logSpan(gui.Tr.Spans.SquashCommitDown)
+				err := gui.GitCommand.InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "squash")
 				return gui.handleGenericMergeCommandResult(err)
 			})
 		},
@@ -202,7 +203,8 @@ func (gui *Gui) handleCommitFixup() error {
 		prompt: gui.Tr.SureFixupThisCommit,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.FixingStatus, func() error {
-				err := gui.GitCommand.WithSpan(gui.Tr.Spans.FixupCommit).InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "fixup")
+				gui.logSpan(gui.Tr.Spans.FixupCommit)
+				err := gui.GitCommand.InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "fixup")
 				return gui.handleGenericMergeCommandResult(err)
 			})
 		},
@@ -240,7 +242,8 @@ func (gui *Gui) handleRenameCommit() error {
 		title:          gui.Tr.LcRenameCommit,
 		initialContent: message,
 		handleConfirm: func(response string) error {
-			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.RewordCommit).RenameCommit(response); err != nil {
+			gui.logSpan(gui.Tr.Spans.RewordCommit)
+			if err := gui.GitCommand.RenameCommit(response); err != nil {
 				return gui.surfaceError(err)
 			}
 
@@ -262,7 +265,8 @@ func (gui *Gui) handleRenameCommitEditor() error {
 		return nil
 	}
 
-	subProcess, err := gui.GitCommand.WithSpan(gui.Tr.Spans.RewordCommit).RewordCommit(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx)
+	gui.logSpan(gui.Tr.Spans.RewordCommit)
+	subProcess, err := gui.GitCommand.RewordCommit(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx)
 	if err != nil {
 		return gui.surfaceError(err)
 	}
@@ -321,7 +325,8 @@ func (gui *Gui) handleCommitDelete() error {
 		prompt: gui.Tr.DeleteCommitPrompt,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.DeletingStatus, func() error {
-				err := gui.GitCommand.WithSpan(gui.Tr.Spans.DropCommit).InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "drop")
+				gui.logSpan(gui.Tr.Spans.DropCommit)
+				err := gui.GitCommand.InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "drop")
 				return gui.handleGenericMergeCommandResult(err)
 			})
 		},
@@ -358,7 +363,8 @@ func (gui *Gui) handleCommitMoveDown() error {
 	}
 
 	return gui.WithWaitingStatus(gui.Tr.MovingStatus, func() error {
-		err := gui.GitCommand.WithSpan(span).MoveCommitDown(gui.State.Commits, index)
+		gui.logSpan(span)
+		err := gui.GitCommand.MoveCommitDown(gui.State.Commits, index)
 		if err == nil {
 			gui.State.Panels.Commits.SelectedLineIdx++
 		}
@@ -396,7 +402,8 @@ func (gui *Gui) handleCommitMoveUp() error {
 	}
 
 	return gui.WithWaitingStatus(gui.Tr.MovingStatus, func() error {
-		err := gui.GitCommand.WithSpan(span).MoveCommitDown(gui.State.Commits, index-1)
+		gui.logSpan(span)
+		err := gui.GitCommand.MoveCommitDown(gui.State.Commits, index-1)
 		if err == nil {
 			gui.State.Panels.Commits.SelectedLineIdx--
 		}
@@ -418,7 +425,8 @@ func (gui *Gui) handleCommitEdit() error {
 	}
 
 	return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
-		err = gui.GitCommand.WithSpan(gui.Tr.Spans.EditCommit).InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "edit")
+		gui.logSpan(gui.Tr.Spans.EditCommit)
+		err = gui.GitCommand.InteractiveRebase(gui.State.Commits, gui.State.Panels.Commits.SelectedLineIdx, "edit")
 		return gui.handleGenericMergeCommandResult(err)
 	})
 }
@@ -433,7 +441,8 @@ func (gui *Gui) handleCommitAmendTo() error {
 		prompt: gui.Tr.AmendCommitPrompt,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.AmendingStatus, func() error {
-				err := gui.GitCommand.WithSpan(gui.Tr.Spans.AmendCommit).AmendTo(gui.State.Commits[gui.State.Panels.Commits.SelectedLineIdx].Sha)
+				gui.logSpan(gui.Tr.Spans.AmendCommit)
+				err := gui.GitCommand.AmendTo(gui.State.Commits[gui.State.Panels.Commits.SelectedLineIdx].Sha)
 				return gui.handleGenericMergeCommandResult(err)
 			})
 		},
@@ -468,7 +477,8 @@ func (gui *Gui) handleCommitRevert() error {
 	if commit.IsMerge() {
 		return gui.createRevertMergeCommitMenu(commit)
 	} else {
-		if err := gui.GitCommand.WithSpan(gui.Tr.Spans.RevertCommit).Revert(commit.Sha); err != nil {
+		gui.logSpan(gui.Tr.Spans.RevertCommit)
+		if err := gui.GitCommand.Revert(commit.Sha); err != nil {
 			return gui.surfaceError(err)
 		}
 		return gui.afterRevertCommit()
@@ -488,7 +498,8 @@ func (gui *Gui) createRevertMergeCommitMenu(commit *models.Commit) error {
 			displayString: fmt.Sprintf("%s: %s", utils.SafeTruncate(parentSha, 8), message),
 			onPress: func() error {
 				parentNumber := i + 1
-				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.RevertCommit).RevertMerge(commit.Sha, parentNumber); err != nil {
+				gui.logSpan(gui.Tr.Spans.RevertCommit)
+				if err := gui.GitCommand.RevertMerge(commit.Sha, parentNumber); err != nil {
 					return gui.surfaceError(err)
 				}
 				return gui.afterRevertCommit()
@@ -534,7 +545,8 @@ func (gui *Gui) handleCreateFixupCommit() error {
 		title:  gui.Tr.CreateFixupCommit,
 		prompt: prompt,
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.CreateFixupCommit).CreateFixupCommit(commit.Sha); err != nil {
+			gui.logSpan(gui.Tr.Spans.CreateFixupCommit)
+			if err := gui.GitCommand.CreateFixupCommit(commit.Sha); err != nil {
 				return gui.surfaceError(err)
 			}
 
@@ -565,7 +577,8 @@ func (gui *Gui) handleSquashAllAboveFixupCommits() error {
 		prompt: prompt,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.SquashingStatus, func() error {
-				err := gui.GitCommand.WithSpan(gui.Tr.Spans.SquashAllAboveFixupCommits).SquashAllAboveFixupCommits(commit.Sha)
+				gui.logSpan(gui.Tr.Spans.SquashAllAboveFixupCommits)
+				err := gui.GitCommand.SquashAllAboveFixupCommits(commit.Sha)
 				return gui.handleGenericMergeCommandResult(err)
 			})
 		},
@@ -612,7 +625,8 @@ func (gui *Gui) handleCreateAnnotatedTag(commitSha string) error {
 			return gui.prompt(promptOpts{
 				title: gui.Tr.TagMessageTitle,
 				handleConfirm: func(msg string) error {
-					if err := gui.GitCommand.WithSpan(gui.Tr.Spans.CreateAnnotatedTag).CreateAnnotatedTag(tagName, commitSha, msg); err != nil {
+					gui.logSpan(gui.Tr.Spans.CreateAnnotatedTag)
+					if err := gui.GitCommand.CreateAnnotatedTag(tagName, commitSha, msg); err != nil {
 						return gui.surfaceError(err)
 					}
 					return gui.afterTagCreate(tagName)
@@ -626,7 +640,8 @@ func (gui *Gui) handleCreateLightweightTag(commitSha string) error {
 	return gui.prompt(promptOpts{
 		title: gui.Tr.TagNameTitle,
 		handleConfirm: func(tagName string) error {
-			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.CreateLightweightTag).CreateLightweightTag(tagName, commitSha); err != nil {
+			gui.logSpan(gui.Tr.Spans.CreateLightweightTag)
+			if err := gui.GitCommand.CreateLightweightTag(tagName, commitSha); err != nil {
 				return gui.surfaceError(err)
 			}
 			return gui.afterTagCreate(tagName)
@@ -644,7 +659,8 @@ func (gui *Gui) handleCheckoutCommit() error {
 		title:  gui.Tr.LcCheckoutCommit,
 		prompt: gui.Tr.SureCheckoutThisCommit,
 		handleConfirm: func() error {
-			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{span: gui.Tr.Spans.CheckoutCommit})
+			gui.logSpan(gui.Tr.Spans.CheckoutCommit)
+			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{})
 		},
 	})
 }
@@ -699,7 +715,8 @@ func (gui *Gui) handleCopySelectedCommitMessageToClipboard() error {
 		return gui.surfaceError(err)
 	}
 
-	if err := gui.OSCommand.WithSpan(gui.Tr.Spans.CopyCommitMessageToClipboard).CopyToClipboard(message); err != nil {
+	gui.logSpan(gui.Tr.Spans.CopyCommitMessageToClipboard)
+	if err := gui.OSCommand.CopyToClipboard(message); err != nil {
 		return gui.surfaceError(err)
 	}
 

--- a/pkg/gui/commits_panel.go
+++ b/pkg/gui/commits_panel.go
@@ -814,12 +814,10 @@ func (gui *Gui) handleOpenCommitInBrowser() error {
 		return gui.surfaceError(err)
 	}
 
+	gui.logAction(gui.Tr.Actions.OpenCommitInBrowser)
 	if err := gui.GitCommand.OSCommand.OpenLink(url); err != nil {
 		return gui.surfaceError(err)
 	}
-
-	gui.logAction(gui.Tr.CreatePullRequest)
-	gui.logCommand(fmt.Sprintf(gui.Tr.OpeningCommitInBrowser, url), false)
 
 	return nil
 }

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -252,7 +252,7 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand config.CustomCommand
 				loadingText = gui.Tr.LcRunningCustomCommandStatus
 			}
 			return gui.WithWaitingStatus(loadingText, func() error {
-				gui.logSpan(gui.Tr.Spans.CustomCommand)
+				gui.logAction(gui.Tr.Actions.CustomCommand)
 				err := gui.OSCommand.Cmd.NewShell(cmdStr).Run()
 				if err != nil {
 					return gui.surfaceError(err)

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -252,7 +252,8 @@ func (gui *Gui) handleCustomCommandKeybinding(customCommand config.CustomCommand
 				loadingText = gui.Tr.LcRunningCustomCommandStatus
 			}
 			return gui.WithWaitingStatus(loadingText, func() error {
-				err := gui.OSCommand.WithSpan(gui.Tr.Spans.CustomCommand).Cmd.NewShell(cmdStr).Run()
+				gui.logSpan(gui.Tr.Spans.CustomCommand)
+				err := gui.OSCommand.Cmd.NewShell(cmdStr).Run()
 				if err != nil {
 					return gui.surfaceError(err)
 				}

--- a/pkg/gui/discard_changes_menu_panel.go
+++ b/pkg/gui/discard_changes_menu_panel.go
@@ -12,7 +12,8 @@ func (gui *Gui) handleCreateDiscardMenu() error {
 			{
 				displayString: gui.Tr.LcDiscardAllChanges,
 				onPress: func() error {
-					if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DiscardAllChangesInDirectory).DiscardAllDirChanges(node); err != nil {
+					gui.logSpan(gui.Tr.Spans.DiscardAllChangesInDirectory)
+					if err := gui.GitCommand.DiscardAllDirChanges(node); err != nil {
 						return gui.surfaceError(err)
 					}
 					return gui.refreshSidePanels(refreshOptions{mode: ASYNC, scope: []RefreshableView{FILES}})
@@ -24,7 +25,8 @@ func (gui *Gui) handleCreateDiscardMenu() error {
 			menuItems = append(menuItems, &menuItem{
 				displayString: gui.Tr.LcDiscardUnstagedChanges,
 				onPress: func() error {
-					if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DiscardUnstagedChangesInDirectory).DiscardUnstagedDirChanges(node); err != nil {
+					gui.logSpan(gui.Tr.Spans.DiscardUnstagedChangesInDirectory)
+					if err := gui.GitCommand.DiscardUnstagedDirChanges(node); err != nil {
 						return gui.surfaceError(err)
 					}
 
@@ -52,7 +54,8 @@ func (gui *Gui) handleCreateDiscardMenu() error {
 				{
 					displayString: gui.Tr.LcDiscardAllChanges,
 					onPress: func() error {
-						if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DiscardAllChangesInFile).DiscardAllFileChanges(file); err != nil {
+						gui.logSpan(gui.Tr.Spans.DiscardAllChangesInFile)
+						if err := gui.GitCommand.DiscardAllFileChanges(file); err != nil {
 							return gui.surfaceError(err)
 						}
 						return gui.refreshSidePanels(refreshOptions{mode: ASYNC, scope: []RefreshableView{FILES}})
@@ -64,7 +67,8 @@ func (gui *Gui) handleCreateDiscardMenu() error {
 				menuItems = append(menuItems, &menuItem{
 					displayString: gui.Tr.LcDiscardUnstagedChanges,
 					onPress: func() error {
-						if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DiscardAllUnstagedChangesInFile).DiscardUnstagedFileChanges(file); err != nil {
+						gui.logSpan(gui.Tr.Spans.DiscardAllUnstagedChangesInFile)
+						if err := gui.GitCommand.DiscardUnstagedFileChanges(file); err != nil {
 							return gui.surfaceError(err)
 						}
 

--- a/pkg/gui/discard_changes_menu_panel.go
+++ b/pkg/gui/discard_changes_menu_panel.go
@@ -12,7 +12,7 @@ func (gui *Gui) handleCreateDiscardMenu() error {
 			{
 				displayString: gui.Tr.LcDiscardAllChanges,
 				onPress: func() error {
-					gui.logSpan(gui.Tr.Spans.DiscardAllChangesInDirectory)
+					gui.logAction(gui.Tr.Actions.DiscardAllChangesInDirectory)
 					if err := gui.GitCommand.DiscardAllDirChanges(node); err != nil {
 						return gui.surfaceError(err)
 					}
@@ -25,7 +25,7 @@ func (gui *Gui) handleCreateDiscardMenu() error {
 			menuItems = append(menuItems, &menuItem{
 				displayString: gui.Tr.LcDiscardUnstagedChanges,
 				onPress: func() error {
-					gui.logSpan(gui.Tr.Spans.DiscardUnstagedChangesInDirectory)
+					gui.logAction(gui.Tr.Actions.DiscardUnstagedChangesInDirectory)
 					if err := gui.GitCommand.DiscardUnstagedDirChanges(node); err != nil {
 						return gui.surfaceError(err)
 					}
@@ -54,7 +54,7 @@ func (gui *Gui) handleCreateDiscardMenu() error {
 				{
 					displayString: gui.Tr.LcDiscardAllChanges,
 					onPress: func() error {
-						gui.logSpan(gui.Tr.Spans.DiscardAllChangesInFile)
+						gui.logAction(gui.Tr.Actions.DiscardAllChangesInFile)
 						if err := gui.GitCommand.DiscardAllFileChanges(file); err != nil {
 							return gui.surfaceError(err)
 						}
@@ -67,7 +67,7 @@ func (gui *Gui) handleCreateDiscardMenu() error {
 				menuItems = append(menuItems, &menuItem{
 					displayString: gui.Tr.LcDiscardUnstagedChanges,
 					onPress: func() error {
-						gui.logSpan(gui.Tr.Spans.DiscardAllUnstagedChangesInFile)
+						gui.logAction(gui.Tr.Actions.DiscardAllUnstagedChangesInFile)
 						if err := gui.GitCommand.DiscardUnstagedFileChanges(file); err != nil {
 							return gui.surfaceError(err)
 						}

--- a/pkg/gui/git_flow.go
+++ b/pkg/gui/git_flow.go
@@ -31,7 +31,7 @@ func (gui *Gui) gitFlowFinishBranch(gitFlowConfig string, branchName string) err
 		return gui.createErrorPanel(gui.Tr.NotAGitFlowBranch)
 	}
 
-	gui.logSpan(gui.Tr.Spans.GitFlowFinish)
+	gui.logAction(gui.Tr.Actions.GitFlowFinish)
 	return gui.runSubprocessWithSuspenseAndRefresh(
 		gui.GitCommand.Cmd.New("git flow " + branchType + " finish " + suffix),
 	)
@@ -56,7 +56,7 @@ func (gui *Gui) handleCreateGitFlowMenu() error {
 			return gui.prompt(promptOpts{
 				title: title,
 				handleConfirm: func(name string) error {
-					gui.logSpan(gui.Tr.Spans.GitFlowStart)
+					gui.logAction(gui.Tr.Actions.GitFlowStart)
 					return gui.runSubprocessWithSuspenseAndRefresh(
 						gui.GitCommand.Cmd.New("git flow " + branchType + " start " + name),
 					)

--- a/pkg/gui/git_flow.go
+++ b/pkg/gui/git_flow.go
@@ -31,8 +31,9 @@ func (gui *Gui) gitFlowFinishBranch(gitFlowConfig string, branchName string) err
 		return gui.createErrorPanel(gui.Tr.NotAGitFlowBranch)
 	}
 
+	gui.logSpan(gui.Tr.Spans.GitFlowFinish)
 	return gui.runSubprocessWithSuspenseAndRefresh(
-		gui.GitCommand.WithSpan(gui.Tr.Spans.GitFlowFinish).Cmd.New("git flow " + branchType + " finish " + suffix).Log(),
+		gui.GitCommand.Cmd.New("git flow " + branchType + " finish " + suffix),
 	)
 }
 
@@ -55,8 +56,9 @@ func (gui *Gui) handleCreateGitFlowMenu() error {
 			return gui.prompt(promptOpts{
 				title: title,
 				handleConfirm: func(name string) error {
+					gui.logSpan(gui.Tr.Spans.GitFlowStart)
 					return gui.runSubprocessWithSuspenseAndRefresh(
-						gui.GitCommand.WithSpan(gui.Tr.Spans.GitFlowStart).Cmd.New("git flow " + branchType + " start " + name).Log(),
+						gui.GitCommand.Cmd.New("git flow " + branchType + " start " + name),
 					)
 				},
 			})

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -210,13 +210,13 @@ func (gui *Gui) handleMouseDownSecondary() error {
 	return nil
 }
 
-func (gui *Gui) fetch(canPromptForCredentials bool, span string) (err error) {
+func (gui *Gui) fetch(canPromptForCredentials bool, action string) (err error) {
 	gui.Mutexes.FetchMutex.Lock()
 	defer gui.Mutexes.FetchMutex.Unlock()
 
 	fetchOpts := commands.FetchOptions{}
 	if canPromptForCredentials {
-		gui.logSpan(span)
+		gui.logAction(action)
 		fetchOpts.PromptUserForCredential = gui.promptUserForCredential
 	}
 
@@ -239,7 +239,7 @@ func (gui *Gui) handleCopySelectedSideContextItemToClipboard() error {
 		return nil
 	}
 
-	gui.logSpan(gui.Tr.Spans.CopyToClipboard)
+	gui.logAction(gui.Tr.Actions.CopyToClipboard)
 	if err := gui.OSCommand.CopyToClipboard(itemId); err != nil {
 		return gui.surfaceError(err)
 	}

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -216,10 +216,11 @@ func (gui *Gui) fetch(canPromptForCredentials bool, span string) (err error) {
 
 	fetchOpts := commands.FetchOptions{}
 	if canPromptForCredentials {
+		gui.logSpan(span)
 		fetchOpts.PromptUserForCredential = gui.promptUserForCredential
 	}
 
-	err = gui.GitCommand.WithSpan(span).Fetch(fetchOpts)
+	err = gui.GitCommand.Fetch(fetchOpts)
 
 	if canPromptForCredentials && err != nil && strings.Contains(err.Error(), "exit status 128") {
 		_ = gui.createErrorPanel(gui.Tr.PassUnameWrong)
@@ -238,7 +239,8 @@ func (gui *Gui) handleCopySelectedSideContextItemToClipboard() error {
 		return nil
 	}
 
-	if err := gui.OSCommand.WithSpan(gui.Tr.Spans.CopyToClipboard).CopyToClipboard(itemId); err != nil {
+	gui.logSpan(gui.Tr.Spans.CopyToClipboard)
+	if err := gui.OSCommand.CopyToClipboard(itemId); err != nil {
 		return gui.surfaceError(err)
 	}
 

--- a/pkg/gui/gpg.go
+++ b/pkg/gui/gpg.go
@@ -13,6 +13,8 @@ import (
 // we don't need to see a loading status if we're in a subprocess.
 // TODO: work out if we actually need to use a shell command here
 func (gui *Gui) withGpgHandling(cmdObj oscommands.ICmdObj, waitingStatus string, onSuccess func() error) error {
+	gui.logCommand(cmdObj.ToString(), true)
+
 	useSubprocess := gui.GitCommand.UsingGpg()
 	if useSubprocess {
 		success, err := gui.runSubprocessWithSuspense(gui.OSCommand.Cmd.NewShell(cmdObj.ToString()))

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -111,8 +111,7 @@ type Gui struct {
 	PauseBackgroundThreads bool
 
 	// Log of the commands that get run, to be displayed to the user.
-	CmdLog       []string
-	OnRunCommand func(entry oscommands.CmdLogEntry)
+	CmdLog []string
 
 	// the extras window contains things like the command log
 	ShowExtrasWindow bool
@@ -457,9 +456,7 @@ func NewGui(cmn *common.Common, gitCommand *commands.GitCommand, oSCommand *osco
 
 	gui.watchFilesForChanges()
 
-	onRunCommand := gui.GetOnRunCommand()
-	oSCommand.SetOnRunCommand(onRunCommand)
-	gui.OnRunCommand = onRunCommand
+	oSCommand.SetLogCommandFn(gui.logCommand)
 	gui.PopupHandler = &RealPopupHandler{gui: gui}
 
 	authors.SetCustomAuthors(gui.UserConfig.Gui.AuthorColors)
@@ -625,6 +622,8 @@ func (gui *Gui) runSubprocessWithSuspense(subprocess oscommands.ICmdObj) (bool, 
 }
 
 func (gui *Gui) runSubprocess(cmdObj oscommands.ICmdObj) error {
+	gui.logCommand(cmdObj.ToString(), true)
+
 	subprocess := cmdObj.GetCmd()
 	subprocess.Stdout = os.Stdout
 	subprocess.Stderr = os.Stdout

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -718,7 +718,7 @@ func (gui *Gui) startBackgroundFetch() {
 	if !isNew {
 		time.After(time.Duration(userConfig.Refresher.FetchInterval) * time.Second)
 	}
-	err := gui.fetch(false, "")
+	err := gui.backgroundFetch()
 	if err != nil && strings.Contains(err.Error(), "exit status 128") && isNew {
 		_ = gui.ask(askOpts{
 			title:  gui.Tr.NoAutomaticGitFetchTitle,
@@ -726,7 +726,7 @@ func (gui *Gui) startBackgroundFetch() {
 		})
 	} else {
 		gui.goEvery(time.Second*time.Duration(userConfig.Refresher.FetchInterval), gui.stopChan, func() error {
-			err := gui.fetch(false, "")
+			err := gui.backgroundFetch()
 			gui.render()
 			return err
 		})

--- a/pkg/gui/line_by_line_panel.go
+++ b/pkg/gui/line_by_line_panel.go
@@ -90,7 +90,7 @@ func (gui *Gui) copySelectedToClipboard() error {
 	return gui.withLBLActiveCheck(func(state *LblPanelState) error {
 		selected := state.PlainRenderSelected()
 
-		gui.logSpan(gui.Tr.Spans.CopySelectedTextToClipboard)
+		gui.logAction(gui.Tr.Actions.CopySelectedTextToClipboard)
 		if err := gui.OSCommand.CopyToClipboard(selected); err != nil {
 			return gui.surfaceError(err)
 		}

--- a/pkg/gui/line_by_line_panel.go
+++ b/pkg/gui/line_by_line_panel.go
@@ -90,9 +90,8 @@ func (gui *Gui) copySelectedToClipboard() error {
 	return gui.withLBLActiveCheck(func(state *LblPanelState) error {
 		selected := state.PlainRenderSelected()
 
-		if err := gui.OSCommand.WithSpan(
-			gui.Tr.Spans.CopySelectedTextToClipboard,
-		).CopyToClipboard(selected); err != nil {
+		gui.logSpan(gui.Tr.Spans.CopySelectedTextToClipboard)
+		if err := gui.OSCommand.CopyToClipboard(selected); err != nil {
 			return gui.surfaceError(err)
 		}
 

--- a/pkg/gui/merge_panel.go
+++ b/pkg/gui/merge_panel.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-errors/errors"
 	"github.com/jesseduffield/gocui"
-	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 	"github.com/jesseduffield/lazygit/pkg/commands/types/enums"
 	"github.com/jesseduffield/lazygit/pkg/gui/mergeconflicts"
 )
@@ -65,7 +64,8 @@ func (gui *Gui) handlePopFileSnapshot() error {
 	if gitFile == nil {
 		return nil
 	}
-	gui.OnRunCommand(oscommands.NewCmdLogEntry("Undoing last conflict resolution", "Undo merge conflict resolution", false))
+	gui.logAction("Restoring file to previous state")
+	gui.logCommand("Undoing last conflict resolution", false)
 	if err := ioutil.WriteFile(gitFile.Name, []byte(prevContent), 0644); err != nil {
 		return err
 	}
@@ -142,7 +142,8 @@ func (gui *Gui) resolveConflict(selection mergeconflicts.Selection) (bool, error
 	case mergeconflicts.ALL:
 		logStr = "Picking all hunks"
 	}
-	gui.OnRunCommand(oscommands.NewCmdLogEntry(logStr, "Resolve merge conflict", false))
+	gui.logAction("Resolve merge conflict")
+	gui.logCommand(logStr, false)
 	return true, ioutil.WriteFile(gitFile.Name, []byte(output), 0644)
 }
 

--- a/pkg/gui/patch_options_panel.go
+++ b/pkg/gui/patch_options_panel.go
@@ -98,7 +98,7 @@ func (gui *Gui) handleDeletePatchFromCommit() error {
 
 	return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
 		commitIndex := gui.getPatchCommitIndex()
-		gui.logSpan(gui.Tr.Spans.RemovePatchFromCommit)
+		gui.logAction(gui.Tr.Actions.RemovePatchFromCommit)
 		err := gui.GitCommand.DeletePatchesFromCommit(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager)
 		return gui.handleGenericMergeCommandResult(err)
 	})
@@ -115,7 +115,7 @@ func (gui *Gui) handleMovePatchToSelectedCommit() error {
 
 	return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
 		commitIndex := gui.getPatchCommitIndex()
-		gui.logSpan(gui.Tr.Spans.MovePatchToSelectedCommit)
+		gui.logAction(gui.Tr.Actions.MovePatchToSelectedCommit)
 		err := gui.GitCommand.MovePatchToSelectedCommit(gui.State.Commits, commitIndex, gui.State.Panels.Commits.SelectedLineIdx, gui.GitCommand.PatchManager)
 		return gui.handleGenericMergeCommandResult(err)
 	})
@@ -133,7 +133,7 @@ func (gui *Gui) handleMovePatchIntoWorkingTree() error {
 	pull := func(stash bool) error {
 		return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
 			commitIndex := gui.getPatchCommitIndex()
-			gui.logSpan(gui.Tr.Spans.MovePatchIntoIndex)
+			gui.logAction(gui.Tr.Actions.MovePatchIntoIndex)
 			err := gui.GitCommand.MovePatchIntoIndex(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager, stash)
 			return gui.handleGenericMergeCommandResult(err)
 		})
@@ -163,7 +163,7 @@ func (gui *Gui) handlePullPatchIntoNewCommit() error {
 
 	return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
 		commitIndex := gui.getPatchCommitIndex()
-		gui.logSpan(gui.Tr.Spans.MovePatchIntoNewCommit)
+		gui.logAction(gui.Tr.Actions.MovePatchIntoNewCommit)
 		err := gui.GitCommand.PullPatchIntoNewCommit(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager)
 		return gui.handleGenericMergeCommandResult(err)
 	})
@@ -174,11 +174,11 @@ func (gui *Gui) handleApplyPatch(reverse bool) error {
 		return err
 	}
 
-	span := gui.Tr.Spans.ApplyPatch
+	action := gui.Tr.Actions.ApplyPatch
 	if reverse {
-		span = "Apply patch in reverse"
+		action = "Apply patch in reverse"
 	}
-	gui.logSpan(span)
+	gui.logAction(action)
 	if err := gui.GitCommand.PatchManager.ApplyPatches(reverse); err != nil {
 		return gui.surfaceError(err)
 	}

--- a/pkg/gui/patch_options_panel.go
+++ b/pkg/gui/patch_options_panel.go
@@ -98,7 +98,8 @@ func (gui *Gui) handleDeletePatchFromCommit() error {
 
 	return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
 		commitIndex := gui.getPatchCommitIndex()
-		err := gui.GitCommand.WithSpan(gui.Tr.Spans.RemovePatchFromCommit).DeletePatchesFromCommit(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager)
+		gui.logSpan(gui.Tr.Spans.RemovePatchFromCommit)
+		err := gui.GitCommand.DeletePatchesFromCommit(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager)
 		return gui.handleGenericMergeCommandResult(err)
 	})
 }
@@ -114,7 +115,8 @@ func (gui *Gui) handleMovePatchToSelectedCommit() error {
 
 	return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
 		commitIndex := gui.getPatchCommitIndex()
-		err := gui.GitCommand.WithSpan(gui.Tr.Spans.MovePatchToSelectedCommit).MovePatchToSelectedCommit(gui.State.Commits, commitIndex, gui.State.Panels.Commits.SelectedLineIdx, gui.GitCommand.PatchManager)
+		gui.logSpan(gui.Tr.Spans.MovePatchToSelectedCommit)
+		err := gui.GitCommand.MovePatchToSelectedCommit(gui.State.Commits, commitIndex, gui.State.Panels.Commits.SelectedLineIdx, gui.GitCommand.PatchManager)
 		return gui.handleGenericMergeCommandResult(err)
 	})
 }
@@ -131,7 +133,8 @@ func (gui *Gui) handleMovePatchIntoWorkingTree() error {
 	pull := func(stash bool) error {
 		return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
 			commitIndex := gui.getPatchCommitIndex()
-			err := gui.GitCommand.WithSpan(gui.Tr.Spans.MovePatchIntoIndex).MovePatchIntoIndex(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager, stash)
+			gui.logSpan(gui.Tr.Spans.MovePatchIntoIndex)
+			err := gui.GitCommand.MovePatchIntoIndex(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager, stash)
 			return gui.handleGenericMergeCommandResult(err)
 		})
 	}
@@ -160,7 +163,8 @@ func (gui *Gui) handlePullPatchIntoNewCommit() error {
 
 	return gui.WithWaitingStatus(gui.Tr.RebasingStatus, func() error {
 		commitIndex := gui.getPatchCommitIndex()
-		err := gui.GitCommand.WithSpan(gui.Tr.Spans.MovePatchIntoNewCommit).PullPatchIntoNewCommit(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager)
+		gui.logSpan(gui.Tr.Spans.MovePatchIntoNewCommit)
+		err := gui.GitCommand.PullPatchIntoNewCommit(gui.State.Commits, commitIndex, gui.GitCommand.PatchManager)
 		return gui.handleGenericMergeCommandResult(err)
 	})
 }
@@ -174,7 +178,8 @@ func (gui *Gui) handleApplyPatch(reverse bool) error {
 	if reverse {
 		span = "Apply patch in reverse"
 	}
-	if err := gui.GitCommand.WithSpan(span).PatchManager.ApplyPatches(reverse); err != nil {
+	gui.logSpan(span)
+	if err := gui.GitCommand.PatchManager.ApplyPatches(reverse); err != nil {
 		return gui.surfaceError(err)
 	}
 	return gui.refreshSidePanels(refreshOptions{mode: ASYNC})

--- a/pkg/gui/pull_request_menu_panel.go
+++ b/pkg/gui/pull_request_menu_panel.go
@@ -61,7 +61,7 @@ func (gui *Gui) createPullRequest(from string, to string) error {
 		return gui.surfaceError(err)
 	}
 
-	gui.logAction(gui.Tr.CreatePullRequest)
+	gui.logAction(gui.Tr.Actions.OpenPullRequest)
 
 	if err := gui.GitCommand.OSCommand.OpenLink(url); err != nil {
 		return gui.surfaceError(err)

--- a/pkg/gui/pull_request_menu_panel.go
+++ b/pkg/gui/pull_request_menu_panel.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/jesseduffield/lazygit/pkg/commands/hosting_service"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
-	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 )
 
 func (gui *Gui) createPullRequestMenu(selectedBranch *models.Branch, checkedOutBranch *models.Branch) error {
@@ -62,11 +61,11 @@ func (gui *Gui) createPullRequest(from string, to string) error {
 		return gui.surfaceError(err)
 	}
 
+	gui.logAction(gui.Tr.CreatePullRequest)
+
 	if err := gui.GitCommand.OSCommand.OpenLink(url); err != nil {
 		return gui.surfaceError(err)
 	}
-
-	gui.OnRunCommand(oscommands.NewCmdLogEntry(fmt.Sprintf(gui.Tr.CreatingPullRequestAtUrl, url), gui.Tr.CreatePullRequest, false))
 
 	return nil
 }

--- a/pkg/gui/rebase_options_panel.go
+++ b/pkg/gui/rebase_options_panel.go
@@ -51,7 +51,7 @@ func (gui *Gui) genericMergeCommand(command string) error {
 		return gui.createErrorPanel(gui.Tr.NotMergingOrRebasing)
 	}
 
-	gui.logSpan(fmt.Sprintf("Merge/Rebase: %s", command))
+	gui.logAction(fmt.Sprintf("Merge/Rebase: %s", command))
 
 	commandType := ""
 	switch status {

--- a/pkg/gui/rebase_options_panel.go
+++ b/pkg/gui/rebase_options_panel.go
@@ -51,7 +51,7 @@ func (gui *Gui) genericMergeCommand(command string) error {
 		return gui.createErrorPanel(gui.Tr.NotMergingOrRebasing)
 	}
 
-	gitCommand := gui.GitCommand.WithSpan(fmt.Sprintf("Merge/Rebase: %s", command))
+	gui.logSpan(fmt.Sprintf("Merge/Rebase: %s", command))
 
 	commandType := ""
 	switch status {
@@ -65,13 +65,13 @@ func (gui *Gui) genericMergeCommand(command string) error {
 
 	// it's impossible for a rebase to require a commit so we'll use a subprocess only if it's a merge
 	if status == enums.REBASE_MODE_MERGING && command != REBASE_OPTION_ABORT && gui.UserConfig.Git.Merging.ManualCommit {
-		sub := gitCommand.Cmd.New("git " + commandType + " --" + command)
+		sub := gui.GitCommand.Cmd.New("git " + commandType + " --" + command)
 		if sub != nil {
 			return gui.runSubprocessWithSuspenseAndRefresh(sub)
 		}
 		return nil
 	}
-	result := gitCommand.GenericMergeOrRebaseAction(commandType, command)
+	result := gui.GitCommand.GenericMergeOrRebaseAction(commandType, command)
 	if err := gui.handleGenericMergeCommandResult(result); err != nil {
 		return err
 	}

--- a/pkg/gui/reflog_panel.go
+++ b/pkg/gui/reflog_panel.go
@@ -93,7 +93,7 @@ func (gui *Gui) handleCheckoutReflogCommit() error {
 		title:  gui.Tr.LcCheckoutCommit,
 		prompt: gui.Tr.SureCheckoutThisCommit,
 		handleConfirm: func() error {
-			gui.logSpan(gui.Tr.Spans.CheckoutReflogCommit)
+			gui.logAction(gui.Tr.Actions.CheckoutReflogCommit)
 			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{})
 		},
 	})

--- a/pkg/gui/reflog_panel.go
+++ b/pkg/gui/reflog_panel.go
@@ -93,7 +93,8 @@ func (gui *Gui) handleCheckoutReflogCommit() error {
 		title:  gui.Tr.LcCheckoutCommit,
 		prompt: gui.Tr.SureCheckoutThisCommit,
 		handleConfirm: func() error {
-			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{span: gui.Tr.Spans.CheckoutReflogCommit})
+			gui.logSpan(gui.Tr.Spans.CheckoutReflogCommit)
+			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{})
 		},
 	})
 	if err != nil {

--- a/pkg/gui/remote_branches_panel.go
+++ b/pkg/gui/remote_branches_panel.go
@@ -57,7 +57,7 @@ func (gui *Gui) handleDeleteRemoteBranch() error {
 		prompt: message,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.DeletingStatus, func() error {
-				gui.logSpan(gui.Tr.Spans.DeleteRemoteBranch)
+				gui.logAction(gui.Tr.Actions.DeleteRemoteBranch)
 				err := gui.GitCommand.DeleteRemoteBranch(remoteBranch.RemoteName, remoteBranch.Name, gui.promptUserForCredential)
 				gui.handleCredentialsPopup(err)
 
@@ -88,7 +88,7 @@ func (gui *Gui) handleSetBranchUpstream() error {
 		title:  gui.Tr.SetUpstreamTitle,
 		prompt: message,
 		handleConfirm: func() error {
-			gui.logSpan(gui.Tr.Spans.SetBranchUpstream)
+			gui.logAction(gui.Tr.Actions.SetBranchUpstream)
 			if err := gui.GitCommand.SetBranchUpstream(selectedBranch.RemoteName, selectedBranch.Name, checkedOutBranch.Name); err != nil {
 				return gui.surfaceError(err)
 			}

--- a/pkg/gui/remote_branches_panel.go
+++ b/pkg/gui/remote_branches_panel.go
@@ -57,7 +57,8 @@ func (gui *Gui) handleDeleteRemoteBranch() error {
 		prompt: message,
 		handleConfirm: func() error {
 			return gui.WithWaitingStatus(gui.Tr.DeletingStatus, func() error {
-				err := gui.GitCommand.WithSpan(gui.Tr.Spans.DeleteRemoteBranch).DeleteRemoteBranch(remoteBranch.RemoteName, remoteBranch.Name, gui.promptUserForCredential)
+				gui.logSpan(gui.Tr.Spans.DeleteRemoteBranch)
+				err := gui.GitCommand.DeleteRemoteBranch(remoteBranch.RemoteName, remoteBranch.Name, gui.promptUserForCredential)
 				gui.handleCredentialsPopup(err)
 
 				return gui.refreshSidePanels(refreshOptions{scope: []RefreshableView{BRANCHES, REMOTES}})
@@ -87,7 +88,8 @@ func (gui *Gui) handleSetBranchUpstream() error {
 		title:  gui.Tr.SetUpstreamTitle,
 		prompt: message,
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.SetBranchUpstream).SetBranchUpstream(selectedBranch.RemoteName, selectedBranch.Name, checkedOutBranch.Name); err != nil {
+			gui.logSpan(gui.Tr.Spans.SetBranchUpstream)
+			if err := gui.GitCommand.SetBranchUpstream(selectedBranch.RemoteName, selectedBranch.Name, checkedOutBranch.Name); err != nil {
 				return gui.surfaceError(err)
 			}
 

--- a/pkg/gui/remotes_panel.go
+++ b/pkg/gui/remotes_panel.go
@@ -85,7 +85,8 @@ func (gui *Gui) handleAddRemote() error {
 			return gui.prompt(promptOpts{
 				title: gui.Tr.LcNewRemoteUrl,
 				handleConfirm: func(remoteUrl string) error {
-					if err := gui.GitCommand.WithSpan(gui.Tr.Spans.AddRemote).AddRemote(remoteName, remoteUrl); err != nil {
+					gui.logSpan(gui.Tr.Spans.AddRemote)
+					if err := gui.GitCommand.AddRemote(remoteName, remoteUrl); err != nil {
 						return err
 					}
 					return gui.refreshSidePanels(refreshOptions{scope: []RefreshableView{REMOTES}})
@@ -106,7 +107,8 @@ func (gui *Gui) handleRemoveRemote() error {
 		title:  gui.Tr.LcRemoveRemote,
 		prompt: gui.Tr.LcRemoveRemotePrompt + " '" + remote.Name + "'?",
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.RemoveRemote).RemoveRemote(remote.Name); err != nil {
+			gui.logSpan(gui.Tr.Spans.RemoveRemote)
+			if err := gui.GitCommand.RemoveRemote(remote.Name); err != nil {
 				return gui.surfaceError(err)
 			}
 
@@ -128,14 +130,13 @@ func (gui *Gui) handleEditRemote() error {
 		},
 	)
 
-	gitCommand := gui.GitCommand.WithSpan(gui.Tr.Spans.UpdateRemote)
-
 	return gui.prompt(promptOpts{
 		title:          editNameMessage,
 		initialContent: remote.Name,
 		handleConfirm: func(updatedRemoteName string) error {
 			if updatedRemoteName != remote.Name {
-				if err := gitCommand.RenameRemote(remote.Name, updatedRemoteName); err != nil {
+				gui.logSpan(gui.Tr.Spans.UpdateRemote)
+				if err := gui.GitCommand.RenameRemote(remote.Name, updatedRemoteName); err != nil {
 					return gui.surfaceError(err)
 				}
 			}
@@ -157,7 +158,8 @@ func (gui *Gui) handleEditRemote() error {
 				title:          editUrlMessage,
 				initialContent: url,
 				handleConfirm: func(updatedRemoteUrl string) error {
-					if err := gitCommand.UpdateRemoteUrl(updatedRemoteName, updatedRemoteUrl); err != nil {
+					gui.logSpan(gui.Tr.Spans.UpdateRemote)
+					if err := gui.GitCommand.UpdateRemoteUrl(updatedRemoteName, updatedRemoteUrl); err != nil {
 						return gui.surfaceError(err)
 					}
 					return gui.refreshSidePanels(refreshOptions{scope: []RefreshableView{BRANCHES, REMOTES}})

--- a/pkg/gui/remotes_panel.go
+++ b/pkg/gui/remotes_panel.go
@@ -85,7 +85,7 @@ func (gui *Gui) handleAddRemote() error {
 			return gui.prompt(promptOpts{
 				title: gui.Tr.LcNewRemoteUrl,
 				handleConfirm: func(remoteUrl string) error {
-					gui.logSpan(gui.Tr.Spans.AddRemote)
+					gui.logAction(gui.Tr.Actions.AddRemote)
 					if err := gui.GitCommand.AddRemote(remoteName, remoteUrl); err != nil {
 						return err
 					}
@@ -107,7 +107,7 @@ func (gui *Gui) handleRemoveRemote() error {
 		title:  gui.Tr.LcRemoveRemote,
 		prompt: gui.Tr.LcRemoveRemotePrompt + " '" + remote.Name + "'?",
 		handleConfirm: func() error {
-			gui.logSpan(gui.Tr.Spans.RemoveRemote)
+			gui.logAction(gui.Tr.Actions.RemoveRemote)
 			if err := gui.GitCommand.RemoveRemote(remote.Name); err != nil {
 				return gui.surfaceError(err)
 			}
@@ -135,7 +135,7 @@ func (gui *Gui) handleEditRemote() error {
 		initialContent: remote.Name,
 		handleConfirm: func(updatedRemoteName string) error {
 			if updatedRemoteName != remote.Name {
-				gui.logSpan(gui.Tr.Spans.UpdateRemote)
+				gui.logAction(gui.Tr.Actions.UpdateRemote)
 				if err := gui.GitCommand.RenameRemote(remote.Name, updatedRemoteName); err != nil {
 					return gui.surfaceError(err)
 				}
@@ -158,7 +158,7 @@ func (gui *Gui) handleEditRemote() error {
 				title:          editUrlMessage,
 				initialContent: url,
 				handleConfirm: func(updatedRemoteUrl string) error {
-					gui.logSpan(gui.Tr.Spans.UpdateRemote)
+					gui.logAction(gui.Tr.Actions.UpdateRemote)
 					if err := gui.GitCommand.UpdateRemoteUrl(updatedRemoteName, updatedRemoteUrl); err != nil {
 						return gui.surfaceError(err)
 					}

--- a/pkg/gui/reset_menu_panel.go
+++ b/pkg/gui/reset_menu_panel.go
@@ -38,7 +38,7 @@ func (gui *Gui) createResetMenu(ref string) error {
 				style.FgRed.Sprintf("reset --%s %s", strength, ref),
 			},
 			onPress: func() error {
-				gui.logSpan("Reset")
+				gui.logAction("Reset")
 				return gui.resetToRef(ref, strength, []string{})
 			},
 		}

--- a/pkg/gui/reset_menu_panel.go
+++ b/pkg/gui/reset_menu_panel.go
@@ -6,8 +6,8 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 )
 
-func (gui *Gui) resetToRef(ref string, strength string, span string, envVars []string) error {
-	if err := gui.GitCommand.WithSpan(span).ResetToCommit(ref, strength, envVars); err != nil {
+func (gui *Gui) resetToRef(ref string, strength string, envVars []string) error {
+	if err := gui.GitCommand.ResetToCommit(ref, strength, envVars); err != nil {
 		return gui.surfaceError(err)
 	}
 
@@ -38,7 +38,8 @@ func (gui *Gui) createResetMenu(ref string) error {
 				style.FgRed.Sprintf("reset --%s %s", strength, ref),
 			},
 			onPress: func() error {
-				return gui.resetToRef(ref, strength, "Reset", []string{})
+				gui.logSpan("Reset")
+				return gui.resetToRef(ref, strength, []string{})
 			},
 		}
 	}

--- a/pkg/gui/staging_panel.go
+++ b/pkg/gui/staging_panel.go
@@ -143,7 +143,8 @@ func (gui *Gui) applySelection(reverse bool, state *LblPanelState) error {
 	if !reverse || state.SecondaryFocused {
 		applyFlags = append(applyFlags, "cached")
 	}
-	err := gui.GitCommand.WithSpan(gui.Tr.Spans.ApplyPatch).ApplyPatch(patch, applyFlags...)
+	gui.logSpan(gui.Tr.Spans.ApplyPatch)
+	err := gui.GitCommand.ApplyPatch(patch, applyFlags...)
 	if err != nil {
 		return gui.surfaceError(err)
 	}

--- a/pkg/gui/staging_panel.go
+++ b/pkg/gui/staging_panel.go
@@ -143,7 +143,7 @@ func (gui *Gui) applySelection(reverse bool, state *LblPanelState) error {
 	if !reverse || state.SecondaryFocused {
 		applyFlags = append(applyFlags, "cached")
 	}
-	gui.logSpan(gui.Tr.Spans.ApplyPatch)
+	gui.logAction(gui.Tr.Actions.ApplyPatch)
 	err := gui.GitCommand.ApplyPatch(patch, applyFlags...)
 	if err != nil {
 		return gui.surfaceError(err)

--- a/pkg/gui/stash_panel.go
+++ b/pkg/gui/stash_panel.go
@@ -23,10 +23,7 @@ func (gui *Gui) stashRenderToMain() error {
 	if stashEntry == nil {
 		task = NewRenderStringTask(gui.Tr.NoStashEntries)
 	} else {
-		cmdObj := gui.OSCommand.Cmd.New(
-			gui.GitCommand.ShowStashEntryCmdStr(stashEntry.Index),
-		)
-		task = NewRunPtyTask(cmdObj.GetCmd())
+		task = NewRunPtyTask(gui.GitCommand.ShowStashEntryCmdObj(stashEntry.Index).GetCmd())
 	}
 
 	return gui.refreshMainViews(refreshMainOpts{
@@ -109,7 +106,8 @@ func (gui *Gui) stashDo(method string) error {
 
 		return gui.createErrorPanel(errorMessage)
 	}
-	if err := gui.GitCommand.WithSpan(gui.Tr.Spans.Stash).StashDo(stashEntry.Index, method); err != nil {
+	gui.logSpan(gui.Tr.Spans.Stash)
+	if err := gui.GitCommand.StashDo(stashEntry.Index, method); err != nil {
 		return gui.surfaceError(err)
 	}
 	return gui.refreshSidePanels(refreshOptions{scope: []RefreshableView{STASH, FILES}})

--- a/pkg/gui/stash_panel.go
+++ b/pkg/gui/stash_panel.go
@@ -106,7 +106,7 @@ func (gui *Gui) stashDo(method string) error {
 
 		return gui.createErrorPanel(errorMessage)
 	}
-	gui.logSpan(gui.Tr.Spans.Stash)
+	gui.logAction(gui.Tr.Actions.Stash)
 	if err := gui.GitCommand.StashDo(stashEntry.Index, method); err != nil {
 		return gui.surfaceError(err)
 	}

--- a/pkg/gui/sub_commits_panel.go
+++ b/pkg/gui/sub_commits_panel.go
@@ -46,7 +46,7 @@ func (gui *Gui) handleCheckoutSubCommit() error {
 		title:  gui.Tr.LcCheckoutCommit,
 		prompt: gui.Tr.SureCheckoutThisCommit,
 		handleConfirm: func() error {
-			gui.logSpan(gui.Tr.Spans.CheckoutCommit)
+			gui.logAction(gui.Tr.Actions.CheckoutCommit)
 			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{})
 		},
 	})

--- a/pkg/gui/sub_commits_panel.go
+++ b/pkg/gui/sub_commits_panel.go
@@ -46,7 +46,8 @@ func (gui *Gui) handleCheckoutSubCommit() error {
 		title:  gui.Tr.LcCheckoutCommit,
 		prompt: gui.Tr.SureCheckoutThisCommit,
 		handleConfirm: func() error {
-			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{span: gui.Tr.Spans.CheckoutCommit})
+			gui.logSpan(gui.Tr.Spans.CheckoutCommit)
+			return gui.handleCheckoutRef(commit.Sha, handleCheckoutRefOptions{})
 		},
 	})
 	if err != nil {

--- a/pkg/gui/submodules_panel.go
+++ b/pkg/gui/submodules_panel.go
@@ -79,7 +79,7 @@ func (gui *Gui) removeSubmodule(submodule *models.SubmoduleConfig) error {
 		title:  gui.Tr.RemoveSubmodule,
 		prompt: fmt.Sprintf(gui.Tr.RemoveSubmodulePrompt, submodule.Name),
 		handleConfirm: func() error {
-			gui.logSpan(gui.Tr.Spans.RemoveSubmodule)
+			gui.logAction(gui.Tr.Actions.RemoveSubmodule)
 			if err := gui.GitCommand.SubmoduleDelete(submodule); err != nil {
 				return gui.surfaceError(err)
 			}
@@ -106,7 +106,7 @@ func (gui *Gui) fileForSubmodule(submodule *models.SubmoduleConfig) *models.File
 }
 
 func (gui *Gui) resetSubmodule(submodule *models.SubmoduleConfig) error {
-	gui.logSpan(gui.Tr.Spans.ResetSubmodule)
+	gui.logAction(gui.Tr.Actions.ResetSubmodule)
 
 	file := gui.fileForSubmodule(submodule)
 	if file != nil {
@@ -141,7 +141,7 @@ func (gui *Gui) handleAddSubmodule() error {
 						initialContent: submoduleName,
 						handleConfirm: func(submodulePath string) error {
 							return gui.WithWaitingStatus(gui.Tr.LcAddingSubmoduleStatus, func() error {
-								gui.logSpan(gui.Tr.Spans.AddSubmodule)
+								gui.logAction(gui.Tr.Actions.AddSubmodule)
 								err := gui.GitCommand.SubmoduleAdd(submoduleName, submodulePath, submoduleUrl)
 								gui.handleCredentialsPopup(err)
 
@@ -162,7 +162,7 @@ func (gui *Gui) handleEditSubmoduleUrl(submodule *models.SubmoduleConfig) error 
 		initialContent: submodule.Url,
 		handleConfirm: func(newUrl string) error {
 			return gui.WithWaitingStatus(gui.Tr.LcUpdatingSubmoduleUrlStatus, func() error {
-				gui.logSpan(gui.Tr.Spans.UpdateSubmoduleUrl)
+				gui.logAction(gui.Tr.Actions.UpdateSubmoduleUrl)
 				err := gui.GitCommand.SubmoduleUpdateUrl(submodule.Name, submodule.Path, newUrl)
 				gui.handleCredentialsPopup(err)
 
@@ -174,7 +174,7 @@ func (gui *Gui) handleEditSubmoduleUrl(submodule *models.SubmoduleConfig) error 
 
 func (gui *Gui) handleSubmoduleInit(submodule *models.SubmoduleConfig) error {
 	return gui.WithWaitingStatus(gui.Tr.LcInitializingSubmoduleStatus, func() error {
-		gui.logSpan(gui.Tr.Spans.InitialiseSubmodule)
+		gui.logAction(gui.Tr.Actions.InitialiseSubmodule)
 		err := gui.GitCommand.SubmoduleInit(submodule.Path)
 		gui.handleCredentialsPopup(err)
 
@@ -218,7 +218,7 @@ func (gui *Gui) handleBulkSubmoduleActionsMenu() error {
 			displayStrings: []string{gui.Tr.LcBulkInitSubmodules, style.FgGreen.Sprint(gui.GitCommand.SubmoduleBulkInitCmdObj().ToString())},
 			onPress: func() error {
 				return gui.WithWaitingStatus(gui.Tr.LcRunningCommand, func() error {
-					gui.logSpan(gui.Tr.Spans.BulkInitialiseSubmodules)
+					gui.logAction(gui.Tr.Actions.BulkInitialiseSubmodules)
 					err := gui.GitCommand.SubmoduleBulkInitCmdObj().Run()
 					if err != nil {
 						return gui.surfaceError(err)
@@ -232,7 +232,7 @@ func (gui *Gui) handleBulkSubmoduleActionsMenu() error {
 			displayStrings: []string{gui.Tr.LcBulkUpdateSubmodules, style.FgYellow.Sprint(gui.GitCommand.SubmoduleBulkUpdateCmdObj().ToString())},
 			onPress: func() error {
 				return gui.WithWaitingStatus(gui.Tr.LcRunningCommand, func() error {
-					gui.logSpan(gui.Tr.Spans.BulkUpdateSubmodules)
+					gui.logAction(gui.Tr.Actions.BulkUpdateSubmodules)
 					if err := gui.GitCommand.SubmoduleBulkUpdateCmdObj().Run(); err != nil {
 						return gui.surfaceError(err)
 					}
@@ -245,7 +245,7 @@ func (gui *Gui) handleBulkSubmoduleActionsMenu() error {
 			displayStrings: []string{gui.Tr.LcSubmoduleStashAndReset, style.FgRed.Sprintf("git stash in each submodule && %s", gui.GitCommand.SubmoduleForceBulkUpdateCmdObj().ToString())},
 			onPress: func() error {
 				return gui.WithWaitingStatus(gui.Tr.LcRunningCommand, func() error {
-					gui.logSpan(gui.Tr.Spans.BulkStashAndResetSubmodules)
+					gui.logAction(gui.Tr.Actions.BulkStashAndResetSubmodules)
 					if err := gui.GitCommand.ResetSubmodules(gui.State.Submodules); err != nil {
 						return gui.surfaceError(err)
 					}
@@ -258,7 +258,7 @@ func (gui *Gui) handleBulkSubmoduleActionsMenu() error {
 			displayStrings: []string{gui.Tr.LcBulkDeinitSubmodules, style.FgRed.Sprint(gui.GitCommand.SubmoduleBulkDeinitCmdObj().ToString())},
 			onPress: func() error {
 				return gui.WithWaitingStatus(gui.Tr.LcRunningCommand, func() error {
-					gui.logSpan(gui.Tr.Spans.BulkDeinitialiseSubmodules)
+					gui.logAction(gui.Tr.Actions.BulkDeinitialiseSubmodules)
 					if err := gui.GitCommand.SubmoduleBulkDeinitCmdObj().Run(); err != nil {
 						return gui.surfaceError(err)
 					}
@@ -274,7 +274,7 @@ func (gui *Gui) handleBulkSubmoduleActionsMenu() error {
 
 func (gui *Gui) handleUpdateSubmodule(submodule *models.SubmoduleConfig) error {
 	return gui.WithWaitingStatus(gui.Tr.LcUpdatingSubmoduleStatus, func() error {
-		gui.logSpan(gui.Tr.Spans.UpdateSubmodule)
+		gui.logAction(gui.Tr.Actions.UpdateSubmodule)
 		err := gui.GitCommand.SubmoduleUpdate(submodule.Path)
 		gui.handleCredentialsPopup(err)
 

--- a/pkg/gui/tags_panel.go
+++ b/pkg/gui/tags_panel.go
@@ -63,7 +63,8 @@ func (gui *Gui) withSelectedTag(f func(tag *models.Tag) error) func() error {
 // tag-specific handlers
 
 func (gui *Gui) handleCheckoutTag(tag *models.Tag) error {
-	if err := gui.handleCheckoutRef(tag.Name, handleCheckoutRefOptions{span: gui.Tr.Spans.CheckoutTag}); err != nil {
+	gui.logSpan(gui.Tr.Spans.CheckoutTag)
+	if err := gui.handleCheckoutRef(tag.Name, handleCheckoutRefOptions{}); err != nil {
 		return err
 	}
 	return gui.pushContext(gui.State.Contexts.Branches)
@@ -81,7 +82,8 @@ func (gui *Gui) handleDeleteTag(tag *models.Tag) error {
 		title:  gui.Tr.DeleteTagTitle,
 		prompt: prompt,
 		handleConfirm: func() error {
-			if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DeleteTag).DeleteTag(tag.Name); err != nil {
+			gui.logSpan(gui.Tr.Spans.DeleteTag)
+			if err := gui.GitCommand.DeleteTag(tag.Name); err != nil {
 				return gui.surfaceError(err)
 			}
 			return gui.refreshSidePanels(refreshOptions{mode: ASYNC, scope: []RefreshableView{COMMITS, TAGS}})
@@ -103,7 +105,8 @@ func (gui *Gui) handlePushTag(tag *models.Tag) error {
 		findSuggestionsFunc: gui.getRemoteSuggestionsFunc(),
 		handleConfirm: func(response string) error {
 			return gui.WithWaitingStatus(gui.Tr.PushingTagStatus, func() error {
-				err := gui.GitCommand.WithSpan(gui.Tr.Spans.PushTag).PushTag(response, tag.Name, gui.promptUserForCredential)
+				gui.logSpan(gui.Tr.Spans.PushTag)
+				err := gui.GitCommand.PushTag(response, tag.Name, gui.promptUserForCredential)
 				gui.handleCredentialsPopup(err)
 
 				return nil

--- a/pkg/gui/tags_panel.go
+++ b/pkg/gui/tags_panel.go
@@ -63,7 +63,7 @@ func (gui *Gui) withSelectedTag(f func(tag *models.Tag) error) func() error {
 // tag-specific handlers
 
 func (gui *Gui) handleCheckoutTag(tag *models.Tag) error {
-	gui.logSpan(gui.Tr.Spans.CheckoutTag)
+	gui.logAction(gui.Tr.Actions.CheckoutTag)
 	if err := gui.handleCheckoutRef(tag.Name, handleCheckoutRefOptions{}); err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (gui *Gui) handleDeleteTag(tag *models.Tag) error {
 		title:  gui.Tr.DeleteTagTitle,
 		prompt: prompt,
 		handleConfirm: func() error {
-			gui.logSpan(gui.Tr.Spans.DeleteTag)
+			gui.logAction(gui.Tr.Actions.DeleteTag)
 			if err := gui.GitCommand.DeleteTag(tag.Name); err != nil {
 				return gui.surfaceError(err)
 			}
@@ -105,7 +105,7 @@ func (gui *Gui) handlePushTag(tag *models.Tag) error {
 		findSuggestionsFunc: gui.getRemoteSuggestionsFunc(),
 		handleConfirm: func(response string) error {
 			return gui.WithWaitingStatus(gui.Tr.PushingTagStatus, func() error {
-				gui.logSpan(gui.Tr.Spans.PushTag)
+				gui.logAction(gui.Tr.Actions.PushTag)
 				err := gui.GitCommand.PushTag(response, tag.Name, gui.promptUserForCredential)
 				gui.handleCredentialsPopup(err)
 

--- a/pkg/gui/undoing.go
+++ b/pkg/gui/undoing.go
@@ -99,13 +99,13 @@ func (gui *Gui) reflogUndo() error {
 
 		switch action.kind {
 		case COMMIT, REBASE:
-			gui.logSpan(gui.Tr.Spans.Undo)
+			gui.logAction(gui.Tr.Actions.Undo)
 			return true, gui.handleHardResetWithAutoStash(action.from, handleHardResetWithAutoStashOptions{
 				EnvVars:       undoEnvVars,
 				WaitingStatus: undoingStatus,
 			})
 		case CHECKOUT:
-			gui.logSpan(gui.Tr.Spans.Undo)
+			gui.logAction(gui.Tr.Actions.Undo)
 			return true, gui.handleCheckoutRef(action.from, handleCheckoutRefOptions{
 				EnvVars:       undoEnvVars,
 				WaitingStatus: undoingStatus,
@@ -135,13 +135,13 @@ func (gui *Gui) reflogRedo() error {
 
 		switch action.kind {
 		case COMMIT, REBASE:
-			gui.logSpan(gui.Tr.Spans.Redo)
+			gui.logAction(gui.Tr.Actions.Redo)
 			return true, gui.handleHardResetWithAutoStash(action.to, handleHardResetWithAutoStashOptions{
 				EnvVars:       redoEnvVars,
 				WaitingStatus: redoingStatus,
 			})
 		case CHECKOUT:
-			gui.logSpan(gui.Tr.Spans.Redo)
+			gui.logAction(gui.Tr.Actions.Redo)
 			return true, gui.handleCheckoutRef(action.to, handleCheckoutRefOptions{
 				EnvVars:       redoEnvVars,
 				WaitingStatus: redoingStatus,

--- a/pkg/gui/workspace_reset_options_panel.go
+++ b/pkg/gui/workspace_reset_options_panel.go
@@ -21,7 +21,7 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint(nukeStr),
 			},
 			onPress: func() error {
-				gui.logSpan(gui.Tr.Spans.NukeWorkingTree)
+				gui.logAction(gui.Tr.Actions.NukeWorkingTree)
 				if err := gui.GitCommand.ResetAndClean(); err != nil {
 					return gui.surfaceError(err)
 				}
@@ -35,7 +35,7 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git checkout -- ."),
 			},
 			onPress: func() error {
-				gui.logSpan(gui.Tr.Spans.DiscardUnstagedFileChanges)
+				gui.logAction(gui.Tr.Actions.DiscardUnstagedFileChanges)
 				if err := gui.GitCommand.DiscardAnyUnstagedFileChanges(); err != nil {
 					return gui.surfaceError(err)
 				}
@@ -49,7 +49,7 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git clean -fd"),
 			},
 			onPress: func() error {
-				gui.logSpan(gui.Tr.Spans.RemoveUntrackedFiles)
+				gui.logAction(gui.Tr.Actions.RemoveUntrackedFiles)
 				if err := gui.GitCommand.RemoveUntrackedFiles(); err != nil {
 					return gui.surfaceError(err)
 				}
@@ -63,7 +63,7 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git reset --soft HEAD"),
 			},
 			onPress: func() error {
-				gui.logSpan(gui.Tr.Spans.SoftReset)
+				gui.logAction(gui.Tr.Actions.SoftReset)
 				if err := gui.GitCommand.ResetSoft("HEAD"); err != nil {
 					return gui.surfaceError(err)
 				}
@@ -77,7 +77,7 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git reset --mixed HEAD"),
 			},
 			onPress: func() error {
-				gui.logSpan(gui.Tr.Spans.MixedReset)
+				gui.logAction(gui.Tr.Actions.MixedReset)
 				if err := gui.GitCommand.ResetMixed("HEAD"); err != nil {
 					return gui.surfaceError(err)
 				}
@@ -91,7 +91,7 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git reset --hard HEAD"),
 			},
 			onPress: func() error {
-				gui.logSpan(gui.Tr.Spans.HardReset)
+				gui.logAction(gui.Tr.Actions.HardReset)
 				if err := gui.GitCommand.ResetHard("HEAD"); err != nil {
 					return gui.surfaceError(err)
 				}

--- a/pkg/gui/workspace_reset_options_panel.go
+++ b/pkg/gui/workspace_reset_options_panel.go
@@ -21,7 +21,8 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint(nukeStr),
 			},
 			onPress: func() error {
-				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.NukeWorkingTree).ResetAndClean(); err != nil {
+				gui.logSpan(gui.Tr.Spans.NukeWorkingTree)
+				if err := gui.GitCommand.ResetAndClean(); err != nil {
 					return gui.surfaceError(err)
 				}
 
@@ -34,7 +35,8 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git checkout -- ."),
 			},
 			onPress: func() error {
-				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.DiscardUnstagedFileChanges).DiscardAnyUnstagedFileChanges(); err != nil {
+				gui.logSpan(gui.Tr.Spans.DiscardUnstagedFileChanges)
+				if err := gui.GitCommand.DiscardAnyUnstagedFileChanges(); err != nil {
 					return gui.surfaceError(err)
 				}
 
@@ -47,7 +49,8 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git clean -fd"),
 			},
 			onPress: func() error {
-				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.RemoveUntrackedFiles).RemoveUntrackedFiles(); err != nil {
+				gui.logSpan(gui.Tr.Spans.RemoveUntrackedFiles)
+				if err := gui.GitCommand.RemoveUntrackedFiles(); err != nil {
 					return gui.surfaceError(err)
 				}
 
@@ -60,7 +63,8 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git reset --soft HEAD"),
 			},
 			onPress: func() error {
-				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.SoftReset).ResetSoft("HEAD"); err != nil {
+				gui.logSpan(gui.Tr.Spans.SoftReset)
+				if err := gui.GitCommand.ResetSoft("HEAD"); err != nil {
 					return gui.surfaceError(err)
 				}
 
@@ -73,7 +77,8 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git reset --mixed HEAD"),
 			},
 			onPress: func() error {
-				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.MixedReset).ResetMixed("HEAD"); err != nil {
+				gui.logSpan(gui.Tr.Spans.MixedReset)
+				if err := gui.GitCommand.ResetMixed("HEAD"); err != nil {
 					return gui.surfaceError(err)
 				}
 
@@ -86,7 +91,8 @@ func (gui *Gui) handleCreateResetMenu() error {
 				red.Sprint("git reset --hard HEAD"),
 			},
 			onPress: func() error {
-				if err := gui.GitCommand.WithSpan(gui.Tr.Spans.HardReset).ResetHard("HEAD"); err != nil {
+				gui.logSpan(gui.Tr.Spans.HardReset)
+				if err := gui.GitCommand.ResetHard("HEAD"); err != nil {
 					return gui.surfaceError(err)
 				}
 

--- a/pkg/i18n/chinese.go
+++ b/pkg/i18n/chinese.go
@@ -441,8 +441,7 @@ func chineseTranslationSet() TranslationSet {
 		LcCreatePullRequestOptions:          "创建抓取请求选项",
 		LcDefaultBranch:                     "默认分支",
 		LcSelectBranch:                      "选择分支",
-		CreatingPullRequestAtUrl:            "在 URL 创建抓取请求: %s",
-		Spans: Spans{
+		Actions: Actions{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)
 			CheckoutCommit:                    "检出提交",
 			CheckoutReflogCommit:              "检出reflog提交",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -438,7 +438,6 @@ type TranslationSet struct {
 	LcDefaultBranch                     string
 	LcSelectBranch                      string
 	CreatePullRequest                   string
-	CreatingPullRequestAtUrl            string
 	OpeningCommitInBrowser              string
 	SelectConfigFile                    string
 	NoConfigFileFoundErr                string
@@ -456,10 +455,10 @@ type TranslationSet struct {
 	SortCommits                         string
 	CantChangeContextSizeError          string
 	LcOpenCommitInBrowser               string
-	Spans                               Spans
+	Actions                             Actions
 }
 
-type Spans struct {
+type Actions struct {
 	CheckoutCommit                    string
 	CheckoutReflogCommit              string
 	CheckoutTag                       string
@@ -540,6 +539,8 @@ type Spans struct {
 	HardReset                         string
 	Undo                              string
 	Redo                              string
+	CopyPullRequestURL                string
+	OpenMergeTool                     string
 }
 
 const englishIntroPopupMessage = `
@@ -989,7 +990,6 @@ func EnglishTranslationSet() TranslationSet {
 		LcCreatePullRequestOptions:          "create pull request options",
 		LcDefaultBranch:                     "default branch",
 		LcSelectBranch:                      "select branch",
-		CreatingPullRequestAtUrl:            "Creating pull request at URL: %s",
 		OpeningCommitInBrowser:              "Opening commit in browser at URL: %s",
 		SelectConfigFile:                    "Select config file",
 		NoConfigFileFoundErr:                "No config file found",
@@ -1007,7 +1007,7 @@ func EnglishTranslationSet() TranslationSet {
 		SortCommits:                         "commit sort order",
 		CantChangeContextSizeError:          "Cannot change context while in patch building mode because we were too lazy to support it when releasing the feature. If you really want it, please let us know!",
 		LcOpenCommitInBrowser:               "open commit in browser",
-		Spans: Spans{
+		Actions: Actions{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)
 			CheckoutCommit:                    "Checkout commit",
 			CheckoutReflogCommit:              "Checkout reflog commit",
@@ -1089,6 +1089,8 @@ func EnglishTranslationSet() TranslationSet {
 			FastForwardBranch:                 "Fast forward branch",
 			Undo:                              "Undo",
 			Redo:                              "Redo",
+			CopyPullRequestURL:                "Copy pull request URL",
+			OpenMergeTool:                     "Open merge tool",
 		},
 	}
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -438,7 +438,6 @@ type TranslationSet struct {
 	LcDefaultBranch                     string
 	LcSelectBranch                      string
 	CreatePullRequest                   string
-	OpeningCommitInBrowser              string
 	SelectConfigFile                    string
 	NoConfigFileFoundErr                string
 	LcLoadingFileSuggestions            string
@@ -541,6 +540,8 @@ type Actions struct {
 	Redo                              string
 	CopyPullRequestURL                string
 	OpenMergeTool                     string
+	OpenCommitInBrowser               string
+	OpenPullRequest                   string
 }
 
 const englishIntroPopupMessage = `
@@ -990,7 +991,6 @@ func EnglishTranslationSet() TranslationSet {
 		LcCreatePullRequestOptions:          "create pull request options",
 		LcDefaultBranch:                     "default branch",
 		LcSelectBranch:                      "select branch",
-		OpeningCommitInBrowser:              "Opening commit in browser at URL: %s",
 		SelectConfigFile:                    "Select config file",
 		NoConfigFileFoundErr:                "No config file found",
 		LcLoadingFileSuggestions:            "loading file suggestions",
@@ -1091,6 +1091,8 @@ func EnglishTranslationSet() TranslationSet {
 			Redo:                              "Redo",
 			CopyPullRequestURL:                "Copy pull request URL",
 			OpenMergeTool:                     "Open merge tool",
+			OpenCommitInBrowser:               "Open commit in browser",
+			OpenPullRequest:                   "Open pull request in browser",
 		},
 	}
 }


### PR DESCRIPTION
Recently we added a 'command log' panel in the UI showing the actual commands run based on user actions. E.g. 
```
Stage File
  git add -- 'filename'
Unstage File
  git reset HEAD 'filename'
```

The way we did this was by introducing a WithSpan method to the GitCommand and OSCommand structs, which internally copied the struct with a 'span' string set (e.g. 'Stage File'), such that any commands run would be logged under that span. This approach has some benefits, for example, it means we only log commands if we have a span to categorise them under. But there are also issues. Firstly, if we did successive file stages, they'd all come under the same heading instead of the heading being re-printed per command. This can make things confusing when a given span involves more than one command (like some complex stash stuff we do). Secondly, the dependence on our span string meant copying our struct and copying any nested structs that also needed to depend on the span string. The upcoming refactor where I'm going to break up the GitCommand struct into domain-specific handlers was going to be a nightmare to work with in this scenario and generally the code wasn't easy to follow.

Another shortcoming of the existing approach was that if a command was run within a span, it would unconditionally be logged, even if it was just a read-only git command that didn't actually change anything in the git state.

So this PR simplifies the process such that:
1) upon creating command objects we say whether they're worth logging
2) the GitCommand and OSCommand structs have no concept of a 'span', that's up to the gui to manually handle before executing commands

Another change is that we're now using the term 'action' instead of 'span' because it's more applicable to what the user is actually doing i.e. pressing a keybinding to invoke an action.

Although the code is simplified, we've got some new problems. Specifically, the code doesn't enforce that you log an action before logging a command. That means if I've just logged `Stage File` and `git add -- filename` underneath, and then I forget to log `Unstage File` before logging `git reset HEAD 'filename'`, it will look like that command was part of the `Stage File` action.

The best solution I can think of for this problem is to maintain an action string in the gui struct (which we were basically doing before) but enforce that if we're trying to log something, that span must be set. Then we'd also need to un-set it after we've completed an action, perhaps with a `withAction` (analogous to `withSpan`) function inside the gui struct. The hard part is being thread-safe. I'm happy to leave that to a future PR