### PR TITLE
 Add showOutput option to custom commands (fixes #1163) 

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -77,6 +77,7 @@ For a given custom command, here are the allowed fields:
 | loadingText | text to display while waiting for command to finish | no |
 | description | text to display in the keybindings menu that appears when you press 'x' | no |
 | stream | whether you want to stream the command's output to the Command Log panel | no |
+| showOutput | whether you want to show the command's output in a gui prompt | no |
 
 ### Contexts
 
@@ -159,7 +160,7 @@ If your custom keybinding collides with an inbuilt keybinding that is defined fo
 
 ### Debugging
 
-If you want to verify that your command actually does what you expect, you can wrap it in an 'echo' call and set `subprocess: true` so that it doesn't actually execute the command but you can see how the placeholders were resolved. Alternatively you can run lazygit in debug mode with `lazygit --debug` and in another terminal window run `lazygit --logs` to see which commands are actually run
+If you want to verify that your command actually does what you expect, you can wrap it in an 'echo' call and set `showOutput: true` so that it doesn't actually execute the command but you can see how the placeholders were resolved. Alternatively you can run lazygit in debug mode with `lazygit --debug` and in another terminal window run `lazygit --logs` to see which commands are actually run
 
 ### More Examples
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -310,6 +310,7 @@ type CustomCommand struct {
 	LoadingText string                `yaml:"loadingText"`
 	Description string                `yaml:"description"`
 	Stream      bool                  `yaml:"stream"`
+	ShowOutput  bool                  `yaml:"showOutput"`
 }
 
 type CustomCommandPrompt struct {

--- a/pkg/gui/services/custom_commands/handler_creator.go
+++ b/pkg/gui/services/custom_commands/handler_creator.go
@@ -187,9 +187,12 @@ func (self *HandlerCreator) finalHandler(customCommand config.CustomCommand, ses
 		if customCommand.Stream {
 			cmdObj.StreamOutput()
 		}
-		err := cmdObj.Run()
+		output, err := cmdObj.RunWithOutput()
 		if err != nil {
 			return self.c.Error(err)
+		}
+		if customCommand.ShowOutput {
+			return self.c.Alert(cmdStr, output)
 		}
 		return self.c.Refresh(types.RefreshOptions{})
 	})

--- a/pkg/gui/services/custom_commands/handler_creator.go
+++ b/pkg/gui/services/custom_commands/handler_creator.go
@@ -1,6 +1,8 @@
 package custom_commands
 
 import (
+	"strings"
+
 	"github.com/jesseduffield/generics/slices"
 	"github.com/jesseduffield/lazygit/pkg/commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
@@ -191,8 +193,15 @@ func (self *HandlerCreator) finalHandler(customCommand config.CustomCommand, ses
 		if err != nil {
 			return self.c.Error(err)
 		}
+
 		if customCommand.ShowOutput {
-			return self.c.Alert(cmdStr, output)
+			if strings.TrimSpace(output) == "" {
+				output = self.c.Tr.EmptyOutput
+			}
+			if err = self.c.Alert(cmdStr, output); err != nil {
+				return self.c.Error(err)
+			}
+			return self.c.Refresh(types.RefreshOptions{})
 		}
 		return self.c.Refresh(types.RefreshOptions{})
 	})

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -501,6 +501,7 @@ type TranslationSet struct {
 	UpstreamGone                        string
 	NukeDescription                     string
 	DiscardStagedChangesDescription     string
+	EmptyOutput                         string
 	Actions                             Actions
 	Bisect                              Bisect
 }
@@ -1136,6 +1137,7 @@ func EnglishTranslationSet() TranslationSet {
 		UpstreamGone:                        "(upstream gone)",
 		NukeDescription:                     "If you want to make all the changes in the worktree go away, this is the way to do it. If there are dirty submodule changes this will stash those changes in the submodule(s).",
 		DiscardStagedChangesDescription:     "This will create a new stash entry containing only staged files and then drop it, so that the working tree is left with only unstaged changes",
+		EmptyOutput:                         "<empty output>",
 		Actions: Actions{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)
 			CheckoutCommit:                    "Checkout commit",


### PR DESCRIPTION
Added a `showOutput` option that allows custom command output to be shown through a gui prompt. Fixes #1163 