### PR TITLE
Fix copying of the commit author to the clipboard

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -87,13 +87,13 @@ type Author struct {
 }
 
 func (self *CommitCommands) GetCommitAuthor(commitSha string) (Author, error) {
-	cmdStr := "git show --no-patch --pretty=format:'%an|%ae' " + commitSha
+	cmdStr := "git show --no-patch --pretty=format:'%an%x00%ae' " + commitSha
 	output, err := self.cmd.New(cmdStr).DontLog().RunWithOutput()
 	if err != nil {
 		return Author{}, err
 	}
 
-	split := strings.Split(strings.TrimSpace(output), "|")
+	split := strings.SplitN(strings.TrimSpace(output), "\x00", 2)
 	if len(split) < 2 {
 		return Author{}, errors.New("unexpected git output")
 	}


### PR DESCRIPTION
When `user.name` contains `|`, `copyAuthorToClipboard` does not work correctly.

1. set user name: `git config user.name "a|b"`
2. commit something: `git commit --allow-empty -m "something"`
3. launch lazygit: `lazygit`
4. `4` (move to `Commits`), `y` (`copy commit attribute...`), `a` (`commit author`)
5. `a <b>` is copied to the clipboard

before:
<img width="652" alt="スクリーンショット 2022-05-07 18 06 14" src="https://user-images.githubusercontent.com/10097437/167247845-6b5290af-70c5-49cb-8779-cc62714c6d52.png">

after:
<img width="652" alt="スクリーンショット 2022-05-07 18 05 50" src="https://user-images.githubusercontent.com/10097437/167247868-b05805d9-9de8-410b-a03e-741f99fe097b.png">
