### PR TITLE
updater: Show popup on success / Make strings translatable

### DIFF
--- a/pkg/gui/popup/popup_handler.go
+++ b/pkg/gui/popup/popup_handler.go
@@ -85,6 +85,10 @@ func (self *RealPopupHandler) ErrorMsg(message string) error {
 	})
 }
 
+func (self *RealPopupHandler) Alert(title string, message string) error {
+	return self.Ask(types.AskOpts{Title: title, Prompt: message})
+}
+
 func (self *RealPopupHandler) Ask(opts types.AskOpts) error {
 	self.Lock()
 	self.index++
@@ -147,7 +151,7 @@ func (self *RealPopupHandler) WithLoaderPanel(message string, f func() error) er
 }
 
 // returns the content that has currently been typed into the prompt. Useful for
-// asyncronously updating the suggestions list under the prompt.
+// asynchronously updating the suggestions list under the prompt.
 func (self *RealPopupHandler) GetPromptInput() string {
 	return self.getPromptInputFn()
 }
@@ -166,6 +170,10 @@ func (self *TestPopupHandler) Error(err error) error {
 
 func (self *TestPopupHandler) ErrorMsg(message string) error {
 	return self.OnErrorMsg(message)
+}
+
+func (self *TestPopupHandler) Alert(title string, message string) error {
+	panic("not yet implemented")
 }
 
 func (self *TestPopupHandler) Ask(opts types.AskOpts) error {

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -50,6 +50,10 @@ type IGuiCommon interface {
 type IPopupHandler interface {
 	ErrorMsg(message string) error
 	Error(err error) error
+	// Shows a notification popup with the given title and message to the user.
+	//
+	// This is a convenience wrapper around Ask(), thus the popup can be closed using both 'Enter' and 'ESC'.
+	Alert(title string, message string) error
 	Ask(opts AskOpts) error
 	Prompt(opts PromptOpts) error
 	WithLoaderPanel(message string, f func() error) error

--- a/pkg/gui/updates.go
+++ b/pkg/gui/updates.go
@@ -68,7 +68,7 @@ func (gui *Gui) onUpdateFinish(statusId int, err error) error {
 			)
 			return gui.c.ErrorMsg(errMessage)
 		}
-		return nil
+		return gui.c.Alert(gui.Tr.UpdateCompletedTitle, gui.Tr.UpdateCompleted)
 	})
 
 	return nil

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -132,6 +132,8 @@ type TranslationSet struct {
 	UpdateAvailableTitle                string
 	UpdateAvailable                     string
 	UpdateInProgressWaitingStatus       string
+	UpdateCompletedTitle                string
+	UpdateCompleted                     string
 	FailedToRetrieveLatestVersionErr    string
 	OnLatestVersionErr                  string
 	MajorVersionErr                     string
@@ -729,6 +731,8 @@ func EnglishTranslationSet() TranslationSet {
 		UpdateAvailableTitle:                "Update available!",
 		UpdateAvailable:                     "Download and install version {{.newVersion}}?",
 		UpdateInProgressWaitingStatus:       "updating",
+		UpdateCompletedTitle:                "Update completed!",
+		UpdateCompleted:                     "Update has been installed successfully. Restart lazygit for it to take effect.",
 		FailedToRetrieveLatestVersionErr:    "Failed to retrieve version information",
 		OnLatestVersionErr:                  "You already have the latest version",
 		MajorVersionErr:                     "New version ({{.newVersion}}) has non-backwards compatible changes compared to the current version ({{.currentVersion}})",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -129,9 +129,16 @@ type TranslationSet struct {
 	UpdatesRejectedAndForcePushDisabled string
 	LcCheckForUpdate                    string
 	CheckingForUpdates                  string
+	UpdateAvailableTitle                string
+	UpdateAvailable                     string
+	UpdateInProgressWaitingStatus       string
+	FailedToRetrieveLatestVersionErr    string
 	OnLatestVersionErr                  string
 	MajorVersionErr                     string
 	CouldNotFindBinaryErr               string
+	UpdateFailedErr                     string
+	ConfirmQuitDuringUpdateTitle        string
+	ConfirmQuitDuringUpdate             string
 	MergeToolTitle                      string
 	MergeToolPrompt                     string
 	IntroPopupMessage                   string
@@ -719,9 +726,16 @@ func EnglishTranslationSet() TranslationSet {
 		UpdatesRejectedAndForcePushDisabled: "Updates were rejected and you have disabled force pushing",
 		LcCheckForUpdate:                    "check for update",
 		CheckingForUpdates:                  "Checking for updates...",
+		UpdateAvailableTitle:                "Update available!",
+		UpdateAvailable:                     "Download and install version {{.newVersion}}?",
+		UpdateInProgressWaitingStatus:       "updating",
+		FailedToRetrieveLatestVersionErr:    "Failed to retrieve version information",
 		OnLatestVersionErr:                  "You already have the latest version",
 		MajorVersionErr:                     "New version ({{.newVersion}}) has non-backwards compatible changes compared to the current version ({{.currentVersion}})",
 		CouldNotFindBinaryErr:               "Could not find any binary at {{.url}}",
+		UpdateFailedErr:                     "Update failed: {{.errMessage}}",
+		ConfirmQuitDuringUpdateTitle:        "Currently Updating",
+		ConfirmQuitDuringUpdate:             "An update is in progress. Are you sure you want to quit?",
 		MergeToolTitle:                      "Merge tool",
 		MergeToolPrompt:                     "Are you sure you want to open `git mergetool`?",
 		IntroPopupMessage:                   englishIntroPopupMessage,


### PR DESCRIPTION
- Add support for 'notification' popups
- Make user-facing strings in the updater translatable
- Show notification popup when update was successful

See commit messages for details. This PR is based on a discussion in [PR 1816](https://github.com/jesseduffield/lazygit/pull/1816#issuecomment-1072971836).