### PR TITLE
Feat: Allow emacs character navigation in the commit editor.

### DIFF
--- a/pkg/gui/editors.go
+++ b/pkg/gui/editors.go
@@ -22,9 +22,9 @@ func (gui *Gui) handleEditorKeypress(textArea *gocui.TextArea, key gocui.Key, ch
 		textArea.MoveCursorDown()
 	case key == gocui.KeyArrowUp:
 		textArea.MoveCursorUp()
-	case key == gocui.KeyArrowLeft:
+	case key == gocui.KeyArrowLeft || key == gocui.KeyCtrlB:
 		textArea.MoveCursorLeft()
-	case key == gocui.KeyArrowRight:
+	case key == gocui.KeyArrowRight || key == gocui.KeyCtrlF:
 		textArea.MoveCursorRight()
 	case key == newlineKey:
 		if allowMultiline {


### PR DESCRIPTION
Haven't used go before, testing the waters a little before thinking about a contribution.

This feels like something not a lot of people would use so would there be room open for customisation of these bindings? What is the general stance on keyboard shortcuts / how flexible would we be to something like jumping/deleting words in the commit editor?

Out of curiosity where else in the application would this keypress handling be used? I can see one call to `handleEditorKeypress` in `commitMessageEditor`. The gui's PopupHandler stuff seems a bit more open ended and complex for me right now.

I understand most people want to open their $VISUAL or $EDITOR but for me personally having the context (diff/reflog etc) in the background and using a popup is more efficient most of time.