### PR TITLE
Add configurable colors for branch prefixes

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -400,6 +400,16 @@ gui:
     '*': '#0000ff'
 ```
 
+## Custom Branch Color
+
+You can customize the color of branches based on the branch prefix:
+
+```yaml
+gui:
+  branchColors:
+    'docs': '#11aaff' # use a light blue for branches beginning with 'docs/'
+```
+
 ## Example Coloring
 
 ![border example](../../assets/colored-border-example.png)

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -25,6 +25,7 @@ type RefresherConfig struct {
 
 type GuiConfig struct {
 	AuthorColors             map[string]string  `yaml:"authorColors"`
+	BranchColors             map[string]string  `yaml:"branchColors"`
 	ScrollHeight             int                `yaml:"scrollHeight"`
 	ScrollPastBottom         bool               `yaml:"scrollPastBottom"`
 	MouseEvents              bool               `yaml:"mouseEvents"`

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -24,8 +24,8 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/modes/cherrypicking"
 	"github.com/jesseduffield/lazygit/pkg/gui/modes/diffing"
 	"github.com/jesseduffield/lazygit/pkg/gui/modes/filtering"
-	"github.com/jesseduffield/lazygit/pkg/gui/presentation/authors"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
+	"github.com/jesseduffield/lazygit/pkg/gui/presentation/authors"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation/graph"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
@@ -493,7 +493,7 @@ func NewGui(
 	gui.PopupHandler = &RealPopupHandler{gui: gui}
 
 	authors.SetCustomAuthors(gui.UserConfig.Gui.AuthorColors)
-	presentation.SetCustomBranchColors(gui.UserConfig.Gui.BranchColors)
+	presentation.SetCustomBranches(gui.UserConfig.Gui.BranchColors)
 
 	return gui, nil
 }

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/modes/diffing"
 	"github.com/jesseduffield/lazygit/pkg/gui/modes/filtering"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation/authors"
+	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation/graph"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
@@ -492,6 +493,7 @@ func NewGui(
 	gui.PopupHandler = &RealPopupHandler{gui: gui}
 
 	authors.SetCustomAuthors(gui.UserConfig.Gui.AuthorColors)
+	presentation.SetCustomBranchColors(gui.UserConfig.Gui.BranchColors)
 
 	return gui, nil
 }

--- a/pkg/gui/presentation/authors/authors.go
+++ b/pkg/gui/presentation/authors/authors.go
@@ -114,8 +114,5 @@ func getFirstRune(str string) rune {
 }
 
 func SetCustomAuthors(customAuthorColors map[string]string) {
-	for authorName, colorSequence := range customAuthorColors {
-		style := style.New().SetFg(style.NewRGBColor(color.HEX(colorSequence, false)))
-		authorStyleCache[authorName] = style
-	}
+	authorStyleCache = utils.SetCustomColors(customAuthorColors)
 }

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gookit/color"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/theme"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
-var branchPrefixColors = make(map[string]style.TextStyle)
+var branchPrefixColorCache = make(map[string]style.TextStyle)
 
 func GetBranchListDisplayStrings(branches []*models.Branch, fullDescription bool, diffName string) [][]string {
 	lines := make([][]string, len(branches))
@@ -61,7 +61,7 @@ func getBranchDisplayStrings(b *models.Branch, fullDescription bool, diffed bool
 func GetBranchTextStyle(name string) style.TextStyle {
 	branchType := strings.Split(name, "/")[0]
 
-	if value, ok := branchPrefixColors[branchType]; ok {
+	if value, ok := branchPrefixColorCache[branchType]; ok {
 		return value
 	}
 
@@ -92,9 +92,6 @@ func BranchStatus(branch *models.Branch) string {
 	return fmt.Sprintf("↑%s↓%s", branch.Pushables, branch.Pullables)
 }
 
-func SetCustomBranchColors(customBranchColors map[string]string) {
-	for branchPrefix, colorSequence := range customBranchColors {
-		style := style.New().SetFg(style.NewRGBColor(color.HEX(colorSequence, false)))
-		branchPrefixColors[branchPrefix] = style
-	}
+func SetCustomBranches(customBranchColors map[string]string) {
+	branchPrefixColorCache = utils.SetCustomColors(customBranchColors)
 }

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gookit/color"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/theme"
 )
+
+var branchPrefixColors = make(map[string]style.TextStyle)
 
 func GetBranchListDisplayStrings(branches []*models.Branch, fullDescription bool, diffName string) [][]string {
 	lines := make([][]string, len(branches))
@@ -58,6 +61,10 @@ func getBranchDisplayStrings(b *models.Branch, fullDescription bool, diffed bool
 func GetBranchTextStyle(name string) style.TextStyle {
 	branchType := strings.Split(name, "/")[0]
 
+	if value, ok := branchPrefixColors[branchType]; ok {
+		return value
+	}
+
 	switch branchType {
 	case "feature":
 		return style.FgGreen
@@ -83,4 +90,11 @@ func ColoredBranchStatus(branch *models.Branch) string {
 
 func BranchStatus(branch *models.Branch) string {
 	return fmt.Sprintf("↑%s↓%s", branch.Pushables, branch.Pullables)
+}
+
+func SetCustomBranchColors(customBranchColors map[string]string) {
+	for branchPrefix, colorSequence := range customBranchColors {
+		style := style.New().SetFg(style.NewRGBColor(color.HEX(colorSequence, false)))
+		branchPrefixColors[branchPrefix] = style
+	}
 }

--- a/pkg/utils/color.go
+++ b/pkg/utils/color.go
@@ -3,6 +3,9 @@ package utils
 import (
 	"regexp"
 	"sync"
+
+	"github.com/gookit/color"
+	"github.com/jesseduffield/lazygit/pkg/gui/style"
 )
 
 var decoloriseCache = make(map[string]string)
@@ -47,4 +50,13 @@ func IsValidHexValue(v string) bool {
 	}
 
 	return true
+}
+
+func SetCustomColors(customColors map[string]string) map[string]style.TextStyle {
+	colors := make(map[string]style.TextStyle)
+	for key, colorSequence := range customColors {
+		style := style.New().SetFg(style.NewRGBColor(color.HEX(colorSequence, false)))
+		colors[key] = style
+	}
+	return colors
 }


### PR DESCRIPTION
Branches can now be colored based on their prefix, if it matches
a user defined prefix in the config file. If no user defined
prefix matches, then it will fallback to the defaults: green for
'feature', yellow for 'bugfix', and red for 'hotfix'. All
remaining branches will be set to the default text color.