### PR TITLE
Replace regex for retrieving latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ sudo eopkg install lazygit
 ### Ubuntu
 
 ```sh
-LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[0-35.]+')
+LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep '"tag_name":' |  sed -E 's/.*"v*([^"]+)".*/\1/')
 ```
 
 ```sh


### PR DESCRIPTION
- **PR Description**
Updating regex in Ubuntu install instructions to account for future versions.

Thank you @lukechilds for [being there](https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c) at the end of my google search.

- **Please check if the PR fulfills these requirements**

* [N/A] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [N/A] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [N/A] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [N/A] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [X] Docs (specifically `docs/Config.md`) have been updated if necessary
* [N/A] You've read through your own file changes for silly mistakes etc
