### PR TITLE
Commit message length warning

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -45,6 +45,7 @@ gui:
       - red
   commitLength:
     show: true
+    warningThreshold: 0
   mouseEvents: true
   skipUnstageLineWarning: false
   skipStashWarning: false

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -67,7 +67,8 @@ type ThemeConfig struct {
 }
 
 type CommitLengthConfig struct {
-	Show bool `yaml:"show"`
+	Show                bool `yaml:"show"`
+	WarningThreshold int  `yaml:"warningThreshold"`
 }
 
 type GitConfig struct {
@@ -362,7 +363,10 @@ func GetDefaultConfig() *UserConfig {
 				CherryPickedCommitFgColor: []string{"blue"},
 				UnstagedChangesColor:      []string{"red"},
 			},
-			CommitLength:             CommitLengthConfig{Show: true},
+			CommitLength: CommitLengthConfig{
+				Show:                true,
+				WarningThreshold: 0,
+			},
 			SkipNoStagedFilesWarning: false,
 			ShowListFooter:           true,
 			ShowCommandLog:           true,


### PR DESCRIPTION
Really simple implementation of a simple warning for when you commit message pass a certain number, from this issue:
- #1552

If someone wants any changes in what I did feel free to point out, I thought about adding `commitLengthWarning` to `CommitLengthConfig` but I'm not sure since they are related but are not exact the same thing (one is the counter and the other is an effect in the actual message).

Thank you!