### PR TITLE
fix glitchy render of stale data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/integrii/flaggy v1.4.0
 	github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68
 	github.com/jesseduffield/go-git/v5 v5.1.2-0.20201006095850-341962be15a4
-	github.com/jesseduffield/gocui v0.3.1-0.20221001154429-72c39318a83d
+	github.com/jesseduffield/gocui v0.3.1-0.20221003033055-3b1444b7ce1c
 	github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10
 	github.com/jesseduffield/minimal/gitignore v0.3.3-0.20211018110810-9cde264e6b1e
 	github.com/jesseduffield/yaml v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68 h1:EQP2Tv8T
 github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68/go.mod h1:+LLj9/WUPAP8LqCchs7P+7X0R98HiFujVFANdNaxhGk=
 github.com/jesseduffield/go-git/v5 v5.1.2-0.20201006095850-341962be15a4 h1:GOQrmaE8i+KEdB8NzAegKYd4tPn/inM0I1uo0NXFerg=
 github.com/jesseduffield/go-git/v5 v5.1.2-0.20201006095850-341962be15a4/go.mod h1:nGNEErzf+NRznT+N2SWqmHnDnF9aLgANB1CUNEan09o=
-github.com/jesseduffield/gocui v0.3.1-0.20221001154429-72c39318a83d h1:OTUa2dO3IvnY53QWCABkKJK9v5yvs3+uv3RMbG698S0=
-github.com/jesseduffield/gocui v0.3.1-0.20221001154429-72c39318a83d/go.mod h1:znJuCDnF2Ph40YZSlBwdX/4GEofnIoWLGdT4mK5zRAU=
+github.com/jesseduffield/gocui v0.3.1-0.20221003033055-3b1444b7ce1c h1:mbOoXlqOzc243zNV71pDxeiEof8IRRw2ZJzVXm/RLjc=
+github.com/jesseduffield/gocui v0.3.1-0.20221003033055-3b1444b7ce1c/go.mod h1:znJuCDnF2Ph40YZSlBwdX/4GEofnIoWLGdT4mK5zRAU=
 github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10 h1:jmpr7KpX2+2GRiE91zTgfq49QvgiqB0nbmlwZ8UnOx0=
 github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10/go.mod h1:aA97kHeNA+sj2Hbki0pvLslmE4CbDyhBeSSTUUnOuVo=
 github.com/jesseduffield/minimal/gitignore v0.3.3-0.20211018110810-9cde264e6b1e h1:uw/oo+kg7t/oeMs6sqlAwr85ND/9cpO3up3VxphxY0U=

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -185,7 +185,7 @@ type GuiRepoState struct {
 	// WindowViewNameMap is a mapping of windows to the current view of that window.
 	// Some views move between windows for example the commitFiles view and when cycling through
 	// side windows we need to know which view to give focus to for a given window
-	WindowViewNameMap map[string]string
+	WindowViewNameMap *utils.ThreadSafeMap[string, string]
 
 	// tells us whether we've set up our views for the current repo. We'll need to
 	// do this whenever we switch back and forth between repos to get the views

--- a/pkg/utils/thread_safe_map.go
+++ b/pkg/utils/thread_safe_map.go
@@ -1,0 +1,90 @@
+package utils
+
+import "sync"
+
+type ThreadSafeMap[K comparable, V any] struct {
+	mutex sync.RWMutex
+
+	innerMap map[K]V
+}
+
+func NewThreadSafeMap[K comparable, V any]() *ThreadSafeMap[K, V] {
+	return &ThreadSafeMap[K, V]{
+		innerMap: make(map[K]V),
+	}
+}
+
+func (m *ThreadSafeMap[K, V]) Get(key K) (V, bool) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	value, ok := m.innerMap[key]
+	return value, ok
+}
+
+func (m *ThreadSafeMap[K, V]) Set(key K, value V) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.innerMap[key] = value
+}
+
+func (m *ThreadSafeMap[K, V]) Delete(key K) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	delete(m.innerMap, key)
+}
+
+func (m *ThreadSafeMap[K, V]) Keys() []K {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	keys := make([]K, 0, len(m.innerMap))
+	for key := range m.innerMap {
+		keys = append(keys, key)
+	}
+
+	return keys
+}
+
+func (m *ThreadSafeMap[K, V]) Values() []V {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	values := make([]V, 0, len(m.innerMap))
+	for _, value := range m.innerMap {
+		values = append(values, value)
+	}
+
+	return values
+}
+
+func (m *ThreadSafeMap[K, V]) Len() int {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	return len(m.innerMap)
+}
+
+func (m *ThreadSafeMap[K, V]) Clear() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.innerMap = make(map[K]V)
+}
+
+func (m *ThreadSafeMap[K, V]) IsEmpty() bool {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	return len(m.innerMap) == 0
+}
+
+func (m *ThreadSafeMap[K, V]) Has(key K) bool {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	_, ok := m.innerMap[key]
+	return ok
+}

--- a/pkg/utils/thread_safe_map_test.go
+++ b/pkg/utils/thread_safe_map_test.go
@@ -1,0 +1,59 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestThreadSafeMap(t *testing.T) {
+	m := NewThreadSafeMap[int, int]()
+
+	m.Set(1, 1)
+	m.Set(2, 2)
+	m.Set(3, 3)
+
+	if m.Len() != 3 {
+		t.Errorf("Expected length to be 3, got %d", m.Len())
+	}
+
+	if !m.Has(1) {
+		t.Errorf("Expected to have key 1")
+	}
+
+	if m.Has(4) {
+		t.Errorf("Expected to not have key 4")
+	}
+
+	if _, ok := m.Get(1); !ok {
+		t.Errorf("Expected to have key 1")
+	}
+
+	if _, ok := m.Get(4); ok {
+		t.Errorf("Expected to not have key 4")
+	}
+
+	m.Delete(1)
+
+	if m.Has(1) {
+		t.Errorf("Expected to not have key 1")
+	}
+
+	m.Clear()
+
+	if m.Len() != 0 {
+		t.Errorf("Expected length to be 0, got %d", m.Len())
+	}
+}
+
+func TestThreadSafeMapConcurrentReadWrite(t *testing.T) {
+	m := NewThreadSafeMap[int, int]()
+
+	go func() {
+		for i := 0; i < 10000; i++ {
+			m.Set(0, 0)
+		}
+	}()
+
+	for i := 0; i < 10000; i++ {
+		m.Get(0)
+	}
+}

--- a/vendor/github.com/jesseduffield/gocui/gui.go
+++ b/vendor/github.com/jesseduffield/gocui/gui.go
@@ -403,6 +403,21 @@ func (g *Gui) SetViewOnTopOf(toMove string, other string) error {
 	return nil
 }
 
+// replaces the content in toView with the content in fromView
+func (g *Gui) CopyContent(fromView *View, toView *View) {
+	g.Mutexes.ViewsMutex.Lock()
+	defer g.Mutexes.ViewsMutex.Unlock()
+
+	toView.clear()
+
+	toView.lines = fromView.lines
+	toView.viewLines = fromView.viewLines
+	toView.ox = fromView.ox
+	toView.oy = fromView.oy
+	toView.cx = fromView.cx
+	toView.cy = fromView.cy
+}
+
 // Views returns all the views in the GUI.
 func (g *Gui) Views() []*View {
 	return g.views

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -172,7 +172,7 @@ github.com/jesseduffield/go-git/v5/utils/merkletrie/filesystem
 github.com/jesseduffield/go-git/v5/utils/merkletrie/index
 github.com/jesseduffield/go-git/v5/utils/merkletrie/internal/frame
 github.com/jesseduffield/go-git/v5/utils/merkletrie/noder
-# github.com/jesseduffield/gocui v0.3.1-0.20221001154429-72c39318a83d
+# github.com/jesseduffield/gocui v0.3.1-0.20221003033055-3b1444b7ce1c
 ## explicit; go 1.12
 github.com/jesseduffield/gocui
 # github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10


### PR DESCRIPTION
fixes https://github.com/jesseduffield/lazygit/issues/2107

**PR Description**

This fixes the issue of stale content being re-rendered when flicking through the files panel. When flicking through the files panel, a different view renders directory contents compared to file contents. This meant if you went from dir A to file B to dir C you would briefly see dir A's content again as you select dir C because it first brings the directory main view to the top and then clears it and loads dir C's contents.

We could clear any views upon them no longer being at the top of the window but we'd then see a flicker as content goes to black before being replaced. Here we instead copy the content of the currently top view to the next view before moving that view to the top of the window.

An alternative approach is to instead only use one view but we've committed to having one set of keybindings per view and the view shown when viewing files had keybindings associated that allow clicking on the main view for the sake of starting a session in the staging view. We'll see if this pays off in the end or just makes things more complicated.



- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
