### PR TITLE
Add keybind to cancel confirmation with 'n'

### DIFF
--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -164,6 +164,7 @@ type KeybindingUniversalConfig struct {
 	GoInto                       string   `yaml:"goInto"`
 	Confirm                      string   `yaml:"confirm"`
 	ConfirmAlt1                  string   `yaml:"confirm-alt1"`
+	Cancel                       string   `yaml:"cancel"`
 	Remove                       string   `yaml:"remove"`
 	New                          string   `yaml:"new"`
 	Edit                         string   `yaml:"edit"`
@@ -451,6 +452,7 @@ func GetDefaultConfig() *UserConfig {
 				GoInto:                       "<enter>",
 				Confirm:                      "<enter>",
 				ConfirmAlt1:                  "y",
+				Cancel:                       "n",
 				Remove:                       "d",
 				New:                          "n",
 				Edit:                         "e",

--- a/pkg/gui/confirmation_panel.go
+++ b/pkg/gui/confirmation_panel.go
@@ -239,6 +239,11 @@ func (gui *Gui) setKeyBindings(opts types.CreatePopupPanelOpts) error {
 		},
 		{
 			ViewName: "confirmation",
+			Key:      keybindings.GetKey(keybindingConfig.Universal.Cancel),
+			Handler:  gui.wrappedConfirmationFunction(opts.HandleClose),
+		},
+		{
+			ViewName: "confirmation",
 			Key:      keybindings.GetKey(keybindingConfig.Universal.TogglePanel),
 			Handler: func() error {
 				if len(gui.State.Suggestions) > 0 {
@@ -283,6 +288,7 @@ func (gui *Gui) clearConfirmationViewKeyBindings() {
 	_ = gui.g.DeleteKeybinding("confirmation", keybindings.GetKey(keybindingConfig.Universal.Confirm), gocui.ModNone)
 	_ = gui.g.DeleteKeybinding("confirmation", keybindings.GetKey(keybindingConfig.Universal.ConfirmAlt1), gocui.ModNone)
 	_ = gui.g.DeleteKeybinding("confirmation", keybindings.GetKey(keybindingConfig.Universal.Return), gocui.ModNone)
+	_ = gui.g.DeleteKeybinding("confirmation", keybindings.GetKey(keybindingConfig.Universal.Cancel), gocui.ModNone)
 	_ = gui.g.DeleteKeybinding("suggestions", keybindings.GetKey(keybindingConfig.Universal.Confirm), gocui.ModNone)
 	_ = gui.g.DeleteKeybinding("suggestions", keybindings.GetKey(keybindingConfig.Universal.ConfirmAlt1), gocui.ModNone)
 	_ = gui.g.DeleteKeybinding("suggestions", keybindings.GetKey(keybindingConfig.Universal.Return), gocui.ModNone)


### PR DESCRIPTION
In confirmation boxes, you're able to confirm with either <kbd>Enter</kbd> or <kbd>y</kbd>. Cancelling is done with <kbd>Esc</kbd>, but not with <kbd>n</kbd>, as you might expect.

I noticed myself trying to dismiss this prompt with <kbd>n</kbd> a lot of times and failing, so I added the option to do so.

In my opinion, this doesn't warrant any tests because it only adds a shortcut for confirmation dialogues.