### PR TITLE
Show confirmation prompt upon attempting to reword in editor

### DIFF
--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -267,18 +267,24 @@ func (self *LocalCommitsController) rewordEditor(commit *models.Commit) error {
 		return nil
 	}
 
-	self.c.LogAction(self.c.Tr.Actions.RewordCommit)
-	subProcess, err := self.git.Rebase.RewordCommitInEditor(
-		self.model.Commits, self.context().GetSelectedLineIdx(),
-	)
-	if err != nil {
-		return self.c.Error(err)
-	}
-	if subProcess != nil {
-		return self.c.RunSubprocessAndRefresh(subProcess)
-	}
+	return self.c.Ask(types.AskOpts{
+		Title:  self.c.Tr.RewordInEditorTitle,
+		Prompt: self.c.Tr.RewordInEditorPrompt,
+		HandleConfirm: func() error {
+			self.c.LogAction(self.c.Tr.Actions.RewordCommit)
+			subProcess, err := self.git.Rebase.RewordCommitInEditor(
+				self.model.Commits, self.context().GetSelectedLineIdx(),
+			)
+			if err != nil {
+				return self.c.Error(err)
+			}
+			if subProcess != nil {
+				return self.c.RunSubprocessAndRefresh(subProcess)
+			}
 
-	return nil
+			return nil
+		},
+	})
 }
 
 func (self *LocalCommitsController) drop(commit *models.Commit) error {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -454,6 +454,8 @@ type TranslationSet struct {
 	LcOpenCommitInBrowser               string
 	LcViewBisectOptions                 string
 	ConfirmRevertCommit                 string
+	RewordInEditorTitle                 string
+	RewordInEditorPrompt                string
 	Actions                             Actions
 	Bisect                              Bisect
 }
@@ -1027,6 +1029,9 @@ func EnglishTranslationSet() TranslationSet {
 		LcOpenCommitInBrowser:               "open commit in browser",
 		LcViewBisectOptions:                 "view bisect options",
 		ConfirmRevertCommit:                 "Are you sure you want to revert {{.selectedCommit}}?",
+		RewordInEditorTitle:                 "Reword in editor",
+		RewordInEditorPrompt:                "Are you sure you want to reword this commit in your editor?",
+
 		Actions: Actions{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)
 			CheckoutCommit:                    "Checkout commit",


### PR DESCRIPTION
We should always ask the user to confirm if they press a keybinding that will take them out of lazygit.