### PR TITLE
use better colour defaults

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -29,7 +29,6 @@ gui:
   language: 'auto' # one of 'auto' | 'en' | 'zh' | 'pl' | 'nl' | 'ja' | 'ko'
   timeFormat: '02 Jan 06 15:04 MST' # https://pkg.go.dev/time#Time.Format
   theme:
-    lightTheme: false # For terminals with a light background
     activeBorderColor:
       - green
       - bold
@@ -343,23 +342,6 @@ The available attributes are:
 - default
 - reverse # useful for high-contrast
 - underline
-
-## Light terminal theme
-
-If you have issues with a light terminal theme where you can't read / see the text add these settings
-
-```yaml
-gui:
-  theme:
-    lightTheme: true
-    activeBorderColor:
-      - black
-      - bold
-    inactiveBorderColor:
-      - black
-    selectedLineBgColor:
-      - default
-```
 
 ## Highlighting the selected line
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -55,7 +55,6 @@ type GuiConfig struct {
 }
 
 type ThemeConfig struct {
-	LightTheme                bool     `yaml:"lightTheme"`
 	ActiveBorderColor         []string `yaml:"activeBorderColor"`
 	InactiveBorderColor       []string `yaml:"inactiveBorderColor"`
 	OptionsTextColor          []string `yaml:"optionsTextColor"`
@@ -358,9 +357,8 @@ func GetDefaultConfig() *UserConfig {
 			Language:               "auto",
 			TimeFormat:             time.RFC822,
 			Theme: ThemeConfig{
-				LightTheme:                false,
 				ActiveBorderColor:         []string{"green", "bold"},
-				InactiveBorderColor:       []string{"white"},
+				InactiveBorderColor:       []string{"default"},
 				OptionsTextColor:          []string{"blue"},
 				SelectedLineBgColor:       []string{"blue"},
 				SelectedRangeBgColor:      []string{"blue"},

--- a/pkg/gui/style/basic_styles.go
+++ b/pkg/gui/style/basic_styles.go
@@ -27,6 +27,7 @@ var (
 	BgBlue    = FromBasicBg(color.BgBlue)
 	BgMagenta = FromBasicBg(color.BgMagenta)
 	BgCyan    = FromBasicBg(color.BgCyan)
+	BgDefault = FromBasicBg(color.BgDefault)
 
 	// will not print any colour escape codes, including the reset escape code
 	Nothing = New()

--- a/pkg/theme/theme.go
+++ b/pkg/theme/theme.go
@@ -24,9 +24,6 @@ var (
 	// DefaultTextColor is the default text color
 	DefaultTextColor = style.FgWhite
 
-	// DefaultHiTextColor is the default highlighted text color
-	DefaultHiTextColor = style.FgLightWhite
-
 	// SelectedLineBgColor is the background color for the selected line
 	SelectedLineBgColor = style.New()
 
@@ -61,14 +58,6 @@ func UpdateTheme(themeConfig config.ThemeConfig) {
 	OptionsColor = GetGocuiStyle(themeConfig.OptionsTextColor)
 	OptionsFgColor = GetTextStyle(themeConfig.OptionsTextColor, false)
 
-	isLightTheme := themeConfig.LightTheme
-	if isLightTheme {
-		DefaultTextColor = style.FgBlack
-		DefaultHiTextColor = style.FgBlackLighter
-		GocuiDefaultTextColor = gocui.ColorBlack
-	} else {
-		DefaultTextColor = style.FgWhite
-		DefaultHiTextColor = style.FgLightWhite
-		GocuiDefaultTextColor = gocui.ColorWhite
-	}
+	DefaultTextColor = style.FgDefault
+	GocuiDefaultTextColor = gocui.ColorDefault
 }


### PR DESCRIPTION
- **PR Description**

We have no way of knowing whether a terminal is in a dark or light theme. HOWEVER we do have one trick up our sleeves: the FgDefault colour is going to be black in a light theme and white in a dark theme. So we need to make use of that colour when rendering text. Previously we allowed the user to configure a 'lightTheme' boolean value that would determine whether to use black or white. We're now removing that config value and just using FgDefault.

fixes https://github.com/jesseduffield/lazygit/issues/2255

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
	* no need
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
