### PR TITLE
Add config to sort origin branches by last commit

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -82,6 +82,7 @@ git:
   autoRefresh: true
   branchLogCmd: 'git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --'
   allBranchesLogCmd: 'git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium'
+  sortRemoteBranchesByLastCommit: false
   overrideGpg: false # prevents lazygit from spawning a separate process when using GPG
   disableForcePushing: false
   parseEmoji: false

--- a/pkg/commands/loaders/remotes.go
+++ b/pkg/commands/loaders/remotes.go
@@ -31,7 +31,12 @@ func NewRemoteLoader(
 }
 
 func (self *RemoteLoader) GetRemotes() ([]*models.Remote, error) {
-	remoteBranchesStr, err := self.cmd.New("git branch -r").DontLog().RunWithOutput()
+	remoteBranchesCommand := "git branch -r"
+	if self.Common.UserConfig.Git.SortRemoteBranchesByLastCommit {
+		remoteBranchesCommand = "git for-each-ref --sort=-authordate refs/remotes --format=\"%(refname:lstrip=2)\""
+	}
+
+	remoteBranchesStr, err := self.cmd.New(remoteBranchesCommand).DontLog().RunWithOutput()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -71,17 +71,18 @@ type CommitLengthConfig struct {
 }
 
 type GitConfig struct {
-	Paging              PagingConfig                  `yaml:"paging"`
-	Commit              CommitConfig                  `yaml:"commit"`
-	Merging             MergingConfig                 `yaml:"merging"`
-	SkipHookPrefix      string                        `yaml:"skipHookPrefix"`
-	AutoFetch           bool                          `yaml:"autoFetch"`
-	AutoRefresh         bool                          `yaml:"autoRefresh"`
-	BranchLogCmd        string                        `yaml:"branchLogCmd"`
-	AllBranchesLogCmd   string                        `yaml:"allBranchesLogCmd"`
-	OverrideGpg         bool                          `yaml:"overrideGpg"`
-	DisableForcePushing bool                          `yaml:"disableForcePushing"`
-	CommitPrefixes      map[string]CommitPrefixConfig `yaml:"commitPrefixes"`
+	Paging                         PagingConfig                  `yaml:"paging"`
+	Commit                         CommitConfig                  `yaml:"commit"`
+	Merging                        MergingConfig                 `yaml:"merging"`
+	SkipHookPrefix                 string                        `yaml:"skipHookPrefix"`
+	AutoFetch                      bool                          `yaml:"autoFetch"`
+	AutoRefresh                    bool                          `yaml:"autoRefresh"`
+	BranchLogCmd                   string                        `yaml:"branchLogCmd"`
+	AllBranchesLogCmd              string                        `yaml:"allBranchesLogCmd"`
+	SortRemoteBranchesByLastCommit bool                          `yaml:"sortRemoteBranchesByLastCommit"`
+	OverrideGpg                    bool                          `yaml:"overrideGpg"`
+	DisableForcePushing            bool                          `yaml:"disableForcePushing"`
+	CommitPrefixes                 map[string]CommitPrefixConfig `yaml:"commitPrefixes"`
 	// this should really be under 'gui', not 'git'
 	ParseEmoji      bool      `yaml:"parseEmoji"`
 	Log             LogConfig `yaml:"log"`


### PR DESCRIPTION
Pretty much a cheap and shameless implementation of @apaatsio's suggestion in 1412: https://github.com/jesseduffield/lazygit/issues/1412
there's really nothing to add there, works like a charm and is super quick.

Guessed not everyone wants the suggestion as default behavior though so I added a configuration flag - I still think the default should be set to 'ordered by last commit' since it's very useful, but I'm not sure.

Would love to start contributing more and this looked like a good way to get my hands dirty.