### PR TITLE
Show active branch for recent repo

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -148,7 +148,7 @@ func isGitVersionValid(versionStr string) bool {
 
 func isDirectoryAGitRepository(dir string) (bool, error) {
 	info, err := os.Stat(filepath.Join(dir, ".git"))
-	return info != nil && info.IsDir(), err
+	return info != nil, err
 }
 
 func (app *App) setupRepo() (bool, error) {

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,12 +17,14 @@ import (
 )
 
 func (gui *Gui) getCurrentBranch(path string) string {
-	if branch, err := gui.os.Cmd.New(
-		fmt.Sprintf("git -C %s rev-parse --abbrev-ref HEAD", gui.os.Quote(path)),
-	).DontLog().RunWithOutput(); err == nil {
-		return strings.Trim(branch, "\n")
+	if headFile, err := ioutil.ReadFile(fmt.Sprintf("%s/.git/HEAD", path)); err == nil {
+		content := strings.TrimSpace(string(headFile))
+		branch := strings.TrimPrefix(content, "ref: refs/heads/")
+		return branch
 	}
-	return ""
+	// worktrees don't have `.git/HEAD`
+	// and detached HEAD repos have only a hash in `.git/HEAD`
+	return "HEAD"
 }
 
 func (gui *Gui) handleCreateRecentReposMenu() error {

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -18,7 +18,7 @@ import (
 
 func (gui *Gui) getCurrentBranch(path string) string {
 	readHeadFile := func(path string) (string, error) {
-		headFile, err := ioutil.ReadFile(fmt.Sprintf("%s%cHEAD", path, os.PathSeparator))
+		headFile, err := ioutil.ReadFile(filepath.Join(path, "HEAD"))
 		if err == nil {
 			content := strings.TrimSpace(string(headFile))
 			branch := strings.TrimPrefix(content, "ref: refs/heads/")
@@ -27,7 +27,7 @@ func (gui *Gui) getCurrentBranch(path string) string {
 		return "", err
 	}
 
-	gitDirPath := fmt.Sprintf("%s%c.git", path, os.PathSeparator)
+	gitDirPath := filepath.Join(path, ".git")
 
 	if gitDir, err := os.Stat(gitDirPath); err == nil {
 		if gitDir.IsDir() {

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation/icons"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 func (gui *Gui) getCurrentBranch(path string) string {
@@ -21,8 +22,16 @@ func (gui *Gui) getCurrentBranch(path string) string {
 		headFile, err := ioutil.ReadFile(filepath.Join(path, "HEAD"))
 		if err == nil {
 			content := strings.TrimSpace(string(headFile))
-			branch := strings.TrimPrefix(content, "ref: refs/heads/")
-			return branch, nil
+			refsPrefix := "ref: refs/heads/"
+			branchDisplay := ""
+			if strings.HasPrefix(content, refsPrefix) {
+				// is a branch
+				branchDisplay = strings.TrimPrefix(content, refsPrefix)
+			} else {
+				// detached HEAD state, displaying short SHA
+				branchDisplay = utils.ShortSha(content)
+			}
+			return branchDisplay, nil
 		}
 		return "", err
 	}
@@ -47,7 +56,7 @@ func (gui *Gui) getCurrentBranch(path string) string {
 		}
 	}
 
-	return "HEAD"
+	return "unknown branch"
 }
 
 func (gui *Gui) handleCreateRecentReposMenu() error {

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -56,7 +56,7 @@ func (gui *Gui) getCurrentBranch(path string) string {
 		}
 	}
 
-	return "unknown branch"
+	return gui.c.Tr.LcBranchUnknown
 }
 
 func (gui *Gui) handleCreateRecentReposMenu() error {

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -110,7 +110,7 @@ func newRecentReposList(recentRepos []string, currentRepo string) (bool, []strin
 	newRepos := []string{currentRepo}
 	for _, repo := range recentRepos {
 		if repo != currentRepo {
-			if _, err := os.Stat(repo); err != nil {
+			if _, err := os.Stat(filepath.Join(repo, ".git")); err != nil {
 				continue
 			}
 			newRepos = append(newRepos, repo)

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -409,6 +409,7 @@ type TranslationSet struct {
 	NoFilesStagedPrompt                 string
 	BranchNotFoundTitle                 string
 	BranchNotFoundPrompt                string
+	LcBranchUnknown                     string
 	UnstageLinesTitle                   string
 	UnstageLinesPrompt                  string
 	LcCreateNewBranchFromCommit         string
@@ -1045,6 +1046,7 @@ func EnglishTranslationSet() TranslationSet {
 		NoFilesStagedPrompt:                 "You have not staged any files. Commit all files?",
 		BranchNotFoundTitle:                 "Branch not found",
 		BranchNotFoundPrompt:                "Branch not found. Create a new branch named",
+		LcBranchUnknown:                     "branch unknown",
 		UnstageLinesTitle:                   "Unstage lines",
 		UnstageLinesPrompt:                  "Are you sure you want to delete the selected lines (git reset)? It is irreversible.\nTo disable this dialogue set the config key of 'gui.skipUnstageLineWarning' to true",
 		LcCreateNewBranchFromCommit:         "create new branch off of commit",


### PR DESCRIPTION
This should close #1949.

It shows `HEAD` if the repo is in `detached HEAD` state, but I guess showing the branch name when not in `detached HEAD` state is better than nothing.