### PR TITLE
WIP: Fix ambiguous refname

### DIFF
--- a/pkg/commands/models/branch.go
+++ b/pkg/commands/models/branch.go
@@ -18,6 +18,10 @@ type Branch struct {
 	UpstreamBranch string
 }
 
+func (b *Branch) FullRefName() string {
+	return "refs/heads/" + b.Name
+}
+
 func (b *Branch) RefName() string {
 	return b.Name
 }

--- a/pkg/commands/models/commit.go
+++ b/pkg/commands/models/commit.go
@@ -29,6 +29,10 @@ func (c *Commit) ShortSha() string {
 	return utils.ShortSha(c.Sha)
 }
 
+func (c *Commit) FullRefName() string {
+	return c.Sha
+}
+
 func (c *Commit) RefName() string {
 	return c.Sha
 }

--- a/pkg/commands/models/remote_branch.go
+++ b/pkg/commands/models/remote_branch.go
@@ -10,6 +10,10 @@ func (r *RemoteBranch) FullName() string {
 	return r.RemoteName + "/" + r.Name
 }
 
+func (r *RemoteBranch) FullRefName() string {
+	return "refs/remotes/" + r.FullName()
+}
+
 func (r *RemoteBranch) RefName() string {
 	return r.FullName()
 }

--- a/pkg/commands/models/stash_entry.go
+++ b/pkg/commands/models/stash_entry.go
@@ -8,6 +8,10 @@ type StashEntry struct {
 	Name  string
 }
 
+func (s *StashEntry) FullRefName() string {
+	return s.RefName()
+}
+
 func (s *StashEntry) RefName() string {
 	return fmt.Sprintf("stash@{%d}", s.Index)
 }

--- a/pkg/commands/models/tag.go
+++ b/pkg/commands/models/tag.go
@@ -5,6 +5,10 @@ type Tag struct {
 	Name string
 }
 
+func (t *Tag) FullRefName() string {
+	return "refs/tags/" + t.RefName()
+}
+
 func (t *Tag) RefName() string {
 	return t.Name
 }

--- a/pkg/gui/branches_panel.go
+++ b/pkg/gui/branches_panel.go
@@ -6,7 +6,7 @@ func (gui *Gui) branchesRenderToMain() error {
 	if branch == nil {
 		task = NewRenderStringTask(gui.c.Tr.NoBranchesThisRepo)
 	} else {
-		cmdObj := gui.git.Branch.GetGraphCmdObj(branch.Name)
+		cmdObj := gui.git.Branch.GetGraphCmdObj(branch.FullRefName())
 
 		task = NewRunPtyTask(cmdObj.GetCmd())
 	}

--- a/pkg/gui/controllers/switch_to_sub_commits_controller.go
+++ b/pkg/gui/controllers/switch_to_sub_commits_controller.go
@@ -62,7 +62,7 @@ func (self *SwitchToSubCommitsController) viewCommits() error {
 			Limit:                true,
 			FilterPath:           self.modes.Filtering.GetPath(),
 			IncludeRebaseCommits: false,
-			RefName:              ref.RefName(),
+			RefName:              ref.FullRefName(),
 		},
 	)
 	if err != nil {

--- a/pkg/gui/remote_branches_panel.go
+++ b/pkg/gui/remote_branches_panel.go
@@ -6,7 +6,7 @@ func (gui *Gui) remoteBranchesRenderToMain() error {
 	if remoteBranch == nil {
 		task = NewRenderStringTask("No branches for this remote")
 	} else {
-		cmdObj := gui.git.Branch.GetGraphCmdObj(remoteBranch.FullName())
+		cmdObj := gui.git.Branch.GetGraphCmdObj(remoteBranch.FullRefName())
 		task = NewRunCommandTask(cmdObj.GetCmd())
 	}
 

--- a/pkg/gui/tags_panel.go
+++ b/pkg/gui/tags_panel.go
@@ -6,7 +6,7 @@ func (self *Gui) tagsRenderToMain() error {
 	if tag == nil {
 		task = NewRenderStringTask("No tags")
 	} else {
-		cmdObj := self.git.Branch.GetGraphCmdObj(tag.Name)
+		cmdObj := self.git.Branch.GetGraphCmdObj(tag.FullRefName())
 		task = NewRunCommandTask(cmdObj.GetCmd())
 	}
 

--- a/pkg/gui/types/ref.go
+++ b/pkg/gui/types/ref.go
@@ -1,6 +1,7 @@
 package types
 
 type Ref interface {
+	FullRefName() string
 	RefName() string
 	ParentRefName() string
 	Description() string


### PR DESCRIPTION
The commits loader fails when a file or directory with the same name as branch/tag exists.

```sh
$ mkdir master
$ lazygit
```

<img width="543" alt="スクリーンショット 2022-05-12 19 47 15" src="https://user-images.githubusercontent.com/10097437/168054651-99326ca5-95db-4eaa-80a8-f236e9c882b4.png">

And, fix the log command to be ambiguous when there is a tag with the same name as the branch.

```sh
$ git tag master
$ lazygit
```
![スクリーンショット 2022-05-12 19 48 24](https://user-images.githubusercontent.com/10097437/168055209-5f6d1d79-3027-4905-9c77-6a2de6b671d7.png)

