### PR TITLE
add devcontainer folder

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+# adapted from https://github.com/devcontainers/images/blob/main/src/go/.devcontainer/Dockerfile
+
+# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.19, 1.18, 1-bullseye, 1.19-bullseye, 1.18-bullseye, 1-buster, 1.19-buster, 1.18-buster
+ARG VARIANT=1-bullseye
+FROM golang:${VARIANT}
+
+RUN go install mvdan.cc/gofumpt@latest
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.0
+RUN golangci-lint --version
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,68 @@
+// adapted from https://github.com/devcontainers/images/blob/main/src/go/.devcontainer/devcontainer.json
+{
+  "build": {
+      "dockerfile": "./Dockerfile",
+      "context": "."
+  },
+  "features": {
+      "ghcr.io/devcontainers/features/common-utils:1": {
+          "installZsh": "true",
+          "username": "vscode",
+          "uid": "1000",
+          "gid": "1000",
+          "upgradePackages": "true"
+      },
+      "ghcr.io/devcontainers/features/go:1": {
+          "version": "none"
+      },
+      "ghcr.io/devcontainers/features/git:1": {
+          "version": "latest",
+          "ppa": "false"
+      }
+  },
+  "overrideFeatureInstallOrder": [
+      "ghcr.io/devcontainers/features/common-utils"
+  ],
+  // not sure if we actually need these
+  "runArgs": [
+      "--cap-add=SYS_PTRACE",
+      "--security-opt",
+      "seccomp=unconfined"
+  ],
+  // Configure tool-specific properties.
+  "customizations": {
+      // Configure properties specific to VS Code.
+      "vscode": {
+          // Set *default* container specific settings.json values on container create.
+          "settings": {
+              "go.toolsManagement.checkForUpdates": "local",
+              "go.useLanguageServer": true,
+              "go.gopath": "/go",
+              "[go]": {
+                "editor.formatOnSave": true,
+                "editor.codeActionsOnSave": {
+                  "source.organizeImports": true
+                }
+              },
+              "go.lintTool": "golangci-lint",
+              "gopls": {
+                "formatting.gofumpt": true,
+                "usePlaceholders": false // add parameter placeholders when completing a function
+              },
+              "files.eol": "\n"
+          },
+          // Add the IDs of extensions you want installed when the container is created.
+          "extensions": [
+              "golang.Go"
+          ]
+      }
+  },
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "go version",
+
+  // See https://www.kenmuse.com/blog/avoiding-dubious-ownership-in-dev-containers/
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+
+  // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ lazygit.exe
 !.circleci/
 !.github/
 !.vscode/
+!.devcontainer/
 
 # these are for our integration tests
 !.git_keep

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,52 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Generate cheatsheet",
+      "type": "process",
+      "command": "go run scripts/cheatsheet/main.go "
+    },
+    {
+      "label": "Bump gocui",
+      "type": "shell",
+      "command": "./scripts/bump_gocui.sh"
+    },
+    {
+      "label": "Run current file integration test",
+      "type": "shell",
+      "command": "go run cmd/integration_test/main.go cli ${relativeFile}",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run current file integration test (slow)",
+      "type": "shell",
+      "command": "go run cmd/integration_test/main.go cli --slow ${relativeFile}",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+      }
+    },
+    {
+      "label": "Run current file integration test (sandbox)",
+      "type": "shell",
+      "command": "go run cmd/integration_test/main.go cli --sandbox ${relativeFile}",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+      }
+    }
+  ],
+  "inputs": [
+    {
+        "id": "testname",
+        "description": "Test name/path (e.g. 'commit/commit'):",
+        "type": "promptString"
+    },
+  ]
+}


### PR DESCRIPTION
- **PR Description**

This adds a .devcontainer folder so that:
* you can run VSCODE against a container that has the required dependencies (go, gofumpt, golangci-lint, the Go extension)
* you can run a codespace in your browser so that you don't even need to set up anything locally.

I'll need to confirm whether first-time contributors are actually able to spin up a codespace, because if so, that would be very cool. It'll reduce the friction involved in working on a PR or even investigating an issue.

One current issue is that when running lazygit in the integrated terminal, as you move from panel to panel you see that cells which have been cleared end leave behind an underscore for some reason, until every cell in the terminal is underscored:

When you first start it:

![image](https://user-images.githubusercontent.com/8456633/201497992-83eca134-832c-4aa6-81c4-7aadc73cf18e.png)

As you use it more:

![image](https://user-images.githubusercontent.com/8456633/201497998-99dfd8ae-c827-455b-ba0c-904f3103ba04.png)

And more:
![image](https://user-images.githubusercontent.com/8456633/201498007-8b0dd46d-0693-465a-bdaf-4b7703af49eb.png)

This happens both locally (when using the dev container) and in the codespace. Confusingly it does _not_ happen locally when not using a dev container. I also checked to see what happened when running `lazygit` within the image that this PR's dockerfile created, and there were no underscores there.

I tested out tig and gitui (two other TUI apps) and neither of those had the same visual artefacts. I had a look for issues in the lazygit, gocui, tcell, vscode and xterm.js repos, and couldn't find anything.

If you look at that first screenshot you'll see that the Donate and Ask Question bits at the bottom right are underlined but that the underline attribute is never turned off. So I suspect that that's what's going on: we're either not sending an escape code to turn off the underline attribute or something like that.

Crazily, you can close lazygit, then re-open it, and all the underscores are back from the last session. So that makes me think there's something wrong with the terminal itself. If you kill that terminal session and start another one, we go back to having no bad underscores to start with.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
