### PR TITLE
Fix parsing of 'y/n' when starting in non-repo

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -172,7 +172,7 @@ func (app *App) setupRepo() (bool, error) {
 			// Offer to initialize a new repository in current directory.
 			fmt.Print(app.Tr.CreateRepo)
 			response, _ := bufio.NewReader(os.Stdin).ReadString('\n')
-			if strings.Trim(response, " \n") != "y" {
+			if strings.Trim(response, " \r\n") != "y" {
 				shouldInitRepo = false
 			}
 		} else if notARepository == "skip" {

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -110,6 +110,9 @@ func newRecentReposList(recentRepos []string, currentRepo string) (bool, []strin
 	newRepos := []string{currentRepo}
 	for _, repo := range recentRepos {
 		if repo != currentRepo {
+			if _, err := os.Stat(repo); err != nil {
+				continue
+			}
 			newRepos = append(newRepos, repo)
 		} else {
 			isNew = false


### PR DESCRIPTION
This should fix #1940, I tested it out and now it actually enters the `if` and inits a new repo.