### PR TITLE
Use editFileAtLine method for line by line panel

### DIFF
--- a/pkg/gui/line_by_line_panel.go
+++ b/pkg/gui/line_by_line_panel.go
@@ -1,8 +1,6 @@
 package gui
 
 import (
-	"fmt"
-
 	"github.com/go-errors/errors"
 	"github.com/jesseduffield/lazygit/pkg/commands/patch"
 	"github.com/jesseduffield/lazygit/pkg/gui/lbl"
@@ -217,8 +215,7 @@ func (gui *Gui) handleOpenFileAtLine() error {
 
 		// need to look at current index, then work out what my hunk's header information is, and see how far my line is away from the hunk header
 		lineNumber := state.CurrentLineNumber()
-		filenameWithLineNum := fmt.Sprintf("%s:%d", filename, lineNumber)
-		if err := gui.OSCommand.OpenFile(filenameWithLineNum); err != nil {
+		if err := gui.editFileAtLine(filename, lineNumber); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
We were not using the `gui.editFileAtLine` method on the line by line panel which handles opening a file at a given line properly.

Fixes #1784 