### PR TITLE
improve integration test portability

### DIFF
--- a/pkg/integration/components/runner.go
+++ b/pkg/integration/components/runner.go
@@ -136,9 +136,10 @@ func createFixture(test *IntegrationTest, paths Paths) error {
 	}
 
 	shell := NewShell()
-	shell.RunCommand("git init")
+	shell.RunCommand("git init -b master")
 	shell.RunCommand(`git config user.email "CI@example.com"`)
 	shell.RunCommand(`git config user.name "CI"`)
+	shell.RunCommand(`git config commit.gpgSign false`)
 
 	test.SetupRepo(shell)
 


### PR DESCRIPTION
- **PR Description**

Ensure that integration testing works even if `initial.defaultBranch=main` and `commit.gpgSign=true`.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
