### PR TITLE
fix: document link

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -136,7 +136,7 @@ If an option has no name the value will be displayed to the user in place of the
 
 ### Placeholder values
 
-Your commands can contain placeholder strings using Go's [template syntax](https://jan.newmarch.name/go/template/chapter-template.html). The template syntax is pretty powerful, letting you do things like conditionals if you want, but for the most part you'll simply want to be accessing the fields on the following objects:
+Your commands can contain placeholder strings using Go's [template syntax](https://jan.newmarch.name/golang/template/chapter-template.html). The template syntax is pretty powerful, letting you do things like conditionals if you want, but for the most part you'll simply want to be accessing the fields on the following objects:
 
 ```
 SelectedLocalCommit


### PR DESCRIPTION
I found a broken link and replaced it with a link that I believe is the same content.

https://jan.newmarch.name/go/template/chapter-template.html
↓
https://jan.newmarch.name/golang/template/chapter-template.html

Sorry if this is a different site than the intended link.

Please let me know if the PR procedure is different, as I don't have much experience contributing to OSS yet.