### PR TITLE
Fix a crash that occurred when pressing enter on an empty commit, reflog, or stash panel

### DIFF
--- a/pkg/gui/context/branches_context.go
+++ b/pkg/gui/context/branches_context.go
@@ -58,5 +58,9 @@ func (self *BranchesContext) GetSelectedItemId() string {
 }
 
 func (self *BranchesContext) GetSelectedRef() types.Ref {
-	return self.GetSelected()
+	branch := self.GetSelected()
+	if branch == nil {
+		return nil
+	}
+	return branch
 }

--- a/pkg/gui/context/local_commits_context.go
+++ b/pkg/gui/context/local_commits_context.go
@@ -84,7 +84,11 @@ func (self *LocalCommitsContext) CanRebase() bool {
 }
 
 func (self *LocalCommitsContext) GetSelectedRef() types.Ref {
-	return self.GetSelected()
+	commit := self.GetSelected()
+	if commit == nil {
+		return nil
+	}
+	return commit
 }
 
 func (self *LocalCommitsViewModel) SetLimitCommits(value bool) {

--- a/pkg/gui/context/reflog_commits_context.go
+++ b/pkg/gui/context/reflog_commits_context.go
@@ -62,7 +62,11 @@ func (self *ReflogCommitsContext) CanRebase() bool {
 }
 
 func (self *ReflogCommitsContext) GetSelectedRef() types.Ref {
-	return self.GetSelected()
+	commit := self.GetSelected()
+	if commit == nil {
+		return nil
+	}
+	return commit
 }
 
 func (self *ReflogCommitsContext) GetCommits() []*models.Commit {

--- a/pkg/gui/context/remote_branches_context.go
+++ b/pkg/gui/context/remote_branches_context.go
@@ -61,5 +61,9 @@ func (self *RemoteBranchesContext) GetSelectedItemId() string {
 }
 
 func (self *RemoteBranchesContext) GetSelectedRef() types.Ref {
-	return self.GetSelected()
+	remoteBranch := self.GetSelected()
+	if remoteBranch == nil {
+		return nil
+	}
+	return remoteBranch
 }

--- a/pkg/gui/context/stash_context.go
+++ b/pkg/gui/context/stash_context.go
@@ -62,5 +62,9 @@ func (self *StashContext) CanRebase() bool {
 }
 
 func (self *StashContext) GetSelectedRef() types.Ref {
-	return self.GetSelected()
+	stash := self.GetSelected()
+	if stash == nil {
+		return nil
+	}
+	return stash
 }

--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -83,7 +83,11 @@ func (self *SubCommitsContext) CanRebase() bool {
 }
 
 func (self *SubCommitsContext) GetSelectedRef() types.Ref {
-	return self.GetSelected()
+	commit := self.GetSelected()
+	if commit == nil {
+		return nil
+	}
+	return commit
 }
 
 func (self *SubCommitsContext) GetCommits() []*models.Commit {

--- a/pkg/gui/context/tags_context.go
+++ b/pkg/gui/context/tags_context.go
@@ -58,5 +58,9 @@ func (self *TagsContext) GetSelectedItemId() string {
 }
 
 func (self *TagsContext) GetSelectedRef() types.Ref {
-	return self.GetSelected()
+	tag := self.GetSelected()
+	if tag == nil {
+		return nil
+	}
+	return tag
 }


### PR DESCRIPTION


```log
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x153db63]

goroutine 1 [running]:
github.com/jesseduffield/lazygit/pkg/commands/models.(*StashEntry).RefName(...)
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/pkg/commands/models/stash_entry.go:12
github.com/jesseduffield/lazygit/pkg/commands/models.(*StashEntry).Description(0x0)
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/pkg/commands/models/stash_entry.go:24 +0x23
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).SwitchToCommitFilesContext(0xc0001ca240, {{0x18c3320, 0x0}, 0x0, {0x18c94f8, 0xc000200a90}})
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/pkg/gui/commit_files_panel.go:44 +0xa8
github.com/jesseduffield/lazygit/pkg/gui/controllers.(*SwitchToDiffFilesController).enter(0xc0002064c0, {0x18c3320, 0x0})
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/pkg/gui/controllers/switch_to_diff_files_controller.go:65 +0xbf
github.com/jesseduffield/lazygit/pkg/gui/controllers.(*SwitchToDiffFilesController).checkSelected.func1()
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/pkg/gui/controllers/switch_to_diff_files_controller.go:60 +0x3e
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).SetKeybinding.func2(0x1045893?, 0x1037176?)
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/pkg/gui/keybindings.go:924 +0x1b
github.com/jesseduffield/gocui.(*Gui).execKeybinding(0xc0003d9800?, 0x10466ef?, 0xc0003d9850?)
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:1302 +0x59
github.com/jesseduffield/gocui.(*Gui).execKeybindings(0xc0001e4000, 0xc000000b40, 0xc0003d9870)
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:1270 +0x530
github.com/jesseduffield/gocui.(*Gui).onKey(0xc000206110?, 0xc000152300?)
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:1146 +0xf1
github.com/jesseduffield/gocui.(*Gui).handleEvent(0xc0003d9850?, 0xc0003d9840?)
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:697 +0x45
github.com/jesseduffield/gocui.(*Gui).MainLoop(0xc0001e4000)
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:657 +0x225
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).Run(0xc0001ca240, {0x0, 0x0})
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/pkg/gui/gui.go:596 +0x696
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).RunAndHandleError.func1()
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/pkg/gui/gui.go:717 +0x3c
github.com/jesseduffield/lazygit/pkg/utils.SafeWithError(0x0?)
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/pkg/utils/utils.go:115 +0x67
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).RunAndHandleError(0xc0001ca240, {0x0, 0x0})
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/pkg/gui/gui.go:716 +0x8f
github.com/jesseduffield/lazygit/pkg/app.(*App).Run(0xc0001328a0, {0x0, 0x0})
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/pkg/app/app.go:254 +0xa5
main.main()
        /Users/XXX/repos/github.com/Ryooooooga/lazygit/main.go:144 +0xe66
```