### PR TITLE
config: Add option 'git.autoRefresh' to en-/disable auto-refresh

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -86,7 +86,7 @@ os:
   openCommand: ''
 refresher:
   refreshInterval: 10 # File/submodule refresh interval in seconds. Auto-refresh can be disabled via option 'git.autoRefresh'.
-  fetchInterval: 60 # re-fetch interval in seconds
+  fetchInterval: 60 # Re-fetch interval in seconds. Auto-fetch can be disabled via option 'git.autoFetch'.
 update:
   method: prompt # can be: prompt | background | never
   days: 14 # how often an update is checked for

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -73,6 +73,7 @@ git:
     showGraph: 'when-maximised'
   skipHookPrefix: WIP
   autoFetch: true
+  autoRefresh: true
   branchLogCmd: 'git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --'
   allBranchesLogCmd: 'git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium'
   overrideGpg: false # prevents lazygit from spawning a separate process when using GPG
@@ -84,7 +85,7 @@ os:
   editCommandTemplate: '{{editor}} {{filename}}'
   openCommand: ''
 refresher:
-  refreshInterval: 10 # file/submodule refresh interval in seconds
+  refreshInterval: 10 # File/submodule refresh interval in seconds. Auto-refresh can be disabled via option 'git.autoRefresh'.
   fetchInterval: 60 # re-fetch interval in seconds
 update:
   method: prompt # can be: prompt | background | never

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -68,6 +68,7 @@ type GitConfig struct {
 	Merging             MergingConfig                 `yaml:"merging"`
 	SkipHookPrefix      string                        `yaml:"skipHookPrefix"`
 	AutoFetch           bool                          `yaml:"autoFetch"`
+	AutoRefresh         bool                          `yaml:"autoRefresh"`
 	BranchLogCmd        string                        `yaml:"branchLogCmd"`
 	AllBranchesLogCmd   string                        `yaml:"allBranchesLogCmd"`
 	OverrideGpg         bool                          `yaml:"overrideGpg"`
@@ -373,6 +374,7 @@ func GetDefaultConfig() *UserConfig {
 			},
 			SkipHookPrefix:      "WIP",
 			AutoFetch:           true,
+			AutoRefresh:         true,
 			BranchLogCmd:        "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",
 			AllBranchesLogCmd:   "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium",
 			DisableForcePushing: false,

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -587,7 +587,16 @@ func (gui *Gui) Run(filterPath string) error {
 		go utils.Safe(gui.startBackgroundFetch)
 	}
 
-	gui.goEvery(time.Second*time.Duration(userConfig.Refresher.RefreshInterval), gui.stopChan, gui.refreshFilesAndSubmodules)
+	if userConfig.Git.AutoRefresh {
+		refreshInterval := userConfig.Refresher.RefreshInterval
+		if refreshInterval > 0 {
+			gui.goEvery(time.Second*time.Duration(refreshInterval), gui.stopChan, gui.refreshFilesAndSubmodules)
+		} else {
+			gui.c.Log.Errorf(
+				"Value of config option 'refresher.refreshInterval' (%d) is invalid, disabling auto-refresh",
+				refreshInterval)
+		}
+	}
 
 	gui.c.Log.Info("starting main loop")
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -583,8 +583,16 @@ func (gui *Gui) Run(filterPath string) error {
 	}
 
 	gui.waitForIntro.Add(1)
-	if gui.c.UserConfig.Git.AutoFetch {
-		go utils.Safe(gui.startBackgroundFetch)
+
+	if userConfig.Git.AutoFetch {
+		fetchInterval := userConfig.Refresher.FetchInterval
+		if fetchInterval > 0 {
+			go utils.Safe(gui.startBackgroundFetch)
+		} else {
+			gui.c.Log.Errorf(
+				"Value of config option 'refresher.fetchInterval' (%d) is invalid, disabling auto-fetch",
+				fetchInterval)
+		}
 	}
 
 	if userConfig.Git.AutoRefresh {


### PR DESCRIPTION
Adds a new 'autoRefresh' option to the 'git' config section that allows user to disable auto-refresh (defaults to on). If auto-refresh is enabled, the refreshInterval is now checked before starting the timer to prevent crashes when it is non-positive.

Also, the fetchInterval is now checked to ensure we don't crash if it is non-positive.

Fixes #1417