### PR TITLE
Fix open commit in browser for some Gitlab repos

### DIFF
--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -3,7 +3,7 @@ package hosting_service
 // if you want to make a custom regex for a given service feel free to test it out
 // at regoio.herokuapp.com
 var defaultUrlRegexStrings = []string{
-	`^(?:https?|ssh)://.*/(?P<owner>.*)/(?P<repo>.*?)(?:\.git)?$`,
+	`^(?:https?|ssh)://[^/]+/(?P<owner>.*)/(?P<repo>.*?)(?:\.git)?$`,
 	`^git@.*:(?P<owner>.*)/(?P<repo>.*?)(?:\.git)?$`,
 }
 var defaultRepoURLTemplate = "https://{{.webDomain}}/{{.owner}}/{{.repo}}"

--- a/pkg/commands/hosting_service/hosting_service_test.go
+++ b/pkg/commands/hosting_service/hosting_service_test.go
@@ -48,6 +48,15 @@ func TestGetPullRequestURL(t *testing.T) {
 			},
 		},
 		{
+			testName:  "Opens a link to new pull request on github with https remote url",
+			from:      "feature/sum-operation",
+			remoteUrl: "https://github.com/peter/calculator.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://github.com/peter/calculator/compare/feature%2Fsum-operation?expand=1", url)
+			},
+		},
+		{
 			testName:  "Opens a link to new pull request on bitbucket with specific target branch",
 			from:      "feature/profile-page/avatar",
 			to:        "feature/profile-page",
@@ -78,6 +87,16 @@ func TestGetPullRequestURL(t *testing.T) {
 			},
 		},
 		{
+			testName:  "Opens a link to new pull request on github with https remote url with specific target branch",
+			from:      "feature/sum-operation",
+			to:        "feature/operations",
+			remoteUrl: "https://github.com/peter/calculator.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://github.com/peter/calculator/compare/feature%2Foperations...feature%2Fsum-operation?expand=1", url)
+			},
+		},
+		{
 			testName:  "Opens a link to new pull request on gitlab",
 			from:      "feature/ui",
 			remoteUrl: "git@gitlab.com:peter/calculator.git",
@@ -90,6 +109,15 @@ func TestGetPullRequestURL(t *testing.T) {
 			testName:  "Opens a link to new pull request on gitlab in nested groups",
 			from:      "feature/ui",
 			remoteUrl: "git@gitlab.com:peter/public/calculator.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://gitlab.com/peter/public/calculator/merge_requests/new?merge_request[source_branch]=feature%2Fui", url)
+			},
+		},
+		{
+			testName:  "Opens a link to new pull request on gitlab with https remote url in nested groups",
+			from:      "feature/ui",
+			remoteUrl: "https://gitlab.com/peter/public/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, "https://gitlab.com/peter/public/calculator/merge_requests/new?merge_request[source_branch]=feature%2Fui", url)
@@ -110,6 +138,16 @@ func TestGetPullRequestURL(t *testing.T) {
 			from:      "feature/commit-ui",
 			to:        "epic/ui",
 			remoteUrl: "git@gitlab.com:peter/public/calculator.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://gitlab.com/peter/public/calculator/merge_requests/new?merge_request[source_branch]=feature%2Fcommit-ui&merge_request[target_branch]=epic%2Fui", url)
+			},
+		},
+		{
+			testName:  "Opens a link to new pull request on gitlab with https remote url with specific target branch in nested groups",
+			from:      "feature/commit-ui",
+			to:        "epic/ui",
+			remoteUrl: "https://gitlab.com/peter/public/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, "https://gitlab.com/peter/public/calculator/merge_requests/new?merge_request[source_branch]=feature%2Fcommit-ui&merge_request[target_branch]=epic%2Fui", url)


### PR DESCRIPTION
- **PR Description**

This PR fixes #2131.

Here I just replaced `.*` with less greedy `[^/]` in the default https remote url regex. Domain name can not include slashes so it is safe to use this matcher.

Test suite checked SSH Gitlab urls and they worked fine but there were no check for https gitlab urls in the suite. So I decided to add a couple of tests for github with https remote urls just to be sure that they work properly too.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
