### PR TITLE
fix initial scroll position of edit box

### DIFF
--- a/pkg/gui/confirmation_panel.go
+++ b/pkg/gui/confirmation_panel.go
@@ -122,6 +122,7 @@ func (gui *Gui) prepareConfirmationPanel(
 	gui.Views.Confirmation.Wrap = !opts.Editable
 	gui.Views.Confirmation.FgColor = theme.GocuiDefaultTextColor
 	gui.Views.Confirmation.Mask = runeForMask(opts.Mask)
+	_ = gui.Views.Confirmation.SetOrigin(0, 0)
 
 	gui.findSuggestions = opts.FindSuggestionsFunc
 	if opts.FindSuggestionsFunc != nil {
@@ -133,6 +134,7 @@ func (gui *Gui) prepareConfirmationPanel(
 		suggestionsView.Title = fmt.Sprintf(gui.c.Tr.SuggestionsTitle, gui.c.UserConfig.Keybinding.Universal.TogglePanel)
 	}
 
+	gui.resizeConfirmationPanel()
 	return nil
 }
 

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -87,7 +87,8 @@ func (gui *Gui) resizeConfirmationPanel() {
 	}
 	panelWidth := gui.getConfirmationPanelWidth()
 	prompt := gui.Views.Confirmation.Buffer()
-	panelHeight := gui.getMessageHeight(true, prompt, panelWidth) + suggestionsViewHeight
+	wrap := !gui.Views.Confirmation.Editable
+	panelHeight := gui.getMessageHeight(wrap, prompt, panelWidth) + suggestionsViewHeight
 	x0, y0, x1, y1 := gui.getConfirmationPanelDimensionsAux(panelWidth, panelHeight)
 	confirmationViewBottom := y1 - suggestionsViewHeight
 	_, _ = gui.g.SetView(gui.Views.Confirmation.Name(), x0, y0, x1, confirmationViewBottom, 0)


### PR DESCRIPTION
- **PR Description**

fix #2122

**reword commit**
<table>
<tr>
	<td>before
	<td><img width="654" alt="スクリーンショット 2022-08-18 23 18 50" src="https://user-images.githubusercontent.com/10097437/185418362-24f847ff-2b6e-4df5-b4cf-927071f52a74.png">
<tr>
	<td>after
	<td><img width="750" alt="スクリーンショット 2022-08-18 23 20 23" src="https://user-images.githubusercontent.com/10097437/185418434-d3469965-a395-4d79-a0f0-8b5f2065d567.png">
</table>

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
