### PR TITLE
Fix the prompt height and appStatus width calculation when using multi byte characters

### DIFF
--- a/pkg/gui/arrangement.go
+++ b/pkg/gui/arrangement.go
@@ -5,6 +5,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
+	"github.com/mattn/go-runewidth"
 )
 
 // In this file we use the boxlayout package, along with knowledge about the app's state,
@@ -78,7 +79,7 @@ func (gui *Gui) infoSectionChildren(informationStr string, appStatus string) []*
 		return []*boxlayout.Box{
 			{
 				Window: "searchPrefix",
-				Size:   len(SEARCH_PREFIX),
+				Size:   runewidth.StringWidth(SEARCH_PREFIX),
 			},
 			{
 				Window: "search",
@@ -93,7 +94,7 @@ func (gui *Gui) infoSectionChildren(informationStr string, appStatus string) []*
 		result = append(result,
 			&boxlayout.Box{
 				Window: "appStatus",
-				Size:   len(appStatus) + len(INFO_SECTION_PADDING),
+				Size:   runewidth.StringWidth(appStatus) + runewidth.StringWidth(INFO_SECTION_PADDING),
 			},
 		)
 	}
@@ -107,7 +108,7 @@ func (gui *Gui) infoSectionChildren(informationStr string, appStatus string) []*
 			{
 				Window: "information",
 				// unlike appStatus, informationStr has various colors so we need to decolorise before taking the length
-				Size: len(INFO_SECTION_PADDING) + len(utils.Decolorise(informationStr)),
+				Size: runewidth.StringWidth(INFO_SECTION_PADDING) + runewidth.StringWidth(utils.Decolorise(informationStr)),
 			},
 		}...,
 	)

--- a/pkg/gui/confirmation_panel.go
+++ b/pkg/gui/confirmation_panel.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/theme"
 	"github.com/jesseduffield/lazygit/pkg/utils"
+	"github.com/mattn/go-runewidth"
 )
 
 // This file is for the rendering of confirmation panels along with setting and handling associated
@@ -76,7 +77,7 @@ func (gui *Gui) getMessageHeight(wrap bool, message string, width int) int {
 	// if we need to wrap, calculate height to fit content within view's width
 	if wrap {
 		for _, line := range lines {
-			lineCount += len(line)/width + 1
+			lineCount += runewidth.StringWidth(line)/width + 1
 		}
 	} else {
 		lineCount = len(lines)

--- a/pkg/gui/information_panel.go
+++ b/pkg/gui/information_panel.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jesseduffield/generics/slices"
 	"github.com/jesseduffield/lazygit/pkg/constants"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
+	"github.com/mattn/go-runewidth"
 )
 
 func (gui *Gui) informationStr() string {
@@ -45,16 +46,16 @@ func (gui *Gui) handleInfoClick() error {
 	width, _ := view.Size()
 
 	if activeMode, ok := gui.getActiveMode(); ok {
-		if width-cx > len(gui.c.Tr.ResetInParentheses) {
+		if width-cx > runewidth.StringWidth(gui.c.Tr.ResetInParentheses) {
 			return nil
 		}
 		return activeMode.reset()
 	}
 
 	// if we're not in an active mode we show the donate button
-	if cx <= len(gui.c.Tr.Donate) {
+	if cx <= runewidth.StringWidth(gui.c.Tr.Donate) {
 		return gui.os.OpenLink(constants.Links.Donate)
-	} else if cx <= len(gui.c.Tr.Donate)+1+len(gui.c.Tr.AskQuestion) {
+	} else if cx <= runewidth.StringWidth(gui.c.Tr.Donate)+1+runewidth.StringWidth(gui.c.Tr.AskQuestion) {
 		return gui.os.OpenLink(constants.Links.Discussions)
 	}
 	return nil


### PR DESCRIPTION
`You have not staged any files. Commit all files?` prompt in Japanese:
<table>
<tr>
	<td>before
	<td><img width="802" alt="スクリーンショット 2022-05-07 16 19 43" src="https://user-images.githubusercontent.com/10097437/167244780-f78322aa-2698-49f8-841d-17ae850e9560.png">
<tr>
	<td>after
	<td><img width="859" alt="スクリーンショット 2022-05-07 16 34 46" src="https://user-images.githubusercontent.com/10097437/167244794-812e83e7-2925-4605-8b04-1626f998d747.png">
</table>

`'<SHA>' copied to clipboard` appStatus in Japanese:
<table>
<tr>
	<td>before
	<td><img src="https://user-images.githubusercontent.com/10097437/167245323-94dffeea-9402-4d39-bc83-6e95101e81a3.png">
<tr>
	<td>after
	<td><img src="https://user-images.githubusercontent.com/10097437/167245329-f703b6a6-3815-4054-b86b-a37995e73343.png">
</table>