### PR TITLE
fix stash with empty message

### DIFF
--- a/pkg/commands/loaders/stash.go
+++ b/pkg/commands/loaders/stash.go
@@ -65,8 +65,8 @@ outer:
 }
 
 func (self *StashLoader) getUnfilteredStashEntries() []*models.StashEntry {
-	rawString, _ := self.cmd.New("git stash list --pretty='%gs'").DontLog().RunWithOutput()
-	return slices.MapWithIndex(utils.SplitLines(rawString), func(line string, index int) *models.StashEntry {
+	rawString, _ := self.cmd.New("git stash list -z --pretty='%gs'").DontLog().RunWithOutput()
+	return slices.MapWithIndex(utils.SplitNul(rawString), func(line string, index int) *models.StashEntry {
 		return self.stashEntryFromLine(line, index)
 	})
 }

--- a/pkg/commands/loaders/stash_test.go
+++ b/pkg/commands/loaders/stash_test.go
@@ -22,7 +22,7 @@ func TestGetStashEntries(t *testing.T) {
 			"No stash entries found",
 			"",
 			oscommands.NewFakeRunner(t).
-				Expect(`git stash list --pretty='%gs'`, "", nil),
+				Expect(`git stash list -z --pretty='%gs'`, "", nil),
 			[]*models.StashEntry{},
 		},
 		{
@@ -30,8 +30,8 @@ func TestGetStashEntries(t *testing.T) {
 			"",
 			oscommands.NewFakeRunner(t).
 				Expect(
-					`git stash list --pretty='%gs'`,
-					"WIP on add-pkg-commands-test: 55c6af2 increase parallel build\nWIP on master: bb86a3f update github template",
+					`git stash list -z --pretty='%gs'`,
+					"WIP on add-pkg-commands-test: 55c6af2 increase parallel build\x00WIP on master: bb86a3f update github template\x00",
 					nil,
 				),
 			[]*models.StashEntry{

--- a/pkg/utils/lines.go
+++ b/pkg/utils/lines.go
@@ -17,6 +17,14 @@ func SplitLines(multilineString string) []string {
 	return lines
 }
 
+func SplitNul(str string) []string {
+	if str == "" {
+		return make([]string, 0)
+	}
+	str = strings.TrimSuffix(str, "\x00")
+	return strings.Split(str, "\x00")
+}
+
 // NormalizeLinefeeds - Removes all Windows and Mac style line feeds
 func NormalizeLinefeeds(str string) string {
 	str = strings.Replace(str, "\r\n", "\n", -1)

--- a/pkg/utils/lines_test.go
+++ b/pkg/utils/lines_test.go
@@ -36,6 +36,37 @@ func TestSplitLines(t *testing.T) {
 	}
 }
 
+func TestSplitNul(t *testing.T) {
+	type scenario struct {
+		multilineString string
+		expected        []string
+	}
+
+	scenarios := []scenario{
+		{
+			"",
+			[]string{},
+		},
+		{
+			"\x00",
+			[]string{
+				"",
+			},
+		},
+		{
+			"hello world !\x00hello universe !\x00",
+			[]string{
+				"hello world !",
+				"hello universe !",
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		assert.EqualValues(t, s.expected, SplitNul(s.multilineString))
+	}
+}
+
 // TestNormalizeLinefeeds is a function.
 func TestNormalizeLinefeeds(t *testing.T) {
 	type scenario struct {


### PR DESCRIPTION
- **PR Description**

Stash entries with empty messages are not displayed.

```sh
# make a stash
$ echo a >a
$ git add -vA
add 'a'
$ git stash
Saved working directory and index state WIP on feature/empty-stash-message: a4239c7a fix: fix stash with empty message
$ git stash drop
Dropped refs/stash@{0} (910f4a2b40a2112becb8627d3df1e7dc62926fa0)
# make a stash with empty message
$ git stash store -m '' 910f4a2b40a2112becb8627d3df1e7dc62926fa0
$ git stash list
stash@{0}:
# run lazygit
$ lazygit stash
```

<table>
<tr>
	<th>before
	<td><img width="540" alt="スクリーンショット 2022-10-13 22 25 06" src="https://user-images.githubusercontent.com/10097437/195610302-516c3707-e01d-4e5b-b431-599384401301.png">
	<td><img width="1070" alt="スクリーンショット 2022-10-13 22 25 14" src="https://user-images.githubusercontent.com/10097437/195610321-10ce0411-b22b-44f0-938e-5e2a656c25b1.png">
<tr>
	<th>after
	<td><img width="541" alt="スクリーンショット 2022-10-13 22 25 29" src="https://user-images.githubusercontent.com/10097437/195610369-d64609a9-c038-45a1-9497-fedd854e215a.png">
	<td><img width="1070" alt="スクリーンショット 2022-10-13 22 25 37" src="https://user-images.githubusercontent.com/10097437/195610421-13dfb239-e065-4bce-ac6e-0503ee6564a4.png">
</table>

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
