### PR TITLE
Support line offset for most common editors by default

### DIFF
--- a/pkg/commands/git_commands/file.go
+++ b/pkg/commands/git_commands/file.go
@@ -66,7 +66,7 @@ func (self *FileCommands) GetEditCmdStr(filename string, lineNumber int) (string
 		case "subl":
 			editCmdTemplate = "{{editor}} {{filename}}:{{line}}"
 		case "code":
-			editCmdTemplate = "{{editor}} --goto {{filename}}:{{line}}"
+			editCmdTemplate = "{{editor}} -r --goto {{filename}}:{{line}}"
 		}
 	}
 	return utils.ResolvePlaceholderString(editCmdTemplate, templateValues), nil

--- a/pkg/commands/git_commands/file.go
+++ b/pkg/commands/git_commands/file.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/go-errors/errors"
+	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
@@ -58,7 +59,7 @@ func (self *FileCommands) GetEditCmdStr(filename string, lineNumber int) (string
 	}
 
 	editCmdTemplate := self.UserConfig.OS.EditCommandTemplate
-	if editCmdTemplate == "{{editor}} {{filename}}" {
+	if editCmdTemplate == config.DefaultEditCommandTemplate {
 		switch editor {
 		case "emacs", "nano", "vi", "vim":
 			editCmdTemplate = "{{editor}} +{{line}} {{filename}}"

--- a/pkg/commands/git_commands/file.go
+++ b/pkg/commands/git_commands/file.go
@@ -58,5 +58,15 @@ func (self *FileCommands) GetEditCmdStr(filename string, lineNumber int) (string
 	}
 
 	editCmdTemplate := self.UserConfig.OS.EditCommandTemplate
+	if editCmdTemplate == "{{editor}} {{filename}}" {
+		switch editor {
+		case "emacs", "nano", "vi", "vim":
+			editCmdTemplate = "{{editor}} +{{line}} {{filename}}"
+		case "subl":
+			editCmdTemplate = "{{editor}} {{filename}}:{{line}}"
+		case "code":
+			editCmdTemplate = "{{editor}} --goto {{filename}}:{{line}}"
+		}
+	}
 	return utils.ResolvePlaceholderString(editCmdTemplate, templateValues), nil
 }

--- a/pkg/commands/git_commands/file_test.go
+++ b/pkg/commands/git_commands/file_test.go
@@ -47,7 +47,7 @@ func TestEditFileCmdStr(t *testing.T) {
 			gitConfigMockResponses: nil,
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, `nano "test"`, cmdStr)
+				assert.Equal(t, `nano +1 "test"`, cmdStr)
 			},
 		},
 		{
@@ -61,7 +61,7 @@ func TestEditFileCmdStr(t *testing.T) {
 			gitConfigMockResponses: map[string]string{"core.editor": "nano"},
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, `nano "test"`, cmdStr)
+				assert.Equal(t, `nano +1 "test"`, cmdStr)
 			},
 		},
 		{
@@ -79,6 +79,7 @@ func TestEditFileCmdStr(t *testing.T) {
 			gitConfigMockResponses: nil,
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
+				assert.Equal(t, `nano +1 "test"`, cmdStr)
 			},
 		},
 		{
@@ -96,7 +97,7 @@ func TestEditFileCmdStr(t *testing.T) {
 			gitConfigMockResponses: nil,
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, `emacs "test"`, cmdStr)
+				assert.Equal(t, `emacs +1 "test"`, cmdStr)
 			},
 		},
 		{
@@ -111,7 +112,7 @@ func TestEditFileCmdStr(t *testing.T) {
 			gitConfigMockResponses: nil,
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, `vi "test"`, cmdStr)
+				assert.Equal(t, `vi +1 "test"`, cmdStr)
 			},
 		},
 		{
@@ -126,7 +127,7 @@ func TestEditFileCmdStr(t *testing.T) {
 			gitConfigMockResponses: nil,
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, `vi "file/with space"`, cmdStr)
+				assert.Equal(t, `vi +1 "file/with space"`, cmdStr)
 			},
 		},
 		{

--- a/pkg/config/config_default_platform.go
+++ b/pkg/config/config_default_platform.go
@@ -3,11 +3,13 @@
 
 package config
 
+const DefaultEditCommandTemplate = `{{editor}} {{filename}}`
+
 // GetPlatformDefaultConfig gets the defaults for the platform
 func GetPlatformDefaultConfig() OSConfig {
 	return OSConfig{
 		EditCommand:         ``,
-		EditCommandTemplate: `{{editor}} {{filename}}`,
+		EditCommandTemplate: DefaultEditCommandTemplate,
 		OpenCommand:         "open {{filename}}",
 		OpenLinkCommand:     "open {{link}}",
 	}

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -1,10 +1,12 @@
 package config
 
+const DefaultEditCommandTemplate = `{{editor}} {{filename}}`
+
 // GetPlatformDefaultConfig gets the defaults for the platform
 func GetPlatformDefaultConfig() OSConfig {
 	return OSConfig{
 		EditCommand:         ``,
-		EditCommandTemplate: `{{editor}} {{filename}}`,
+		EditCommandTemplate: DefaultEditCommandTemplate,
 		OpenCommand:         `xdg-open {{filename}} >/dev/null`,
 		OpenLinkCommand:     `xdg-open {{link}} >/dev/null`,
 	}

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -1,10 +1,12 @@
 package config
 
+const DefaultEditCommandTemplate = `{{editor}} {{filename}}`
+
 // GetPlatformDefaultConfig gets the defaults for the platform
 func GetPlatformDefaultConfig() OSConfig {
 	return OSConfig{
 		EditCommand:         ``,
-		EditCommandTemplate: `{{editor}} {{filename}}`,
+		EditCommandTemplate: DefaultEditCommandTemplate,
 		OpenCommand:         `start "" {{filename}}`,
 		OpenLinkCommand:     `start "" {{link}}`,
 	}


### PR DESCRIPTION
This should close #1671 .

I am not sure about the `subl` and `code` being cross platform since I only have linux at disposal, so I'm looking forward to hearing an idea.