### PR TITLE
add copy branch url to clipboard option in branches menu

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -124,7 +124,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>n</kbd>: new branch
   <kbd>o</kbd>: create pull request
   <kbd>O</kbd>: create pull request options
-  <kbd>ctrl+y</kbd>: copy pull request URL to clipboard
+  <kbd>ctrl+y</kbd>: copy to clipboard menu
   <kbd>c</kbd>: checkout by name
   <kbd>F</kbd>: force checkout
   <kbd>d</kbd>: delete branch

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -183,7 +183,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>n</kbd>: 新しいブランチを作成
   <kbd>o</kbd>: Pull Requestを作成
   <kbd>O</kbd>: create pull request options
-  <kbd>ctrl+y</kbd>: Pull RequestのURLをクリップボードにコピー
+  <kbd>ctrl+y</kbd>: copy to clipboard menu
   <kbd>c</kbd>: checkout by name
   <kbd>F</kbd>: force checkout
   <kbd>d</kbd>: ブランチを削除

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -149,7 +149,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>n</kbd>: 새 브랜치 생성
   <kbd>o</kbd>: 풀 리퀘스트 생성
   <kbd>O</kbd>: 풀 리퀘스트 생성 옵션
-  <kbd>ctrl+y</kbd>: 풀 리퀘스트 URL을 클립보드에 복사
+  <kbd>ctrl+y</kbd>: copy to clipboard menu
   <kbd>c</kbd>: 이름으로 체크아웃
   <kbd>F</kbd>: 강제 체크아웃
   <kbd>d</kbd>: 브랜치 삭제

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -77,7 +77,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>n</kbd>: nieuwe branch
   <kbd>o</kbd>: maak een pull-request
   <kbd>O</kbd>: bekijk opties voor pull-aanvraag
-  <kbd>ctrl+y</kbd>: kopieer de URL van het pull-verzoek naar het klembord
+  <kbd>ctrl+y</kbd>: copy to clipboard menu
   <kbd>c</kbd>: uitchecken bij naam
   <kbd>F</kbd>: forceer checkout
   <kbd>d</kbd>: verwijder branch

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -83,7 +83,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>n</kbd>: nowa gałąź
   <kbd>o</kbd>: utwórz żądanie pobrania
   <kbd>O</kbd>: utwórz opcje żądania ściągnięcia
-  <kbd>ctrl+y</kbd>: skopiuj adres URL żądania pobrania do schowka
+  <kbd>ctrl+y</kbd>: copy to clipboard menu
   <kbd>c</kbd>: przełącz używając nazwy
   <kbd>F</kbd>: wymuś przełączenie
   <kbd>d</kbd>: usuń gałąź

--- a/docs/keybindings/Keybindings_zh.md
+++ b/docs/keybindings/Keybindings_zh.md
@@ -65,7 +65,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>n</kbd>: 新分支
   <kbd>o</kbd>: 创建抓取请求
   <kbd>O</kbd>: 创建抓取请求选项
-  <kbd>ctrl+y</kbd>: 将抓取请求 URL 复制到剪贴板
+  <kbd>ctrl+y</kbd>: copy to clipboard menu
   <kbd>c</kbd>: 按名称检出
   <kbd>F</kbd>: 强制检出
   <kbd>d</kbd>: 删除分支

--- a/pkg/commands/git_commands/remote.go
+++ b/pkg/commands/git_commands/remote.go
@@ -44,11 +44,16 @@ func (self *RemoteCommands) DeleteRemoteBranch(remoteName string, branchName str
 }
 
 // CheckRemoteBranchExists Returns remote branch
-func (self *RemoteCommands) CheckRemoteBranchExists(branchName string) bool {
+func (self *RemoteCommands) CheckRemoteBranchExists(branchName string, upstreamRemote string) bool {
+	if upstreamRemote == "" {
+		upstreamRemote = "origin"
+	}
+
 	_, err := self.cmd.
 		New(
-			fmt.Sprintf("git show-ref --verify -- refs/remotes/origin/%s",
+			fmt.Sprintf("git show-ref --verify -- refs/remotes/%s/%s",
 				self.cmd.Quote(branchName),
+				self.cmd.Quote(upstreamRemote),
 			),
 		).
 		DontLog().

--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -25,7 +25,7 @@ var bitbucketServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pull-requests/new?source={{.From}}&t=1",
 	pullRequestURLIntoTargetBranch:  "/pull-requests/new?source={{.From}}&dest={{.To}}&t=1",
 	commitURL:                       "/commits/{{.CommitSha}}",
-	branchURL:                       "/branch/{{.BranchName}}",
+	branchURL:                       "/src/{{.CommitSha}}/?at={{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }

--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -15,6 +15,7 @@ var githubServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/compare/{{.From}}?expand=1",
 	pullRequestURLIntoTargetBranch:  "/compare/{{.To}}...{{.From}}?expand=1",
 	commitURL:                       "/commit/{{.CommitSha}}",
+	branchURL:                       "/tree/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }
@@ -24,6 +25,7 @@ var bitbucketServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pull-requests/new?source={{.From}}&t=1",
 	pullRequestURLIntoTargetBranch:  "/pull-requests/new?source={{.From}}&dest={{.To}}&t=1",
 	commitURL:                       "/commits/{{.CommitSha}}",
+	branchURL:                       "/branch/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }
@@ -33,6 +35,7 @@ var gitLabServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/merge_requests/new?merge_request[source_branch]={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/merge_requests/new?merge_request[source_branch]={{.From}}&merge_request[target_branch]={{.To}}",
 	commitURL:                       "/commit/{{.CommitSha}}",
+	branchURL:                       "/-/tree/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }
@@ -42,6 +45,7 @@ var azdoServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pullrequestcreate?sourceRef={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/pullrequestcreate?sourceRef={{.From}}&targetRef={{.To}}",
 	commitURL:                       "/commit/{{.CommitSha}}",
+	branchURL:                       "&version=GB{{.BranchName}}",
 	regexStrings: []string{
 		`^git@ssh.dev.azure.com.*/(?P<org>.*)/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
 		`^https://.*@dev.azure.com/(?P<org>.*?)/(?P<project>.*?)/_git/(?P<repo>.*?)(?:\.git)?$`,
@@ -54,6 +58,7 @@ var bitbucketServerServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pull-requests?create&sourceBranch={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/pull-requests?create&targetBranch={{.To}}&sourceBranch={{.From}}",
 	commitURL:                       "/commits/{{.CommitSha}}",
+	branchURL:                       "/branch/{{.Branch}}",
 	regexStrings: []string{
 		`^ssh://git@.*/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
 		`^https://.*/scm/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,

--- a/pkg/commands/hosting_service/hosting_service.go
+++ b/pkg/commands/hosting_service/hosting_service.go
@@ -61,13 +61,13 @@ func (self *HostingServiceMgr) GetCommitURL(commitSha string) (string, error) {
 	return pullRequestURL, nil
 }
 
-func (self *HostingServiceMgr) GetBranchURL(branchName string) (string, error) {
+func (self *HostingServiceMgr) GetBranchURL(branchName string, commitSha string) (string, error) {
 	gitService, err := self.getService()
 	if err != nil {
 		return "", nil
 	}
 
-	branchURL := gitService.getBranchURL(branchName)
+	branchURL := gitService.getBranchURL(branchName, commitSha)
 
 	return branchURL, nil
 }
@@ -192,8 +192,8 @@ func (self *Service) getCommitURL(commitSha string) string {
 	return self.resolveUrl(self.commitURL, map[string]string{"CommitSha": commitSha})
 }
 
-func (self *Service) getBranchURL(branchName string) string {
-	return self.resolveUrl(self.branchURL, map[string]string{"BranchName": branchName})
+func (self *Service) getBranchURL(branchName string, commitSha string) string {
+	return self.resolveUrl(self.branchURL, map[string]string{"BranchName": branchName, "CommitSha": commitSha})
 }
 
 func (self *Service) resolveUrl(templateString string, args map[string]string) string {

--- a/pkg/commands/hosting_service/hosting_service.go
+++ b/pkg/commands/hosting_service/hosting_service.go
@@ -61,6 +61,17 @@ func (self *HostingServiceMgr) GetCommitURL(commitSha string) (string, error) {
 	return pullRequestURL, nil
 }
 
+func (self *HostingServiceMgr) GetBranchURL(branchName string) (string, error) {
+	gitService, err := self.getService()
+	if err != nil {
+		return "", nil
+	}
+
+	branchURL := gitService.getBranchURL(branchName)
+
+	return branchURL, nil
+}
+
 func (self *HostingServiceMgr) getService() (*Service, error) {
 	serviceDomain, err := self.getServiceDomain(self.remoteURL)
 	if err != nil {
@@ -144,6 +155,7 @@ type ServiceDefinition struct {
 	pullRequestURLIntoDefaultBranch string
 	pullRequestURLIntoTargetBranch  string
 	commitURL                       string
+	branchURL                       string
 	regexStrings                    []string
 
 	// can expect 'webdomain' to be passed in. Otherwise, you get to pick what we match in the regex
@@ -178,6 +190,10 @@ func (self *Service) getPullRequestURLIntoTargetBranch(from string, to string) s
 
 func (self *Service) getCommitURL(commitSha string) string {
 	return self.resolveUrl(self.commitURL, map[string]string{"CommitSha": commitSha})
+}
+
+func (self *Service) getBranchURL(branchName string) string {
+	return self.resolveUrl(self.branchURL, map[string]string{"BranchName": branchName})
 }
 
 func (self *Service) resolveUrl(templateString string, args map[string]string) string {

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -226,6 +226,7 @@ type KeybindingBranchesConfig struct {
 	CreatePullRequest      string `yaml:"createPullRequest"`
 	ViewPullRequestOptions string `yaml:"viewPullRequestOptions"`
 	CopyPullRequestURL     string `yaml:"copyPullRequestURL"`
+	CopyBranchURL          string `yaml:"copyBranchURL"`
 	CheckoutBranchByName   string `yaml:"checkoutBranchByName"`
 	ForceCheckoutBranch    string `yaml:"forceCheckoutBranch"`
 	RebaseBranch           string `yaml:"rebaseBranch"`
@@ -503,6 +504,7 @@ func GetDefaultConfig() *UserConfig {
 			},
 			Branches: KeybindingBranchesConfig{
 				CopyPullRequestURL:     "<c-y>",
+				CopyBranchURL:          "<c-b>",
 				CreatePullRequest:      "o",
 				ViewPullRequestOptions: "O",
 				CheckoutBranchByName:   "c",

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -225,8 +225,7 @@ type KeybindingFilesConfig struct {
 type KeybindingBranchesConfig struct {
 	CreatePullRequest      string `yaml:"createPullRequest"`
 	ViewPullRequestOptions string `yaml:"viewPullRequestOptions"`
-	CopyPullRequestURL     string `yaml:"copyPullRequestURL"`
-	CopyBranchURL          string `yaml:"copyBranchURL"`
+	CopyToClipboardMenu    string `yaml:"copyToClipboardMenu"`
 	CheckoutBranchByName   string `yaml:"checkoutBranchByName"`
 	ForceCheckoutBranch    string `yaml:"forceCheckoutBranch"`
 	RebaseBranch           string `yaml:"rebaseBranch"`
@@ -503,8 +502,7 @@ func GetDefaultConfig() *UserConfig {
 				OpenStatusFilter:         "<c-b>",
 			},
 			Branches: KeybindingBranchesConfig{
-				CopyPullRequestURL:     "<c-y>",
-				CopyBranchURL:          "<c-b>",
+				CopyToClipboardMenu:    "<c-y>",
 				CreatePullRequest:      "o",
 				ViewPullRequestOptions: "O",
 				CheckoutBranchByName:   "c",

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -57,6 +57,11 @@ func (self *BranchesController) GetKeybindings(opts types.KeybindingsOpts) []*ty
 			Description: self.c.Tr.LcCopyPullRequestURL,
 		},
 		{
+			Key:         opts.GetKey(opts.Config.Branches.CopyBranchURL),
+			Handler:     self.copyBranchURL,
+			Description: self.c.Tr.LcCopyBranchURL,
+		},
+		{
 			Key:         opts.GetKey(opts.Config.Branches.CheckoutBranchByName),
 			Handler:     self.checkoutByName,
 			Description: self.c.Tr.LcCheckoutByName,
@@ -205,6 +210,30 @@ func (self *BranchesController) copyPullRequestURL() error {
 	}
 
 	self.c.Toast(self.c.Tr.PullRequestURLCopiedToClipboard)
+
+	return nil
+}
+
+func (self *BranchesController) copyBranchURL() error {
+	branch := self.context().GetSelected()
+
+	branchExistsOnRemote := self.git.Remote.CheckRemoteBranchExists(branch.Name)
+
+	if !branchExistsOnRemote {
+		return self.c.Error(errors.New(self.c.Tr.NoBranchOnRemote))
+	}
+
+	url, err := self.helpers.Host.GetBranchURL(branch.Name)
+	if err != nil {
+		return self.c.Error(err)
+	}
+
+	self.c.LogAction(self.c.Tr.Actions.CopyBranchURL)
+	if err := self.os.CopyToClipboard(url); err != nil {
+		return self.c.Error(err)
+	}
+
+	self.c.Toast(self.c.Tr.BranchURLCopiedToClipboard)
 
 	return nil
 }

--- a/pkg/gui/controllers/helpers/host_helper.go
+++ b/pkg/gui/controllers/helpers/host_helper.go
@@ -37,8 +37,8 @@ func (self *HostHelper) GetCommitURL(commitSha string) (string, error) {
 	return self.getHostingServiceMgr().GetCommitURL(commitSha)
 }
 
-func (self *HostHelper) GetBranchURL(branchName string) (string, error) {
-	return self.getHostingServiceMgr().GetBranchURL(branchName)
+func (self *HostHelper) GetBranchURL(branchName string, commitSha string) (string, error) {
+	return self.getHostingServiceMgr().GetBranchURL(branchName, commitSha)
 }
 
 // getting this on every request rather than storing it in state in case our remoteURL changes

--- a/pkg/gui/controllers/helpers/host_helper.go
+++ b/pkg/gui/controllers/helpers/host_helper.go
@@ -11,6 +11,7 @@ import (
 type IHostHelper interface {
 	GetPullRequestURL(from string, to string) (string, error)
 	GetCommitURL(commitSha string) (string, error)
+	GetBranchUrl(branchName string) (string, error)
 }
 
 type HostHelper struct {
@@ -34,6 +35,10 @@ func (self *HostHelper) GetPullRequestURL(from string, to string) (string, error
 
 func (self *HostHelper) GetCommitURL(commitSha string) (string, error) {
 	return self.getHostingServiceMgr().GetCommitURL(commitSha)
+}
+
+func (self *HostHelper) GetBranchURL(branchName string) (string, error) {
+	return self.getHostingServiceMgr().GetBranchURL(branchName)
 }
 
 // getting this on every request rather than storing it in state in case our remoteURL changes

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -152,6 +152,7 @@ type TranslationSet struct {
 	MergeToolPrompt                     string
 	IntroPopupMessage                   string
 	GitconfigParseErr                   string
+	GitRevParseError                    string
 	LcEditFile                          string
 	LcOpenFile                          string
 	LcIgnoreFile                        string
@@ -163,6 +164,8 @@ type TranslationSet struct {
 	LcAllBranchesLogGraph               string
 	UnsupportedGitService               string
 	LcCreatePullRequest                 string
+	LcCopyToClipboardMenu               string
+	CopyToClipboardMenuTitle            string
 	LcCopyPullRequestURL                string
 	LcCopyBranchURL                     string
 	NoBranchOnRemote                    string
@@ -789,6 +792,7 @@ func EnglishTranslationSet() TranslationSet {
 		MergeToolPrompt:                     "Are you sure you want to open `git mergetool`?",
 		IntroPopupMessage:                   englishIntroPopupMessage,
 		GitconfigParseErr:                   `Gogit failed to parse your gitconfig file due to the presence of unquoted '\' characters. Removing these should fix the issue.`,
+		GitRevParseError:                    `Error retrieving last commit sha.`,
 		LcEditFile:                          `edit file`,
 		LcOpenFile:                          `open file`,
 		LcIgnoreFile:                        `add to .gitignore`,
@@ -800,6 +804,8 @@ func EnglishTranslationSet() TranslationSet {
 		LcAllBranchesLogGraph:               `show all branch logs`,
 		UnsupportedGitService:               `Unsupported git service`,
 		LcCreatePullRequest:                 `create pull request`,
+		LcCopyToClipboardMenu:               `copy to clipboard menu`,
+		CopyToClipboardMenuTitle:            `Copy to clipboard`,
 		LcCopyPullRequestURL:                `copy pull request URL to clipboard`,
 		LcCopyBranchURL:                     `copy branch URL to clipboard`,
 		NoBranchOnRemote:                    `This branch doesn't exist on remote. You need to push it to remote first.`,

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -164,6 +164,7 @@ type TranslationSet struct {
 	UnsupportedGitService               string
 	LcCreatePullRequest                 string
 	LcCopyPullRequestURL                string
+	LcCopyBranchURL                     string
 	NoBranchOnRemote                    string
 	LcFetch                             string
 	NoAutomaticGitFetchTitle            string
@@ -451,6 +452,7 @@ type TranslationSet struct {
 	ExtrasTitle                         string
 	PushingTagStatus                    string
 	PullRequestURLCopiedToClipboard     string
+	BranchURLCopiedToClipboard          string
 	CommitDiffCopiedToClipboard         string
 	CommitSHACopiedToClipboard          string
 	CommitURLCopiedToClipboard          string
@@ -617,6 +619,7 @@ type Actions struct {
 	Undo                              string
 	Redo                              string
 	CopyPullRequestURL                string
+	CopyBranchURL                     string
 	OpenMergeTool                     string
 	OpenCommitInBrowser               string
 	OpenPullRequest                   string
@@ -798,6 +801,7 @@ func EnglishTranslationSet() TranslationSet {
 		UnsupportedGitService:               `Unsupported git service`,
 		LcCreatePullRequest:                 `create pull request`,
 		LcCopyPullRequestURL:                `copy pull request URL to clipboard`,
+		LcCopyBranchURL:                     `copy branch URL to clipboard`,
 		NoBranchOnRemote:                    `This branch doesn't exist on remote. You need to push it to remote first.`,
 		LcFetch:                             `fetch`,
 		NoAutomaticGitFetchTitle:            `No automatic git fetch`,
@@ -1086,6 +1090,7 @@ func EnglishTranslationSet() TranslationSet {
 		ExtrasTitle:                         "Command Log",
 		PushingTagStatus:                    "pushing tag",
 		PullRequestURLCopiedToClipboard:     "Pull request URL copied to clipboard",
+		BranchURLCopiedToClipboard:          "Branch URL copied to clipboard",
 		CommitDiffCopiedToClipboard:         "Commit diff copied to clipboard",
 		CommitSHACopiedToClipboard:          "Commit SHA copied to clipboard",
 		CommitURLCopiedToClipboard:          "Commit URL copied to clipboard",
@@ -1234,6 +1239,7 @@ func EnglishTranslationSet() TranslationSet {
 			Undo:                              "Undo",
 			Redo:                              "Redo",
 			CopyPullRequestURL:                "Copy pull request URL",
+			CopyBranchURL:                     "Copy branch URL",
 			OpenMergeTool:                     "Open merge tool",
 			OpenCommitInBrowser:               "Open commit in browser",
 			OpenPullRequest:                   "Open pull request in browser",


### PR DESCRIPTION
Before there was not an option to copy the branch URL to the clipboard. Now Ctrl + B will copy branch URL to keyboard. 

I believe git service paths are correct, was gathered through a combination of my own accounts and watching branches tutorials on YouTube to see how the path changes :) (azure devops, bitbucket server specifically). Let me know if anything needs to be changed. Thanks!

Related Issue: https://github.com/jesseduffield/lazygit/issues/1959