### PR TITLE
better upstream changes presentation

### DIFF
--- a/pkg/commands/models/branch.go
+++ b/pkg/commands/models/branch.go
@@ -44,6 +44,10 @@ func (b *Branch) RemoteBranchStoredLocally() bool {
 	return b.IsTrackingRemote() && b.Pushables != "?" && b.Pullables != "?"
 }
 
+func (b *Branch) RemoteBranchNotStoredLocally() bool {
+	return b.IsTrackingRemote() && b.Pushables == "?" && b.Pullables == "?"
+}
+
 func (b *Branch) MatchesUpstream() bool {
 	return b.RemoteBranchStoredLocally() && b.Pushables == "0" && b.Pullables == "0"
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1077,7 +1077,7 @@ func EnglishTranslationSet() TranslationSet {
 		RewordInEditorPrompt:                "Are you sure you want to reword this commit in your editor?",
 		HardResetAutostashPrompt:            "Are you sure you want to hard reset to '%s'? An auto-stash will be performed if necessary.",
 		CheckoutPrompt:                      "Are you sure you want to checkout '%s'?",
-		UpstreamGone:                        "↑gone",
+		UpstreamGone:                        "(upstream gone)",
 		Actions: Actions{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)
 			CheckoutCommit:                    "Checkout commit",


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/8456633/163738705-34186044-cab7-4013-b999-29cbe6dc694d.png)

after:

![image](https://user-images.githubusercontent.com/8456633/163738513-48e29eca-04b6-4e23-a6ca-7d5db1882896.png)

Legend:
* nothing: not tracking an upstream
* tick: aligned with upstream
* question mark: tracking an upstream but with no local copy
* up/down count: pushables and pullables
* (upstream gone): upstream branch not found on remote

I played around having the statuses in their own column to the left of the branch name and it looked pretty good, except for when there were upstream/downstream changes. In that case you either pad the whole column to compensate, which can push out the branch names quite a bit, or you set a max padding and then push the branch name to the right to make room for the stuff on the left. Neither of which looked good. You could do a hybrid thing where you just have a one-character column where you say that something is aligned with the upstream or not and if not then we show the actual pushable/pullable count to the right of the branch name, but that feels overly complicated to me.