### PR TITLE
fix not to trim renamed file names

### DIFF
--- a/pkg/commands/loaders/files.go
+++ b/pkg/commands/loaders/files.go
@@ -125,7 +125,7 @@ func (c *FileLoader) GitStatus(opts GitStatusOptions) ([]FileStatus, error) {
 
 		if strings.HasPrefix(status.Change, "R") {
 			// if a line starts with 'R' then the next line is the original file.
-			status.PreviousName = strings.TrimSpace(splitLines[i+1])
+			status.PreviousName = splitLines[i+1]
 			status.StatusString = fmt.Sprintf("%s %s -> %s", status.Change, status.PreviousName, status.Name)
 			i++
 		}


### PR DESCRIPTION
Fix that the file is not considered renamed if `PreviousName` contains only spaces.

```sh
seq 1 5 >' '
git add ' '
git commit -m 'test'

mv ' ' a
seq 2 6 >a
git add ' ' a
```

<table>
<tr>
	<td>before
	<td>
<img width="802" alt="スクリーンショット 2022-04-14 21 39 36" src="https://user-images.githubusercontent.com/10097437/163392405-37a3f20d-0b62-48d6-ae38-ba8ae62ddc19.png">
<tr>
	<td>after
	<td><img width="799" alt="スクリーンショット 2022-04-14 21 39 51" src="https://user-images.githubusercontent.com/10097437/163392432-fa94ce3e-b873-4c36-a76d-de6009f0292b.png">
</table>