### PR TITLE
fix initial origin of commit message panel

### DIFF
--- a/pkg/gui/files_panel.go
+++ b/pkg/gui/files_panel.go
@@ -89,6 +89,7 @@ func (gui *Gui) getSetTextareaTextFn(getView func() *gocui.View) func(string) {
 		view := getView()
 		view.ClearTextArea()
 		view.TextArea.TypeString(text)
+		_ = gui.resizePopupPanel(view, view.TextArea.GetContent())
 		view.RenderTextArea()
 	}
 }


### PR DESCRIPTION
- **PR Description**

This is similar to https://github.com/jesseduffield/lazygit/pull/2146.

Fixes a partially hidden commit message prefix when using `git.commitPrefixes`.

```yaml
git:
  commitPrefixes:
    lazygit:
      pattern: '.*'
      replace: '[$0] '
```

before:
<img width="155" alt="スクリーンショット 2022-10-15 19 58 42" src="https://user-images.githubusercontent.com/10097437/195982917-8add3093-1778-418d-9d30-24b29eff662b.png">

after:
<img width="254" alt="スクリーンショット 2022-10-15 19 58 58" src="https://user-images.githubusercontent.com/10097437/195982926-2a8c41e1-cd24-48b8-aca1-ed201abc8e6b.png">


- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
