### PR TITLE
Detect and display deleted upstream branches

### DIFF
--- a/pkg/commands/loaders/branches_test.go
+++ b/pkg/commands/loaders/branches_test.go
@@ -1,0 +1,73 @@
+package loaders
+
+// "*|feat/detect-purge|origin/feat/detect-purge|[ahead 1]"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObtainBranchTrimHeads(t *testing.T) {
+	// Given
+	split := []string{"", "heads/a_branch", "", ""}
+
+	// When
+	branch := obtainBranch(split)
+
+	// Then
+	assert.EqualValues(t, "a_branch", branch.Name)
+}
+
+func TestObtainBranchNoUpstream(t *testing.T) {
+	// Given
+	split := []string{"", "a_branch", "", ""}
+
+	// When
+	branch := obtainBranch(split)
+
+	// Then
+	// We get the default values for pullables and pushables i.e. "?"
+	assert.EqualValues(t, "a_branch", branch.Name)
+	assert.EqualValues(t, false, branch.Head)
+	assert.EqualValues(t, "?", branch.Pushables)
+	assert.EqualValues(t, "?", branch.Pullables)
+}
+
+func TestObtainBranchIsHead(t *testing.T) {
+	// Given
+	split := []string{"*", "", "", ""}
+
+	// When
+	branch := obtainBranch(split)
+
+	// Then
+	assert.EqualValues(t, true, branch.Head)
+}
+
+func TestObtainBranchIsBehindAndAhead(t *testing.T) {
+	// Given
+	split := []string{"", "a_branch", "a_remote/a_branch", "[behind 2, ahead 3]"}
+
+	// When
+	branch := obtainBranch(split)
+
+	// Then
+	assert.EqualValues(t, "a_branch", branch.Name)
+	assert.EqualValues(t, false, branch.Head)
+	assert.EqualValues(t, "2", branch.Pullables)
+	assert.EqualValues(t, "3", branch.Pushables)
+}
+
+func TestObtainBranchDeletedInRemote(t *testing.T) {
+	// Given
+	split := []string{"", "a_branch", "a_remote/a_branch", "[gone]"}
+
+	// When
+	branch := obtainBranch(split)
+
+	// Then
+	assert.EqualValues(t, "a_branch", branch.Name)
+	assert.EqualValues(t, false, branch.Head)
+	assert.EqualValues(t, "d", branch.Pullables)
+	assert.EqualValues(t, "?", branch.Pushables)
+}

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -81,7 +81,7 @@ func ColoredBranchStatus(branch *models.Branch) string {
 	colour := style.FgYellow
 	if branch.MatchesUpstream() {
 		colour = style.FgGreen
-	} else if !branch.IsTrackingRemote() {
+	} else if !branch.IsTrackingRemote() || branch.Pullables == "d" {
 		colour = style.FgRed
 	}
 


### PR DESCRIPTION
- It is a common occurrence for the upstream tracked instance of a branch
  to be deleted while the local instance still exists e.g. when a pull
  request created from a feature branch is deleted.
  Detect this occurence and display a red '?'+'d' as the status for the
  branch.
- Addresses #1797 