### PR TITLE
add ability to customize time format in commit log

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -23,6 +23,7 @@ gui:
   expandFocusedSidePanel: false
   mainPanelSplitMode: 'flexible' # one of 'horizontal' | 'flexible' | 'vertical'
   language: 'auto' # one of 'auto' | 'en' | 'zh' | 'pl' | 'nl' | 'ja'
+  timeFormat: '02 Jan 06 15:04 MST' # https://pkg.go.dev/time#Time.Format
   theme:
     lightTheme: false # For terminals with a light background
     activeBorderColor:

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"time"
+)
+
 type UserConfig struct {
 	Gui                  GuiConfig        `yaml:"gui"`
 	Git                  GitConfig        `yaml:"git"`
@@ -36,6 +40,7 @@ type GuiConfig struct {
 	ExpandFocusedSidePanel   bool               `yaml:"expandFocusedSidePanel"`
 	MainPanelSplitMode       string             `yaml:"mainPanelSplitMode"`
 	Language                 string             `yaml:"language"`
+	TimeFormat               string             `yaml:"timeFormat"`
 	Theme                    ThemeConfig        `yaml:"theme"`
 	CommitLength             CommitLengthConfig `yaml:"commitLength"`
 	SkipNoStagedFilesWarning bool               `yaml:"skipNoStagedFilesWarning"`
@@ -341,6 +346,7 @@ func GetDefaultConfig() *UserConfig {
 			ExpandFocusedSidePanel: false,
 			MainPanelSplitMode:     "flexible",
 			Language:               "auto",
+			TimeFormat:             time.RFC822,
 			Theme: ThemeConfig{
 				LightTheme:                false,
 				ActiveBorderColor:         []string{"green", "bold"},

--- a/pkg/gui/list_context_config.go
+++ b/pkg/gui/list_context_config.go
@@ -123,6 +123,7 @@ func (gui *Gui) branchCommitsListContext() *context.LocalCommitsContext {
 				gui.State.ScreenMode != SCREEN_NORMAL,
 				gui.helpers.CherryPick.CherryPickedCommitShaSet(),
 				gui.State.Modes.Diffing.Ref,
+				gui.c.UserConfig.Gui.TimeFormat,
 				gui.c.UserConfig.Git.ParseEmoji,
 				selectedCommitSha,
 				startIdx,
@@ -155,6 +156,7 @@ func (gui *Gui) subCommitsListContext() *context.SubCommitsContext {
 				gui.State.ScreenMode != SCREEN_NORMAL,
 				gui.helpers.CherryPick.CherryPickedCommitShaSet(),
 				gui.State.Modes.Diffing.Ref,
+				gui.c.UserConfig.Gui.TimeFormat,
 				gui.c.UserConfig.Git.ParseEmoji,
 				selectedCommitSha,
 				startIdx,
@@ -199,6 +201,7 @@ func (gui *Gui) reflogCommitsListContext() *context.ReflogCommitsContext {
 				gui.State.ScreenMode != SCREEN_NORMAL,
 				gui.helpers.CherryPick.CherryPickedCommitShaSet(),
 				gui.State.Modes.Diffing.Ref,
+				gui.c.UserConfig.Gui.TimeFormat,
 				gui.c.UserConfig.Git.ParseEmoji,
 			)
 		},

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -36,6 +36,7 @@ func GetCommitListDisplayStrings(
 	fullDescription bool,
 	cherryPickedCommitShaSet *set.Set[string],
 	diffName string,
+	timeFormat string,
 	parseEmoji bool,
 	selectedCommitSha string,
 	startIdx int,
@@ -98,6 +99,7 @@ func GetCommitListDisplayStrings(
 			commit,
 			cherryPickedCommitShaSet,
 			diffName,
+			timeFormat,
 			parseEmoji,
 			getGraphLine(unfilteredIdx),
 			fullDescription,
@@ -241,6 +243,7 @@ func displayCommit(
 	commit *models.Commit,
 	cherryPickedCommitShaSet *set.Set[string],
 	diffName string,
+	timeFormat string,
 	parseEmoji bool,
 	graphLine string,
 	fullDescription bool,
@@ -283,7 +286,7 @@ func displayCommit(
 	cols = append(cols, shaColor.Sprint(commit.ShortSha()))
 	cols = append(cols, bisectString)
 	if fullDescription {
-		cols = append(cols, style.FgBlue.Sprint(utils.UnixToDate(commit.UnixTimestamp)))
+		cols = append(cols, style.FgBlue.Sprint(utils.UnixToDate(commit.UnixTimestamp, timeFormat)))
 	}
 	cols = append(
 		cols,

--- a/pkg/gui/presentation/commits_test.go
+++ b/pkg/gui/presentation/commits_test.go
@@ -28,6 +28,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 		fullDescription          bool
 		cherryPickedCommitShaSet *set.Set[string]
 		diffName                 string
+		timeFormat               string
 		parseEmoji               bool
 		selectedCommitSha        string
 		startIdx                 int
@@ -203,6 +204,24 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			sha2 pick  commit2
 				`),
 		},
+		{
+			testName: "custom time format",
+			commits: []*models.Commit{
+				{Name: "commit1", Sha: "sha1", UnixTimestamp: 1652443200, AuthorName: "Jesse Duffield"},
+				{Name: "commit2", Sha: "sha2", UnixTimestamp: 1652529600, AuthorName: "Jesse Duffield"},
+			},
+			fullDescription:          true,
+			timeFormat:               "2006-01-02 15:04:05",
+			startIdx:                 0,
+			length:                   2,
+			showGraph:                false,
+			bisectInfo:               git_commands.NewNullBisectInfo(),
+			cherryPickedCommitShaSet: set.New[string](),
+			expected: formatExpected(`
+		sha1 2022-05-13 21:00:00 Jesse Duffield    commit1
+		sha2 2022-05-14 21:00:00 Jesse Duffield    commit2
+						`),
+		},
 	}
 
 	focusing := false
@@ -221,6 +240,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 					s.fullDescription,
 					s.cherryPickedCommitShaSet,
 					s.diffName,
+					s.timeFormat,
 					s.parseEmoji,
 					s.selectedCommitSha,
 					s.startIdx,

--- a/pkg/gui/presentation/commits_test.go
+++ b/pkg/gui/presentation/commits_test.go
@@ -1,6 +1,7 @@
 package presentation
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -218,11 +219,13 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			bisectInfo:               git_commands.NewNullBisectInfo(),
 			cherryPickedCommitShaSet: set.New[string](),
 			expected: formatExpected(`
-		sha1 2022-05-13 21:00:00 Jesse Duffield    commit1
-		sha2 2022-05-14 21:00:00 Jesse Duffield    commit2
+		sha1 2022-05-13 12:00:00 Jesse Duffield    commit1
+		sha2 2022-05-14 12:00:00 Jesse Duffield    commit2
 						`),
 		},
 	}
+
+	os.Setenv("TZ", "UTC")
 
 	focusing := false
 	for _, scenario := range scenarios {

--- a/pkg/gui/presentation/reflog_commits.go
+++ b/pkg/gui/presentation/reflog_commits.go
@@ -10,8 +10,8 @@ import (
 	"github.com/kyokomi/emoji/v2"
 )
 
-func GetReflogCommitListDisplayStrings(commits []*models.Commit, fullDescription bool, cherryPickedCommitShaSet *set.Set[string], diffName string, parseEmoji bool) [][]string {
-	var displayFunc func(*models.Commit, bool, bool, bool) []string
+func GetReflogCommitListDisplayStrings(commits []*models.Commit, fullDescription bool, cherryPickedCommitShaSet *set.Set[string], diffName string, timeFormat string, parseEmoji bool) [][]string {
+	var displayFunc func(*models.Commit, string, bool, bool, bool) []string
 	if fullDescription {
 		displayFunc = getFullDescriptionDisplayStringsForReflogCommit
 	} else {
@@ -21,7 +21,7 @@ func GetReflogCommitListDisplayStrings(commits []*models.Commit, fullDescription
 	return slices.Map(commits, func(commit *models.Commit) []string {
 		diffed := commit.Sha == diffName
 		cherryPicked := cherryPickedCommitShaSet.Includes(commit.Sha)
-		return displayFunc(commit, cherryPicked, diffed, parseEmoji)
+		return displayFunc(commit, timeFormat, cherryPicked, diffed, parseEmoji)
 	})
 }
 
@@ -38,7 +38,7 @@ func reflogShaColor(cherryPicked, diffed bool) style.TextStyle {
 	return shaColor
 }
 
-func getFullDescriptionDisplayStringsForReflogCommit(c *models.Commit, cherryPicked, diffed, parseEmoji bool) []string {
+func getFullDescriptionDisplayStringsForReflogCommit(c *models.Commit, timeFormat string, cherryPicked, diffed, parseEmoji bool) []string {
 	name := c.Name
 	if parseEmoji {
 		name = emoji.Sprint(name)
@@ -46,12 +46,12 @@ func getFullDescriptionDisplayStringsForReflogCommit(c *models.Commit, cherryPic
 
 	return []string{
 		reflogShaColor(cherryPicked, diffed).Sprint(c.ShortSha()),
-		style.FgMagenta.Sprint(utils.UnixToDate(c.UnixTimestamp)),
+		style.FgMagenta.Sprint(utils.UnixToDate(c.UnixTimestamp, timeFormat)),
 		theme.DefaultTextColor.Sprint(name),
 	}
 }
 
-func getDisplayStringsForReflogCommit(c *models.Commit, cherryPicked, diffed, parseEmoji bool) []string {
+func getDisplayStringsForReflogCommit(c *models.Commit, timeFormat string, cherryPicked, diffed, parseEmoji bool) []string {
 	name := c.Name
 	if parseEmoji {
 		name = emoji.Sprint(name)

--- a/pkg/utils/date.go
+++ b/pkg/utils/date.go
@@ -20,6 +20,6 @@ func UnixToTimeAgo(timestamp int64) string {
 	return fmt.Sprintf("%dy", int(delta))
 }
 
-func UnixToDate(timestamp int64) string {
-	return time.Unix(timestamp, 0).Format(time.RFC822)
+func UnixToDate(timestamp int64, timeFormat string) string {
+	return time.Unix(timestamp, 0).Format(timeFormat)
 }


### PR DESCRIPTION
```yaml
gui:
  timeFormat: 2006-01-02 15:04
```

<img width="435" alt="スクリーンショット 2022-05-13 21 58 38" src="https://user-images.githubusercontent.com/10097437/168289083-6cbf969b-0baa-49c1-85a5-83b81b7f1a70.png">
