### PR TITLE
add square brackets around file status

### DIFF
--- a/pkg/gui/presentation/files.go
+++ b/pkg/gui/presentation/files.go
@@ -149,8 +149,10 @@ func getFileLine(hasUnstagedChanges bool, hasStagedChanges bool, name string, di
 			secondCharCl = restColor
 		}
 
-		output = firstCharCl.Sprint(firstChar)
+		output = "["
+		output += firstCharCl.Sprint(firstChar)
 		output += secondCharCl.Sprint(secondChar)
+		output += "]"
 		output += restColor.Sprint(" ")
 	}
 

--- a/pkg/gui/presentation/files_test.go
+++ b/pkg/gui/presentation/files_test.go
@@ -39,7 +39,7 @@ func TestRenderFileTree(t *testing.T) {
 			files: []*models.File{
 				{Name: "test", ShortStatus: " M", HasStagedChanges: true},
 			},
-			expected: []string{" M test"},
+			expected: []string{"[ M] test"},
 		},
 		{
 			name: "big example",
@@ -56,10 +56,10 @@ func TestRenderFileTree(t *testing.T) {
 ► dir1
 ▼ dir2
   ▼ dir2
-     M file3
-    M  file4
-  M  file5
-M  file1
+    [ M] file3
+    [M ] file4
+  [M ] file5
+[M ] file1
 `,
 			),
 			collapsedPaths: []string{"dir1"},


### PR DESCRIPTION
- **PR Description**

This PR is just a proposal for wrapping file statuses in square brackets. Reason being, we're indenting the statuses along with the file names and without the brackets, the indentation is less clear. I'm not actually sure whether I consider this an improvement on the existing look, but I wanna know people's thoughts.

before:
![image](https://user-images.githubusercontent.com/8456633/201462739-802aaf2a-7cad-417c-9c74-8e87e8064d0f.png)

after:

![image](https://user-images.githubusercontent.com/8456633/201462727-a8de60d3-6619-4222-80c8-dbb3d3e52c7f.png)

alternatives:

aligning statuses, with brackets:

![image](https://user-images.githubusercontent.com/8456633/201462795-1dadab77-d5ef-40d3-882c-600cb1b323e8.png)

aligning statuses, without brackets:

![image](https://user-images.githubusercontent.com/8456633/201462858-1488292c-f912-4546-a461-c5efe0c19e15.png)

icon before status:

![image](https://user-images.githubusercontent.com/8456633/201463406-c4a8a175-dda9-4050-889e-fe0c10306bbf.png)


- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc
