### PR TITLE
Fix diff of renamed files

### DIFF
--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -230,6 +230,7 @@ func (self *WorkingTreeCommands) WorktreeFileDiffCmdObj(node models.IFile, plain
 	trackedArg := "--"
 	colorArg := self.UserConfig.Git.Paging.ColorArg
 	quotedPath := self.cmd.Quote(node.GetPath())
+	quotedPrevPath := ""
 	ignoreWhitespaceArg := ""
 	contextSize := self.UserConfig.Git.DiffContextSize
 	if cached {
@@ -244,8 +245,11 @@ func (self *WorkingTreeCommands) WorktreeFileDiffCmdObj(node models.IFile, plain
 	if ignoreWhitespace {
 		ignoreWhitespaceArg = " --ignore-all-space"
 	}
+	if prevPath := node.GetPreviousPath(); prevPath != "" {
+		quotedPrevPath = " " + self.cmd.Quote(prevPath)
+	}
 
-	cmdStr := fmt.Sprintf("git diff --submodule --no-ext-diff --unified=%d --color=%s%s%s %s %s", contextSize, colorArg, ignoreWhitespaceArg, cachedArg, trackedArg, quotedPath)
+	cmdStr := fmt.Sprintf("git diff --submodule --no-ext-diff --unified=%d --color=%s%s%s %s %s%s", contextSize, colorArg, ignoreWhitespaceArg, cachedArg, trackedArg, quotedPath, quotedPrevPath)
 
 	return self.cmd.New(cmdStr).DontLog()
 }

--- a/pkg/commands/models/file.go
+++ b/pkg/commands/models/file.go
@@ -27,6 +27,7 @@ type IFile interface {
 	GetHasStagedChanges() bool
 	GetIsTracked() bool
 	GetPath() string
+	GetPreviousPath() string
 }
 
 func (f *File) IsRename() bool {
@@ -84,4 +85,8 @@ func (f *File) GetIsTracked() bool {
 func (f *File) GetPath() string {
 	// TODO: remove concept of name; just use path
 	return f.Name
+}
+
+func (f *File) GetPreviousPath() string {
+	return f.PreviousName
 }

--- a/pkg/gui/filetree/file_node.go
+++ b/pkg/gui/filetree/file_node.go
@@ -42,6 +42,13 @@ func (s *FileNode) GetPath() string {
 	return s.Path
 }
 
+func (s *FileNode) GetPreviousPath() string {
+	if s.File != nil {
+		return s.File.GetPreviousPath()
+	}
+	return ""
+}
+
 func (s *FileNode) GetChildren() []INode {
 	return slices.Map(s.Children, func(child *FileNode) INode {
 		return child


### PR DESCRIPTION
#1722 

before:
<img width="917" alt="スクリーンショット 2022-04-05 23 28 26" src="https://user-images.githubusercontent.com/10097437/161778505-29aa82dc-4616-4eb5-b078-3d424d968056.png">

after:
<img width="917" alt="スクリーンショット 2022-04-05 23 27 13" src="https://user-images.githubusercontent.com/10097437/161778563-cce41b78-a510-4161-8212-42918ce29dfa.png">

when all changes to a renamed file are unstaged:
<img width="1608" alt="スクリーンショット 2022-04-05 23 40 06" src="https://user-images.githubusercontent.com/10097437/161779453-831176fb-e0f0-465e-a9bb-dbb78fd5b371.png">

