### PR TITLE
fix: how to change the config dir for MacOS

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -12,6 +12,10 @@ For old installations (slightly embarrassing: I didn't realise at the time that 
 - MacOS: `~/Library/Application Support/jesseduffield/lazygit/config.yml`
 - Windows: `%APPDATA%\jesseduffield\lazygit\config.yml`
 
+If you want to change the config directory:
+
+- MacOS: `export XDG_CONFIG_HOME="$HOME/.config"`
+
 ## Default
 
 ```yaml


### PR DESCRIPTION
- **PR Description**
How to change the directory location of Config is described.


- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
