### PR TITLE
Fix/show loading state when bottomline disabled

### DIFF
--- a/pkg/gui/app_status_manager.go
+++ b/pkg/gui/app_status_manager.go
@@ -82,6 +82,10 @@ func (m *statusManager) getStatusString() string {
 	return topStatus.message
 }
 
+func (m *statusManager) showStatus() bool {
+	return len(m.statuses) > 0
+}
+
 func (gui *Gui) toast(message string) {
 	gui.statusManager.addToastStatus(message)
 

--- a/pkg/gui/arrangement.go
+++ b/pkg/gui/arrangement.go
@@ -31,7 +31,7 @@ func (gui *Gui) getWindowDimensions(informationStr string, appStatus string) map
 
 	extrasWindowSize := gui.getExtrasWindowSize(height)
 
-	showInfoSection := gui.c.UserConfig.Gui.ShowBottomLine || (gui.State.Searching.isSearching || gui.isAnyModeActive())
+	showInfoSection := gui.c.UserConfig.Gui.ShowBottomLine || gui.State.Searching.isSearching || gui.isAnyModeActive() || gui.statusManager.showStatus()
 	infoSectionSize := 0
 	if showInfoSection {
 		infoSectionSize = 1

--- a/pkg/gui/arrangement.go
+++ b/pkg/gui/arrangement.go
@@ -159,30 +159,26 @@ func (gui *Gui) infoSectionChildren(informationStr string, appStatus string) []*
 		}
 	}
 
-	result := []*boxlayout.Box{}
+	appStatusBox := &boxlayout.Box{Window: "appStatus"}
+	optionsBox := &boxlayout.Box{Window: "options"}
 
-	if len(appStatus) > 0 {
-		result = append(result,
-			&boxlayout.Box{
-				Window: "appStatus",
-				Size:   runewidth.StringWidth(appStatus) + runewidth.StringWidth(INFO_SECTION_PADDING),
-			},
-		)
+	if !gui.c.UserConfig.Gui.ShowBottomLine {
+		optionsBox.Weight = 0
+		appStatusBox.Weight = 1
+	} else {
+		optionsBox.Weight = 1
+		appStatusBox.Size = runewidth.StringWidth(INFO_SECTION_PADDING) + runewidth.StringWidth(appStatus)
 	}
 
-	result = append(result,
-		[]*boxlayout.Box{
-			{
-				Window: "options",
-				Weight: 1,
-			},
-			{
-				Window: "information",
-				// unlike appStatus, informationStr has various colors so we need to decolorise before taking the length
-				Size: runewidth.StringWidth(INFO_SECTION_PADDING) + runewidth.StringWidth(utils.Decolorise(informationStr)),
-			},
-		}...,
-	)
+	result := []*boxlayout.Box{appStatusBox, optionsBox}
+
+	if gui.c.UserConfig.Gui.ShowBottomLine || gui.isAnyModeActive() {
+		result = append(result, &boxlayout.Box{
+			Window: "information",
+			// unlike appStatus, informationStr has various colors so we need to decolorise before taking the length
+			Size: runewidth.StringWidth(INFO_SECTION_PADDING) + runewidth.StringWidth(utils.Decolorise(informationStr)),
+		})
+	}
 
 	return result
 }


### PR DESCRIPTION
- **PR Description**
1. Fixes the issue with missing loading indicator when `showBottom` line is `false`.
2. Hides other info in the bottom line (except mode info). This change was discussed in:
#2258

NOTE: when `showBottomLine` is set to `false`, only status and mode information will appear in the info section. Options panel, which contains navigation tips, will be visible only with enabled bottom line
- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
