### PR TITLE
docs: add alternative keybinding to scroll up/down main panel

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -6,8 +6,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 <pre>
   <kbd>ctrl+r</kbd>: switch to a recent repo
-  <kbd>pgup</kbd>: scroll up main panel (fn+up)
-  <kbd>pgdown</kbd>: scroll down main panel (fn+down)
+  <kbd>pgup</kbd>: scroll up main panel (fn+up/shift+k)
+  <kbd>pgdown</kbd>: scroll down main panel (fn+down/shift+j)
   <kbd>m</kbd>: view merge/rebase options
   <kbd>ctrl+p</kbd>: view custom patch options
   <kbd>R</kbd>: refresh

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -6,8 +6,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 <pre>
   <kbd>ctrl+r</kbd>: wissel naar een recente repo
-  <kbd>pgup</kbd>: scroll naar beneden vanaf hoofdpaneel (fn+up)
-  <kbd>pgdown</kbd>: scroll naar beneden vanaf hoofdpaneel (fn+down)
+  <kbd>pgup</kbd>: scroll naar beneden vanaf hoofdpaneel (fn+up/shift+k)
+  <kbd>pgdown</kbd>: scroll naar beneden vanaf hoofdpaneel (fn+down/shift+j)
   <kbd>m</kbd>: bekijk merge/rebase opties
   <kbd>ctrl+p</kbd>: bekijk aangepaste patch opties
   <kbd>R</kbd>: verversen

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -6,8 +6,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 <pre>
   <kbd>ctrl+r</kbd>: switch to a recent repo
-  <kbd>pgup</kbd>: scroll up main panel (fn+up)
-  <kbd>pgdown</kbd>: scroll down main panel (fn+down)
+  <kbd>pgup</kbd>: scroll up main panel (fn+up/shift+k)
+  <kbd>pgdown</kbd>: scroll down main panel (fn+down/shift+j)
   <kbd>m</kbd>: widok scalenia/opcje zmiany bazy
   <kbd>ctrl+p</kbd>: view custom patch options
   <kbd>R</kbd>: odśwież

--- a/docs/keybindings/Keybindings_zh.md
+++ b/docs/keybindings/Keybindings_zh.md
@@ -6,8 +6,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 <pre>
   <kbd>ctrl+r</kbd>: 切换到最近的仓库
-  <kbd>pgup</kbd>: 向上滚动主面板 (fn+up)
-  <kbd>pgdown</kbd>: 向下滚动主面板 (fn+down)
+  <kbd>pgup</kbd>: 向上滚动主面板 (fn+up/shift+k)
+  <kbd>pgdown</kbd>: 向下滚动主面板 (fn+down/shift+j)
   <kbd>m</kbd>: 查看 合并/变基 选项
   <kbd>ctrl+p</kbd>: 查看自定义补丁选项
   <kbd>R</kbd>: 刷新

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -104,14 +104,14 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 			ViewName:    "",
 			Key:         opts.GetKey(opts.Config.Universal.ScrollUpMain),
 			Handler:     self.scrollUpMain,
-			Alternative: "fn+up",
+			Alternative: "fn+up/shift+k",
 			Description: self.c.Tr.LcScrollUpMainPanel,
 		},
 		{
 			ViewName:    "",
 			Key:         opts.GetKey(opts.Config.Universal.ScrollDownMain),
 			Handler:     self.scrollDownMain,
-			Alternative: "fn+down",
+			Alternative: "fn+down/shift+j",
 			Description: self.c.Tr.LcScrollDownMainPanel,
 		},
 		{


### PR DESCRIPTION
I notice that ```shift+k/j``` can also scroll up and down the main panel, so why not add it to the keybindings docs?