### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ conda install -c conda-forge lazygit
 ### Go
 
 ```sh
-go get github.com/jesseduffield/lazygit
+go install github.com/jesseduffield/lazygit@latest
 ```
 
 Please note:


### PR DESCRIPTION
Use `go install` instead of `go get` to install as `$GOPATH/bin/lazygit`, since using `go get` to install binary is deprecated