### PR TITLE
add build info when building from source

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -23,10 +23,8 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. Windows]
- - Lazygit Version [e.g. v0.1.45]
- - The last commit id if you built project from sources (run : ```git rev-parse HEAD```)
+**Version info:**
+_Run `lazygit --version` and paste the result here_
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: enhancement
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/pkg/app/logging.go
+++ b/pkg/app/logging.go
@@ -11,7 +11,7 @@ import (
 
 func newLogger(config config.AppConfigurer) *logrus.Entry {
 	var log *logrus.Logger
-	if config.GetDebug() || os.Getenv("DEBUG") == "TRUE" {
+	if config.GetDebug() {
 		log = newDevelopmentLogger()
 	} else {
 		log = newProductionLogger()
@@ -21,12 +21,7 @@ func newLogger(config config.AppConfigurer) *logrus.Entry {
 	// https://github.com/aybabtme/humanlog
 	log.Formatter = &logrus.JSONFormatter{}
 
-	return log.WithFields(logrus.Fields{
-		"debug":     config.GetDebug(),
-		"version":   config.GetVersion(),
-		"commit":    config.GetCommit(),
-		"buildDate": config.GetBuildDate(),
-	})
+	return log.WithFields(logrus.Fields{})
 }
 
 func newProductionLogger() *logrus.Logger {

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -130,7 +130,7 @@ func (self *RebaseCommands) PrepareInteractiveRebaseCommand(baseSha string, todo
 	}
 
 	cmdStr := fmt.Sprintf("git rebase --interactive --autostash --keep-empty %s", baseSha)
-	self.Log.WithField("command", cmdStr).Info("RunCommand")
+	self.Log.WithField("command", cmdStr).Debug("RunCommand")
 
 	cmdObj := self.cmd.New(cmdStr)
 

--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -215,7 +215,7 @@ func (self *cmdObjRunner) runAndStreamAux(
 	if cmdObj.ShouldLog() {
 		self.logCmdObj(cmdObj)
 	}
-	self.log.WithField("command", cmdObj.ToString()).Info("RunCommand")
+	self.log.WithField("command", cmdObj.ToString()).Debug("RunCommand")
 	cmd := cmdObj.GetCmd()
 
 	var stderr bytes.Buffer

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -15,7 +15,6 @@ import (
 type AppConfig struct {
 	Debug            bool   `long:"debug" env:"DEBUG" default:"false"`
 	Version          string `long:"version" env:"VERSION" default:"unversioned"`
-	Commit           string `long:"commit" env:"COMMIT"`
 	BuildDate        string `long:"build-date" env:"BUILD_DATE"`
 	Name             string `long:"name" env:"NAME" default:"lazygit"`
 	BuildSource      string `long:"build-source" env:"BUILD_SOURCE" default:""`
@@ -35,8 +34,6 @@ type AppConfigurer interface {
 
 	// build info
 	GetVersion() string
-	GetCommit() string
-	GetBuildDate() string
 	GetName() string
 	GetBuildSource() string
 
@@ -80,10 +77,6 @@ func NewAppConfig(
 		return nil, err
 	}
 
-	if os.Getenv("DEBUG") == "TRUE" {
-		debuggingFlag = true
-	}
-
 	appState, err := loadAppState()
 	if err != nil {
 		return nil, err
@@ -92,7 +85,6 @@ func NewAppConfig(
 	appConfig := &AppConfig{
 		Name:            name,
 		Version:         version,
-		Commit:          commit,
 		BuildDate:       date,
 		Debug:           debuggingFlag,
 		BuildSource:     buildSource,
@@ -181,14 +173,6 @@ func (c *AppConfig) GetDebug() bool {
 
 func (c *AppConfig) GetVersion() string {
 	return c.Version
-}
-
-func (c *AppConfig) GetCommit() string {
-	return c.Commit
-}
-
-func (c *AppConfig) GetBuildDate() string {
-	return c.BuildDate
 }
 
 func (c *AppConfig) GetName() string {

--- a/pkg/config/dummies.go
+++ b/pkg/config/dummies.go
@@ -7,14 +7,11 @@ import (
 // NewDummyAppConfig creates a new dummy AppConfig for testing
 func NewDummyAppConfig() *AppConfig {
 	appConfig := &AppConfig{
-		Name:        "lazygit",
-		Version:     "unversioned",
-		Commit:      "",
-		BuildDate:   "",
-		Debug:       false,
-		BuildSource: "",
-		UserConfig:  GetDefaultConfig(),
-		AppState:    &AppState{},
+		Name:       "lazygit",
+		Version:    "unversioned",
+		Debug:      false,
+		UserConfig: GetDefaultConfig(),
+		AppState:   &AppState{},
 	}
 	_ = yaml.Unmarshal([]byte{}, appConfig.AppState)
 	return appConfig


### PR DESCRIPTION
Long has the 'unversioned' version plagued us. No longer!

Now when you do a `go install` or `go build`, the binary will automatically have its current commit hash injected into it to be displayed at the bottom right of the screen. Likewise if you run `lazygit --version` you'll get:
```
commit=7c117a3c9db97d5aef1c783d1bba75db8818e015, build date=2022-08-01T10:04:22Z, build source=unknown, version=7c117a3c, os=darwin, arch=amd64
```

Pretty cool.

This is thanks to changes introduced in Go 1.18