### PR TITLE
do not show branch graph when in filtering mode

### DIFF
--- a/pkg/gui/list_context_config.go
+++ b/pkg/gui/list_context_config.go
@@ -229,6 +229,10 @@ func (gui *Gui) subCommitsListContext() IListContext {
 }
 
 func (gui *Gui) shouldShowGraph() bool {
+	if gui.State.Modes.Filtering.Active() {
+		return false
+	}
+
 	value := gui.UserConfig.Git.Log.ShowGraph
 	switch value {
 	case "always":


### PR DESCRIPTION
It looked pretty silly before!
![image](https://user-images.githubusercontent.com/8456633/149733486-000a3be9-2341-47b4-82db-8f77e88d3463.png)

After:
![image](https://user-images.githubusercontent.com/8456633/149733517-02aef484-a978-4398-b493-30e9eeca81ff.png)
