### PR TITLE
fix initial origin of editor box

### DIFF
--- a/pkg/gui/confirmation_panel.go
+++ b/pkg/gui/confirmation_panel.go
@@ -181,6 +181,7 @@ func (gui *Gui) createPopupPanel(opts types.CreatePopupPanelOpts) error {
 		textArea := confirmationView.TextArea
 		textArea.Clear()
 		textArea.TypeString(opts.Prompt)
+		gui.resizeConfirmationPanel()
 		confirmationView.RenderTextArea()
 	} else {
 		if err := gui.renderString(confirmationView, style.AttrBold.Sprint(opts.Prompt)); err != nil {

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -87,7 +87,11 @@ func (gui *Gui) resizeConfirmationPanel() {
 	}
 	panelWidth := gui.getConfirmationPanelWidth()
 	prompt := gui.Views.Confirmation.Buffer()
-	wrap := !gui.Views.Confirmation.Editable
+	wrap := true
+	if gui.Views.Confirmation.Editable {
+		prompt = gui.Views.Confirmation.TextArea.GetContent()
+		wrap = false
+	}
 	panelHeight := gui.getMessageHeight(wrap, prompt, panelWidth) + suggestionsViewHeight
 	x0, y0, x1, y1 := gui.getConfirmationPanelDimensionsAux(panelWidth, panelHeight)
 	confirmationViewBottom := y1 - suggestionsViewHeight


### PR DESCRIPTION
- **PR Description**

When trying to reword a commit with a multi-line message, only the last line is displayed in the edit box.

#### To reproduce

1. commit changes with multi-line message: `git commit -m "$(seq 100)" --allow-empty`

2. launch `lazygit`

3. move to `Commits` panel (`3`), reword latest commit (`r`)

**before**
<img width="581" alt="スクリーンショット 2022-09-01 19 44 56" src="https://user-images.githubusercontent.com/10097437/187896291-8661524f-f9d4-4bbb-a58b-67498711bdbd.png">

**after**
<img width="439" alt="スクリーンショット 2022-09-01 19 45 05" src="https://user-images.githubusercontent.com/10097437/187896310-2b665637-1bd7-4193-a94d-3f6b65f247a1.png">

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
