### PR TITLE
strip NUL bytes instead of replacing with space

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/integrii/flaggy v1.4.0
 	github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68
 	github.com/jesseduffield/go-git/v5 v5.1.2-0.20201006095850-341962be15a4
-	github.com/jesseduffield/gocui v0.3.1-0.20221003033055-3b1444b7ce1c
+	github.com/jesseduffield/gocui v0.3.1-0.20221003162644-fead10f7b360
 	github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10
 	github.com/jesseduffield/minimal/gitignore v0.3.3-0.20211018110810-9cde264e6b1e
 	github.com/jesseduffield/yaml v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68 h1:EQP2Tv8T
 github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68/go.mod h1:+LLj9/WUPAP8LqCchs7P+7X0R98HiFujVFANdNaxhGk=
 github.com/jesseduffield/go-git/v5 v5.1.2-0.20201006095850-341962be15a4 h1:GOQrmaE8i+KEdB8NzAegKYd4tPn/inM0I1uo0NXFerg=
 github.com/jesseduffield/go-git/v5 v5.1.2-0.20201006095850-341962be15a4/go.mod h1:nGNEErzf+NRznT+N2SWqmHnDnF9aLgANB1CUNEan09o=
-github.com/jesseduffield/gocui v0.3.1-0.20221003033055-3b1444b7ce1c h1:mbOoXlqOzc243zNV71pDxeiEof8IRRw2ZJzVXm/RLjc=
-github.com/jesseduffield/gocui v0.3.1-0.20221003033055-3b1444b7ce1c/go.mod h1:znJuCDnF2Ph40YZSlBwdX/4GEofnIoWLGdT4mK5zRAU=
+github.com/jesseduffield/gocui v0.3.1-0.20221003162644-fead10f7b360 h1:43F6SAmNzsjwhNa7hBfYCXUgPSl76b+3IogJIloMDnU=
+github.com/jesseduffield/gocui v0.3.1-0.20221003162644-fead10f7b360/go.mod h1:znJuCDnF2Ph40YZSlBwdX/4GEofnIoWLGdT4mK5zRAU=
 github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10 h1:jmpr7KpX2+2GRiE91zTgfq49QvgiqB0nbmlwZ8UnOx0=
 github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10/go.mod h1:aA97kHeNA+sj2Hbki0pvLslmE4CbDyhBeSSTUUnOuVo=
 github.com/jesseduffield/minimal/gitignore v0.3.3-0.20211018110810-9cde264e6b1e h1:uw/oo+kg7t/oeMs6sqlAwr85ND/9cpO3up3VxphxY0U=

--- a/pkg/integration/tests/custom_commands/menu_from_command.go
+++ b/pkg/integration/tests/custom_commands/menu_from_command.go
@@ -55,9 +55,9 @@ var MenuFromCommand = NewIntegrationTest(NewIntegrationTestArgs{
 
 		assert.InMenu()
 		assert.MatchCurrentViewTitle(Equals("Choose commit message"))
-		assert.MatchSelectedLine(Equals("baz ")) // TODO: remove the trailing space
+		assert.MatchSelectedLine(Equals("baz"))
 		input.NextItem()
-		assert.MatchSelectedLine(Equals("bar ")) // TODO: remove the trailing space
+		assert.MatchSelectedLine(Equals("bar"))
 		input.Confirm()
 
 		assert.InPrompt()

--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -1080,7 +1080,7 @@ func (v *View) BufferLines() []string {
 	lines := make([]string, len(v.lines))
 	for i, l := range v.lines {
 		str := lineType(l).String()
-		str = strings.Replace(str, "\x00", " ", -1)
+		str = strings.Replace(str, "\x00", "", -1)
 		lines[i] = str
 	}
 	return lines
@@ -1098,7 +1098,7 @@ func (v *View) ViewBufferLines() []string {
 	lines := make([]string, len(v.viewLines))
 	for i, l := range v.viewLines {
 		str := lineType(l.line).String()
-		str = strings.Replace(str, "\x00", " ", -1)
+		str = strings.Replace(str, "\x00", "", -1)
 		lines[i] = str
 	}
 	return lines
@@ -1274,7 +1274,7 @@ func (v *View) SelectedLine() string {
 	}
 	line := v.lines[v.SelectedLineIdx()]
 	str := lineType(line).String()
-	return strings.Replace(str, "\x00", " ", -1)
+	return strings.Replace(str, "\x00", "", -1)
 }
 
 func (v *View) SelectedPoint() (int, int) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -172,7 +172,7 @@ github.com/jesseduffield/go-git/v5/utils/merkletrie/filesystem
 github.com/jesseduffield/go-git/v5/utils/merkletrie/index
 github.com/jesseduffield/go-git/v5/utils/merkletrie/internal/frame
 github.com/jesseduffield/go-git/v5/utils/merkletrie/noder
-# github.com/jesseduffield/gocui v0.3.1-0.20221003033055-3b1444b7ce1c
+# github.com/jesseduffield/gocui v0.3.1-0.20221003162644-fead10f7b360
 ## explicit; go 1.12
 github.com/jesseduffield/gocui
 # github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10


### PR DESCRIPTION
**PR Description**

Ignore NUL bytes instead of representing with spaces.

There's no need for NUL bytes to be shown as spaces when we're trying to render the content of a view for test purposes, and showing them as spaces prevents us from using Equals matchers on view content in integration tests.

**Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
