### PR TITLE
Improve loading speed of commits and reflog when `log.showSignature=true`

### DIFF
--- a/pkg/commands/loaders/commits.go
+++ b/pkg/commands/loaders/commits.go
@@ -89,14 +89,12 @@ func (self *CommitLoader) GetCommits(opts GetCommitsOptions) ([]*models.Commit, 
 	}
 
 	err = self.getLogCmd(opts).RunAndProcessLines(func(line string) (bool, error) {
-		if canExtractCommit(line) {
-			commit := self.extractCommitFromLine(line)
-			if commit.Sha == firstPushedCommit {
-				passedFirstPushedCommit = true
-			}
-			commit.Status = map[bool]string{true: "unpushed", false: "pushed"}[!passedFirstPushedCommit]
-			commits = append(commits, commit)
+		commit := self.extractCommitFromLine(line)
+		if commit.Sha == firstPushedCommit {
+			passedFirstPushedCommit = true
 		}
+		commit.Status = map[bool]string{true: "unpushed", false: "pushed"}[!passedFirstPushedCommit]
+		commits = append(commits, commit)
 		return false, nil
 	})
 	if err != nil {
@@ -435,7 +433,7 @@ func (self *CommitLoader) getLogCmd(opts GetCommitsOptions) oscommands.ICmdObj {
 
 	return self.cmd.New(
 		fmt.Sprintf(
-			"git log %s %s %s --oneline %s%s --abbrev=%d%s",
+			"git -c log.showSignature=false log %s %s %s --oneline %s%s --abbrev=%d%s",
 			self.cmd.Quote(opts.RefName),
 			orderFlag,
 			allFlag,

--- a/pkg/commands/loaders/commits.go
+++ b/pkg/commands/loaders/commits.go
@@ -212,7 +212,7 @@ func (self *CommitLoader) getHydratedRebasingCommits(rebaseMode enums.RebaseMode
 	// I suspect that will cause some damage
 	cmdObj := self.cmd.New(
 		fmt.Sprintf(
-			"git show %s --no-patch --oneline %s --abbrev=%d",
+			"git -c log.showSignature=false show %s --no-patch --oneline %s --abbrev=%d",
 			strings.Join(commitShas, " "),
 			prettyFormat,
 			20,
@@ -222,14 +222,12 @@ func (self *CommitLoader) getHydratedRebasingCommits(rebaseMode enums.RebaseMode
 	hydratedCommits := make([]*models.Commit, 0, len(commits))
 	i := 0
 	err = cmdObj.RunAndProcessLines(func(line string) (bool, error) {
-		if canExtractCommit(line) {
-			commit := self.extractCommitFromLine(line)
-			matchingCommit := commits[i]
-			commit.Action = matchingCommit.Action
-			commit.Status = matchingCommit.Status
-			hydratedCommits = append(hydratedCommits, commit)
-			i++
-		}
+		commit := self.extractCommitFromLine(line)
+		matchingCommit := commits[i]
+		commit.Action = matchingCommit.Action
+		commit.Status = matchingCommit.Status
+		hydratedCommits = append(hydratedCommits, commit)
+		i++
 		return false, nil
 	})
 	if err != nil {
@@ -456,7 +454,3 @@ var prettyFormat = fmt.Sprintf(
 )
 
 const NULL_CODE = "%x00"
-
-func canExtractCommit(line string) bool {
-	return line != "" && strings.Split(line, " ")[0] != "gpg:"
-}

--- a/pkg/commands/loaders/commits_test.go
+++ b/pkg/commands/loaders/commits_test.go
@@ -40,7 +40,7 @@ func TestGetCommits(t *testing.T) {
 			opts:              GetCommitsOptions{RefName: "HEAD", IncludeRebaseCommits: false},
 			runner: oscommands.NewFakeRunner(t).
 				Expect(`git merge-base "HEAD" "HEAD"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
-				Expect(`git log "HEAD" --topo-order  --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40`, "", nil),
+				Expect(`git -c log.showSignature=false log "HEAD" --topo-order  --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40`, "", nil),
 
 			expectedCommits: []*models.Commit{},
 			expectedError:   nil,
@@ -54,7 +54,7 @@ func TestGetCommits(t *testing.T) {
 				// here it's seeing which commits are yet to be pushed
 				Expect(`git merge-base "HEAD" "HEAD"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
-				Expect(`git log "HEAD" --topo-order  --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40`, commitsOutput, nil).
+				Expect(`git -c log.showSignature=false log "HEAD" --topo-order  --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40`, commitsOutput, nil).
 				// here it's seeing where our branch diverged from the master branch so that we can mark that commit and parent commits as 'merged'
 				Expect(`git merge-base "HEAD" "master"`, "26c07b1ab33860a1a7591a0638f9925ccf497ffa", nil),
 

--- a/pkg/commands/loaders/reflog_commits.go
+++ b/pkg/commands/loaders/reflog_commits.go
@@ -32,7 +32,7 @@ func (self *ReflogCommitLoader) GetReflogCommits(lastReflogCommit *models.Commit
 		filterPathArg = fmt.Sprintf(" --follow -- %s", self.cmd.Quote(filterPath))
 	}
 
-	cmdObj := self.cmd.New(fmt.Sprintf(`git log -g --abbrev=40 --format="%s"%s`, "%h%x00%ct%x00%gs%x00%p", filterPathArg)).DontLog()
+	cmdObj := self.cmd.New(fmt.Sprintf(`git -c log.showSignature=false log -g --abbrev=40 --format="%s"%s`, "%h%x00%ct%x00%gs%x00%p", filterPathArg)).DontLog()
 	onlyObtainedNewReflogCommits := false
 	err := cmdObj.RunAndProcessLines(func(line string) (bool, error) {
 		fields := strings.SplitN(line, "\x00", 4)

--- a/pkg/commands/loaders/reflog_commits_test.go
+++ b/pkg/commands/loaders/reflog_commits_test.go
@@ -34,7 +34,7 @@ func TestGetReflogCommits(t *testing.T) {
 		{
 			testName: "no reflog entries",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p"`, "", nil),
+				Expect(`git -c log.showSignature=false log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p"`, "", nil),
 
 			lastReflogCommit:        nil,
 			expectedCommits:         []*models.Commit{},
@@ -44,7 +44,7 @@ func TestGetReflogCommits(t *testing.T) {
 		{
 			testName: "some reflog entries",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p"`, reflogOutput, nil),
+				Expect(`git -c log.showSignature=false log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p"`, reflogOutput, nil),
 
 			lastReflogCommit: nil,
 			expectedCommits: []*models.Commit{
@@ -90,7 +90,7 @@ func TestGetReflogCommits(t *testing.T) {
 		{
 			testName: "some reflog entries where last commit is given",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p"`, reflogOutput, nil),
+				Expect(`git -c log.showSignature=false log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p"`, reflogOutput, nil),
 
 			lastReflogCommit: &models.Commit{
 				Sha:           "c3c4b66b64c97ffeecde",
@@ -114,7 +114,7 @@ func TestGetReflogCommits(t *testing.T) {
 		{
 			testName: "when passing filterPath",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p" --follow -- "path"`, reflogOutput, nil),
+				Expect(`git -c log.showSignature=false log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p" --follow -- "path"`, reflogOutput, nil),
 
 			lastReflogCommit: &models.Commit{
 				Sha:           "c3c4b66b64c97ffeecde",
@@ -139,7 +139,7 @@ func TestGetReflogCommits(t *testing.T) {
 		{
 			testName: "when command returns error",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p"`, "", errors.New("haha")),
+				Expect(`git -c log.showSignature=false log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p"`, "", errors.New("haha")),
 
 			lastReflogCommit:        nil,
 			filterPath:              "",


### PR DESCRIPTION
Loading speed of commits and reflog is very slow when `log.showSignature=true`.
<img width="541" alt="スクリーンショット 2022-05-04 19 38 06" src="https://user-images.githubusercontent.com/10097437/166667037-08dab132-c87f-4c3b-a53d-292c33738d9e.png">
<img width="540" alt="スクリーンショット 2022-05-04 19 37 54" src="https://user-images.githubusercontent.com/10097437/166666996-7cb03d27-8f30-4707-9e38-361547392ad1.png">

maybe related to #1901 (I couldn't reproduce the panic)