### PR TITLE
remove deprecated function calls

### DIFF
--- a/pkg/app/daemon/daemon.go
+++ b/pkg/app/daemon/daemon.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -77,7 +76,7 @@ func (self *rebaseDaemon) Run() error {
 	self.c.Log.Info("args: ", os.Args)
 
 	if strings.HasSuffix(os.Args[1], "git-rebase-todo") {
-		if err := ioutil.WriteFile(os.Args[1], []byte(os.Getenv(RebaseTODOEnvKey)), 0o644); err != nil {
+		if err := os.WriteFile(os.Args[1], []byte(os.Getenv(RebaseTODOEnvKey)), 0o644); err != nil {
 			return err
 		}
 	} else if strings.HasSuffix(os.Args[1], filepath.Join(gitDir(), "COMMIT_EDITMSG")) { // TODO: test

--- a/pkg/app/logging.go
+++ b/pkg/app/logging.go
@@ -1,7 +1,7 @@
 package app
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -26,7 +26,7 @@ func newLogger(config config.AppConfigurer) *logrus.Entry {
 
 func newProductionLogger() *logrus.Logger {
 	log := logrus.New()
-	log.Out = ioutil.Discard
+	log.Out = io.Discard
 	log.SetLevel(logrus.ErrorLevel)
 	return log
 }

--- a/pkg/cheatsheet/check.go
+++ b/pkg/cheatsheet/check.go
@@ -3,7 +3,6 @@ package cheatsheet
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -60,7 +59,7 @@ func obtainContent(dir string) string {
 	content := ""
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if re.MatchString(path) {
-			bytes, err := ioutil.ReadFile(path)
+			bytes, err := os.ReadFile(path)
 			if err != nil {
 				log.Fatalf("Error occurred while checking if cheatsheets are up to date: %v", err)
 			}

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,7 +67,7 @@ func NewGitCommand(
 		return nil, err
 	}
 
-	dotGitDir, err := findDotGitDir(os.Stat, ioutil.ReadFile)
+	dotGitDir, err := findDotGitDir(os.Stat, os.ReadFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/git_commands/file.go
+++ b/pkg/commands/git_commands/file.go
@@ -1,7 +1,7 @@
 package git_commands
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"github.com/go-errors/errors"
@@ -20,7 +20,7 @@ func NewFileCommands(gitCommon *GitCommon) *FileCommands {
 
 // Cat obtains the content of a file
 func (self *FileCommands) Cat(fileName string) (string, error) {
-	buf, err := ioutil.ReadFile(fileName)
+	buf, err := os.ReadFile(fileName)
 	if err != nil {
 		return "", nil
 	}

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -2,7 +2,7 @@ package git_commands
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -202,7 +202,7 @@ func (self *RebaseCommands) AmendTo(sha string) error {
 // EditRebaseTodo sets the action at a given index in the git-rebase-todo file
 func (self *RebaseCommands) EditRebaseTodo(index int, action string) error {
 	fileName := filepath.Join(self.dotGitDir, "rebase-merge/git-rebase-todo")
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func (self *RebaseCommands) EditRebaseTodo(index int, action string) error {
 	content[contentIndex] = action + " " + strings.Join(splitLine[1:], " ")
 	result := strings.Join(content, "\n")
 
-	return ioutil.WriteFile(fileName, []byte(result), 0o644)
+	return os.WriteFile(fileName, []byte(result), 0o644)
 }
 
 func (self *RebaseCommands) getTodoCommitCount(content []string) int {
@@ -234,7 +234,7 @@ func (self *RebaseCommands) getTodoCommitCount(content []string) int {
 // MoveTodoDown moves a rebase todo item down by one position
 func (self *RebaseCommands) MoveTodoDown(index int) error {
 	fileName := filepath.Join(self.dotGitDir, "rebase-merge/git-rebase-todo")
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}
@@ -247,7 +247,7 @@ func (self *RebaseCommands) MoveTodoDown(index int) error {
 	rearrangedContent = append(rearrangedContent, content[contentIndex+1:]...)
 	result := strings.Join(rearrangedContent, "\n")
 
-	return ioutil.WriteFile(fileName, []byte(result), 0o644)
+	return os.WriteFile(fileName, []byte(result), 0o644)
 }
 
 // SquashAllAboveFixupCommits squashes all fixup! commits above the given one

--- a/pkg/commands/git_commands/working_tree_test.go
+++ b/pkg/commands/git_commands/working_tree_test.go
@@ -2,7 +2,7 @@ package git_commands
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"testing"
 
@@ -432,7 +432,7 @@ func TestWorkingTreeApplyPatch(t *testing.T) {
 
 			filename := matches[1]
 
-			content, err := ioutil.ReadFile(filename)
+			content, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 
 			assert.Equal(t, "test", string(content))

--- a/pkg/commands/git_config/get_key.go
+++ b/pkg/commands/git_config/get_key.go
@@ -3,7 +3,7 @@ package git_config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -38,7 +38,7 @@ import (
 func runGitConfigCmd(cmd *exec.Cmd) (string, error) {
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
-	cmd.Stderr = ioutil.Discard
+	cmd.Stderr = io.Discard
 
 	err := cmd.Run()
 	if exitError, ok := err.(*exec.ExitError); ok {

--- a/pkg/commands/loaders/commits.go
+++ b/pkg/commands/loaders/commits.go
@@ -3,7 +3,6 @@ package loaders
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -50,7 +49,7 @@ func NewCommitLoader(
 		cmd:                  cmd,
 		getCurrentBranchName: getCurrentBranchName,
 		getRebaseMode:        getRebaseMode,
-		readFile:             ioutil.ReadFile,
+		readFile:             os.ReadFile,
 		walkFiles:            filepath.Walk,
 		dotGitDir:            dotGitDir,
 	}

--- a/pkg/commands/oscommands/gui_io.go
+++ b/pkg/commands/oscommands/gui_io.go
@@ -1,10 +1,8 @@
 package oscommands
 
 import (
-	"io"
-	"io/ioutil"
-
 	"github.com/sirupsen/logrus"
+	"io"
 )
 
 // this struct captures some IO stuff
@@ -45,7 +43,7 @@ func NewNullGuiIO(log *logrus.Entry) *guiIO {
 	return &guiIO{
 		log:                   log,
 		logCommandFn:          func(string, bool) {},
-		newCmdWriterFn:        func() io.Writer { return ioutil.Discard },
+		newCmdWriterFn:        func() io.Writer { return io.Discard },
 		promptForCredentialFn: failPromptFn,
 	}
 }

--- a/pkg/commands/oscommands/gui_io.go
+++ b/pkg/commands/oscommands/gui_io.go
@@ -1,8 +1,9 @@
 package oscommands
 
 import (
-	"github.com/sirupsen/logrus"
 	"io"
+
+	"github.com/sirupsen/logrus"
 )
 
 // this struct captures some IO stuff

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -2,7 +2,7 @@ package oscommands
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -151,7 +151,7 @@ func (c *OSCommand) CreateFileWithContent(path string, content string) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		c.Log.Error(err)
 		return utils.WrapError(err)
 	}
@@ -215,7 +215,7 @@ func (c *OSCommand) PipeCommands(commandStrings ...string) error {
 				c.Log.Error(err)
 			}
 
-			if b, err := ioutil.ReadAll(stderr); err == nil {
+			if b, err := io.ReadAll(stderr); err == nil {
 				if len(b) > 0 {
 					finalErrors = append(finalErrors, string(b))
 				}

--- a/pkg/commands/oscommands/os_test.go
+++ b/pkg/commands/oscommands/os_test.go
@@ -1,7 +1,6 @@
 package oscommands
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -149,7 +148,7 @@ func TestOSCommandAppendLineToFile(t *testing.T) {
 		{
 			filepath.Join(os.TempDir(), "testFile"),
 			func(path string) {
-				if err := ioutil.WriteFile(path, []byte("hello"), 0o600); err != nil {
+				if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
 					panic(err)
 				}
 			},
@@ -160,7 +159,7 @@ func TestOSCommandAppendLineToFile(t *testing.T) {
 		{
 			filepath.Join(os.TempDir(), "emptyTestFile"),
 			func(path string) {
-				if err := ioutil.WriteFile(path, []byte(""), 0o600); err != nil {
+				if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
 					panic(err)
 				}
 			},
@@ -171,7 +170,7 @@ func TestOSCommandAppendLineToFile(t *testing.T) {
 		{
 			filepath.Join(os.TempDir(), "testFileWithNewline"),
 			func(path string) {
-				if err := ioutil.WriteFile(path, []byte("hello\n"), 0o600); err != nil {
+				if err := os.WriteFile(path, []byte("hello\n"), 0o600); err != nil {
 					panic(err)
 				}
 			},
@@ -187,7 +186,7 @@ func TestOSCommandAppendLineToFile(t *testing.T) {
 		if err := osCommand.AppendLineToFile(s.path, "world"); err != nil {
 			panic(err)
 		}
-		f, err := ioutil.ReadFile(s.path)
+		f, err := os.ReadFile(s.path)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -152,7 +151,7 @@ func loadUserConfig(configFiles []string, base *UserConfig) (*UserConfig, error)
 			file.Close()
 		}
 
-		content, err := ioutil.ReadFile(path)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
@@ -243,7 +242,7 @@ func (c *AppConfig) SaveAppState() error {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath, marshalledAppState, 0o644)
+	err = os.WriteFile(filepath, marshalledAppState, 0o644)
 	if err != nil && os.IsPermission(err) {
 		// apparently when people have read-only permissions they prefer us to fail silently
 		return nil
@@ -263,7 +262,7 @@ func loadAppState() (*AppState, error) {
 		return nil, err
 	}
 
-	appStateBytes, err := ioutil.ReadFile(filepath)
+	appStateBytes, err := os.ReadFile(filepath)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}

--- a/pkg/gui/controllers/merge_conflicts_controller.go
+++ b/pkg/gui/controllers/merge_conflicts_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"io/ioutil"
+	"os"
 
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
@@ -192,7 +193,7 @@ func (self *MergeConflictsController) HandleUndo() error {
 
 	self.c.LogAction("Restoring file to previous state")
 	self.c.LogCommand("Undoing last conflict resolution", false)
-	if err := ioutil.WriteFile(state.GetPath(), []byte(state.GetContent()), 0o644); err != nil {
+	if err := ioutil.os(state.GetPath(), []byte(state.GetContent()), 0o644); err != nil {
 		return err
 	}
 
@@ -280,7 +281,7 @@ func (self *MergeConflictsController) resolveConflict(selection mergeconflicts.S
 	self.c.LogAction("Resolve merge conflict")
 	self.c.LogCommand(logStr, false)
 	state.PushContent(content)
-	return true, ioutil.WriteFile(state.GetPath(), []byte(content), 0o644)
+	return true, os.WriteFile(state.GetPath(), []byte(content), 0o644)
 }
 
 func (self *MergeConflictsController) onLastConflictResolved() error {

--- a/pkg/gui/controllers/merge_conflicts_controller.go
+++ b/pkg/gui/controllers/merge_conflicts_controller.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/jesseduffield/gocui"
@@ -193,7 +192,7 @@ func (self *MergeConflictsController) HandleUndo() error {
 
 	self.c.LogAction("Restoring file to previous state")
 	self.c.LogCommand("Undoing last conflict resolution", false)
-	if err := ioutil.os(state.GetPath(), []byte(state.GetContent()), 0o644); err != nil {
+	if err := os.WriteFile(state.GetPath(), []byte(state.GetContent()), 0o644); err != nil {
 		return err
 	}
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -2,7 +2,7 @@ package gui
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -656,8 +656,8 @@ func (gui *Gui) runSubprocess(cmdObj oscommands.ICmdObj) error { //nolint:unpara
 
 	err := subprocess.Run()
 
-	subprocess.Stdout = ioutil.Discard
-	subprocess.Stderr = ioutil.Discard
+	subprocess.Stdout = io.Discard
+	subprocess.Stderr = io.Discard
 	subprocess.Stdin = nil
 
 	if gui.Config.GetUserConfig().PromptToReturnFromSubprocess {

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -2,7 +2,6 @@ package gui
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +19,7 @@ import (
 
 func (gui *Gui) getCurrentBranch(path string) string {
 	readHeadFile := func(path string) (string, error) {
-		headFile, err := ioutil.ReadFile(filepath.Join(path, "HEAD"))
+		headFile, err := os.ReadFile(filepath.Join(path, "HEAD"))
 		if err == nil {
 			content := strings.TrimSpace(string(headFile))
 			refsPrefix := "ref: refs/heads/"
@@ -47,7 +46,7 @@ func (gui *Gui) getCurrentBranch(path string) string {
 			}
 		} else {
 			// worktree
-			if worktreeGitDir, err := ioutil.ReadFile(gitDirPath); err == nil {
+			if worktreeGitDir, err := os.ReadFile(gitDirPath); err == nil {
 				content := strings.TrimSpace(string(worktreeGitDir))
 				worktreePath := strings.TrimPrefix(content, "gitdir: ")
 				if branch, err := readHeadFile(worktreePath); err == nil {

--- a/pkg/gui/test_mode.go
+++ b/pkg/gui/test_mode.go
@@ -2,7 +2,6 @@ package gui
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -93,7 +92,7 @@ func GetRecordingSpeed() float64 {
 func LoadRecording() (*gocui.Recording, error) {
 	path := os.Getenv("REPLAY_EVENTS_FROM")
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -120,5 +119,5 @@ func SaveRecording(recording *gocui.Recording) error {
 
 	path := recordEventsTo()
 
-	return ioutil.WriteFile(path, jsonEvents, 0o600)
+	return os.WriteFile(path, jsonEvents, 0o600)
 }

--- a/pkg/integration/components/shell.go
+++ b/pkg/integration/components/shell.go
@@ -2,7 +2,6 @@ package components
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -38,7 +37,7 @@ func (s *Shell) RunCommand(cmdStr string) *Shell {
 
 func (s *Shell) CreateFile(path string, content string) *Shell {
 	fullPath := filepath.Join(s.dir, path)
-	err := ioutil.WriteFile(fullPath, []byte(content), 0o644)
+	err := os.WriteFile(fullPath, []byte(content), 0o644)
 	if err != nil {
 		panic(fmt.Sprintf("error creating file: %s\n%s", fullPath, err))
 	}
@@ -48,7 +47,7 @@ func (s *Shell) CreateFile(path string, content string) *Shell {
 
 func (s *Shell) UpdateFile(path string, content string) *Shell {
 	fullPath := filepath.Join(s.dir, path)
-	err := ioutil.WriteFile(fullPath, []byte(content), 0o644)
+	err := os.WriteFile(fullPath, []byte(content), 0o644)
 	if err != nil {
 		panic(fmt.Sprintf("error updating file: %s\n%s", fullPath, err))
 	}

--- a/pkg/integration/components/snapshot.go
+++ b/pkg/integration/components/snapshot.go
@@ -168,7 +168,7 @@ func (self *Snapshotter) compareSnapshots() error {
 
 		if expectedRepo != actualRepo {
 			// get the log file and print it
-			bytes, err := ioutil.ReadFile(filepath.Join(self.paths.Config(), "development.log"))
+			bytes, err := os.ReadFile(filepath.Join(self.paths.Config(), "development.log"))
 			if err != nil {
 				return err
 			}
@@ -250,7 +250,7 @@ func generateSnapshot(dir string) (string, error) {
 			return nil
 		}
 
-		bytes, err := ioutil.ReadFile(path)
+		bytes, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/pkg/integration/deprecated/integration.go
+++ b/pkg/integration/deprecated/integration.go
@@ -178,7 +178,7 @@ func RunTests(
 							}
 
 							// get the log file and print it
-							bytes, err := ioutil.ReadFile(filepath.Join(configDir, "development.log"))
+							bytes, err := os.ReadFile(filepath.Join(configDir, "development.log"))
 							if err != nil {
 								return err
 							}
@@ -324,7 +324,7 @@ func LoadTests(testDir string) ([]*IntegrationTest, error) {
 	tests := make([]*IntegrationTest, len(paths))
 
 	for i, path := range paths {
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
@@ -406,7 +406,7 @@ func generateSnapshot(dir string) (string, error) {
 			return nil
 		}
 
-		bytes, err := ioutil.ReadFile(path)
+		bytes, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/pkg/utils/dummies.go
+++ b/pkg/utils/dummies.go
@@ -1,11 +1,12 @@
 package utils
 
 import (
+	"io"
+
 	"github.com/jesseduffield/lazygit/pkg/common"
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/i18n"
 	"github.com/sirupsen/logrus"
-	"io"
 )
 
 // NewDummyLog creates a new dummy Log for testing

--- a/pkg/utils/dummies.go
+++ b/pkg/utils/dummies.go
@@ -1,18 +1,17 @@
 package utils
 
 import (
-	"io/ioutil"
-
 	"github.com/jesseduffield/lazygit/pkg/common"
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/i18n"
 	"github.com/sirupsen/logrus"
+	"io"
 )
 
 // NewDummyLog creates a new dummy Log for testing
 func NewDummyLog() *logrus.Entry {
 	log := logrus.New()
-	log.Out = ioutil.Discard
+	log.Out = io.Discard
 	return log.WithField("test", "test")
 }
 


### PR DESCRIPTION
- **PR Description**
1. change `ioutil.WriteFile` to `os.WriteFile`
2. change `ioutil.ReadFile` to `os.ReadFile`
3. chang `ioutil.Discard` to `io.Discard`
4. chang `ioutil.ReadAll` to `io.ReadAll`

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
