### PR TITLE
stop refreshing the screen so much

### DIFF
--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -51,6 +51,8 @@ func (self *cmdObjRunner) RunWithOutput(cmdObj ICmdObj) (string, error) {
 		return "", err
 	}
 
+	self.log.WithField("command", cmdObj.ToString()).Debug("RunCommand")
+
 	if cmdObj.ShouldLog() {
 		self.logCmdObj(cmdObj)
 	}

--- a/pkg/gui/app_status_manager.go
+++ b/pkg/gui/app_status_manager.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
@@ -96,11 +95,13 @@ func (gui *Gui) renderAppStatus() {
 		defer ticker.Stop()
 		for range ticker.C {
 			appStatus := gui.statusManager.getStatusString()
+			gui.OnUIThread(func() error {
+				return gui.renderString(gui.Views.AppStatus, appStatus)
+			})
+
 			if appStatus == "" {
-				gui.renderString(gui.Views.AppStatus, "")
 				return
 			}
-			gui.renderString(gui.Views.AppStatus, appStatus)
 		}
 	})
 }
@@ -117,7 +118,7 @@ func (gui *Gui) WithWaitingStatus(message string, f func() error) error {
 		gui.renderAppStatus()
 
 		if err := f(); err != nil {
-			gui.g.Update(func(g *gocui.Gui) error {
+			gui.OnUIThread(func() error {
 				return gui.surfaceError(err)
 			})
 		}

--- a/pkg/gui/commit_files_panel.go
+++ b/pkg/gui/commit_files_panel.go
@@ -226,15 +226,11 @@ func (gui *Gui) enterCommitFile(opts OnFocusOpts) error {
 
 	if gui.Git.Patch.PatchManager.Active() && gui.Git.Patch.PatchManager.To != gui.State.CommitFileManager.GetParent() {
 		return gui.ask(askOpts{
-			title:               gui.Tr.DiscardPatch,
-			prompt:              gui.Tr.DiscardPatchConfirm,
-			handlersManageFocus: true,
+			title:  gui.Tr.DiscardPatch,
+			prompt: gui.Tr.DiscardPatchConfirm,
 			handleConfirm: func() error {
 				gui.Git.Patch.PatchManager.Reset()
 				return enterTheFile()
-			},
-			handleClose: func() error {
-				return gui.pushContext(gui.State.Contexts.CommitFiles)
 			},
 		})
 	}

--- a/pkg/gui/commit_message_panel.go
+++ b/pkg/gui/commit_message_panel.go
@@ -40,8 +40,7 @@ func (gui *Gui) handleCommitMessageFocused() error {
 		},
 	)
 
-	gui.renderString(gui.Views.Options, message)
-	return nil
+	return gui.renderString(gui.Views.Options, message)
 }
 
 func (gui *Gui) getBufferLength(view *gocui.View) string {

--- a/pkg/gui/context.go
+++ b/pkg/gui/context.go
@@ -71,21 +71,17 @@ func (gui *Gui) currentContextKeyIgnoringPopups() ContextKey {
 // use replaceContext when you don't want to return to the original context upon
 // hitting escape: you want to go that context's parent instead.
 func (gui *Gui) replaceContext(c Context) error {
-	gui.g.Update(func(*gocui.Gui) error {
-		gui.State.ContextManager.Lock()
-		defer gui.State.ContextManager.Unlock()
+	gui.State.ContextManager.Lock()
+	defer gui.State.ContextManager.Unlock()
 
-		if len(gui.State.ContextManager.ContextStack) == 0 {
-			gui.State.ContextManager.ContextStack = []Context{c}
-		} else {
-			// replace the last item with the given item
-			gui.State.ContextManager.ContextStack = append(gui.State.ContextManager.ContextStack[0:len(gui.State.ContextManager.ContextStack)-1], c)
-		}
+	if len(gui.State.ContextManager.ContextStack) == 0 {
+		gui.State.ContextManager.ContextStack = []Context{c}
+	} else {
+		// replace the last item with the given item
+		gui.State.ContextManager.ContextStack = append(gui.State.ContextManager.ContextStack[0:len(gui.State.ContextManager.ContextStack)-1], c)
+	}
 
-		return gui.activateContext(c)
-	})
-
-	return nil
+	return gui.activateContext(c)
 }
 
 func (gui *Gui) pushContext(c Context, opts ...OnFocusOpts) error {
@@ -94,14 +90,6 @@ func (gui *Gui) pushContext(c Context, opts ...OnFocusOpts) error {
 		return errors.New("cannot pass multiple opts to pushContext")
 	}
 
-	gui.g.Update(func(*gocui.Gui) error {
-		return gui.pushContextDirect(c, opts...)
-	})
-
-	return nil
-}
-
-func (gui *Gui) pushContextDirect(c Context, opts ...OnFocusOpts) error {
 	gui.State.ContextManager.Lock()
 
 	// push onto stack
@@ -139,14 +127,6 @@ func (gui *Gui) pushContextWithView(viewName string) error {
 }
 
 func (gui *Gui) returnFromContext() error {
-	gui.g.Update(func(*gocui.Gui) error {
-		return gui.returnFromContextSync()
-	})
-
-	return nil
-}
-
-func (gui *Gui) returnFromContextSync() error {
 	gui.State.ContextManager.Lock()
 
 	if len(gui.State.ContextManager.ContextStack) == 1 {

--- a/pkg/gui/credentials_panel.go
+++ b/pkg/gui/credentials_panel.go
@@ -3,7 +3,6 @@ package gui
 import (
 	"strings"
 
-	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
@@ -13,7 +12,7 @@ type credentials chan string
 // promptUserForCredential wait for a username, password or passphrase input from the credentials popup
 func (gui *Gui) promptUserForCredential(passOrUname oscommands.CredentialType) string {
 	gui.credentials = make(chan string)
-	gui.g.Update(func(g *gocui.Gui) error {
+	gui.OnUIThread(func() error {
 		credentialsView := gui.Views.Credentials
 		switch passOrUname {
 		case oscommands.Username:
@@ -68,8 +67,7 @@ func (gui *Gui) handleCredentialsViewFocused() error {
 		},
 	)
 
-	gui.renderString(gui.Views.Options, message)
-	return nil
+	return gui.renderString(gui.Views.Options, message)
 }
 
 // handleCredentialsPopup handles the views after executing a command that might ask for credentials

--- a/pkg/gui/diff_context_size.go
+++ b/pkg/gui/diff_context_size.go
@@ -4,10 +4,25 @@ import (
 	"errors"
 )
 
+var CONTEXT_KEYS_SHOWING_DIFFS = []ContextKey{
+	FILES_CONTEXT_KEY,
+	COMMIT_FILES_CONTEXT_KEY,
+	STASH_CONTEXT_KEY,
+	BRANCH_COMMITS_CONTEXT_KEY,
+	SUB_COMMITS_CONTEXT_KEY,
+	MAIN_STAGING_CONTEXT_KEY,
+	MAIN_PATCH_BUILDING_CONTEXT_KEY,
+}
+
 func isShowingDiff(gui *Gui) bool {
 	key := gui.currentStaticContext().GetKey()
 
-	return key == FILES_CONTEXT_KEY || key == COMMIT_FILES_CONTEXT_KEY || key == STASH_CONTEXT_KEY || key == BRANCH_COMMITS_CONTEXT_KEY || key == SUB_COMMITS_CONTEXT_KEY || key == MAIN_STAGING_CONTEXT_KEY || key == MAIN_PATCH_BUILDING_CONTEXT_KEY
+	for _, contextKey := range CONTEXT_KEYS_SHOWING_DIFFS {
+		if key == contextKey {
+			return true
+		}
+	}
+	return false
 }
 
 func (gui *Gui) IncreaseContextInDiffView() error {

--- a/pkg/gui/diff_context_size_test.go
+++ b/pkg/gui/diff_context_size_test.go
@@ -27,6 +27,7 @@ func setupGuiForTest(gui *Gui) {
 	gui.g = &gocui.Gui{}
 	gui.Views.Main, _ = gui.prepareView("main")
 	gui.Views.Secondary, _ = gui.prepareView("secondary")
+	gui.Views.Options, _ = gui.prepareView("options")
 	gui.Git.Patch.PatchManager = &patch.PatchManager{}
 	_, _ = gui.refreshLineByLinePanel(diffForTest, "", false, 11)
 }
@@ -47,7 +48,7 @@ func TestIncreasesContextInDiffViewByOneInContextWithDiff(t *testing.T) {
 		context := c(gui)
 		setupGuiForTest(gui)
 		gui.UserConfig.Git.DiffContextSize = 1
-		_ = gui.pushContextDirect(context)
+		_ = gui.pushContext(context)
 
 		_ = gui.IncreaseContextInDiffView()
 
@@ -73,7 +74,7 @@ func TestDoesntIncreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
 		context := c(gui)
 		setupGuiForTest(gui)
 		gui.UserConfig.Git.DiffContextSize = 1
-		_ = gui.pushContextDirect(context)
+		_ = gui.pushContext(context)
 
 		_ = gui.IncreaseContextInDiffView()
 
@@ -97,7 +98,7 @@ func TestDecreasesContextInDiffViewByOneInContextWithDiff(t *testing.T) {
 		context := c(gui)
 		setupGuiForTest(gui)
 		gui.UserConfig.Git.DiffContextSize = 2
-		_ = gui.pushContextDirect(context)
+		_ = gui.pushContext(context)
 
 		_ = gui.DecreaseContextInDiffView()
 
@@ -123,7 +124,7 @@ func TestDoesntDecreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
 		context := c(gui)
 		setupGuiForTest(gui)
 		gui.UserConfig.Git.DiffContextSize = 2
-		_ = gui.pushContextDirect(context)
+		_ = gui.pushContext(context)
 
 		_ = gui.DecreaseContextInDiffView()
 
@@ -135,7 +136,7 @@ func TestDoesntIncreaseContextInDiffViewInContextWhenInPatchBuildingMode(t *test
 	gui := NewDummyGui()
 	setupGuiForTest(gui)
 	gui.UserConfig.Git.DiffContextSize = 2
-	_ = gui.pushContextDirect(gui.State.Contexts.CommitFiles)
+	_ = gui.pushContext(gui.State.Contexts.CommitFiles)
 	gui.Git.Patch.PatchManager.Start("from", "to", false, false)
 
 	errorCount := 0
@@ -157,7 +158,7 @@ func TestDoesntDecreaseContextInDiffViewInContextWhenInPatchBuildingMode(t *test
 	gui := NewDummyGui()
 	setupGuiForTest(gui)
 	gui.UserConfig.Git.DiffContextSize = 2
-	_ = gui.pushContextDirect(gui.State.Contexts.CommitFiles)
+	_ = gui.pushContext(gui.State.Contexts.CommitFiles)
 	gui.Git.Patch.PatchManager.Start("from", "to", false, false)
 
 	errorCount := 0

--- a/pkg/gui/diff_context_size_test.go
+++ b/pkg/gui/diff_context_size_test.go
@@ -65,7 +65,9 @@ func TestDoesntIncreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
 		func(gui *Gui) Context { return gui.State.Contexts.ReflogCommits },
 		func(gui *Gui) Context { return gui.State.Contexts.RemoteBranches },
 		func(gui *Gui) Context { return gui.State.Contexts.Tags },
-		func(gui *Gui) Context { return gui.State.Contexts.Merging },
+		// not testing this because it will kick straight back to the files context
+		// upon pushing the context
+		// func(gui *Gui) Context { return gui.State.Contexts.Merging },
 		func(gui *Gui) Context { return gui.State.Contexts.CommandLog },
 	}
 
@@ -115,7 +117,9 @@ func TestDoesntDecreaseContextInDiffViewInContextWithoutDiff(t *testing.T) {
 		func(gui *Gui) Context { return gui.State.Contexts.ReflogCommits },
 		func(gui *Gui) Context { return gui.State.Contexts.RemoteBranches },
 		func(gui *Gui) Context { return gui.State.Contexts.Tags },
-		func(gui *Gui) Context { return gui.State.Contexts.Merging },
+		// not testing this because it will kick straight back to the files context
+		// upon pushing the context
+		// func(gui *Gui) Context { return gui.State.Contexts.Merging },
 		func(gui *Gui) Context { return gui.State.Contexts.CommandLog },
 	}
 

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -54,7 +54,7 @@ func (gui *Gui) filesRenderToMain() error {
 	}
 
 	if node.File != nil && node.File.HasInlineMergeConflicts {
-		return gui.refreshMergePanelWithLock()
+		return gui.renderConflictsFromFilesPanel()
 	}
 
 	cmdObj := gui.Git.WorkingTree.WorktreeFileDiffCmdObj(node, false, !node.GetHasUnstagedChanges() && node.GetHasStagedChanges(), gui.State.IgnoreWhitespaceInDiffView)
@@ -182,7 +182,7 @@ func (gui *Gui) enterFile(opts OnFocusOpts) error {
 	}
 
 	if file.HasInlineMergeConflicts {
-		return gui.handleSwitchToMerge()
+		return gui.switchToMerge()
 	}
 	if file.HasMergeConflicts {
 		return gui.createErrorPanel(gui.Tr.FileStagingRequirements)
@@ -201,7 +201,7 @@ func (gui *Gui) handleFilePress() error {
 		file := node.File
 
 		if file.HasInlineMergeConflicts {
-			return gui.handleSwitchToMerge()
+			return gui.switchToMerge()
 		}
 
 		if file.HasUnstagedChanges {
@@ -880,14 +880,10 @@ func (gui *Gui) upstreamForBranchInConfig(branchName string) (string, string, er
 	return "", "", nil
 }
 
-func (gui *Gui) handleSwitchToMerge() error {
+func (gui *Gui) switchToMerge() error {
 	file := gui.getSelectedFile()
 	if file == nil {
 		return nil
-	}
-
-	if !file.HasInlineMergeConflicts {
-		return gui.createErrorPanel(gui.Tr.FileNoMergeCons)
 	}
 
 	return gui.pushContext(gui.State.Contexts.Merging)

--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/loaders"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
@@ -98,7 +97,7 @@ func (gui *Gui) refreshFilesAndSubmodules() error {
 		return err
 	}
 
-	gui.g.Update(func(g *gocui.Gui) error {
+	gui.OnUIThread(func() error {
 		if err := gui.postRefreshUpdate(gui.State.Contexts.Submodules); err != nil {
 			gui.Log.Error(err)
 		}
@@ -110,7 +109,7 @@ func (gui *Gui) refreshFilesAndSubmodules() error {
 			}
 		}
 
-		if gui.currentContext().GetKey() == FILES_CONTEXT_KEY || (g.CurrentView() == gui.Views.Main && ContextKey(g.CurrentView().Context) == MAIN_MERGING_CONTEXT_KEY) {
+		if gui.currentContext().GetKey() == FILES_CONTEXT_KEY || (gui.g.CurrentView() == gui.Views.Main && ContextKey(gui.g.CurrentView().Context) == MAIN_MERGING_CONTEXT_KEY) {
 			newSelectedPath := gui.getSelectedPath()
 			alreadySelected := selectedPath != "" && newSelectedPath == selectedPath
 			if !alreadySelected {
@@ -407,14 +406,11 @@ func (gui *Gui) handleCommitPress() error {
 		}
 	}
 
-	gui.g.Update(func(g *gocui.Gui) error {
-		if err := gui.pushContext(gui.State.Contexts.CommitMessage); err != nil {
-			return err
-		}
+	if err := gui.pushContext(gui.State.Contexts.CommitMessage); err != nil {
+		return err
+	}
 
-		gui.RenderCommitLength()
-		return nil
-	})
+	gui.RenderCommitLength()
 	return nil
 }
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -768,3 +768,9 @@ func (gui *Gui) setColorScheme() error {
 
 	return nil
 }
+
+func (gui *Gui) OnUIThread(f func() error) {
+	gui.g.Update(func(*gocui.Gui) error {
+		return f()
+	})
+}

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -48,7 +48,7 @@ func (gui *Gui) createAllViews() error {
 	gui.Views.SearchPrefix.BgColor = gocui.ColorDefault
 	gui.Views.SearchPrefix.FgColor = gocui.ColorGreen
 	gui.Views.SearchPrefix.Frame = false
-	gui.setViewContentSync(gui.Views.SearchPrefix, SEARCH_PREFIX)
+	gui.setViewContent(gui.Views.SearchPrefix, SEARCH_PREFIX)
 
 	gui.Views.Stash.Title = gui.Tr.StashTitle
 	gui.Views.Stash.FgColor = theme.GocuiDefaultTextColor
@@ -235,7 +235,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 	gui.Views.CommitFiles.Visible = gui.getViewNameForWindow(gui.State.Contexts.CommitFiles.GetWindowName()) == "commitFiles"
 
 	if gui.State.OldInformation != informationStr {
-		gui.setViewContentSync(gui.Views.Information, informationStr)
+		gui.setViewContent(gui.Views.Information, informationStr)
 		gui.State.OldInformation = informationStr
 	}
 

--- a/pkg/gui/line_by_line_panel.go
+++ b/pkg/gui/line_by_line_panel.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/go-errors/errors"
-	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/patch"
 	"github.com/jesseduffield/lazygit/pkg/gui/lbl"
 )
@@ -172,15 +171,11 @@ func (gui *Gui) focusSelection(state *LblPanelState) error {
 
 	newOrigin := state.CalculateOrigin(origin, bufferHeight)
 
-	gui.g.Update(func(*gocui.Gui) error {
-		if err := stagingView.SetOriginY(newOrigin); err != nil {
-			return err
-		}
+	if err := stagingView.SetOriginY(newOrigin); err != nil {
+		return err
+	}
 
-		return stagingView.SetCursor(0, selectedLineIdx-newOrigin)
-	})
-
-	return nil
+	return stagingView.SetCursor(0, selectedLineIdx-newOrigin)
 }
 
 func (gui *Gui) handleToggleSelectRange() error {

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -39,7 +39,7 @@ func (gui *Gui) getMenuOptions() map[string]string {
 }
 
 func (gui *Gui) handleMenuClose() error {
-	return gui.returnFromContextSync()
+	return gui.returnFromContext()
 }
 
 type createMenuOptions struct {

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/theme"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
@@ -89,11 +88,7 @@ func (gui *Gui) createMenu(title string, items []*menuItem, createMenuOptions cr
 	menuView.SetContent(list)
 	gui.State.Panels.Menu.SelectedLineIdx = 0
 
-	gui.g.Update(func(g *gocui.Gui) error {
-		return gui.pushContext(gui.State.Contexts.Menu)
-	})
-
-	return nil
+	return gui.pushContext(gui.State.Contexts.Menu)
 }
 
 func (gui *Gui) onMenuPress() error {

--- a/pkg/gui/merge_panel.go
+++ b/pkg/gui/merge_panel.go
@@ -222,9 +222,7 @@ func (gui *Gui) centerYPos(view *gocui.View, y int) {
 	ox, _ := view.Origin()
 	_, height := view.Size()
 	newOriginY := int(math.Max(0, float64(y-(height/2))))
-	gui.g.Update(func(g *gocui.Gui) error {
-		return view.SetOrigin(ox, newOriginY)
-	})
+	_ = view.SetOrigin(ox, newOriginY)
 }
 
 func (gui *Gui) getMergingOptions() map[string]string {

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_config"
 	"github.com/jesseduffield/lazygit/pkg/env"
@@ -77,19 +76,15 @@ func (gui *Gui) dispatchSwitchToRepo(path string, reuse bool) error {
 	}
 	gui.Git = newGitCommand
 
-	gui.g.Update(func(*gocui.Gui) error {
-		// these two mutexes are used by our background goroutines (triggered via `gui.goEvery`. We don't want to
-		// switch to a repo while one of these goroutines is in the process of updating something
-		gui.Mutexes.FetchMutex.Lock()
-		defer gui.Mutexes.FetchMutex.Unlock()
+	// these two mutexes are used by our background goroutines (triggered via `gui.goEvery`. We don't want to
+	// switch to a repo while one of these goroutines is in the process of updating something
+	gui.Mutexes.FetchMutex.Lock()
+	defer gui.Mutexes.FetchMutex.Unlock()
 
-		gui.Mutexes.RefreshingFilesMutex.Lock()
-		defer gui.Mutexes.RefreshingFilesMutex.Unlock()
+	gui.Mutexes.RefreshingFilesMutex.Lock()
+	defer gui.Mutexes.RefreshingFilesMutex.Unlock()
 
-		gui.resetState("", reuse)
-
-		return nil
-	})
+	gui.resetState("", reuse)
 
 	return nil
 }

--- a/pkg/gui/searching.go
+++ b/pkg/gui/searching.go
@@ -47,7 +47,7 @@ func (gui *Gui) onSelectItemWrapper(innerFunc func(int) error) func(int, int, in
 
 	return func(y int, index int, total int) error {
 		if total == 0 {
-			gui.renderString(
+			return gui.renderString(
 				gui.Views.Search,
 				fmt.Sprintf(
 					"no matches for '%s' %s",
@@ -55,9 +55,8 @@ func (gui *Gui) onSelectItemWrapper(innerFunc func(int) error) func(int, int, in
 					theme.OptionsFgColor.Sprintf("%s: exit search mode", gui.getKeyDisplay(keybindingConfig.Universal.Return)),
 				),
 			)
-			return nil
 		}
-		gui.renderString(
+		_ = gui.renderString(
 			gui.Views.Search,
 			fmt.Sprintf(
 				"matches for '%s' (%d of %d) %s",

--- a/pkg/gui/staging_panel.go
+++ b/pkg/gui/staging_panel.go
@@ -102,20 +102,12 @@ func (gui *Gui) handleResetSelection() error {
 
 		if !gui.UserConfig.Gui.SkipUnstageLineWarning {
 			return gui.ask(askOpts{
-				title:               gui.Tr.UnstageLinesTitle,
-				prompt:              gui.Tr.UnstageLinesPrompt,
-				handlersManageFocus: true,
+				title:  gui.Tr.UnstageLinesTitle,
+				prompt: gui.Tr.UnstageLinesPrompt,
 				handleConfirm: func() error {
 					return gui.withLBLActiveCheck(func(state *LblPanelState) error {
-						if err := gui.pushContext(gui.State.Contexts.Staging); err != nil {
-							return err
-						}
-
 						return gui.applySelection(true, state)
 					})
-				},
-				handleClose: func() error {
-					return gui.pushContext(gui.State.Contexts.Staging)
 				},
 			})
 		} else {

--- a/pkg/gui/tasks_adapter.go
+++ b/pkg/gui/tasks_adapter.go
@@ -68,8 +68,7 @@ func (gui *Gui) newStringTaskWithKey(view *gocui.View, str string, key string) e
 	manager := gui.getManager(view)
 
 	f := func(stop chan struct{}) error {
-		gui.renderString(view, str)
-		return nil
+		return gui.renderString(view, str)
 	}
 
 	if err := manager.NewTask(f, key); err != nil {

--- a/pkg/gui/updates.go
+++ b/pkg/gui/updates.go
@@ -52,10 +52,14 @@ func (gui *Gui) startUpdating(newVersion string) {
 func (gui *Gui) onUpdateFinish(statusId int, err error) error {
 	gui.State.Updating = false
 	gui.statusManager.removeStatus(statusId)
-	gui.renderString(gui.Views.AppStatus, "")
-	if err != nil {
-		return gui.createErrorPanel("Update failed: " + err.Error())
-	}
+	gui.OnUIThread(func() error {
+		_ = gui.renderString(gui.Views.AppStatus, "")
+		if err != nil {
+			return gui.createErrorPanel("Update failed: " + err.Error())
+		}
+		return nil
+	})
+
 	return nil
 }
 

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -180,7 +180,7 @@ func (gui *Gui) refreshSidePanels(options refreshOptions) error {
 	}
 
 	if options.mode == BLOCK_UI {
-		gui.g.Update(func(g *gocui.Gui) error {
+		gui.OnUIThread(func() error {
 			f()
 			return nil
 		})
@@ -201,32 +201,19 @@ func (gui *Gui) cleanString(s string) string {
 	return utils.NormalizeLinefeeds(output)
 }
 
-func (gui *Gui) setViewContentSync(v *gocui.View, s string) {
+func (gui *Gui) setViewContent(v *gocui.View, s string) {
 	v.SetContent(gui.cleanString(s))
 }
 
-func (gui *Gui) setViewContent(v *gocui.View, s string) {
-	gui.g.Update(func(*gocui.Gui) error {
-		gui.setViewContentSync(v, s)
-		return nil
-	})
-}
-
 // renderString resets the origin of a view and sets its content
-func (gui *Gui) renderString(view *gocui.View, s string) {
-	gui.g.Update(func(*gocui.Gui) error {
-		return gui.renderStringSync(view, s)
-	})
-}
-
-func (gui *Gui) renderStringSync(view *gocui.View, s string) error {
+func (gui *Gui) renderString(view *gocui.View, s string) error {
 	if err := view.SetOrigin(0, 0); err != nil {
 		return err
 	}
 	if err := view.SetCursor(0, 0); err != nil {
 		return err
 	}
-	gui.setViewContentSync(view, s)
+	gui.setViewContent(view, s)
 	return nil
 }
 
@@ -240,7 +227,7 @@ func (gui *Gui) optionsMapToString(optionsMap map[string]string) string {
 }
 
 func (gui *Gui) renderOptionsMap(optionsMap map[string]string) {
-	gui.renderString(gui.Views.Options, gui.optionsMapToString(optionsMap))
+	_ = gui.renderString(gui.Views.Options, gui.optionsMapToString(optionsMap))
 }
 
 func (gui *Gui) currentViewName() string {
@@ -391,5 +378,5 @@ func getTabbedView(gui *Gui) *gocui.View {
 }
 
 func (gui *Gui) render() {
-	gui.g.Update(func(g *gocui.Gui) error { return nil })
+	gui.OnUIThread(func() error { return nil })
 }

--- a/pkg/i18n/chinese.go
+++ b/pkg/i18n/chinese.go
@@ -73,7 +73,6 @@ func chineseTranslationSet() TranslationSet {
 		PullWait:                            "拉取中……",
 		PushWait:                            "推送中……",
 		FetchWait:                           "正在抓取……",
-		FileNoMergeCons:                     "该文件没有合并冲突",
 		LcSoftReset:                         "软重置",
 		AlreadyCheckedOutBranch:             "您已经检出了这个分支",
 		SureForceCheckout:                   "您确定要强制检出吗？您将丢失所有本地更改",

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -44,7 +44,6 @@ func dutchTranslationSet() TranslationSet {
 		PullWait:                            "Pullen...",
 		PushWait:                            "Pushen...",
 		FetchWait:                           "Fetchen...",
-		FileNoMergeCons:                     "Dit bestand heeft geen merge conflicten",
 		LcSoftReset:                         "zacht reset",
 		AlreadyCheckedOutBranch:             "Je hebt deze branch al uitgecheckt",
 		SureForceCheckout:                   "Weet je zeker dat je het uitchecken wil forceren? Al je lokale verandering zullen worden verwijdert",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -58,7 +58,6 @@ type TranslationSet struct {
 	PullWait                            string
 	PushWait                            string
 	FetchWait                           string
-	FileNoMergeCons                     string
 	LcSoftReset                         string
 	AlreadyCheckedOutBranch             string
 	SureForceCheckout                   string
@@ -608,7 +607,6 @@ func EnglishTranslationSet() TranslationSet {
 		PullWait:                            "Pulling...",
 		PushWait:                            "Pushing...",
 		FetchWait:                           "Fetching...",
-		FileNoMergeCons:                     "This file has no inline merge conflicts",
 		LcSoftReset:                         "soft reset",
 		AlreadyCheckedOutBranch:             "You have already checked out this branch",
 		SureForceCheckout:                   "Are you sure you want force checkout? You will lose all local changes",

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -39,7 +39,6 @@ func polishTranslationSet() TranslationSet {
 		PullWait:                            "Pobieranie zmian...",
 		PushWait:                            "Wysyłanie zmian...",
 		FetchWait:                           "Pobieram...",
-		FileNoMergeCons:                     "Brak konfliktów scalania w pliku",
 		AlreadyCheckedOutBranch:             "Już przęłączono na tą gałąź",
 		SureForceCheckout:                   "Jesteś pewny, że chcesz wymusić przełączenie? Stracisz wszystkie lokalne zmiany",
 		ForceCheckoutBranch:                 "Wymuś przełączenie gałęzi",


### PR DESCRIPTION
We've been kind of abusing the gui.g.Update call and it's not necessary to be calling it so much. The call ensures that the callback is run on the main thread, but we've been using it to do various things e.g. 'refresh the screen after this' or 'do this asynchronously'. We should only really be calling it from within a go-routine, that wants to do some work on the UI thread. If we want to run something asynchronously, we should actually invoke a goroutine and then have that call gui.g.Update. I've wrapped that in a method called `gui.OnUIThread` so that it's unambiguous what we're doing.