### PR TITLE
add optimistic rendering for staging and unstaging files

### DIFF
--- a/pkg/commands/models/file.go
+++ b/pkg/commands/models/file.go
@@ -120,17 +120,17 @@ func SetStatusFields(file *File, shortStatus string) {
 func deriveStatusFields(shortStatus string) StatusFields {
 	stagedChange := shortStatus[0:1]
 	unstagedChange := shortStatus[1:2]
-	untracked := lo.Contains([]string{"??", "A ", "AM"}, shortStatus)
-	hasNoStagedChanges := lo.Contains([]string{" ", "U", "?"}, stagedChange)
+	tracked := !lo.Contains([]string{"??", "A ", "AM"}, shortStatus)
+	hasStagedChanges := !lo.Contains([]string{" ", "U", "?"}, stagedChange)
 	hasInlineMergeConflicts := lo.Contains([]string{"UU", "AA"}, shortStatus)
 	hasMergeConflicts := hasInlineMergeConflicts || lo.Contains([]string{"DD", "AU", "UA", "UD", "DU"}, shortStatus)
 
 	return StatusFields{
-		HasStagedChanges:        !hasNoStagedChanges,
+		HasStagedChanges:        hasStagedChanges,
 		HasUnstagedChanges:      unstagedChange != " ",
-		Tracked:                 !untracked,
+		Tracked:                 tracked,
 		Deleted:                 unstagedChange == "D" || stagedChange == "D",
-		Added:                   unstagedChange == "A" || untracked,
+		Added:                   unstagedChange == "A" || !tracked,
 		HasMergeConflicts:       hasMergeConflicts,
 		HasInlineMergeConflicts: hasInlineMergeConflicts,
 		ShortStatus:             shortStatus,

--- a/pkg/commands/models/file.go
+++ b/pkg/commands/models/file.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
+	"github.com/samber/lo"
 )
 
 // File : A file from git status
@@ -89,4 +90,49 @@ func (f *File) GetPath() string {
 
 func (f *File) GetPreviousPath() string {
 	return f.PreviousName
+}
+
+type StatusFields struct {
+	HasStagedChanges        bool
+	HasUnstagedChanges      bool
+	Tracked                 bool
+	Deleted                 bool
+	Added                   bool
+	HasMergeConflicts       bool
+	HasInlineMergeConflicts bool
+	ShortStatus             string
+}
+
+func SetStatusFields(file *File, shortStatus string) {
+	derived := deriveStatusFields(shortStatus)
+
+	file.HasStagedChanges = derived.HasStagedChanges
+	file.HasUnstagedChanges = derived.HasUnstagedChanges
+	file.Tracked = derived.Tracked
+	file.Deleted = derived.Deleted
+	file.Added = derived.Added
+	file.HasMergeConflicts = derived.HasMergeConflicts
+	file.HasInlineMergeConflicts = derived.HasInlineMergeConflicts
+	file.ShortStatus = derived.ShortStatus
+}
+
+// shortStatus is something like '??' or 'A '
+func deriveStatusFields(shortStatus string) StatusFields {
+	stagedChange := shortStatus[0:1]
+	unstagedChange := shortStatus[1:2]
+	untracked := lo.Contains([]string{"??", "A ", "AM"}, shortStatus)
+	hasNoStagedChanges := lo.Contains([]string{" ", "U", "?"}, stagedChange)
+	hasInlineMergeConflicts := lo.Contains([]string{"UU", "AA"}, shortStatus)
+	hasMergeConflicts := hasInlineMergeConflicts || lo.Contains([]string{"DD", "AU", "UA", "UD", "DU"}, shortStatus)
+
+	return StatusFields{
+		HasStagedChanges:        !hasNoStagedChanges,
+		HasUnstagedChanges:      unstagedChange != " ",
+		Tracked:                 !untracked,
+		Deleted:                 unstagedChange == "D" || stagedChange == "D",
+		Added:                   unstagedChange == "A" || untracked,
+		HasMergeConflicts:       hasMergeConflicts,
+		HasInlineMergeConflicts: hasInlineMergeConflicts,
+		ShortStatus:             shortStatus,
+	}
 }

--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -62,6 +62,7 @@ func (gui *Gui) resetControllers() {
 		model,
 		gui.State.Contexts,
 		gui.State.Modes,
+		&gui.Mutexes,
 	)
 
 	syncController := controllers.NewSyncController(

--- a/pkg/gui/controllers/common.go
+++ b/pkg/gui/controllers/common.go
@@ -16,6 +16,7 @@ type controllerCommon struct {
 	model    *types.Model
 	contexts *context.ContextTree
 	modes    *types.Modes
+	mutexes  *types.Mutexes
 }
 
 func NewControllerCommon(
@@ -26,6 +27,7 @@ func NewControllerCommon(
 	model *types.Model,
 	contexts *context.ContextTree,
 	modes *types.Modes,
+	mutexes *types.Mutexes,
 ) *controllerCommon {
 	return &controllerCommon{
 		c:        c,
@@ -35,5 +37,6 @@ func NewControllerCommon(
 		model:    model,
 		contexts: contexts,
 		modes:    modes,
+		mutexes:  mutexes,
 	}
 }

--- a/pkg/gui/filetree/file_tree.go
+++ b/pkg/gui/filetree/file_tree.go
@@ -41,6 +41,7 @@ type IFileTree interface {
 	GetAllItems() []*FileNode
 	GetAllFiles() []*models.File
 	GetFilter() FileTreeDisplayFilter
+	GetRoot() *FileNode
 }
 
 type FileTree struct {
@@ -156,6 +157,10 @@ func (self *FileTree) ToggleCollapsed(path string) {
 }
 
 func (self *FileTree) Tree() INode {
+	return self.tree
+}
+
+func (self *FileTree) GetRoot() *FileNode {
 	return self.tree
 }
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -97,7 +97,7 @@ type Gui struct {
 	// recent repo with the recent repos popup showing
 	showRecentRepos bool
 
-	Mutexes guiMutexes
+	Mutexes types.Mutexes
 
 	// findSuggestions will take a string that the user has typed into a prompt
 	// and return a slice of suggestions which match that string.
@@ -236,18 +236,6 @@ const (
 	INITIAL StartupStage = iota
 	COMPLETE
 )
-
-// if you add a new mutex here be sure to instantiate it. We're using pointers to
-// mutexes so that we can pass the mutexes to controllers.
-type guiMutexes struct {
-	RefreshingFilesMutex  *sync.Mutex
-	RefreshingStatusMutex *sync.Mutex
-	SyncMutex             *sync.Mutex
-	LocalCommitsMutex     *sync.Mutex
-	LineByLinePanelMutex  *sync.Mutex
-	SubprocessMutex       *sync.Mutex
-	PopupMutex            *sync.Mutex
-}
 
 func (gui *Gui) onNewRepo(startArgs types.StartArgs, reuseState bool) error {
 	var err error
@@ -418,7 +406,7 @@ func NewGui(
 		// but now we do it via state. So we need to still support the config for the
 		// sake of backwards compatibility. We're making use of short circuiting here
 		ShowExtrasWindow: cmn.UserConfig.Gui.ShowCommandLog && !config.GetAppState().HideCommandLog,
-		Mutexes: guiMutexes{
+		Mutexes: types.Mutexes{
 			RefreshingFilesMutex:  &sync.Mutex{},
 			RefreshingStatusMutex: &sync.Mutex{},
 			SyncMutex:             &sync.Mutex{},

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"sync"
+
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
@@ -155,4 +157,16 @@ type Model struct {
 
 	// for displaying suggestions while typing in a file name
 	FilesTrie *patricia.Trie
+}
+
+// if you add a new mutex here be sure to instantiate it. We're using pointers to
+// mutexes so that we can pass the mutexes to controllers.
+type Mutexes struct {
+	RefreshingFilesMutex  *sync.Mutex
+	RefreshingStatusMutex *sync.Mutex
+	SyncMutex             *sync.Mutex
+	LocalCommitsMutex     *sync.Mutex
+	LineByLinePanelMutex  *sync.Mutex
+	SubprocessMutex       *sync.Mutex
+	PopupMutex            *sync.Mutex
 }


### PR DESCRIPTION
Staging/unstaging files has always felt kind of sluggish and that's because `git status` takes a while to run. when we stage a file, we don't just do a git status for that file: we do it for the whole repo. Reason being that if a file is renamed we can't know that by just looking at one file (super annoying reason).

This PR has us doing a quick in-memory mapping from the old file status to what we expect it to be, and then rendering that before we actually call git status to get the proper result.

pressing 'a' to stage all is still pretty slow because the `git add -A` command itself is slow and we don't render until after that (in part because of the fact we want to obtain a mutex lock when doing the optimistic rendering and when making the change). Nonetheless things feel faster on net.

We could have made an actual call to `git status -- <filename>` instead of taking the in-memory approach but that slows things down more when you're talking about staging whole directories.