### PR TITLE
Pull request support for Bitbucket Server

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -468,7 +468,7 @@ services:
 Where:
 
 - `gitDomain` stands for the domain used by git itself (i.e. the one present on clone URLs), e.g. `git.work.com`
-- `provider` is one of `github`, `bitbucket` or `gitlab`
+- `provider` is one of `github`, `bitbucket`, `bitbucketServer`, `azuredevops` or `gitlab`
 - `webDomain` is the URL where your git service exposes a web interface and APIs, e.g. `gitservice.work.com`
 
 ## Predefined commit message prefix

--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -49,11 +49,24 @@ var azdoServiceDef = ServiceDefinition{
 	repoURLTemplate: "https://{{.webDomain}}/{{.org}}/{{.project}}/_git/{{.repo}}",
 }
 
+var bitbucketServerServiceDef = ServiceDefinition{
+	provider:                        "bitbucketServer",
+	pullRequestURLIntoDefaultBranch: "/pull-requests?create&sourceBranch={{.From}}",
+	pullRequestURLIntoTargetBranch:  "/pull-requests?create&targetBranch={{.To}}&sourceBranch={{.From}}",
+	commitURL:                       "/commits/{{.CommitSha}}",
+	regexStrings: []string{
+		`^ssh://git@.*/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
+		`^https://.*/scm/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
+	},
+	repoURLTemplate: "https://{{.webDomain}}/projects/{{.project}}/repos/{{.repo}}",
+}
+
 var serviceDefinitions = []ServiceDefinition{
 	githubServiceDef,
 	bitbucketServiceDef,
 	gitLabServiceDef,
 	azdoServiceDef,
+	bitbucketServerServiceDef,
 }
 
 var defaultServiceDomains = []ServiceDomain{

--- a/pkg/commands/hosting_service/hosting_service_test.go
+++ b/pkg/commands/hosting_service/hosting_service_test.go
@@ -154,6 +154,60 @@ func TestGetPullRequestURL(t *testing.T) {
 			},
 		},
 		{
+			testName:  "Opens a link to new pull request on Bitbucket Server (SSH)",
+			from:      "feature/new",
+			remoteUrl: "ssh://git@mycompany.bitbucket.com/myproject/myrepo.git",
+			configServiceDomains: map[string]string{
+				// valid configuration for a bitbucket server URL
+				"mycompany.bitbucket.com": "bitbucketServer:mycompany.bitbucket.com",
+			},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://mycompany.bitbucket.com/projects/myproject/repos/myrepo/pull-requests?create&sourceBranch=feature%2Fnew", url)
+			},
+		},
+		{
+			testName:  "Opens a link to new pull request on Bitbucket Server (SSH) with specific target",
+			from:      "feature/new",
+			to:        "dev",
+			remoteUrl: "ssh://git@mycompany.bitbucket.com/myproject/myrepo.git",
+			configServiceDomains: map[string]string{
+				// valid configuration for a bitbucket server URL
+				"mycompany.bitbucket.com": "bitbucketServer:mycompany.bitbucket.com",
+			},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://mycompany.bitbucket.com/projects/myproject/repos/myrepo/pull-requests?create&targetBranch=dev&sourceBranch=feature%2Fnew", url)
+			},
+		},
+		{
+			testName:  "Opens a link to new pull request on Bitbucket Server (HTTP)",
+			from:      "feature/new",
+			remoteUrl: "https://mycompany.bitbucket.com/scm/myproject/myrepo.git",
+			configServiceDomains: map[string]string{
+				// valid configuration for a bitbucket server URL
+				"mycompany.bitbucket.com": "bitbucketServer:mycompany.bitbucket.com",
+			},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://mycompany.bitbucket.com/projects/myproject/repos/myrepo/pull-requests?create&sourceBranch=feature%2Fnew", url)
+			},
+		},
+		{
+			testName:  "Opens a link to new pull request on Bitbucket Server (HTTP) with specific target",
+			from:      "feature/new",
+			to:        "dev",
+			remoteUrl: "https://mycompany.bitbucket.com/scm/myproject/myrepo.git",
+			configServiceDomains: map[string]string{
+				// valid configuration for a bitbucket server URL
+				"mycompany.bitbucket.com": "bitbucketServer:mycompany.bitbucket.com",
+			},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://mycompany.bitbucket.com/projects/myproject/repos/myrepo/pull-requests?create&targetBranch=dev&sourceBranch=feature%2Fnew", url)
+			},
+		},
+		{
 			testName:  "Throws an error if git service is unsupported",
 			from:      "feature/divide-operation",
 			remoteUrl: "git@something.com:peter/calculator.git",
@@ -199,7 +253,7 @@ func TestGetPullRequestURL(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, "https://bitbucket.org/johndoe/social_network/pull-requests/new?source=feature%2Fprofile-page&t=1", url)
 			},
-			expectedLoggedErrors: []string{"Unknown git service type: 'noservice'. Expected one of github, bitbucket, gitlab, azuredevops"},
+			expectedLoggedErrors: []string{"Unknown git service type: 'noservice'. Expected one of github, bitbucket, gitlab, azuredevops, bitbucketServer"},
 		},
 		{
 			testName:  "Escapes reserved URL characters in from branch name",


### PR DESCRIPTION
This is the follow up PR for #1604 (finally)
Stash was renamed to Bitbucket Server (see [here](https://confluence.atlassian.com/bitbucketserver/bitbucket-rebrand-faq-779298912.html)) which is why I changed the name

I am not experienced with the go programming language at all, so if there is a better way to implement certain things I am open for suggestions :slightly_smiling_face: of course also for lazygit specific conventions etc.

One note: Bitbucket Server does not really have a "default URL" since it is mostly hosted under a company specific URL instead, which is why I added some "dummy" URL, which does not exist, for the `defaultServiceDomains`