### PR TITLE
use tempdir in tests to prevent polluting worktree

### DIFF
--- a/pkg/commands/git_commands/deps_test.go
+++ b/pkg/commands/git_commands/deps_test.go
@@ -1,6 +1,8 @@
 package git_commands
 
 import (
+	"os"
+
 	"github.com/go-errors/errors"
 	gogit "github.com/jesseduffield/go-git/v5"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_config"
@@ -70,6 +72,7 @@ func buildGitCommon(deps commonDeps) *GitCommon {
 		GetenvFn:     getenv,
 		Cmd:          cmd,
 		RemoveFileFn: removeFile,
+		TempDir:      os.TempDir(),
 	})
 
 	gitCommon.dotGitDir = deps.dotGitDir

--- a/pkg/commands/oscommands/dummies.go
+++ b/pkg/commands/oscommands/dummies.go
@@ -19,6 +19,7 @@ type OSCommandDeps struct {
 	GetenvFn     func(string) string
 	RemoveFileFn func(string) error
 	Cmd          *CmdObjBuilder
+	TempDir      string
 }
 
 func NewDummyOSCommandWithDeps(deps OSCommandDeps) *OSCommand {
@@ -38,6 +39,7 @@ func NewDummyOSCommandWithDeps(deps OSCommandDeps) *OSCommand {
 		getenvFn:     deps.GetenvFn,
 		removeFileFn: deps.RemoveFileFn,
 		guiIO:        NewNullGuiIO(utils.NewDummyLog()),
+		tempDir:      deps.TempDir,
 	}
 }
 


### PR DESCRIPTION
- **PR Description**

When tempdir isn't set in a test, we'll end up with some patch files being created in the current directory instead of a temp directory, which is messy. This PR has us using a temp directory.
