### PR TITLE
Allow rebase onto commit refs in branch commit view

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -201,6 +201,7 @@ keybinding:
     fetchRemote: 'f'
   commits:
     squashDown: 's'
+    rebaseCommit: 'r' # only in branch commit view
     renameCommit: 'r'
     renameCommitWithEditor: 'R'
     viewResetOptions: 'g'

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -240,6 +240,7 @@ type KeybindingBranchesConfig struct {
 
 type KeybindingCommitsConfig struct {
 	SquashDown                     string `yaml:"squashDown"`
+	RebaseCommit                   string `yaml:"rebaseCommit"`
 	RenameCommit                   string `yaml:"renameCommit"`
 	RenameCommitWithEditor         string `yaml:"renameCommitWithEditor"`
 	ViewResetOptions               string `yaml:"viewResetOptions"`
@@ -523,6 +524,7 @@ func GetDefaultConfig() *UserConfig {
 			},
 			Commits: KeybindingCommitsConfig{
 				SquashDown:                     "s",
+				RebaseCommit:                   "r",
 				RenameCommit:                   "r",
 				RenameCommitWithEditor:         "R",
 				ViewResetOptions:               "g",

--- a/pkg/gui/controllers/basic_commits_controller.go
+++ b/pkg/gui/controllers/basic_commits_controller.go
@@ -40,6 +40,11 @@ func (self *BasicCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 			Description: self.c.Tr.LcCheckoutCommit,
 		},
 		{
+			Key:         opts.GetKey(opts.Config.Commits.RebaseCommit),
+			Handler:     self.checkSelected(self.rebase),
+			Description: self.c.Tr.LcRebaseCommit,
+		},
+		{
 			Key:         opts.GetKey(opts.Config.Commits.CopyCommitAttributeToClipboard),
 			Handler:     self.checkSelected(self.copyCommitAttribute),
 			Description: self.c.Tr.LcCopyCommitAttributeToClipboard,
@@ -94,6 +99,10 @@ func (self *BasicCommitsController) checkSelected(callback func(*models.Commit) 
 
 func (self *BasicCommitsController) Context() types.Context {
 	return self.context
+}
+
+func (self *BasicCommitsController) rebase(commit *models.Commit) error {
+	return self.helpers.MergeAndRebase.RebaseOntoRef(commit.Sha)
 }
 
 func (self *BasicCommitsController) copyCommitAttribute(commit *models.Commit) error {

--- a/pkg/i18n/chinese.go
+++ b/pkg/i18n/chinese.go
@@ -112,6 +112,7 @@ func chineseTranslationSet() TranslationSet {
 		Squash:                              "压缩",
 		LcPickCommit:                        "选择提交（变基过程中）",
 		LcRevertCommit:                      "还原提交",
+		// LcRebaseCommit:                      "rebase checked out branch onto selected commit",
 		LcRewordCommit:                      "改写提交",
 		LcDeleteCommit:                      "删除提交",
 		LcMoveDownCommit:                    "下移提交",

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -77,6 +77,7 @@ func dutchTranslationSet() TranslationSet {
 		Squash:                              "Squash",
 		LcPickCommit:                        "kies commit (wanneer midden in rebase)",
 		LcRevertCommit:                      "commit ongedaan maken",
+		// LcRebaseCommit:                      "rebase checked out branch onto selected commit",
 		LcRewordCommit:                      "hernoem commit",
 		LcDeleteCommit:                      "verwijder commit",
 		LcMoveDownCommit:                    "verplaats commit 1 naar beneden",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -94,6 +94,7 @@ type TranslationSet struct {
 	Squash                              string
 	LcPickCommit                        string
 	LcRevertCommit                      string
+	LcRebaseCommit                      string
 	LcRewordCommit                      string
 	LcDeleteCommit                      string
 	LcMoveDownCommit                    string
@@ -736,6 +737,7 @@ func EnglishTranslationSet() TranslationSet {
 		Squash:                              "Squash",
 		LcPickCommit:                        "pick commit (when mid-rebase)",
 		LcRevertCommit:                      "revert commit",
+		LcRebaseCommit:                      "rebase checked out branch onto selected commit",
 		LcRewordCommit:                      "reword commit",
 		LcDeleteCommit:                      "delete commit",
 		LcMoveDownCommit:                    "move commit down one",

--- a/pkg/i18n/japanese.go
+++ b/pkg/i18n/japanese.go
@@ -103,6 +103,7 @@ func japaneseTranslationSet() TranslationSet {
 		// Squash:                              "Squash",
 		// LcPickCommit:                        "pick commit (when mid-rebase)",
 		LcRevertCommit:       "コミットをrevert",
+		// LcRebaseCommit:                      "rebase checked out branch onto selected commit",
 		LcRewordCommit:       "コミットメッセージを変更",
 		LcDeleteCommit:       "コミットを削除",
 		LcMoveDownCommit:     "コミットを1つ下に移動",

--- a/pkg/i18n/korean.go
+++ b/pkg/i18n/korean.go
@@ -102,6 +102,7 @@ func koreanTranslationSet() TranslationSet {
 		Squash:                              "Squash",
 		LcPickCommit:                        "pick commit (when mid-rebase)",
 		LcRevertCommit:                      "커밋 되돌리기",
+		// LcRebaseCommit:                      "rebase checked out branch onto selected commit",
 		LcRewordCommit:                      "커밋메시지 변경",
 		LcDeleteCommit:                      "커밋 삭제",
 		LcMoveDownCommit:                    "커밋을 1개 아래로 이동",

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -67,6 +67,7 @@ func polishTranslationSet() TranslationSet {
 		YouNoCommitsToSquash:                "Nie masz commitów do spłaszczenia",
 		Fixup:                               "Napraw",
 		SureFixupThisCommit:                 "Jesteś pewny, ze chcesz naprawić ten commit? Commit poniżej zostanie spłaszczony w górę wraz z tym",
+		// LcRebaseCommit:                      "rebase checked out branch onto selected commit",
 		LcRewordCommit:                      "zmień nazwę commita",
 		LcRenameCommitEditor:                "zmień nazwę commita w edytorze",
 		Error:                               "Błąd",


### PR DESCRIPTION
- **PR Description**
Incomplete PR (see list below).
Allow to press r in commit view *for a local/remote branch only* in order to rebase the current branch on top of that commit.
Note that I reused r since renaming commits makes no sense in the branch view and rebasing onto commits makes no sense in local commits view. This makes the docs a bit confusing though.


- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (English only)
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

