### PR TITLE
add keybindings to menus

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -189,9 +189,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>v</kbd>: toggle drag select
   <kbd>V</kbd>: toggle drag select
   <kbd>a</kbd>: toggle select hunk
-  <kbd>c</kbd>: commit changes
-  <kbd>w</kbd>: commit changes without pre-commit hook
-  <kbd>C</kbd>: commit changes using git editor
 </pre>
 
 ## Reflog

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -227,9 +227,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>v</kbd>: toggle drag selecteer
   <kbd>V</kbd>: toggle drag selecteer
   <kbd>a</kbd>: toggle selecteer hunk
-  <kbd>c</kbd>: commit veranderingen
-  <kbd>w</kbd>: commit veranderingen zonder pre-commit hook
-  <kbd>C</kbd>: commit veranderingen met de git editor
 </pre>
 
 ## Stash

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -168,9 +168,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>v</kbd>: toggle drag select
   <kbd>V</kbd>: toggle drag select
   <kbd>a</kbd>: toggle select hunk
-  <kbd>c</kbd>: Zatwierdź zmiany
-  <kbd>w</kbd>: zatwierdź zmiany bez skryptu pre-commit
-  <kbd>C</kbd>: Zatwierdź zmiany używając edytora
 </pre>
 
 ## Reflog

--- a/docs/keybindings/Keybindings_zh.md
+++ b/docs/keybindings/Keybindings_zh.md
@@ -236,9 +236,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>v</kbd>: 切换拖动选择
   <kbd>V</kbd>: 切换拖动选择
   <kbd>a</kbd>: 切换选择区块
-  <kbd>c</kbd>: 提交更改
-  <kbd>w</kbd>: 提交更改而无需预先提交钩子
-  <kbd>C</kbd>: 提交更改（使用编辑器编辑提交信息）
 </pre>
 
 ## 正常

--- a/pkg/cheatsheet/generate.go
+++ b/pkg/cheatsheet/generate.go
@@ -17,7 +17,7 @@ import (
 	"github.com/jesseduffield/generics/slices"
 	"github.com/jesseduffield/lazygit/pkg/app"
 	"github.com/jesseduffield/lazygit/pkg/config"
-	"github.com/jesseduffield/lazygit/pkg/gui"
+	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/i18n"
 	"github.com/jesseduffield/lazygit/pkg/integration"
@@ -135,7 +135,7 @@ func getBindingSections(bindings []*types.Binding, tr *i18n.TranslationSet) []*b
 		bindingsByHeader,
 		func(header header, hBindings []*types.Binding) headerWithBindings {
 			uniqBindings := lo.UniqBy(hBindings, func(binding *types.Binding) string {
-				return binding.Description + gui.GetKeyDisplay(binding.Key)
+				return binding.Description + keybindings.GetKeyDisplay(binding.Key)
 			})
 
 			return headerWithBindings{
@@ -203,10 +203,10 @@ func formatBinding(binding *types.Binding) string {
 	if binding.Alternative != "" {
 		return fmt.Sprintf(
 			"  <kbd>%s</kbd>: %s (%s)\n",
-			gui.GetKeyDisplay(binding.Key),
+			keybindings.GetKeyDisplay(binding.Key),
 			binding.Description,
 			binding.Alternative,
 		)
 	}
-	return fmt.Sprintf("  <kbd>%s</kbd>: %s\n", gui.GetKeyDisplay(binding.Key), binding.Description)
+	return fmt.Sprintf("  <kbd>%s</kbd>: %s\n", keybindings.GetKeyDisplay(binding.Key), binding.Description)
 }

--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -88,7 +88,7 @@ func (self *MenuViewModel) GetDisplayStrings(_startIdx int, _length int) [][]str
 	return slices.Map(self.menuItems, func(item *types.MenuItem) []string {
 		displayStrings := getItemDisplayStrings(item)
 		if showKeys {
-			displayStrings = slices.Prepend(displayStrings, style.FgYellow.Sprint(keybindings.GetKeyDisplay(item.Key)))
+			displayStrings = slices.Prepend(displayStrings, style.FgCyan.Sprint(keybindings.GetKeyDisplay(item.Key)))
 		}
 		return displayStrings
 	})

--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -5,6 +5,7 @@ import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
+	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 )
 
@@ -87,7 +88,7 @@ func (self *MenuViewModel) GetDisplayStrings(_startIdx int, _length int) [][]str
 	return slices.Map(self.menuItems, func(item *types.MenuItem) []string {
 		displayStrings := getItemDisplayStrings(item)
 		if showKeys {
-			displayStrings = slices.Prepend(displayStrings, keybindings.GetKeyDisplay(item.Key))
+			displayStrings = slices.Prepend(displayStrings, style.FgYellow.Sprint(keybindings.GetKeyDisplay(item.Key)))
 		}
 		return displayStrings
 	})

--- a/pkg/gui/controllers/basic_commits_controller.go
+++ b/pkg/gui/controllers/basic_commits_controller.go
@@ -103,24 +103,28 @@ func (self *BasicCommitsController) copyCommitAttribute(commit *models.Commit) e
 				OnPress: func() error {
 					return self.copyCommitSHAToClipboard(commit)
 				},
+				Key: 's',
 			},
 			{
 				DisplayString: self.c.Tr.LcCommitURL,
 				OnPress: func() error {
 					return self.copyCommitURLToClipboard(commit)
 				},
+				Key: 'u',
 			},
 			{
 				DisplayString: self.c.Tr.LcCommitDiff,
 				OnPress: func() error {
 					return self.copyCommitDiffToClipboard(commit)
 				},
+				Key: 'd',
 			},
 			{
 				DisplayString: self.c.Tr.LcCommitMessage,
 				OnPress: func() error {
 					return self.copyCommitMessageToClipboard(commit)
 				},
+				Key: 'm',
 			},
 		},
 	})

--- a/pkg/gui/controllers/bisect_controller.go
+++ b/pkg/gui/controllers/bisect_controller.go
@@ -76,6 +76,7 @@ func (self *BisectController) openMidBisectMenu(info *git_commands.BisectInfo, c
 
 				return self.afterMark(selectCurrentAfter, waitToReselect)
 			},
+			Key: 'b',
 		},
 		{
 			DisplayString: fmt.Sprintf(self.c.Tr.Bisect.Mark, commit.ShortSha(), info.OldTerm()),
@@ -87,6 +88,7 @@ func (self *BisectController) openMidBisectMenu(info *git_commands.BisectInfo, c
 
 				return self.afterMark(selectCurrentAfter, waitToReselect)
 			},
+			Key: 'g',
 		},
 		{
 			DisplayString: fmt.Sprintf(self.c.Tr.Bisect.Skip, commit.ShortSha()),
@@ -98,12 +100,14 @@ func (self *BisectController) openMidBisectMenu(info *git_commands.BisectInfo, c
 
 				return self.afterMark(selectCurrentAfter, waitToReselect)
 			},
+			Key: 's',
 		},
 		{
 			DisplayString: self.c.Tr.Bisect.ResetOption,
 			OnPress: func() error {
 				return self.helpers.Bisect.Reset()
 			},
+			Key: 'r',
 		},
 	}
 
@@ -131,6 +135,7 @@ func (self *BisectController) openStartBisectMenu(info *git_commands.BisectInfo,
 
 					return self.helpers.Bisect.PostBisectCommandRefresh()
 				},
+				Key: 'b',
 			},
 			{
 				DisplayString: fmt.Sprintf(self.c.Tr.Bisect.MarkStart, commit.ShortSha(), info.OldTerm()),
@@ -146,6 +151,7 @@ func (self *BisectController) openStartBisectMenu(info *git_commands.BisectInfo,
 
 					return self.helpers.Bisect.PostBisectCommandRefresh()
 				},
+				Key: 'g',
 			},
 		},
 	})

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -559,16 +559,14 @@ func (self *FilesController) createStashMenu() error {
 			{
 				DisplayString: self.c.Tr.LcStashAllChanges,
 				OnPress: func() error {
-					self.c.LogAction(self.c.Tr.Actions.StashAllChanges)
-					return self.handleStashSave(self.git.Stash.Save)
+					return self.handleStashSave(self.git.Stash.Save, self.c.Tr.Actions.StashAllChanges)
 				},
 				Key: 's',
 			},
 			{
 				DisplayString: self.c.Tr.LcStashStagedChanges,
 				OnPress: func() error {
-					self.c.LogAction(self.c.Tr.Actions.StashStagedChanges)
-					return self.handleStashSave(self.git.Stash.SaveStagedChanges)
+					return self.handleStashSave(self.git.Stash.SaveStagedChanges, self.c.Tr.Actions.StashStagedChanges)
 				},
 				Key: 'S',
 			},
@@ -577,7 +575,7 @@ func (self *FilesController) createStashMenu() error {
 }
 
 func (self *FilesController) stash() error {
-	return self.handleStashSave(self.git.Stash.Save)
+	return self.handleStashSave(self.git.Stash.Save, self.c.Tr.Actions.StashAllChanges)
 }
 
 func (self *FilesController) createResetToUpstreamMenu() error {
@@ -605,7 +603,7 @@ func (self *FilesController) toggleTreeView() error {
 	return self.c.PostRefreshUpdate(self.context())
 }
 
-func (self *FilesController) handleStashSave(stashFunc func(message string) error) error {
+func (self *FilesController) handleStashSave(stashFunc func(message string) error, action string) error {
 	if !self.helpers.WorkingTree.IsWorkingTreeDirty() {
 		return self.c.ErrorMsg(self.c.Tr.NoTrackedStagedFilesStash)
 	}
@@ -613,6 +611,8 @@ func (self *FilesController) handleStashSave(stashFunc func(message string) erro
 	return self.c.Prompt(types.PromptOpts{
 		Title: self.c.Tr.StashChanges,
 		HandleConfirm: func(stashComment string) error {
+			self.c.LogAction(action)
+
 			if err := stashFunc(stashComment); err != nil {
 				return self.c.Error(err)
 			}

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -135,7 +135,7 @@ func (self *FilesController) GetKeybindings(opts types.KeybindingsOpts) []*types
 		},
 		{
 			Key:         opts.GetKey(opts.Config.Files.OpenMergeTool),
-			Handler:     self.OpenMergeTool,
+			Handler:     self.helpers.WorkingTree.OpenMergeTool,
 			Description: self.c.Tr.LcOpenMergeTool,
 		},
 		{
@@ -601,19 +601,6 @@ func (self *FilesController) toggleTreeView() error {
 	self.context().FileTreeViewModel.ToggleShowTree()
 
 	return self.c.PostRefreshUpdate(self.context())
-}
-
-func (self *FilesController) OpenMergeTool() error {
-	return self.c.Ask(types.AskOpts{
-		Title:  self.c.Tr.MergeToolTitle,
-		Prompt: self.c.Tr.MergeToolPrompt,
-		HandleConfirm: func() error {
-			self.c.LogAction(self.c.Tr.Actions.OpenMergeTool)
-			return self.c.RunSubprocessAndRefresh(
-				self.git.WorkingTree.OpenMergeToolCmdObj(),
-			)
-		},
-	})
 }
 
 func (self *FilesController) handleStashSave(stashFunc func(message string) error) error {

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -562,6 +562,7 @@ func (self *FilesController) createStashMenu() error {
 					self.c.LogAction(self.c.Tr.Actions.StashAllChanges)
 					return self.handleStashSave(self.git.Stash.Save)
 				},
+				Key: 's',
 			},
 			{
 				DisplayString: self.c.Tr.LcStashStagedChanges,
@@ -569,6 +570,7 @@ func (self *FilesController) createStashMenu() error {
 					self.c.LogAction(self.c.Tr.Actions.StashStagedChanges)
 					return self.handleStashSave(self.git.Stash.SaveStagedChanges)
 				},
+				Key: 'S',
 			},
 		},
 	})

--- a/pkg/gui/controllers/files_remove_controller.go
+++ b/pkg/gui/controllers/files_remove_controller.go
@@ -51,6 +51,7 @@ func (self *FilesRemoveController) remove(node *filetree.FileNode) error {
 					}
 					return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}})
 				},
+				Key: 'd',
 			},
 		}
 
@@ -65,6 +66,7 @@ func (self *FilesRemoveController) remove(node *filetree.FileNode) error {
 
 					return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}})
 				},
+				Key: 'u',
 			})
 		}
 	} else {
@@ -93,6 +95,7 @@ func (self *FilesRemoveController) remove(node *filetree.FileNode) error {
 						}
 						return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}})
 					},
+					Key: 'd',
 				},
 			}
 
@@ -107,6 +110,7 @@ func (self *FilesRemoveController) remove(node *filetree.FileNode) error {
 
 						return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}})
 					},
+					Key: 'u',
 				})
 			}
 		}

--- a/pkg/gui/controllers/git_flow_controller.go
+++ b/pkg/gui/controllers/git_flow_controller.go
@@ -72,18 +72,22 @@ func (self *GitFlowController) handleCreateGitFlowMenu(branch *models.Branch) er
 			{
 				DisplayString: "start feature",
 				OnPress:       startHandler("feature"),
+				Key:           'f',
 			},
 			{
 				DisplayString: "start hotfix",
 				OnPress:       startHandler("hotfix"),
+				Key:           'h',
 			},
 			{
 				DisplayString: "start bugfix",
 				OnPress:       startHandler("bugfix"),
+				Key:           'b',
 			},
 			{
 				DisplayString: "start release",
 				OnPress:       startHandler("release"),
+				Key:           'r',
 			},
 		},
 	})

--- a/pkg/gui/controllers/helpers/merge_and_rebase_helper.go
+++ b/pkg/gui/controllers/helpers/merge_and_rebase_helper.go
@@ -46,18 +46,29 @@ const (
 )
 
 func (self *MergeAndRebaseHelper) CreateRebaseOptionsMenu() error {
-	options := []string{REBASE_OPTION_CONTINUE, REBASE_OPTION_ABORT}
-
-	if self.git.Status.WorkingTreeState() == enums.REBASE_MODE_REBASING {
-		options = append(options, REBASE_OPTION_SKIP)
+	type optionAndKey struct {
+		option string
+		key    types.Key
 	}
 
-	menuItems := slices.Map(options, func(option string) *types.MenuItem {
+	options := []optionAndKey{
+		{option: REBASE_OPTION_CONTINUE, key: 'c'},
+		{option: REBASE_OPTION_ABORT, key: 'a'},
+	}
+
+	if self.git.Status.WorkingTreeState() == enums.REBASE_MODE_REBASING {
+		options = append(options, optionAndKey{
+			option: REBASE_OPTION_SKIP, key: 's',
+		})
+	}
+
+	menuItems := slices.Map(options, func(row optionAndKey) *types.MenuItem {
 		return &types.MenuItem{
-			DisplayString: option,
+			DisplayString: row.option,
 			OnPress: func() error {
-				return self.genericMergeCommand(option)
+				return self.genericMergeCommand(row.option)
 			},
+			Key: row.key,
 		}
 	})
 

--- a/pkg/gui/controllers/helpers/merge_and_rebase_helper.go
+++ b/pkg/gui/controllers/helpers/merge_and_rebase_helper.go
@@ -246,7 +246,7 @@ func (self *MergeAndRebaseHelper) MergeRefIntoCheckedOutBranch(refName string) e
 	)
 
 	return self.c.Ask(types.AskOpts{
-		Title:  self.c.Tr.MergingTitle,
+		Title:  self.c.Tr.MergeConfirmTitle,
 		Prompt: prompt,
 		HandleConfirm: func() error {
 			self.c.LogAction(self.c.Tr.Actions.Merge)

--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -134,17 +134,27 @@ func (self *RefsHelper) ResetToRef(ref string, strength string, envVars []string
 }
 
 func (self *RefsHelper) CreateGitResetMenu(ref string) error {
-	strengths := []string{"soft", "mixed", "hard"}
-	menuItems := slices.Map(strengths, func(strength string) *types.MenuItem {
+	type strengthWithKey struct {
+		strength string
+		key      types.Key
+	}
+	strengths := []strengthWithKey{
+		{strength: "soft", key: 's'},
+		{strength: "mixed", key: 'm'},
+		{strength: "hard", key: 'h'},
+	}
+
+	menuItems := slices.Map(strengths, func(row strengthWithKey) *types.MenuItem {
 		return &types.MenuItem{
 			DisplayStrings: []string{
-				fmt.Sprintf("%s reset", strength),
-				style.FgRed.Sprintf("reset --%s %s", strength, ref),
+				fmt.Sprintf("%s reset", row.strength),
+				style.FgRed.Sprintf("reset --%s %s", row.strength, ref),
 			},
 			OnPress: func() error {
 				self.c.LogAction("Reset")
-				return self.ResetToRef(ref, strength, []string{})
+				return self.ResetToRef(ref, row.strength, []string{})
 			},
+			Key: row.key,
 		}
 	})
 

--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"github.com/jesseduffield/lazygit/pkg/commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 )
@@ -13,11 +14,16 @@ type IWorkingTreeHelper interface {
 }
 
 type WorkingTreeHelper struct {
+	c   *types.HelperCommon
+	git *commands.GitCommand
+
 	model *types.Model
 }
 
-func NewWorkingTreeHelper(model *types.Model) *WorkingTreeHelper {
+func NewWorkingTreeHelper(c *types.HelperCommon, git *commands.GitCommand, model *types.Model) *WorkingTreeHelper {
 	return &WorkingTreeHelper{
+		c:     c,
+		git:   git,
 		model: model,
 	}
 }
@@ -52,4 +58,17 @@ func (self *WorkingTreeHelper) FileForSubmodule(submodule *models.SubmoduleConfi
 	}
 
 	return nil
+}
+
+func (self *WorkingTreeHelper) OpenMergeTool() error {
+	return self.c.Ask(types.AskOpts{
+		Title:  self.c.Tr.MergeToolTitle,
+		Prompt: self.c.Tr.MergeToolPrompt,
+		HandleConfirm: func() error {
+			self.c.LogAction(self.c.Tr.Actions.OpenMergeTool)
+			return self.c.RunSubprocessAndRefresh(
+				self.git.WorkingTree.OpenMergeToolCmdObj(),
+			)
+		},
+	})
 }

--- a/pkg/gui/controllers/menu_controller.go
+++ b/pkg/gui/controllers/menu_controller.go
@@ -35,6 +35,10 @@ func (self *MenuController) GetKeybindings(opts types.KeybindingsOpts) []*types.
 			Key:     opts.GetKey(opts.Config.Universal.ConfirmAlt1),
 			Handler: self.press,
 		},
+		{
+			Key:     opts.GetKey(opts.Config.Universal.Return),
+			Handler: self.close,
+		},
 	}
 
 	return bindings
@@ -56,6 +60,10 @@ func (self *MenuController) press() error {
 	}
 
 	return nil
+}
+
+func (self *MenuController) close() error {
+	return self.c.PopContext()
 }
 
 func (self *MenuController) Context() types.Context {

--- a/pkg/gui/controllers/menu_controller.go
+++ b/pkg/gui/controllers/menu_controller.go
@@ -49,17 +49,7 @@ func (self *MenuController) GetOnClick() func() error {
 }
 
 func (self *MenuController) press() error {
-	selectedItem := self.context().GetSelected()
-
-	if err := self.c.PopContext(); err != nil {
-		return err
-	}
-
-	if err := selectedItem.OnPress(); err != nil {
-		return err
-	}
-
-	return nil
+	return self.context().OnMenuPress(self.context().GetSelected())
 }
 
 func (self *MenuController) close() error {

--- a/pkg/gui/controllers/submodules_controller.go
+++ b/pkg/gui/controllers/submodules_controller.go
@@ -158,6 +158,7 @@ func (self *SubmodulesController) openBulkActionsMenu() error {
 						return self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.SUBMODULES}})
 					})
 				},
+				Key: 'i',
 			},
 			{
 				DisplayStrings: []string{self.c.Tr.LcBulkUpdateSubmodules, style.FgYellow.Sprint(self.git.Submodule.BulkUpdateCmdObj().ToString())},
@@ -171,6 +172,7 @@ func (self *SubmodulesController) openBulkActionsMenu() error {
 						return self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.SUBMODULES}})
 					})
 				},
+				Key: 'u',
 			},
 			{
 				DisplayStrings: []string{self.c.Tr.LcBulkDeinitSubmodules, style.FgRed.Sprint(self.git.Submodule.BulkDeinitCmdObj().ToString())},
@@ -184,6 +186,7 @@ func (self *SubmodulesController) openBulkActionsMenu() error {
 						return self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.SUBMODULES}})
 					})
 				},
+				Key: 'd',
 			},
 		},
 	})

--- a/pkg/gui/controllers/workspace_reset_controller.go
+++ b/pkg/gui/controllers/workspace_reset_controller.go
@@ -31,6 +31,7 @@ func (self *FilesController) createResetMenu() error {
 
 				return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}})
 			},
+			Key: 'D',
 		},
 		{
 			DisplayStrings: []string{
@@ -45,6 +46,7 @@ func (self *FilesController) createResetMenu() error {
 
 				return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}})
 			},
+			Key: 'u',
 		},
 		{
 			DisplayStrings: []string{
@@ -59,6 +61,7 @@ func (self *FilesController) createResetMenu() error {
 
 				return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}})
 			},
+			Key: 'c',
 		},
 		{
 			DisplayStrings: []string{
@@ -73,6 +76,7 @@ func (self *FilesController) createResetMenu() error {
 
 				return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}})
 			},
+			Key: 's',
 		},
 		{
 			DisplayStrings: []string{
@@ -87,6 +91,7 @@ func (self *FilesController) createResetMenu() error {
 
 				return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}})
 			},
+			Key: 'm',
 		},
 		{
 			DisplayStrings: []string{
@@ -101,6 +106,7 @@ func (self *FilesController) createResetMenu() error {
 
 				return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}})
 			},
+			Key: 'h',
 		},
 	}
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -18,7 +18,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/common"
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
-	"github.com/jesseduffield/lazygit/pkg/gui/controllers"
 	"github.com/jesseduffield/lazygit/pkg/gui/controllers/helpers"
 	"github.com/jesseduffield/lazygit/pkg/gui/lbl"
 	"github.com/jesseduffield/lazygit/pkg/gui/mergeconflicts"
@@ -129,9 +128,6 @@ type Gui struct {
 
 	IsNewRepo bool
 
-	// controllers define keybindings for a given context
-	Controllers Controllers
-
 	// flag as to whether or not the diff view should ignore whitespace
 	IgnoreWhitespaceInDiffView bool
 
@@ -201,19 +197,6 @@ type GuiRepoState struct {
 	ScreenMode WindowMaximisation
 
 	CurrentPopupOpts *types.CreatePopupPanelOpts
-}
-
-type Controllers struct {
-	Submodules   *controllers.SubmodulesController
-	Tags         *controllers.TagsController
-	LocalCommits *controllers.LocalCommitsController
-	Files        *controllers.FilesController
-	Remotes      *controllers.RemotesController
-	Menu         *controllers.MenuController
-	Bisect       *controllers.BisectController
-	Undo         *controllers.UndoController
-	Sync         *controllers.SyncController
-	Global       *controllers.GlobalController
 }
 
 // for now the staging panel state, unlike the other panel states, is going to be

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -1,7 +1,6 @@
 package gui
 
 import (
-	"fmt"
 	"log"
 	"strings"
 	"unicode/utf8"
@@ -10,170 +9,19 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/constants"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/controllers/helpers"
+	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 )
 
-var keyMapReversed = map[gocui.Key]string{
-	gocui.KeyF1:          "f1",
-	gocui.KeyF2:          "f2",
-	gocui.KeyF3:          "f3",
-	gocui.KeyF4:          "f4",
-	gocui.KeyF5:          "f5",
-	gocui.KeyF6:          "f6",
-	gocui.KeyF7:          "f7",
-	gocui.KeyF8:          "f8",
-	gocui.KeyF9:          "f9",
-	gocui.KeyF10:         "f10",
-	gocui.KeyF11:         "f11",
-	gocui.KeyF12:         "f12",
-	gocui.KeyInsert:      "insert",
-	gocui.KeyDelete:      "delete",
-	gocui.KeyHome:        "home",
-	gocui.KeyEnd:         "end",
-	gocui.KeyPgup:        "pgup",
-	gocui.KeyPgdn:        "pgdown",
-	gocui.KeyArrowUp:     "▲",
-	gocui.KeyArrowDown:   "▼",
-	gocui.KeyArrowLeft:   "◄",
-	gocui.KeyArrowRight:  "►",
-	gocui.KeyTab:         "tab", // ctrl+i
-	gocui.KeyBacktab:     "shift+tab",
-	gocui.KeyEnter:       "enter", // ctrl+m
-	gocui.KeyAltEnter:    "alt+enter",
-	gocui.KeyEsc:         "esc",        // ctrl+[, ctrl+3
-	gocui.KeyBackspace:   "backspace",  // ctrl+h
-	gocui.KeyCtrlSpace:   "ctrl+space", // ctrl+~, ctrl+2
-	gocui.KeyCtrlSlash:   "ctrl+/",     // ctrl+_
-	gocui.KeySpace:       "space",
-	gocui.KeyCtrlA:       "ctrl+a",
-	gocui.KeyCtrlB:       "ctrl+b",
-	gocui.KeyCtrlC:       "ctrl+c",
-	gocui.KeyCtrlD:       "ctrl+d",
-	gocui.KeyCtrlE:       "ctrl+e",
-	gocui.KeyCtrlF:       "ctrl+f",
-	gocui.KeyCtrlG:       "ctrl+g",
-	gocui.KeyCtrlJ:       "ctrl+j",
-	gocui.KeyCtrlK:       "ctrl+k",
-	gocui.KeyCtrlL:       "ctrl+l",
-	gocui.KeyCtrlN:       "ctrl+n",
-	gocui.KeyCtrlO:       "ctrl+o",
-	gocui.KeyCtrlP:       "ctrl+p",
-	gocui.KeyCtrlQ:       "ctrl+q",
-	gocui.KeyCtrlR:       "ctrl+r",
-	gocui.KeyCtrlS:       "ctrl+s",
-	gocui.KeyCtrlT:       "ctrl+t",
-	gocui.KeyCtrlU:       "ctrl+u",
-	gocui.KeyCtrlV:       "ctrl+v",
-	gocui.KeyCtrlW:       "ctrl+w",
-	gocui.KeyCtrlX:       "ctrl+x",
-	gocui.KeyCtrlY:       "ctrl+y",
-	gocui.KeyCtrlZ:       "ctrl+z",
-	gocui.KeyCtrl4:       "ctrl+4", // ctrl+\
-	gocui.KeyCtrl5:       "ctrl+5", // ctrl+]
-	gocui.KeyCtrl6:       "ctrl+6",
-	gocui.KeyCtrl8:       "ctrl+8",
-	gocui.MouseWheelUp:   "mouse wheel up",
-	gocui.MouseWheelDown: "mouse wheel down",
-}
-
-var keymap = map[string]types.Key{
-	"<c-a>":       gocui.KeyCtrlA,
-	"<c-b>":       gocui.KeyCtrlB,
-	"<c-c>":       gocui.KeyCtrlC,
-	"<c-d>":       gocui.KeyCtrlD,
-	"<c-e>":       gocui.KeyCtrlE,
-	"<c-f>":       gocui.KeyCtrlF,
-	"<c-g>":       gocui.KeyCtrlG,
-	"<c-h>":       gocui.KeyCtrlH,
-	"<c-i>":       gocui.KeyCtrlI,
-	"<c-j>":       gocui.KeyCtrlJ,
-	"<c-k>":       gocui.KeyCtrlK,
-	"<c-l>":       gocui.KeyCtrlL,
-	"<c-m>":       gocui.KeyCtrlM,
-	"<c-n>":       gocui.KeyCtrlN,
-	"<c-o>":       gocui.KeyCtrlO,
-	"<c-p>":       gocui.KeyCtrlP,
-	"<c-q>":       gocui.KeyCtrlQ,
-	"<c-r>":       gocui.KeyCtrlR,
-	"<c-s>":       gocui.KeyCtrlS,
-	"<c-t>":       gocui.KeyCtrlT,
-	"<c-u>":       gocui.KeyCtrlU,
-	"<c-v>":       gocui.KeyCtrlV,
-	"<c-w>":       gocui.KeyCtrlW,
-	"<c-x>":       gocui.KeyCtrlX,
-	"<c-y>":       gocui.KeyCtrlY,
-	"<c-z>":       gocui.KeyCtrlZ,
-	"<c-~>":       gocui.KeyCtrlTilde,
-	"<c-2>":       gocui.KeyCtrl2,
-	"<c-3>":       gocui.KeyCtrl3,
-	"<c-4>":       gocui.KeyCtrl4,
-	"<c-5>":       gocui.KeyCtrl5,
-	"<c-6>":       gocui.KeyCtrl6,
-	"<c-7>":       gocui.KeyCtrl7,
-	"<c-8>":       gocui.KeyCtrl8,
-	"<c-space>":   gocui.KeyCtrlSpace,
-	"<c-\\>":      gocui.KeyCtrlBackslash,
-	"<c-[>":       gocui.KeyCtrlLsqBracket,
-	"<c-]>":       gocui.KeyCtrlRsqBracket,
-	"<c-/>":       gocui.KeyCtrlSlash,
-	"<c-_>":       gocui.KeyCtrlUnderscore,
-	"<backspace>": gocui.KeyBackspace,
-	"<tab>":       gocui.KeyTab,
-	"<backtab>":   gocui.KeyBacktab,
-	"<enter>":     gocui.KeyEnter,
-	"<a-enter>":   gocui.KeyAltEnter,
-	"<esc>":       gocui.KeyEsc,
-	"<space>":     gocui.KeySpace,
-	"<f1>":        gocui.KeyF1,
-	"<f2>":        gocui.KeyF2,
-	"<f3>":        gocui.KeyF3,
-	"<f4>":        gocui.KeyF4,
-	"<f5>":        gocui.KeyF5,
-	"<f6>":        gocui.KeyF6,
-	"<f7>":        gocui.KeyF7,
-	"<f8>":        gocui.KeyF8,
-	"<f9>":        gocui.KeyF9,
-	"<f10>":       gocui.KeyF10,
-	"<f11>":       gocui.KeyF11,
-	"<f12>":       gocui.KeyF12,
-	"<insert>":    gocui.KeyInsert,
-	"<delete>":    gocui.KeyDelete,
-	"<home>":      gocui.KeyHome,
-	"<end>":       gocui.KeyEnd,
-	"<pgup>":      gocui.KeyPgup,
-	"<pgdown>":    gocui.KeyPgdn,
-	"<up>":        gocui.KeyArrowUp,
-	"<down>":      gocui.KeyArrowDown,
-	"<left>":      gocui.KeyArrowLeft,
-	"<right>":     gocui.KeyArrowRight,
-}
-
 func (gui *Gui) getKeyDisplay(name string) string {
 	key := gui.getKey(name)
-	return GetKeyDisplay(key)
-}
-
-func GetKeyDisplay(key types.Key) string {
-	keyInt := 0
-
-	switch key := key.(type) {
-	case rune:
-		keyInt = int(key)
-	case gocui.Key:
-		value, ok := keyMapReversed[key]
-		if ok {
-			return value
-		}
-		keyInt = int(key)
-	}
-
-	return fmt.Sprintf("%c", keyInt)
+	return keybindings.GetKeyDisplay(key)
 }
 
 func (gui *Gui) getKey(key string) types.Key {
 	runeCount := utf8.RuneCountInString(key)
 	if runeCount > 1 {
-		binding := keymap[strings.ToLower(key)]
+		binding := keybindings.Keymap[strings.ToLower(key)]
 		if binding == nil {
 			log.Fatalf("Unrecognized key %s for keybinding. For permitted values see %s", strings.ToLower(key), constants.Links.Docs.CustomKeybindings)
 		} else {

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -413,12 +413,6 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 			Description: self.c.Tr.LcCopyCommitShaToClipboard,
 		},
 		{
-			ViewName:    "menu",
-			Key:         opts.GetKey(opts.Config.Universal.Return),
-			Handler:     self.handleMenuClose,
-			Description: self.c.Tr.LcCloseMenu,
-		},
-		{
 			ViewName: "information",
 			Key:      gocui.MouseLeft,
 			Modifier: gocui.ModNone,

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -619,7 +619,7 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 			ViewName:    "main",
 			Contexts:    []string{string(context.MAIN_STAGING_CONTEXT_KEY)},
 			Key:         opts.GetKey(opts.Config.Universal.OpenFile),
-			Handler:     self.Controllers.Files.Open,
+			Handler:     self.HandleOpenFile,
 			Description: self.c.Tr.LcOpenFile,
 		},
 		{
@@ -741,27 +741,6 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 		},
 		{
 			ViewName:    "main",
-			Contexts:    []string{string(context.MAIN_STAGING_CONTEXT_KEY)},
-			Key:         opts.GetKey(opts.Config.Files.CommitChanges),
-			Handler:     self.Controllers.Files.HandleCommitPress,
-			Description: self.c.Tr.CommitChanges,
-		},
-		{
-			ViewName:    "main",
-			Contexts:    []string{string(context.MAIN_STAGING_CONTEXT_KEY)},
-			Key:         opts.GetKey(opts.Config.Files.CommitChangesWithoutHook),
-			Handler:     self.Controllers.Files.HandleWIPCommitPress,
-			Description: self.c.Tr.LcCommitChangesWithoutHook,
-		},
-		{
-			ViewName:    "main",
-			Contexts:    []string{string(context.MAIN_STAGING_CONTEXT_KEY)},
-			Key:         opts.GetKey(opts.Config.Files.CommitChangesWithEditor),
-			Handler:     self.Controllers.Files.HandleCommitEditorPress,
-			Description: self.c.Tr.CommitChangesWithEditor,
-		},
-		{
-			ViewName:    "main",
 			Contexts:    []string{string(context.MAIN_MERGING_CONTEXT_KEY)},
 			Key:         opts.GetKey(opts.Config.Universal.Return),
 			Handler:     self.handleEscapeMerge,
@@ -771,7 +750,7 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 			ViewName:    "main",
 			Contexts:    []string{string(context.MAIN_MERGING_CONTEXT_KEY)},
 			Key:         opts.GetKey(opts.Config.Files.OpenMergeTool),
-			Handler:     self.Controllers.Files.OpenMergeTool,
+			Handler:     self.helpers.WorkingTree.OpenMergeTool,
 			Description: self.c.Tr.LcOpenMergeTool,
 		},
 		{

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -76,7 +76,7 @@ var keyMapReversed = map[gocui.Key]string{
 	gocui.MouseWheelDown: "mouse wheel down",
 }
 
-var keymap = map[string]interface{}{
+var keymap = map[string]types.Key{
 	"<c-a>":       gocui.KeyCtrlA,
 	"<c-b>":       gocui.KeyCtrlB,
 	"<c-c>":       gocui.KeyCtrlC,
@@ -153,7 +153,7 @@ func (gui *Gui) getKeyDisplay(name string) string {
 	return GetKeyDisplay(key)
 }
 
-func GetKeyDisplay(key interface{}) string {
+func GetKeyDisplay(key types.Key) string {
 	keyInt := 0
 
 	switch key := key.(type) {
@@ -170,7 +170,7 @@ func GetKeyDisplay(key interface{}) string {
 	return fmt.Sprintf("%c", keyInt)
 }
 
-func (gui *Gui) getKey(key string) interface{} {
+func (gui *Gui) getKey(key string) types.Key {
 	runeCount := utf8.RuneCountInString(key)
 	if runeCount > 1 {
 		binding := keymap[strings.ToLower(key)]

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -972,7 +972,7 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 		mouseKeybindings = append(mouseKeybindings, c.GetMouseKeybindings(opts)...)
 	}
 
-	for _, viewName := range []string{"status", "branches", "remoteBranches", "files", "commits", "commitFiles", "subCommits", "stash", "menu"} {
+	for _, viewName := range []string{"status", "branches", "remoteBranches", "files", "commits", "commitFiles", "subCommits", "stash"} {
 		bindings = append(bindings, []*types.Binding{
 			{ViewName: viewName, Key: opts.GetKey(opts.Config.Universal.PrevBlock), Modifier: gocui.ModNone, Handler: self.previousSideWindow},
 			{ViewName: viewName, Key: opts.GetKey(opts.Config.Universal.NextBlock), Modifier: gocui.ModNone, Handler: self.nextSideWindow},

--- a/pkg/gui/keybindings/keybindings.go
+++ b/pkg/gui/keybindings/keybindings.go
@@ -1,0 +1,160 @@
+package keybindings
+
+import (
+	"fmt"
+
+	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+)
+
+var KeyMapReversed = map[gocui.Key]string{
+	gocui.KeyF1:          "f1",
+	gocui.KeyF2:          "f2",
+	gocui.KeyF3:          "f3",
+	gocui.KeyF4:          "f4",
+	gocui.KeyF5:          "f5",
+	gocui.KeyF6:          "f6",
+	gocui.KeyF7:          "f7",
+	gocui.KeyF8:          "f8",
+	gocui.KeyF9:          "f9",
+	gocui.KeyF10:         "f10",
+	gocui.KeyF11:         "f11",
+	gocui.KeyF12:         "f12",
+	gocui.KeyInsert:      "insert",
+	gocui.KeyDelete:      "delete",
+	gocui.KeyHome:        "home",
+	gocui.KeyEnd:         "end",
+	gocui.KeyPgup:        "pgup",
+	gocui.KeyPgdn:        "pgdown",
+	gocui.KeyArrowUp:     "▲",
+	gocui.KeyArrowDown:   "▼",
+	gocui.KeyArrowLeft:   "◄",
+	gocui.KeyArrowRight:  "►",
+	gocui.KeyTab:         "tab", // ctrl+i
+	gocui.KeyBacktab:     "shift+tab",
+	gocui.KeyEnter:       "enter", // ctrl+m
+	gocui.KeyAltEnter:    "alt+enter",
+	gocui.KeyEsc:         "esc",        // ctrl+[, ctrl+3
+	gocui.KeyBackspace:   "backspace",  // ctrl+h
+	gocui.KeyCtrlSpace:   "ctrl+space", // ctrl+~, ctrl+2
+	gocui.KeyCtrlSlash:   "ctrl+/",     // ctrl+_
+	gocui.KeySpace:       "space",
+	gocui.KeyCtrlA:       "ctrl+a",
+	gocui.KeyCtrlB:       "ctrl+b",
+	gocui.KeyCtrlC:       "ctrl+c",
+	gocui.KeyCtrlD:       "ctrl+d",
+	gocui.KeyCtrlE:       "ctrl+e",
+	gocui.KeyCtrlF:       "ctrl+f",
+	gocui.KeyCtrlG:       "ctrl+g",
+	gocui.KeyCtrlJ:       "ctrl+j",
+	gocui.KeyCtrlK:       "ctrl+k",
+	gocui.KeyCtrlL:       "ctrl+l",
+	gocui.KeyCtrlN:       "ctrl+n",
+	gocui.KeyCtrlO:       "ctrl+o",
+	gocui.KeyCtrlP:       "ctrl+p",
+	gocui.KeyCtrlQ:       "ctrl+q",
+	gocui.KeyCtrlR:       "ctrl+r",
+	gocui.KeyCtrlS:       "ctrl+s",
+	gocui.KeyCtrlT:       "ctrl+t",
+	gocui.KeyCtrlU:       "ctrl+u",
+	gocui.KeyCtrlV:       "ctrl+v",
+	gocui.KeyCtrlW:       "ctrl+w",
+	gocui.KeyCtrlX:       "ctrl+x",
+	gocui.KeyCtrlY:       "ctrl+y",
+	gocui.KeyCtrlZ:       "ctrl+z",
+	gocui.KeyCtrl4:       "ctrl+4", // ctrl+\
+	gocui.KeyCtrl5:       "ctrl+5", // ctrl+]
+	gocui.KeyCtrl6:       "ctrl+6",
+	gocui.KeyCtrl8:       "ctrl+8",
+	gocui.MouseWheelUp:   "mouse wheel up",
+	gocui.MouseWheelDown: "mouse wheel down",
+}
+
+var Keymap = map[string]types.Key{
+	"<c-a>":       gocui.KeyCtrlA,
+	"<c-b>":       gocui.KeyCtrlB,
+	"<c-c>":       gocui.KeyCtrlC,
+	"<c-d>":       gocui.KeyCtrlD,
+	"<c-e>":       gocui.KeyCtrlE,
+	"<c-f>":       gocui.KeyCtrlF,
+	"<c-g>":       gocui.KeyCtrlG,
+	"<c-h>":       gocui.KeyCtrlH,
+	"<c-i>":       gocui.KeyCtrlI,
+	"<c-j>":       gocui.KeyCtrlJ,
+	"<c-k>":       gocui.KeyCtrlK,
+	"<c-l>":       gocui.KeyCtrlL,
+	"<c-m>":       gocui.KeyCtrlM,
+	"<c-n>":       gocui.KeyCtrlN,
+	"<c-o>":       gocui.KeyCtrlO,
+	"<c-p>":       gocui.KeyCtrlP,
+	"<c-q>":       gocui.KeyCtrlQ,
+	"<c-r>":       gocui.KeyCtrlR,
+	"<c-s>":       gocui.KeyCtrlS,
+	"<c-t>":       gocui.KeyCtrlT,
+	"<c-u>":       gocui.KeyCtrlU,
+	"<c-v>":       gocui.KeyCtrlV,
+	"<c-w>":       gocui.KeyCtrlW,
+	"<c-x>":       gocui.KeyCtrlX,
+	"<c-y>":       gocui.KeyCtrlY,
+	"<c-z>":       gocui.KeyCtrlZ,
+	"<c-~>":       gocui.KeyCtrlTilde,
+	"<c-2>":       gocui.KeyCtrl2,
+	"<c-3>":       gocui.KeyCtrl3,
+	"<c-4>":       gocui.KeyCtrl4,
+	"<c-5>":       gocui.KeyCtrl5,
+	"<c-6>":       gocui.KeyCtrl6,
+	"<c-7>":       gocui.KeyCtrl7,
+	"<c-8>":       gocui.KeyCtrl8,
+	"<c-space>":   gocui.KeyCtrlSpace,
+	"<c-\\>":      gocui.KeyCtrlBackslash,
+	"<c-[>":       gocui.KeyCtrlLsqBracket,
+	"<c-]>":       gocui.KeyCtrlRsqBracket,
+	"<c-/>":       gocui.KeyCtrlSlash,
+	"<c-_>":       gocui.KeyCtrlUnderscore,
+	"<backspace>": gocui.KeyBackspace,
+	"<tab>":       gocui.KeyTab,
+	"<backtab>":   gocui.KeyBacktab,
+	"<enter>":     gocui.KeyEnter,
+	"<a-enter>":   gocui.KeyAltEnter,
+	"<esc>":       gocui.KeyEsc,
+	"<space>":     gocui.KeySpace,
+	"<f1>":        gocui.KeyF1,
+	"<f2>":        gocui.KeyF2,
+	"<f3>":        gocui.KeyF3,
+	"<f4>":        gocui.KeyF4,
+	"<f5>":        gocui.KeyF5,
+	"<f6>":        gocui.KeyF6,
+	"<f7>":        gocui.KeyF7,
+	"<f8>":        gocui.KeyF8,
+	"<f9>":        gocui.KeyF9,
+	"<f10>":       gocui.KeyF10,
+	"<f11>":       gocui.KeyF11,
+	"<f12>":       gocui.KeyF12,
+	"<insert>":    gocui.KeyInsert,
+	"<delete>":    gocui.KeyDelete,
+	"<home>":      gocui.KeyHome,
+	"<end>":       gocui.KeyEnd,
+	"<pgup>":      gocui.KeyPgup,
+	"<pgdown>":    gocui.KeyPgdn,
+	"<up>":        gocui.KeyArrowUp,
+	"<down>":      gocui.KeyArrowDown,
+	"<left>":      gocui.KeyArrowLeft,
+	"<right>":     gocui.KeyArrowRight,
+}
+
+func GetKeyDisplay(key types.Key) string {
+	keyInt := 0
+
+	switch key := key.(type) {
+	case rune:
+		keyInt = int(key)
+	case gocui.Key:
+		value, ok := KeyMapReversed[key]
+		if ok {
+			return value
+		}
+		keyInt = int(key)
+	}
+
+	return fmt.Sprintf("%c", keyInt)
+}

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -46,6 +46,12 @@ func (gui *Gui) createMenu(opts types.CreateMenuOptions) error {
 
 	gui.State.Contexts.Menu.SetMenuItems(opts.Items)
 	gui.State.Contexts.Menu.SetSelectedLineIdx(0)
+
+	// resetting keybindings so that the menu-specific keybindings are registered
+	if err := gui.resetKeybindings(); err != nil {
+		return err
+	}
+
 	_ = gui.c.PostRefreshUpdate(gui.State.Contexts.Menu)
 
 	// TODO: ensure that if we're opened a menu from within a menu that it renders correctly

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -18,10 +18,6 @@ func (gui *Gui) getMenuOptions() map[string]string {
 	}
 }
 
-func (gui *Gui) handleMenuClose() error {
-	return gui.c.PopContext()
-}
-
 // note: items option is mutated by this function
 func (gui *Gui) createMenu(opts types.CreateMenuOptions) error {
 	if !opts.HideCancel {

--- a/pkg/gui/options_menu_panel.go
+++ b/pkg/gui/options_menu_panel.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/jesseduffield/generics/slices"
+	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
@@ -22,7 +23,7 @@ func (gui *Gui) getBindings(context types.Context) []*types.Binding {
 	bindings = append(customBindings, bindings...)
 
 	for _, binding := range bindings {
-		if GetKeyDisplay(binding.Key) != "" && binding.Description != "" {
+		if keybindings.GetKeyDisplay(binding.Key) != "" && binding.Description != "" {
 			if len(binding.Contexts) == 0 && binding.ViewName == "" {
 				bindingsGlobal = append(bindingsGlobal, binding)
 			} else if binding.Tag == "navigation" {
@@ -65,17 +66,15 @@ func (gui *Gui) handleCreateOptionsMenu() error {
 
 	menuItems := slices.Map(bindings, func(binding *types.Binding) *types.MenuItem {
 		return &types.MenuItem{
-			DisplayStrings: []string{GetKeyDisplay(binding.Key), gui.displayDescription(binding)},
+			DisplayString: gui.displayDescription(binding),
 			OnPress: func() error {
 				if binding.Key == nil {
 					return nil
 				}
 
-				if err := gui.c.PopContext(); err != nil {
-					return err
-				}
 				return binding.Handler()
 			},
+			Key: binding.Key,
 		}
 	})
 

--- a/pkg/gui/options_menu_panel.go
+++ b/pkg/gui/options_menu_panel.go
@@ -70,7 +70,8 @@ func (gui *Gui) handleCreateOptionsMenu() error {
 				if binding.Key == nil {
 					return nil
 				}
-				if err := gui.handleMenuClose(); err != nil {
+
+				if err := gui.c.PopContext(); err != nil {
 					return err
 				}
 				return binding.Handler()

--- a/pkg/gui/options_menu_panel.go
+++ b/pkg/gui/options_menu_panel.go
@@ -7,7 +7,6 @@ import (
 	"github.com/jesseduffield/generics/slices"
 	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
-	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/samber/lo"
 )
@@ -57,7 +56,7 @@ func (gui *Gui) displayDescription(binding *types.Binding) string {
 		return presentation.OpensMenuStyle(binding.Description)
 	}
 
-	return style.FgCyan.Sprint(binding.Description)
+	return binding.Description
 }
 
 func (gui *Gui) handleCreateOptionsMenu() error {

--- a/pkg/gui/patch_options_panel.go
+++ b/pkg/gui/patch_options_panel.go
@@ -17,14 +17,17 @@ func (gui *Gui) handleCreatePatchOptionsMenu() error {
 		{
 			DisplayString: "reset patch",
 			OnPress:       gui.handleResetPatch,
+			Key:           'c',
 		},
 		{
 			DisplayString: "apply patch",
 			OnPress:       func() error { return gui.handleApplyPatch(false) },
+			Key:           'a',
 		},
 		{
 			DisplayString: "apply patch in reverse",
 			OnPress:       func() error { return gui.handleApplyPatch(true) },
+			Key:           'r',
 		},
 	}
 
@@ -33,14 +36,17 @@ func (gui *Gui) handleCreatePatchOptionsMenu() error {
 			{
 				DisplayString: fmt.Sprintf("remove patch from original commit (%s)", gui.git.Patch.PatchManager.To),
 				OnPress:       gui.handleDeletePatchFromCommit,
+				Key:           'd',
 			},
 			{
 				DisplayString: "move patch out into index",
 				OnPress:       gui.handleMovePatchIntoWorkingTree,
+				Key:           'i',
 			},
 			{
 				DisplayString: "move patch into new commit",
 				OnPress:       gui.handlePullPatchIntoNewCommit,
+				Key:           'n',
 			},
 		}...)
 
@@ -55,6 +61,7 @@ func (gui *Gui) handleCreatePatchOptionsMenu() error {
 							{
 								DisplayString: fmt.Sprintf("move patch to selected commit (%s)", selectedCommit.Sha),
 								OnPress:       gui.handleMovePatchToSelectedCommit,
+								Key:           'm',
 							},
 						}, menuItems[1:]...,
 					)...,

--- a/pkg/gui/services/custom_commands/client.go
+++ b/pkg/gui/services/custom_commands/client.go
@@ -23,7 +23,7 @@ func NewClient(
 	git *commands.GitCommand,
 	contexts *context.ContextTree,
 	helpers *helpers.Helpers,
-	getKey func(string) interface{},
+	getKey func(string) types.Key,
 ) *Client {
 	sessionStateLoader := NewSessionStateLoader(contexts, helpers)
 	handlerCreator := NewHandlerCreator(c, os, git, sessionStateLoader)

--- a/pkg/gui/services/custom_commands/keybinding_creator.go
+++ b/pkg/gui/services/custom_commands/keybinding_creator.go
@@ -14,10 +14,10 @@ import (
 // KeybindingCreator takes a custom command along with its handler and returns a corresponding keybinding
 type KeybindingCreator struct {
 	contexts *context.ContextTree
-	getKey   func(string) interface{}
+	getKey   func(string) types.Key
 }
 
-func NewKeybindingCreator(contexts *context.ContextTree, getKey func(string) interface{}) *KeybindingCreator {
+func NewKeybindingCreator(contexts *context.ContextTree, getKey func(string) types.Key) *KeybindingCreator {
 	return &KeybindingCreator{
 		contexts: contexts,
 		getKey:   getKey,

--- a/pkg/gui/staging_panel.go
+++ b/pkg/gui/staging_panel.go
@@ -165,3 +165,12 @@ func (gui *Gui) applySelection(reverse bool, state *LblPanelState) error {
 	}
 	return nil
 }
+
+func (gui *Gui) HandleOpenFile() error {
+	file := gui.getSelectedFile()
+	if file == nil {
+		return nil
+	}
+
+	return gui.helpers.Files.OpenFile(file.GetPath())
+}

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -105,6 +105,10 @@ type MenuItem struct {
 	OnPress        func() error
 	// only applies when displayString is used
 	OpensMenu bool
+
+	// if Key is defined it allows the user to press the key to invoke the menu
+	// item, as opposed to having to navigate to it
+	Key Key
 }
 
 type Model struct {

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -97,7 +97,7 @@ type OnFocusOpts struct {
 type ContextKey string
 
 type KeybindingsOpts struct {
-	GetKey func(key string) interface{}
+	GetKey func(key string) Key
 	Config config.KeybindingConfig
 	Guards KeybindingGuards
 }

--- a/pkg/gui/types/keybindings.go
+++ b/pkg/gui/types/keybindings.go
@@ -2,6 +2,8 @@ package types
 
 import "github.com/jesseduffield/gocui"
 
+type Key interface{} // FIXME: find out how to get `gocui.Key | rune`
+
 // Binding - a keybinding mapping a key and modifier to a handler. The keypress
 // is only handled if the given view has focus, or handled globally if the view
 // is ""
@@ -9,7 +11,7 @@ type Binding struct {
 	ViewName    string
 	Contexts    []string
 	Handler     func() error
-	Key         interface{} // FIXME: find out how to get `gocui.Key | rune`
+	Key         Key
 	Modifier    gocui.Modifier
 	Description string
 	Alternative string

--- a/pkg/i18n/chinese.go
+++ b/pkg/i18n/chinese.go
@@ -347,7 +347,6 @@ func chineseTranslationSet() TranslationSet {
 		NewBranchNamePrompt:                 "输入分支的新名称",
 		RenameBranchWarning:                 "该分支正在跟踪远程仓库。此操作将仅会重命名本地分支名称，而不会重命名远程分支的名称。确定继续？",
 		LcOpenMenu:                          "打开菜单",
-		LcCloseMenu:                         "关闭菜单",
 		LcResetCherryPick:                   "重置已拣选（复制）的提交",
 		LcNextTab:                           "下一个标签",
 		LcPrevTab:                           "上一个标签",

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -302,7 +302,6 @@ func dutchTranslationSet() TranslationSet {
 		NewBranchNamePrompt:                 "Noem een nieuwe branch naam",
 		RenameBranchWarning:                 "Deze branch volgt een remote. Deze actie zal alleen de locale branch name wijzigen niet de naam van de remote branch. Verder gaan?",
 		LcOpenMenu:                          "open menu",
-		LcCloseMenu:                         "sluit menu",
 		LcResetCherryPick:                   "reset cherry-picked (gekopieerde) commits selectie",
 		LcNextTab:                           "volgende tabblad",
 		LcPrevTab:                           "vorige tabblad",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -332,7 +332,6 @@ type TranslationSet struct {
 	NewGitFlowBranchPrompt              string
 	RenameBranchWarning                 string
 	LcOpenMenu                          string
-	LcCloseMenu                         string
 	LcResetCherryPick                   string
 	LcNextTab                           string
 	LcPrevTab                           string
@@ -923,7 +922,6 @@ func EnglishTranslationSet() TranslationSet {
 		NewBranchNamePrompt:                 "Enter new branch name for branch",
 		RenameBranchWarning:                 "This branch is tracking a remote. This action will only rename the local branch name, not the name of the remote branch. Continue?",
 		LcOpenMenu:                          "open menu",
-		LcCloseMenu:                         "close menu",
 		LcResetCherryPick:                   "reset cherry-picked (copied) commits selection",
 		LcNextTab:                           "next tab",
 		LcPrevTab:                           "previous tab",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -22,6 +22,7 @@ type TranslationSet struct {
 	MainTitle                           string
 	StagingTitle                        string
 	MergingTitle                        string
+	MergeConfirmTitle                   string
 	NormalTitle                         string
 	CommitMessage                       string
 	CredentialsUsername                 string
@@ -610,6 +611,7 @@ func EnglishTranslationSet() TranslationSet {
 		UnstagedChanges:                     `Unstaged Changes`,
 		StagedChanges:                       `Staged Changes`,
 		MainTitle:                           "Main",
+		MergeConfirmTitle:                   "Merge",
 		StagingTitle:                        "Main Panel (Staging)",
 		MergingTitle:                        "Main Panel (Merging)",
 		NormalTitle:                         "Main Panel (Normal)",


### PR DESCRIPTION
This is going to speed things up a lot: now we've got keybindings assigned to pretty much every menu in the app (I didn't bother with menus that I expected would rarely be accessed).

This means that if you press 'x' to view the menu that shows all available keybindings for the current context, you can now invoke one of those menu items without needing to navigate to it.

Some more examples:
* If you want to stage staged changes you can press 'SS'.
* If you want to continue a rebase you can press 'mc'
* If you want to hard reset onto a commit you can press 'gh'
* If you want to begin mark a commit as bad during a git bisect you can press 'bb'

Importantly, if the menu already has a keybinding defined, that takes precedence. So for example if you specify `Key: 'i'` in a menu item that binding will be ignored because 'i' is already used for navigating the menu.

I'm not making these configurable because I don't anticipate the need but it should be easy to add later if we need to.

Some other things this PR does:
* fixed up some copy issues
* fixed issue where stash action was logged prematurely
* cleaned up some code