### PR TITLE
Change not to run `Generate Sponsors` action on the fork repository

### DIFF
--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           token: ${{ secrets.SPONSORS_TOKEN }}
           file: 'README.md'
+        if: ${{ github.repository == 'jesseduffield/lazygit' }}
 
       - name: Commit and push if changed
         run: |-


### PR DESCRIPTION
Prevents CI from failing when syncing fork with upstream.