### PR TITLE
better locking of merge panel state

### DIFF
--- a/pkg/commands/git_cmd_obj_runner.go
+++ b/pkg/commands/git_cmd_obj_runner.go
@@ -1,9 +1,6 @@
 package commands
 
 import (
-	"strings"
-	"time"
-
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 	"github.com/sirupsen/logrus"
 )
@@ -21,27 +18,7 @@ func (self *gitCmdObjRunner) Run(cmdObj oscommands.ICmdObj) error {
 }
 
 func (self *gitCmdObjRunner) RunWithOutput(cmdObj oscommands.ICmdObj) (string, error) {
-	// TODO: have this retry logic in other places we run the command
-	waitTime := 50 * time.Millisecond
-	retryCount := 5
-	attempt := 0
-
-	for {
-		output, err := self.innerRunner.RunWithOutput(cmdObj)
-		if err != nil {
-			// if we have an error based on the index lock, we should wait a bit and then retry
-			if strings.Contains(output, ".git/index.lock") {
-				self.log.Error(output)
-				self.log.Info("index.lock prevented command from running. Retrying command after a small wait")
-				attempt++
-				time.Sleep(waitTime)
-				if attempt < retryCount {
-					continue
-				}
-			}
-		}
-		return output, err
-	}
+	return self.innerRunner.RunWithOutput(cmdObj)
 }
 
 func (self *gitCmdObjRunner) RunAndProcessLines(cmdObj oscommands.ICmdObj, onLine func(line string) (bool, error)) error {

--- a/pkg/gui/context_config.go
+++ b/pkg/gui/context_config.go
@@ -167,7 +167,7 @@ func (gui *Gui) contextTree() ContextTree {
 			Key:      MAIN_PATCH_BUILDING_CONTEXT_KEY,
 		},
 		Merging: &BasicContext{
-			OnFocus:         OnFocusWrapper(gui.renderConflictsWithFocus),
+			OnFocus:         OnFocusWrapper(func() error { return gui.renderConflictsWithLock(true) }),
 			Kind:            MAIN_CONTEXT,
 			ViewName:        "main",
 			Key:             MAIN_MERGING_CONTEXT_KEY,

--- a/pkg/gui/mergeconflicts/state.go
+++ b/pkg/gui/mergeconflicts/state.go
@@ -155,7 +155,13 @@ func (s *State) Active() bool {
 }
 
 func (s *State) GetConflictMiddle() int {
-	return s.currentConflict().target
+	currentConflict := s.currentConflict()
+
+	if currentConflict == nil {
+		return 0
+	}
+
+	return currentConflict.target
 }
 
 func (s *State) ContentAfterConflictResolve(selection Selection) (bool, string, error) {


### PR DESCRIPTION
Shouldn't have any race conditions now.

I'm also removing the index.lock check because it was raising a meaningless error message. I'll see if that comes up now though and if so we can reinstate it in a better way