### PR TITLE
Accept named colors for authorColors #1879

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -384,7 +384,8 @@ You can customize the color in case you're not happy with the randomly assigned 
 ```yaml
 gui:
   authorColors:
-    'John Smith': '#ff0000' # use red for John Smith
+    'John Smith': 'red' # use red for John Smith
+    'Alan Smithee': '#00ff00' # use green for Alan Smithee
 ```
 
 You can use wildcard to set a unified color in case your are lazy to customize the color for every author or you just want a single color for all/other authors:
@@ -393,7 +394,7 @@ You can use wildcard to set a unified color in case your are lazy to customize t
 gui:
   authorColors:
     # use red for John Smith
-    'John Smith': '#ff0000'
+    'John Smith': 'red'
     # use blue for other authors
     '*': '#0000ff'
 ```

--- a/pkg/utils/color.go
+++ b/pkg/utils/color.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gookit/color"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
+	"github.com/samber/lo"
 )
 
 var (
@@ -55,10 +56,10 @@ func IsValidHexValue(v string) bool {
 }
 
 func SetCustomColors(customColors map[string]string) map[string]style.TextStyle {
-	colors := make(map[string]style.TextStyle)
-	for key, colorSequence := range customColors {
-		style := style.New().SetFg(style.NewRGBColor(color.HEX(colorSequence, false)))
-		colors[key] = style
-	}
-	return colors
+	return lo.MapValues(customColors, func(c string, key string) style.TextStyle {
+		if s, ok := style.ColorMap[c]; ok {
+			return s.Foreground
+		}
+		return style.New().SetFg(style.NewRGBColor(color.HEX(c, false)))
+	})
 }


### PR DESCRIPTION
#1879

```yaml
gui:
  authorColors:
    'Jesse Duffield': red
    Ryooooooga: '#00ff00'
```

<img width="268" alt="スクリーンショット 2022-05-04 19 01 26" src="https://user-images.githubusercontent.com/10097437/166661778-b54fd407-e65e-43f4-a1aa-ac48bf7240b2.png">

