### PR TITLE
Scroll partial pages

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -21,7 +21,7 @@ If you want to change the config directory:
 ```yaml
 gui:
   # stuff relating to the UI
-  scrollHeight: 2 # how many lines you scroll by
+  scrollHeight: 2 # how many lines you scroll by; a value of 0.5 means to scroll half a page
   scrollPastBottom: true # enable scrolling past the bottom
   sidePanelWidth: 0.3333 # number from 0 to 1
   expandFocusedSidePanel: false

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -31,7 +31,7 @@ type RefresherConfig struct {
 type GuiConfig struct {
 	AuthorColors             map[string]string  `yaml:"authorColors"`
 	BranchColors             map[string]string  `yaml:"branchColors"`
-	ScrollHeight             int                `yaml:"scrollHeight"`
+	ScrollHeight             float64            `yaml:"scrollHeight"`
 	ScrollPastBottom         bool               `yaml:"scrollPastBottom"`
 	MouseEvents              bool               `yaml:"mouseEvents"`
 	SkipUnstageLineWarning   bool               `yaml:"skipUnstageLineWarning"`

--- a/pkg/gui/controllers/list_controller.go
+++ b/pkg/gui/controllers/list_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 type ListControllerFactory struct {
@@ -51,7 +52,8 @@ func (self *ListController) HandleScrollRight() error {
 }
 
 func (self *ListController) HandleScrollUp() error {
-	scrollHeight := self.c.UserConfig.Gui.ScrollHeight
+	var _, windowHeight int = self.context.GetViewTrait().ViewPortYBounds()
+	scrollHeight := utils.ScrollHeight(windowHeight, self.c.UserConfig.Gui.ScrollHeight)
 	self.context.GetViewTrait().ScrollUp(scrollHeight)
 
 	// we only need to do a line change if our line has been pushed out of the viewport, because
@@ -64,7 +66,8 @@ func (self *ListController) HandleScrollUp() error {
 }
 
 func (self *ListController) HandleScrollDown() error {
-	scrollHeight := self.c.UserConfig.Gui.ScrollHeight
+	var _, windowHeight int = self.context.GetViewTrait().ViewPortYBounds()
+	scrollHeight := utils.ScrollHeight(windowHeight, self.c.UserConfig.Gui.ScrollHeight)
 	self.context.GetViewTrait().ScrollDown(scrollHeight)
 
 	if !self.isSelectedLineInViewPort() {

--- a/pkg/gui/controllers/merge_conflicts_controller.go
+++ b/pkg/gui/controllers/merge_conflicts_controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/mergeconflicts"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 type MergeConflictsController struct {
@@ -136,14 +137,16 @@ func (self *MergeConflictsController) GetMouseKeybindings(opts types.Keybindings
 
 func (self *MergeConflictsController) HandleScrollUp() error {
 	self.context().SetUserScrolling(true)
-	self.context().GetViewTrait().ScrollUp(self.c.UserConfig.Gui.ScrollHeight)
+	var _, windowHeight = self.context().GetViewTrait().ViewPortYBounds()
+	self.context().GetViewTrait().ScrollUp(utils.ScrollHeight(windowHeight, self.c.UserConfig.Gui.ScrollHeight))
 
 	return nil
 }
 
 func (self *MergeConflictsController) HandleScrollDown() error {
 	self.context().SetUserScrolling(true)
-	self.context().GetViewTrait().ScrollDown(self.c.UserConfig.Gui.ScrollHeight)
+	var _, windowHeight = self.context().GetViewTrait().ViewPortYBounds()
+	self.context().GetViewTrait().ScrollDown(utils.ScrollHeight(windowHeight, self.c.UserConfig.Gui.ScrollHeight))
 
 	return nil
 }

--- a/pkg/gui/controllers/vertical_scroll_controller.go
+++ b/pkg/gui/controllers/vertical_scroll_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 // given we have no fields here, arguably we shouldn't even need this factory
@@ -58,13 +59,15 @@ func (self *VerticalScrollController) GetMouseKeybindings(opts types.Keybindings
 }
 
 func (self *VerticalScrollController) HandleScrollUp() error {
-	self.context.GetViewTrait().ScrollUp(self.c.UserConfig.Gui.ScrollHeight)
+	var _, windowHeight = self.context.GetViewTrait().ViewPortYBounds()
+	self.context.GetViewTrait().ScrollUp(utils.ScrollHeight(windowHeight, self.c.UserConfig.Gui.ScrollHeight))
 
 	return nil
 }
 
 func (self *VerticalScrollController) HandleScrollDown() error {
-	self.context.GetViewTrait().ScrollDown(self.c.UserConfig.Gui.ScrollHeight)
+	var _, windowHeight = self.context.GetViewTrait().ViewPortYBounds()
+	self.context.GetViewTrait().ScrollDown(utils.ScrollHeight(windowHeight, self.c.UserConfig.Gui.ScrollHeight))
 
 	return nil
 }

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -62,11 +62,11 @@ func (gui *Gui) prevScreenMode() error {
 }
 
 func (gui *Gui) scrollUpView(view *gocui.View) {
-	view.ScrollUp(gui.c.UserConfig.Gui.ScrollHeight)
+	view.ScrollUp(utils.ScrollHeight(view.Height(), gui.c.UserConfig.Gui.ScrollHeight))
 }
 
 func (gui *Gui) scrollDownView(view *gocui.View) {
-	scrollHeight := gui.c.UserConfig.Gui.ScrollHeight
+	scrollHeight := utils.ScrollHeight(view.Height(), gui.c.UserConfig.Gui.ScrollHeight)
 	view.ScrollDown(scrollHeight)
 
 	if manager, ok := gui.viewBufferManagerMap[view.Name()]; ok {

--- a/pkg/utils/scroll_lines.go
+++ b/pkg/utils/scroll_lines.go
@@ -1,0 +1,24 @@
+package utils
+
+import "math"
+
+// The configuration option for scrollheight uses partial pages when it is
+// between (-1,1). This function calculates the scroll height based based of
+// the window height.
+func ScrollHeight(windowHeight int, scrollHeight float64) int {
+	if scrollHeight == 0 || windowHeight <= 0 {
+		// non-sensical value
+		return 2
+	} else if math.Abs(scrollHeight) <= 1 {
+		// scroll partial pages
+		var linesToScroll float64 = math.RoundToEven(math.Abs(scrollHeight) * float64(windowHeight))
+		linesToScroll = math.Max(1, linesToScroll)
+		if scrollHeight < 0 {
+			return -1 * int(linesToScroll)
+		} else {
+			return int(linesToScroll)
+		}
+	} else {
+		return int(math.Round(scrollHeight))
+	}
+}

--- a/pkg/utils/scroll_lines_test.go
+++ b/pkg/utils/scroll_lines_test.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScrollHeight(t *testing.T) {
+	type scenario struct {
+		windowHeight           int
+		scrollHeightFromConfig float64
+		expected               int
+	}
+
+	scenarios := []scenario{
+		{
+			10,
+			5,
+			5,
+		},
+		{
+			1000,
+			-5,
+			-5,
+		},
+		{
+			10,
+			-5.2,
+			-5,
+		},
+		{
+			10,
+			0.5,
+			5,
+		},
+		{
+			12,
+			-0.25,
+			-3,
+		},
+		{
+			9,
+			0.5,
+			4,
+		},
+		{
+			9,
+			-0.5,
+			-4,
+		},
+		{
+			1,
+			-0.5,
+			-1,
+		},
+		{
+			1,
+			0.5,
+			1,
+		},
+	}
+
+	for _, s := range scenarios {
+		assert.EqualValues(t, s.expected, ScrollHeight(s.windowHeight, s.scrollHeightFromConfig))
+	}
+}


### PR DESCRIPTION
- **PR Description**

This PR allows one to configure scrolling partial pages.

I have changed the `gui.scrollHeight` configuration option to a `float64`. If it is defined in the range `(-1, 1)`, then scrolling with `pgup`/`pgdn` (and the alternate keys) advances the page by that portion of the page. E.g. if you configure `0.5`, then half a page is scrolled.

I think that this implementation is kind of a hack, but no configuration will be broken by this. I'm happy to implement this in a different way. This is the first time I programmed anything in go.

Fixes #2032

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
    I haven't added a keybinding.

* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
    No text was added.
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
