### PR TITLE
Add better support for OpensMenu option when creating a menu

### DIFF
--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -4,7 +4,6 @@ import (
 	"github.com/jesseduffield/generics/slices"
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
-	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 )
@@ -87,24 +86,12 @@ func (self *MenuViewModel) GetDisplayStrings(_startIdx int, _length int) [][]str
 	})
 
 	return slices.Map(self.menuItems, func(item *types.MenuItem) []string {
-		displayStrings := getItemDisplayStrings(item)
+		displayStrings := item.LabelColumns
 		if showKeys {
 			displayStrings = slices.Prepend(displayStrings, style.FgCyan.Sprint(keybindings.GetKeyDisplay(item.Key)))
 		}
 		return displayStrings
 	})
-}
-
-func getItemDisplayStrings(item *types.MenuItem) []string {
-	if item.LabelColumns != nil {
-		return item.LabelColumns
-	}
-
-	styledStr := item.Label
-	if item.OpensMenu {
-		styledStr = presentation.OpensMenuStyle(styledStr)
-	}
-	return []string{styledStr}
 }
 
 func (self *MenuContext) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -1,11 +1,12 @@
 package gui
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/theme"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 func (gui *Gui) getMenuOptions() map[string]string {
@@ -30,9 +31,25 @@ func (gui *Gui) createMenu(opts types.CreateMenuOptions) error {
 		})
 	}
 
+	maxColumnSize := 1
+
 	for _, item := range opts.Items {
-		if item.OpensMenu && item.LabelColumns != nil {
-			return errors.New("Message for the developer of this app: you've set opensMenu with displaystrings on the menu panel. Bad developer!. Apologies, user")
+		if item.LabelColumns == nil {
+			item.LabelColumns = []string{item.Label}
+		}
+
+		if item.OpensMenu {
+			item.LabelColumns[0] = presentation.OpensMenuStyle(item.LabelColumns[0])
+		}
+
+		maxColumnSize = utils.Max(maxColumnSize, len(item.LabelColumns))
+	}
+
+	for _, item := range opts.Items {
+		if len(item.LabelColumns) < maxColumnSize {
+			// we require that each item has the same number of columns so we're padding out with blank strings
+			// if this item has too few
+			item.LabelColumns = append(item.LabelColumns, make([]string, maxColumnSize-len(item.LabelColumns))...)
 		}
 	}
 

--- a/pkg/gui/options_menu_panel.go
+++ b/pkg/gui/options_menu_panel.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/jesseduffield/generics/slices"
 	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
-	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/samber/lo"
 )
@@ -50,21 +49,14 @@ func uniqueBindings(bindings []*types.Binding) []*types.Binding {
 	})
 }
 
-func (gui *Gui) displayDescription(binding *types.Binding) string {
-	if binding.OpensMenu {
-		return presentation.OpensMenuStyle(binding.Description)
-	}
-
-	return binding.Description
-}
-
 func (gui *Gui) handleCreateOptionsMenu() error {
 	context := gui.currentContext()
 	bindings := gui.getBindings(context)
 
 	menuItems := slices.Map(bindings, func(binding *types.Binding) *types.MenuItem {
 		return &types.MenuItem{
-			Label: gui.displayDescription(binding),
+			OpensMenu: binding.OpensMenu,
+			Label:     binding.Description,
 			OnPress: func() error {
 				if binding.Key == nil {
 					return nil


### PR DESCRIPTION
Now, you're able to use Label and LabelColumns interchangeably when building a menu, and you're able set the OpensMenu field to true in either case. If you have multiple columns in your menu, the first will be given the purple styling with the ellipsis.

This allows us to have something like the following without any issues:
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/8456633/181906335-bb6dab1e-3ab0-482a-9d62-b7412b2b6b83.png">
