### PR TITLE
Add credential prompts for U2F-backed SSH keys

### DIFF
--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -25,6 +25,7 @@ const (
 	Password CredentialType = iota
 	Username
 	Passphrase
+	PIN
 )
 
 type cmdObjRunner struct {
@@ -335,6 +336,7 @@ func (self *cmdObjRunner) getCheckForCredentialRequestFunc() func([]byte) (Crede
 			`Password\s*for\s*'.+':`:                 Password,
 			`Username\s*for\s*'.+':`:                 Username,
 			`Enter\s*passphrase\s*for\s*key\s*'.+':`: Passphrase,
+			`Enter\s*PIN\s*for\s*.+\s*key\s*.+:`:     PIN,
 		}
 
 		for pattern, askFor := range prompts {

--- a/pkg/gui/controllers/helpers/credentials_helper.go
+++ b/pkg/gui/controllers/helpers/credentials_helper.go
@@ -61,6 +61,8 @@ func (self *CredentialsHelper) getTitleAndMask(passOrUname oscommands.Credential
 		return self.c.Tr.CredentialsPassword, true
 	case oscommands.Passphrase:
 		return self.c.Tr.CredentialsPassphrase, true
+	case oscommands.PIN:
+		return self.c.Tr.CredentialsPIN, true
 	}
 
 	// should never land here

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -29,6 +29,7 @@ type TranslationSet struct {
 	CredentialsUsername                 string
 	CredentialsPassword                 string
 	CredentialsPassphrase               string
+	CredentialsPIN                      string
 	PassUnameWrong                      string
 	CommitChanges                       string
 	AmendLastCommit                     string
@@ -676,6 +677,7 @@ func EnglishTranslationSet() TranslationSet {
 		CredentialsUsername:                 "Username",
 		CredentialsPassword:                 "Password",
 		CredentialsPassphrase:               "Enter passphrase for SSH key",
+		CredentialsPIN:                      "Enter PIN for SSH key",
 		PassUnameWrong:                      "Password, passphrase and/or username wrong",
 		CommitChanges:                       "commit changes",
 		AmendLastCommit:                     "amend last commit",


### PR DESCRIPTION
This would close #2230 for me. Apologies if unwanted, but the issue has been hanging there without a response for a bit now so I figure that maybe I can just PR this for everyone's sake and get things sorted this way?

## PR Description

The 8.2 release of OpenSSH added support for FIDO/U2F hardware authenticators, which manifests in being able to create new types of SSH key, named `ecdsa-sk` nad `ed25519-sk`. This is relevant to lazygit, as those SSH keys can be used to authorise git operations over SSH, as well as signing git commits. Actual code changes are required for correct support, as the authentication process for these types of keys is different than the process for types supported previously.

When an operation requiring credentials is initialised with a U2F authenticator-backed key, the first prompt is:

	Enter PIN for ${key_type} key ${path_to_key}:

at which point the user is supposed to enter a numeric (and secret) PIN, specific to the particular FIDO/U2F authenticator using which the SSH keypair was generated. Upon entering the correct key, the user is supposed to physically interact with the authenticator to confirm presence. Sometimes this is accompanied by the following text prompt:

	Confirm user presence for key ${key_type} ${key_fingerprint}

This second prompt does not always occur and it is presumed that the user will know to perform this step even if not prompted specifically. At this stage some authenticator devices may also begin to blink a LED to indicate that they're waiting for input.

To facilitate lazygit's interoperability with these types of keys, add support for the first PIN prompt, which allows "fetch", "pull", and "push" git operations to complete.

## Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
    - No changes.
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
    - The requirements for generating a U2F-backed SSH key seem prohibitive to adding testing for this enhancement.
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
    - Don't think there's much to update there.
* [x] You've read through your own file changes for silly mistakes etc

## Preview video

It probably doesn't help much to include this but I figure I might as well, as baseline proof that this patch does Something™:

https://user-images.githubusercontent.com/20418176/199119443-098800a1-734f-4f3a-9f0b-40018fa70c9b.mp4