### PR TITLE
Detect the user's shell for running custom commands

### DIFF
--- a/pkg/commands/oscommands/os_default_platform.go
+++ b/pkg/commands/oscommands/os_default_platform.go
@@ -4,14 +4,23 @@
 package oscommands
 
 import (
+	"os"
 	"runtime"
 )
+
+func getShell() string {
+	defaultShell := "bash"
+	if shell := os.Getenv("SHELL"); shell != defaultShell {
+		return shell
+	}
+	return defaultShell
+}
 
 func GetPlatform() *Platform {
 	return &Platform{
 		OS:              runtime.GOOS,
-		Shell:           "bash",
-		ShellArg:        "-c",
+		Shell:           getShell(),
+		ShellArg:        "-ic",
 		OpenCommand:     "open {{filename}}",
 		OpenLinkCommand: "open {{link}}",
 	}


### PR DESCRIPTION
This makes it possible to use any shell, and by adding the `-i` flag it
makes it interactive (running aliases and functions is possible now)

Should close #770 .

Tests are still `TODO`