### PR TITLE
Use lazycore utils: Clamp and GetLazyRootDirectory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/jesseduffield/go-git/v5 v5.1.2-0.20201006095850-341962be15a4
 	github.com/jesseduffield/gocui v0.3.1-0.20221003162644-fead10f7b360
 	github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10
-	github.com/jesseduffield/lazycore v0.0.0-20221009164442-17c8b878c316
+	github.com/jesseduffield/lazycore v0.0.0-20221012050358-03d2e40243c5
 	github.com/jesseduffield/minimal/gitignore v0.3.3-0.20211018110810-9cde264e6b1e
 	github.com/jesseduffield/yaml v2.1.0+incompatible
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/jesseduffield/gocui v0.3.1-0.20221003162644-fead10f7b360 h1:43F6SAmNz
 github.com/jesseduffield/gocui v0.3.1-0.20221003162644-fead10f7b360/go.mod h1:znJuCDnF2Ph40YZSlBwdX/4GEofnIoWLGdT4mK5zRAU=
 github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10 h1:jmpr7KpX2+2GRiE91zTgfq49QvgiqB0nbmlwZ8UnOx0=
 github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10/go.mod h1:aA97kHeNA+sj2Hbki0pvLslmE4CbDyhBeSSTUUnOuVo=
-github.com/jesseduffield/lazycore v0.0.0-20221009164442-17c8b878c316 h1:UzTg0utG+cLS94Qjb/ZFDzfMeZDFXErSbNgJOyj70EA=
-github.com/jesseduffield/lazycore v0.0.0-20221009164442-17c8b878c316/go.mod h1:qxN4mHOAyeIDLP7IK7defgPClM/z1Kze8VVQiaEjzsQ=
+github.com/jesseduffield/lazycore v0.0.0-20221012050358-03d2e40243c5 h1:CDuQmfOjAtb1Gms6a1p5L2P8RhbLUq5t8aL7PiQd2uY=
+github.com/jesseduffield/lazycore v0.0.0-20221012050358-03d2e40243c5/go.mod h1:qxN4mHOAyeIDLP7IK7defgPClM/z1Kze8VVQiaEjzsQ=
 github.com/jesseduffield/minimal/gitignore v0.3.3-0.20211018110810-9cde264e6b1e h1:uw/oo+kg7t/oeMs6sqlAwr85ND/9cpO3up3VxphxY0U=
 github.com/jesseduffield/minimal/gitignore v0.3.3-0.20211018110810-9cde264e6b1e/go.mod h1:u60qdFGXRd36jyEXxetz0vQceQIxzI13lIo3EFUDf4I=
 github.com/jesseduffield/yaml v2.1.0+incompatible h1:HWQJ1gIv2zHKbDYNp0Jwjlj24K8aqpFHnMCynY1EpmE=

--- a/pkg/cheatsheet/check.go
+++ b/pkg/cheatsheet/check.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Check() {
-	dir := GetDir()
+	dir := GetKeybindingsDir()
 	tmpDir := filepath.Join(os.TempDir(), "lazygit_cheatsheet")
 	err := os.RemoveAll(tmpDir)
 	if err != nil {

--- a/pkg/cheatsheet/generate.go
+++ b/pkg/cheatsheet/generate.go
@@ -15,12 +15,12 @@ import (
 
 	"github.com/jesseduffield/generics/maps"
 	"github.com/jesseduffield/generics/slices"
+	"github.com/jesseduffield/lazycore/pkg/utils"
 	"github.com/jesseduffield/lazygit/pkg/app"
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/i18n"
-	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
 )
 
@@ -44,8 +44,8 @@ func CommandToRun() string {
 	return "go run scripts/cheatsheet/main.go generate"
 }
 
-func GetDir() string {
-	return utils.GetLazygitRootDirectory() + "/docs/keybindings"
+func GetKeybindingsDir() string {
+	return utils.GetLazyRootDirectory() + "/docs/keybindings"
 }
 
 func generateAtDir(cheatsheetDir string) {
@@ -75,7 +75,7 @@ func generateAtDir(cheatsheetDir string) {
 }
 
 func Generate() {
-	generateAtDir(GetDir())
+	generateAtDir(GetKeybindingsDir())
 }
 
 func writeString(file *os.File, str string) {

--- a/pkg/integration/clients/tui.go
+++ b/pkg/integration/clients/tui.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/jesseduffield/generics/slices"
 	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazycore/pkg/utils"
 	"github.com/jesseduffield/lazygit/pkg/gui"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/integration/components"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests"
 	"github.com/jesseduffield/lazygit/pkg/secureexec"
-	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 // This program lets you run integration tests from a TUI. See pkg/integration/README.md for more info.
@@ -22,7 +22,7 @@ import (
 var SLOW_KEY_PRESS_DELAY = 300
 
 func RunTUI() {
-	rootDir := utils.GetLazygitRootDirectory()
+	rootDir := utils.GetLazyRootDirectory()
 	testDir := filepath.Join(rootDir, "test", "integration")
 
 	app := newApp(testDir)

--- a/pkg/integration/components/runner.go
+++ b/pkg/integration/components/runner.go
@@ -7,8 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/jesseduffield/lazycore/pkg/utils"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
-	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 // this is the integration runner for the new and improved integration interface
@@ -44,7 +44,7 @@ func RunTests(
 	keyPressDelay int,
 	maxAttempts int,
 ) error {
-	projectRootDir := utils.GetLazygitRootDirectory()
+	projectRootDir := utils.GetLazyRootDirectory()
 	err := os.Chdir(projectRootDir)
 	if err != nil {
 		return err

--- a/pkg/integration/tests/tests.go
+++ b/pkg/integration/tests/tests.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jesseduffield/generics/set"
 	"github.com/jesseduffield/generics/slices"
+	"github.com/jesseduffield/lazycore/pkg/utils"
 	"github.com/jesseduffield/lazygit/pkg/integration/components"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/bisect"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/branch"
@@ -15,7 +16,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/commit"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/custom_commands"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/interactive_rebase"
-	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 // Here is where we lists the actual tests that will run. When you create a new test,
@@ -53,7 +53,7 @@ func GetTests() []*components.IntegrationTest {
 
 	missingTestNames := []string{}
 
-	if err := filepath.Walk(filepath.Join(utils.GetLazygitRootDirectory(), "pkg/integration/tests"), func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(filepath.Join(utils.GetLazyRootDirectory(), "pkg/integration/tests"), func(path string, info os.FileInfo, err error) error {
 		if !info.IsDir() && strings.HasSuffix(path, ".go") {
 			// ignoring this current file
 			if filepath.Base(path) == "tests.go" {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -135,30 +135,3 @@ func FilePath(skip int) string {
 	_, path, _, _ := runtime.Caller(skip)
 	return path
 }
-
-// for our cheatsheet script and integration tests. Not to be confused with finding the
-// root directory of _any_ random repo.
-func GetLazygitRootDirectory() string {
-	path, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-
-	for {
-		_, err := os.Stat(filepath.Join(path, ".git"))
-
-		if err == nil {
-			return path
-		}
-
-		if !os.IsNotExist(err) {
-			panic(err)
-		}
-
-		path = filepath.Dir(path)
-
-		if path == "/" {
-			log.Fatal("must run in lazygit folder or child folder")
-		}
-	}
-}

--- a/scripts/cheatsheet/main.go
+++ b/scripts/cheatsheet/main.go
@@ -18,7 +18,7 @@ func main() {
 	switch command {
 	case "generate":
 		cheatsheet.Generate()
-		fmt.Printf("\nGenerated cheatsheets in %s\n", cheatsheet.GetDir())
+		fmt.Printf("\nGenerated cheatsheets in %s\n", cheatsheet.GetKeybindingsDir())
 	case "check":
 		cheatsheet.Check()
 	default:

--- a/vendor/github.com/jesseduffield/lazycore/pkg/utils/utils.go
+++ b/vendor/github.com/jesseduffield/lazycore/pkg/utils/utils.go
@@ -1,5 +1,11 @@
 package utils
 
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
 // Min returns the minimum of two integers
 func Min(x, y int) int {
 	if x < y {
@@ -8,9 +14,48 @@ func Min(x, y int) int {
 	return y
 }
 
+// Max returns the maximum of two integers
 func Max(x, y int) int {
 	if x > y {
 		return x
 	}
 	return y
+}
+
+// Clamp returns a value x restricted between min and max
+func Clamp(x int, min int, max int) int {
+	if x < min {
+		return min
+	} else if x > max {
+		return max
+	}
+	return x
+}
+
+// GetLazyRootDirectory finds a lazy project root directory.
+//
+// It's used for cheatsheet scripts and integration tests. Not to be confused with finding the
+// root directory of _any_ random repo.
+func GetLazyRootDirectory() string {
+	path, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	for {
+		_, err := os.Stat(filepath.Join(path, ".git"))
+		if err == nil {
+			return path
+		}
+
+		if !os.IsNotExist(err) {
+			panic(err)
+		}
+
+		path = filepath.Dir(path)
+
+		if path == "/" {
+			log.Fatal("must run in lazy project folder or child folder")
+		}
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,7 +178,7 @@ github.com/jesseduffield/gocui
 # github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10
 ## explicit; go 1.18
 github.com/jesseduffield/kill
-# github.com/jesseduffield/lazycore v0.0.0-20221009164442-17c8b878c316
+# github.com/jesseduffield/lazycore v0.0.0-20221012050358-03d2e40243c5
 ## explicit; go 1.18
 github.com/jesseduffield/lazycore/pkg/boxlayout
 github.com/jesseduffield/lazycore/pkg/utils


### PR DESCRIPTION
- **PR Description**
This PR updates some functions to start using `lazycore`'s utils. This changes all instances of `GetLazygitRootDirectory` and one instance of `Clamp` to avoid conflicts.


- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalized (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
