### PR TITLE
pkg/updates: Fix resource availability check in Updater

### DIFF
--- a/pkg/updates/updates.go
+++ b/pkg/updates/updates.go
@@ -329,7 +329,6 @@ func (u *Updater) verifyResourceFound(rawUrl string) bool {
 	}
 	defer resp.Body.Close()
 	u.Log.Info("Received status code ", resp.StatusCode)
-	// 403 means the resource is there (not going to bother adding extra request headers)
-	// 404 means its not
-	return resp.StatusCode == 403
+	// OK (200) indicates that the resource is present.
+	return resp.StatusCode == http.StatusOK
 }


### PR DESCRIPTION
When trying to download an update, a 'Could not find any binary at ...' error
message is shown erroneously. This happens since when checking the availability,
a response code of 403 ('Forbidden') instead of 200 ('OK') is expected. Since
'http.Head()' handles redirects automatically, there is no need to also accept
3xx status codes.

Fixes #1450.