### PR TITLE
allow hiding bottom line

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -50,6 +50,7 @@ gui:
   showFileTree: true # for rendering changes files in a tree format
   showListFooter: true # for seeing the '5 of 20' message in list panels
   showRandomTip: true
+  showBottomLine: true # for hiding the bottom information line (unless it has important information to tell you)
   showCommandLog: true
   commandLogSize: 8
 git:

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -43,6 +43,7 @@ type GuiConfig struct {
 	ShowFileTree             bool               `yaml:"showFileTree"`
 	ShowRandomTip            bool               `yaml:"showRandomTip"`
 	ShowCommandLog           bool               `yaml:"showCommandLog"`
+	ShowBottomLine           bool               `yaml:"showBottomLine"`
 	CommandLogSize           int                `yaml:"commandLogSize"`
 }
 
@@ -351,6 +352,7 @@ func GetDefaultConfig() *UserConfig {
 			SkipNoStagedFilesWarning: false,
 			ShowListFooter:           true,
 			ShowCommandLog:           true,
+			ShowBottomLine:           true,
 			ShowFileTree:             true,
 			ShowRandomTip:            true,
 			CommandLogSize:           8,

--- a/pkg/gui/arrangement.go
+++ b/pkg/gui/arrangement.go
@@ -170,6 +170,12 @@ func (gui *Gui) getWindowDimensions(informationStr string, appStatus string) map
 
 	extrasWindowSize := gui.getExtrasWindowSize(height)
 
+	showInfoSection := gui.c.UserConfig.Gui.ShowBottomLine || (gui.State.Searching.isSearching || gui.isAnyModeActive())
+	infoSectionSize := 0
+	if showInfoSection {
+		infoSectionSize = 1
+	}
+
 	root := &boxlayout.Box{
 		Direction: boxlayout.ROW,
 		Children: []*boxlayout.Box{
@@ -201,7 +207,7 @@ func (gui *Gui) getWindowDimensions(informationStr string, appStatus string) map
 			},
 			{
 				Direction: boxlayout.COLUMN,
-				Size:      1,
+				Size:      infoSectionSize,
 				Children:  gui.infoSectionChildren(informationStr, appStatus),
 			},
 		},

--- a/pkg/gui/information_panel.go
+++ b/pkg/gui/information_panel.go
@@ -28,6 +28,12 @@ func (gui *Gui) getActiveMode() (modeStatus, bool) {
 	})
 }
 
+func (gui *Gui) isAnyModeActive() bool {
+	return slices.Some(gui.modeStatuses(), func(mode modeStatus) bool {
+		return mode.isActive()
+	})
+}
+
 func (gui *Gui) handleInfoClick() error {
 	if !gui.g.Mouse {
 		return nil


### PR DESCRIPTION
I was hanging around in the window arrangement code so figured I may as well add support for hiding the bottom line. It still appears when you're searching and when some mode is active (e.g. you've copied some commits to cherry pick) but it does not appear when in a loading state. Reason being that I want to have loading states for much more actions and it's going to be distracting to have the bottom line appear and disappear all the time, requiring other windows to shrink/expand in tandem. Not sure if we should have the loading state live somewhere else (I'm talking about the one that appears at the bottom left). Maybe the command log would be a good place for that.