### PR TITLE
Improve merge conflict flow

### DIFF
--- a/pkg/commands/git_commands/submodule.go
+++ b/pkg/commands/git_commands/submodule.go
@@ -35,6 +35,7 @@ func (self *SubmoduleCommands) GetConfigs() ([]*models.SubmoduleConfig, error) {
 		}
 		return nil, err
 	}
+	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
 	scanner.Split(bufio.ScanLines)

--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/go-errors/errors"
@@ -40,8 +41,16 @@ func (self *WorkingTreeCommands) OpenMergeTool() error {
 }
 
 // StageFile stages a file
-func (self *WorkingTreeCommands) StageFile(fileName string) error {
-	return self.cmd.New("git add -- " + self.cmd.Quote(fileName)).Run()
+func (self *WorkingTreeCommands) StageFile(path string) error {
+	return self.StageFiles([]string{path})
+}
+
+func (self *WorkingTreeCommands) StageFiles(paths []string) error {
+	quotedPaths := make([]string, len(paths))
+	for i, path := range paths {
+		quotedPaths[i] = self.cmd.Quote(path)
+	}
+	return self.cmd.New(fmt.Sprintf("git add -- %s", strings.Join(quotedPaths, " "))).Run()
 }
 
 // StageAll stages all files

--- a/pkg/commands/git_commands/working_tree_test.go
+++ b/pkg/commands/git_commands/working_tree_test.go
@@ -23,6 +23,16 @@ func TestWorkingTreeStageFile(t *testing.T) {
 	runner.CheckForMissingCalls()
 }
 
+func TestWorkingTreeStageFiles(t *testing.T) {
+	runner := oscommands.NewFakeRunner(t).
+		Expect(`git add -- "test.txt" "test2.txt"`, "", nil)
+
+	instance := buildWorkingTreeCommands(commonDeps{runner: runner})
+
+	assert.NoError(t, instance.StageFiles([]string{"test.txt", "test2.txt"}))
+	runner.CheckForMissingCalls()
+}
+
 func TestWorkingTreeUnstageFile(t *testing.T) {
 	type scenario struct {
 		testName string

--- a/pkg/commands/loaders/files.go
+++ b/pkg/commands/loaders/files.go
@@ -59,8 +59,8 @@ func (self *FileLoader) GetStatusFiles(opts GetStatusFileOptions) []*models.File
 		unstagedChange := change[1:2]
 		untracked := utils.IncludesString([]string{"??", "A ", "AM"}, change)
 		hasNoStagedChanges := utils.IncludesString([]string{" ", "U", "?"}, stagedChange)
-		hasMergeConflicts := utils.IncludesString([]string{"DD", "AA", "UU", "AU", "UA", "UD", "DU"}, change)
 		hasInlineMergeConflicts := utils.IncludesString([]string{"UU", "AA"}, change)
+		hasMergeConflicts := hasInlineMergeConflicts || utils.IncludesString([]string{"DD", "AU", "UA", "UD", "DU"}, change)
 
 		file := &models.File{
 			Name:                    status.Name,

--- a/pkg/gui/context_config.go
+++ b/pkg/gui/context_config.go
@@ -167,7 +167,7 @@ func (gui *Gui) contextTree() ContextTree {
 			Key:      MAIN_PATCH_BUILDING_CONTEXT_KEY,
 		},
 		Merging: &BasicContext{
-			OnFocus:         OnFocusWrapper(gui.refreshMergePanelWithLock),
+			OnFocus:         OnFocusWrapper(gui.renderConflictsWithFocus),
 			Kind:            MAIN_CONTEXT,
 			ViewName:        "main",
 			Key:             MAIN_MERGING_CONTEXT_KEY,

--- a/pkg/gui/filetree/file_node_test.go
+++ b/pkg/gui/filetree/file_node_test.go
@@ -132,3 +132,32 @@ func TestCompress(t *testing.T) {
 		})
 	}
 }
+
+func TestGetFile(t *testing.T) {
+	scenarios := []struct {
+		name      string
+		viewModel *FileTreeViewModel
+		path      string
+		expected  *models.File
+	}{
+		{
+			name:      "valid case",
+			viewModel: NewFileTreeViewModel([]*models.File{{Name: "blah/one"}, {Name: "blah/two"}}, nil, false),
+			path:      "blah/two",
+			expected:  &models.File{Name: "blah/two"},
+		},
+		{
+			name:      "not found",
+			viewModel: NewFileTreeViewModel([]*models.File{{Name: "blah/one"}, {Name: "blah/two"}}, nil, false),
+			path:      "blah/three",
+			expected:  nil,
+		},
+	}
+
+	for _, s := range scenarios {
+		s := s
+		t.Run(s.name, func(t *testing.T) {
+			assert.EqualValues(t, s.expected, s.viewModel.GetFile(s.path))
+		})
+	}
+}

--- a/pkg/gui/filetree/file_tree_view_model.go
+++ b/pkg/gui/filetree/file_tree_view_model.go
@@ -86,6 +86,16 @@ func (self *FileTreeViewModel) GetItemAtIndex(index int) *FileNode {
 	return self.tree.GetNodeAtIndex(index+1, self.collapsedPaths) // ignoring root
 }
 
+func (self *FileTreeViewModel) GetFile(path string) *models.File {
+	for _, file := range self.files {
+		if file.Name == path {
+			return file
+		}
+	}
+
+	return nil
+}
+
 func (self *FileTreeViewModel) GetIndexForPath(path string) (int, bool) {
 	index, found := self.tree.GetIndexForPath(path, self.collapsedPaths)
 	return index - 1, found

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -115,7 +115,7 @@ func (gui *Gui) linesToScrollDown(view *gocui.View) int {
 }
 
 func (gui *Gui) scrollUpMain() error {
-	if gui.canScrollMergePanel() {
+	if gui.renderingConflicts() {
 		gui.State.Panels.Merging.UserVerticalScrolling = true
 	}
 
@@ -123,7 +123,7 @@ func (gui *Gui) scrollUpMain() error {
 }
 
 func (gui *Gui) scrollDownMain() error {
-	if gui.canScrollMergePanel() {
+	if gui.renderingConflicts() {
 		gui.State.Panels.Merging.UserVerticalScrolling = true
 	}
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -292,10 +292,11 @@ type guiState struct {
 	// managers for them which handle rendering a flat list of files in tree form
 	FileTreeViewModel       *filetree.FileTreeViewModel
 	CommitFileTreeViewModel *filetree.CommitFileTreeViewModel
-	Submodules              []*models.SubmoduleConfig
-	Branches                []*models.Branch
-	Commits                 []*models.Commit
-	StashEntries            []*models.StashEntry
+
+	Submodules   []*models.SubmoduleConfig
+	Branches     []*models.Branch
+	Commits      []*models.Commit
+	StashEntries []*models.StashEntry
 	// Suggestions will sometimes appear when typing into a prompt
 	Suggestions []*types.Suggestion
 	// FilteredReflogCommits are the ones that appear in the reflog panel.
@@ -304,13 +305,14 @@ type guiState struct {
 	// ReflogCommits are the ones used by the branches panel to obtain recency values
 	// if we're not in filtering mode, CommitFiles and FilteredReflogCommits will be
 	// one and the same
-	ReflogCommits     []*models.Commit
-	SubCommits        []*models.Commit
-	Remotes           []*models.Remote
-	RemoteBranches    []*models.RemoteBranch
-	Tags              []*models.Tag
-	MenuItems         []*menuItem
-	BisectInfo        *git_commands.BisectInfo
+	ReflogCommits  []*models.Commit
+	SubCommits     []*models.Commit
+	Remotes        []*models.Remote
+	RemoteBranches []*models.RemoteBranch
+	Tags           []*models.Tag
+	MenuItems      []*menuItem
+	BisectInfo     *git_commands.BisectInfo
+
 	Updating          bool
 	Panels            *panelStates
 	SplitMainPanel    bool

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1543,20 +1543,6 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		{
 			ViewName: "main",
 			Contexts: []string{string(MAIN_MERGING_CONTEXT_KEY)},
-			Key:      gocui.MouseWheelUp,
-			Modifier: gocui.ModNone,
-			Handler:  gui.handleSelectPrevConflictHunk,
-		},
-		{
-			ViewName: "main",
-			Contexts: []string{string(MAIN_MERGING_CONTEXT_KEY)},
-			Key:      gocui.MouseWheelDown,
-			Modifier: gocui.ModNone,
-			Handler:  gui.handleSelectNextConflictHunk,
-		},
-		{
-			ViewName: "main",
-			Contexts: []string{string(MAIN_MERGING_CONTEXT_KEY)},
 			Key:      gui.getKey(config.Universal.PrevBlockAlt),
 			Modifier: gocui.ModNone,
 			Handler:  gui.handleSelectPrevConflict,
@@ -1586,7 +1572,7 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			ViewName:    "main",
 			Contexts:    []string{string(MAIN_MERGING_CONTEXT_KEY)},
 			Key:         gui.getKey(config.Universal.Undo),
-			Handler:     gui.handlePopFileSnapshot,
+			Handler:     gui.handleMergeConflictUndo,
 			Description: gui.Tr.LcUndo,
 		},
 		{

--- a/pkg/gui/mergeconflicts/find_conflicts_test.go
+++ b/pkg/gui/mergeconflicts/find_conflicts_test.go
@@ -1,6 +1,7 @@
 package mergeconflicts
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,5 +58,44 @@ func TestDetermineLineType(t *testing.T) {
 
 	for _, s := range scenarios {
 		assert.EqualValues(t, s.expected, determineLineType(s.line))
+	}
+}
+
+func TestFindConflictsAux(t *testing.T) {
+	type scenario struct {
+		content  string
+		expected bool
+	}
+
+	scenarios := []scenario{
+		{
+			content:  "",
+			expected: false,
+		},
+		{
+			content:  "blah",
+			expected: false,
+		},
+		{
+			content:  ">>>>>>> ",
+			expected: true,
+		},
+		{
+			content:  "<<<<<<< ",
+			expected: true,
+		},
+		{
+			content:  " <<<<<<< ",
+			expected: false,
+		},
+		{
+			content:  "a\nb\nc\n<<<<<<< ",
+			expected: true,
+		},
+	}
+
+	for _, s := range scenarios {
+		reader := strings.NewReader(s.content)
+		assert.EqualValues(t, s.expected, fileHasConflictMarkersAux(reader))
 	}
 }

--- a/pkg/gui/mergeconflicts/rendering.go
+++ b/pkg/gui/mergeconflicts/rendering.go
@@ -8,7 +8,8 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
-func ColoredConflictFile(content string, state *State, hasFocus bool) string {
+func ColoredConflictFile(state *State, hasFocus bool) string {
+	content := state.GetContent()
 	if len(state.conflicts) == 0 {
 		return content
 	}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -507,6 +507,7 @@ type Actions struct {
 	DiscardAllChangesInFile           string
 	DiscardAllUnstagedChangesInFile   string
 	StageFile                         string
+	StageResolvedFiles                string
 	UnstageFile                       string
 	UnstageAllFiles                   string
 	StageAllFiles                     string
@@ -1064,6 +1065,7 @@ func EnglishTranslationSet() TranslationSet {
 			DiscardAllChangesInFile:           "Discard all changes in file",
 			DiscardAllUnstagedChangesInFile:   "Discard all unstaged changes in file",
 			StageFile:                         "Stage file",
+			StageResolvedFiles:                "Stage files whose merge conflicts were resolved",
 			UnstageFile:                       "Unstage file",
 			UnstageAllFiles:                   "Unstage all files",
 			StageAllFiles:                     "Stage all files",

--- a/test/integration/mergeConflicts/config/config.yml
+++ b/test/integration/mergeConflicts/config/config.yml
@@ -1,0 +1,5 @@
+disableStartupPopups: true
+gui:
+  showFileTree: false
+refresher:
+  refreshInterval: 1


### PR DESCRIPTION
this:
* fixes a bug where we were clearing the merge panel selection upon file refresh
* ensures that whenever a file's merge conflicts are resolved externally, we stage the file (and prompt to continue if all conflicts are resolved). Previously we only checked this if a given file was selected.

fixes https://github.com/jesseduffield/lazygit/issues/1325 and https://github.com/jesseduffield/lazygit/issues/1718