### PR TITLE
Add helpful message on unmarshall error

### DIFF
--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -168,7 +168,7 @@ func loadUserConfig(configFiles []string, base *UserConfig) (*UserConfig, error)
 		}
 
 		if err := yaml.Unmarshal(content, base); err != nil {
-			return nil, fmt.Errorf("The config at `%s` couldn't be parsed, please inspect it before opening up an issue.", path)
+			return nil, fmt.Errorf("The config at `%s` couldn't be parsed, please inspect it before opening up an issue.\n%w", path, err)
 		}
 	}
 

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -167,7 +168,7 @@ func loadUserConfig(configFiles []string, base *UserConfig) (*UserConfig, error)
 		}
 
 		if err := yaml.Unmarshal(content, base); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("The config at `%s` couldn't be parsed, please inspect it before opening up an issue.", path)
 		}
 	}
 


### PR DESCRIPTION
This should help prevent issues such as #1968.

And it's the implementation of #1935 .

The reason why I didn't i18n it because the `TranslationSet` isn't created yet, so I'm not sure how exactly could I fetch it.