### PR TITLE
Improve default editCommandTemplate

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -83,7 +83,7 @@ git:
   diffContextSize: 3 # how many lines of context are shown around a change in diffs
 os:
   editCommand: '' # see 'Configuring File Editing' section
-  editCommandTemplate: '{{editor}} {{filename}}'
+  editCommandTemplate: ''
   openCommand: ''
 refresher:
   refreshInterval: 10 # File/submodule refresh interval in seconds. Auto-refresh can be disabled via option 'git.autoRefresh'.
@@ -273,7 +273,7 @@ You can specify a line number you are currently at when in the line-by-line mode
 ```yaml
 os:
   editCommand: 'vim'
-  editCommandTemplate: '{{editor}} +{{line}} {{filename}}'
+  editCommandTemplate: '{{editor}} +{{line}} -- {{filename}}'
 ```
 
 or
@@ -281,7 +281,7 @@ or
 ```yaml
 os:
   editCommand: 'code'
-  editCommandTemplate: '{{editor}} --goto {{filename}}:{{line}}'
+  editCommandTemplate: '{{editor}} --goto -- {{filename}}:{{line}}'
 ```
 
 `{{editor}}` in `editCommandTemplate` is replaced with the value of `editCommand`.

--- a/pkg/commands/git_commands/file.go
+++ b/pkg/commands/git_commands/file.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/go-errors/errors"
-	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
@@ -59,14 +58,16 @@ func (self *FileCommands) GetEditCmdStr(filename string, lineNumber int) (string
 	}
 
 	editCmdTemplate := self.UserConfig.OS.EditCommandTemplate
-	if editCmdTemplate == config.DefaultEditCommandTemplate {
+	if len(editCmdTemplate) == 0 {
 		switch editor {
-		case "emacs", "nano", "vi", "vim":
-			editCmdTemplate = "{{editor}} +{{line}} {{filename}}"
+		case "emacs", "nano", "vi", "vim", "nvim":
+			editCmdTemplate = "{{editor}} +{{line}} -- {{filename}}"
 		case "subl":
-			editCmdTemplate = "{{editor}} {{filename}}:{{line}}"
+			editCmdTemplate = "{{editor}} -- {{filename}}:{{line}}"
 		case "code":
-			editCmdTemplate = "{{editor}} -r --goto {{filename}}:{{line}}"
+			editCmdTemplate = "{{editor}} -r --goto -- {{filename}}:{{line}}"
+		default:
+			editCmdTemplate = "{{editor}} -- {{filename}}"
 		}
 	}
 	return utils.ResolvePlaceholderString(editCmdTemplate, templateValues), nil

--- a/pkg/commands/git_commands/file_test.go
+++ b/pkg/commands/git_commands/file_test.go
@@ -47,7 +47,7 @@ func TestEditFileCmdStr(t *testing.T) {
 			gitConfigMockResponses: nil,
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, `nano +1 "test"`, cmdStr)
+				assert.Equal(t, `nano "test"`, cmdStr)
 			},
 		},
 		{
@@ -61,7 +61,7 @@ func TestEditFileCmdStr(t *testing.T) {
 			gitConfigMockResponses: map[string]string{"core.editor": "nano"},
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, `nano +1 "test"`, cmdStr)
+				assert.Equal(t, `nano "test"`, cmdStr)
 			},
 		},
 		{
@@ -79,7 +79,7 @@ func TestEditFileCmdStr(t *testing.T) {
 			gitConfigMockResponses: nil,
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, `nano +1 "test"`, cmdStr)
+				assert.Equal(t, `nano "test"`, cmdStr)
 			},
 		},
 		{
@@ -97,7 +97,7 @@ func TestEditFileCmdStr(t *testing.T) {
 			gitConfigMockResponses: nil,
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, `emacs +1 "test"`, cmdStr)
+				assert.Equal(t, `emacs "test"`, cmdStr)
 			},
 		},
 		{
@@ -112,7 +112,7 @@ func TestEditFileCmdStr(t *testing.T) {
 			gitConfigMockResponses: nil,
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, `vi +1 "test"`, cmdStr)
+				assert.Equal(t, `vi "test"`, cmdStr)
 			},
 		},
 		{
@@ -127,7 +127,7 @@ func TestEditFileCmdStr(t *testing.T) {
 			gitConfigMockResponses: nil,
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, `vi +1 "file/with space"`, cmdStr)
+				assert.Equal(t, `vi "file/with space"`, cmdStr)
 			},
 		},
 		{
@@ -142,6 +142,20 @@ func TestEditFileCmdStr(t *testing.T) {
 			test: func(cmdStr string, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, `vim +1 "open file/at line"`, cmdStr)
+			},
+		},
+		{
+			filename:                  "default edit command template",
+			configEditCommand:         "vim",
+			configEditCommandTemplate: "",
+			runner:                    oscommands.NewFakeRunner(t),
+			getenv: func(env string) string {
+				return ""
+			},
+			gitConfigMockResponses: nil,
+			test: func(cmdStr string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, `vim +1 -- "default edit command template"`, cmdStr)
 			},
 		},
 	}

--- a/pkg/config/config_default_platform.go
+++ b/pkg/config/config_default_platform.go
@@ -3,14 +3,12 @@
 
 package config
 
-const DefaultEditCommandTemplate = `{{editor}} {{filename}}`
-
 // GetPlatformDefaultConfig gets the defaults for the platform
 func GetPlatformDefaultConfig() OSConfig {
 	return OSConfig{
 		EditCommand:         ``,
-		EditCommandTemplate: DefaultEditCommandTemplate,
-		OpenCommand:         "open {{filename}}",
+		EditCommandTemplate: "",
+		OpenCommand:         "open -- {{filename}}",
 		OpenLinkCommand:     "open {{link}}",
 	}
 }

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -1,12 +1,10 @@
 package config
 
-const DefaultEditCommandTemplate = `{{editor}} {{filename}}`
-
 // GetPlatformDefaultConfig gets the defaults for the platform
 func GetPlatformDefaultConfig() OSConfig {
 	return OSConfig{
 		EditCommand:         ``,
-		EditCommandTemplate: DefaultEditCommandTemplate,
+		EditCommandTemplate: "",
 		OpenCommand:         `xdg-open {{filename}} >/dev/null`,
 		OpenLinkCommand:     `xdg-open {{link}} >/dev/null`,
 	}

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -1,12 +1,10 @@
 package config
 
-const DefaultEditCommandTemplate = `{{editor}} {{filename}}`
-
 // GetPlatformDefaultConfig gets the defaults for the platform
 func GetPlatformDefaultConfig() OSConfig {
 	return OSConfig{
 		EditCommand:         ``,
-		EditCommandTemplate: DefaultEditCommandTemplate,
+		EditCommandTemplate: "",
 		OpenCommand:         `start "" {{filename}}`,
 		OpenLinkCommand:     `start "" {{link}}`,
 	}


### PR DESCRIPTION
rel: #1775

fix default `os.editCommandTemplate`.

<img width="485" alt="スクリーンショット 2022-04-22 21 58 07" src="https://user-images.githubusercontent.com/10097437/164718881-ae61ae96-6b08-4f9f-b48d-6de35b3d222c.png">

before:
<img width="717" alt="スクリーンショット 2022-04-22 21 57 32" src="https://user-images.githubusercontent.com/10097437/164718918-0ee9f149-21cf-40d0-bdf6-b0ce28938e23.png">

after:
<img width="703" alt="スクリーンショット 2022-04-22 22 00 40" src="https://user-images.githubusercontent.com/10097437/164719325-cd1e6531-a6f8-4b3b-a743-09a51096124e.png">

Also changes the default value of `editCommandTemplate` to empty (isn't it strange to ignore it if the user explicitly specifies `editCommandTemplate:'{{editor}} {{filename}}'`?) 

It does not affect almost any user who does not specify `editCommandTemplate`.