### PR TITLE
Don't panic when there are no valid git repos

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -190,9 +190,9 @@ func (app *App) setupRepo() (bool, error) {
 						return true, nil
 					}
 				}
-				return false, err
 			}
 
+			fmt.Println(app.Tr.NoRecentRepositories)
 			os.Exit(1)
 		}
 		if err := app.OSCommand.Cmd.New("git init").Run(); err != nil {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -255,6 +255,7 @@ type TranslationSet struct {
 	DiscardFileChangesPrompt            string
 	DisabledForGPG                      string
 	CreateRepo                          string
+	NoRecentRepositories                string
 	AutoStashTitle                      string
 	AutoStashPrompt                     string
 	StashPrefix                         string
@@ -873,6 +874,7 @@ func EnglishTranslationSet() TranslationSet {
 		DiscardFileChangesPrompt:            "Are you sure you want to discard this commit's changes to this file? If this file was created in this commit, it will be deleted",
 		DisabledForGPG:                      "Feature not available for users using GPG",
 		CreateRepo:                          "Not in a git repository. Create a new git repository? (y/n): ",
+		NoRecentRepositories:                "Must open lazygit in a git repository. No valid recent repositories. Exiting.",
 		AutoStashTitle:                      "Autostash?",
 		AutoStashPrompt:                     "You must stash and pop your changes to bring them across. Do this automatically? (enter/esc)",
 		StashPrefix:                         "Auto-stashing changes for ",


### PR DESCRIPTION
This should help with #1596 , it won't panic and the user will be informed why `lazygit` failed to start.

But invalid paths should also probably be removed from the `state.yml` when they're iterated through, do we already do that somewhere?