### PR TITLE
Show commit hashes against branches

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -58,6 +58,7 @@ gui:
   showFileTree: true # for rendering changes files in a tree format
   showListFooter: true # for seeing the '5 of 20' message in list panels
   showRandomTip: true
+  showBranchCommitHash: false # show commit hashes alongside branch names
   experimentalShowBranchHeads: false # visualize branch heads with (*) in commits list
   showBottomLine: true # for hiding the bottom information line (unless it has important information to tell you)
   showCommandLog: true

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -128,7 +128,7 @@ func NewGitCommandAux(
 	patchCommands := git_commands.NewPatchCommands(gitCommon, rebaseCommands, commitCommands, statusCommands, stashCommands, patchBuilder)
 	bisectCommands := git_commands.NewBisectCommands(gitCommon)
 
-	branchLoader := git_commands.NewBranchLoader(cmn, branchCommands.GetRawBranches, branchCommands.CurrentBranchInfo, configCommands)
+	branchLoader := git_commands.NewBranchLoader(cmn, cmd, branchCommands.CurrentBranchInfo, configCommands)
 	commitFileLoader := git_commands.NewCommitFileLoader(cmn, cmd)
 	commitLoader := git_commands.NewCommitLoader(cmn, cmd, dotGitDir, statusCommands.RebaseMode)
 	reflogCommitLoader := git_commands.NewReflogCommitLoader(cmn, cmd)

--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -188,16 +188,6 @@ func (self *BranchCommands) Rename(oldName string, newName string) error {
 	return self.cmd.New(cmdArgs).Run()
 }
 
-func (self *BranchCommands) GetRawBranches() (string, error) {
-	cmdArgs := NewGitCmd("for-each-ref").
-		Arg("--sort=-committerdate").
-		Arg(`--format=%(HEAD)%00%(refname:short)%00%(upstream:short)%00%(upstream:track)`).
-		Arg("refs/heads").
-		ToArgv()
-
-	return self.cmd.New(cmdArgs).DontLog().RunWithOutput()
-}
-
 type MergeOpts struct {
 	FastForwardOnly bool
 }

--- a/pkg/commands/git_commands/branch_loader_test.go
+++ b/pkg/commands/git_commands/branch_loader_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestObtainBanch(t *testing.T) {
+func TestObtainBranch(t *testing.T) {
 	type scenario struct {
 		testName       string
 		input          []string
@@ -17,29 +17,65 @@ func TestObtainBanch(t *testing.T) {
 
 	scenarios := []scenario{
 		{
-			testName:       "TrimHeads",
-			input:          []string{"", "heads/a_branch", "", ""},
-			expectedBranch: &models.Branch{Name: "a_branch", Pushables: "?", Pullables: "?", Head: false},
+			testName: "TrimHeads",
+			input:    []string{"", "heads/a_branch", "", "", "subject", "123"},
+			expectedBranch: &models.Branch{
+				Name:       "a_branch",
+				Pushables:  "?",
+				Pullables:  "?",
+				Head:       false,
+				Subject:    "subject",
+				CommitHash: "123",
+			},
 		},
 		{
-			testName:       "NoUpstream",
-			input:          []string{"", "a_branch", "", ""},
-			expectedBranch: &models.Branch{Name: "a_branch", Pushables: "?", Pullables: "?", Head: false},
+			testName: "NoUpstream",
+			input:    []string{"", "a_branch", "", "", "subject", "123"},
+			expectedBranch: &models.Branch{
+				Name:       "a_branch",
+				Pushables:  "?",
+				Pullables:  "?",
+				Head:       false,
+				Subject:    "subject",
+				CommitHash: "123",
+			},
 		},
 		{
-			testName:       "IsHead",
-			input:          []string{"*", "a_branch", "", ""},
-			expectedBranch: &models.Branch{Name: "a_branch", Pushables: "?", Pullables: "?", Head: true},
+			testName: "IsHead",
+			input:    []string{"*", "a_branch", "", "", "subject", "123"},
+			expectedBranch: &models.Branch{
+				Name:       "a_branch",
+				Pushables:  "?",
+				Pullables:  "?",
+				Head:       true,
+				Subject:    "subject",
+				CommitHash: "123",
+			},
 		},
 		{
-			testName:       "IsBehindAndAhead",
-			input:          []string{"", "a_branch", "a_remote/a_branch", "[behind 2, ahead 3]"},
-			expectedBranch: &models.Branch{Name: "a_branch", Pushables: "3", Pullables: "2", Head: false},
+			testName: "IsBehindAndAhead",
+			input:    []string{"", "a_branch", "a_remote/a_branch", "[behind 2, ahead 3]", "subject", "123"},
+			expectedBranch: &models.Branch{
+				Name:       "a_branch",
+				Pushables:  "3",
+				Pullables:  "2",
+				Head:       false,
+				Subject:    "subject",
+				CommitHash: "123",
+			},
 		},
 		{
-			testName:       "RemoteBranchIsGone",
-			input:          []string{"", "a_branch", "a_remote/a_branch", "[gone]"},
-			expectedBranch: &models.Branch{Name: "a_branch", UpstreamGone: true, Pushables: "?", Pullables: "?", Head: false},
+			testName: "RemoteBranchIsGone",
+			input:    []string{"", "a_branch", "a_remote/a_branch", "[gone]", "subject", "123"},
+			expectedBranch: &models.Branch{
+				Name:         "a_branch",
+				UpstreamGone: true,
+				Pushables:    "?",
+				Pullables:    "?",
+				Head:         false,
+				Subject:      "subject",
+				CommitHash:   "123",
+			},
 		},
 	}
 

--- a/pkg/commands/models/branch.go
+++ b/pkg/commands/models/branch.go
@@ -5,11 +5,16 @@ package models
 type Branch struct {
 	Name string
 	// the displayname is something like '(HEAD detached at 123asdf)', whereas in that case the name would be '123asdf'
-	DisplayName  string
-	Recency      string
-	Pushables    string
-	Pullables    string
+	DisplayName string
+	// indicator of when the branch was last checked out e.g. '2d', '3m'
+	Recency string
+	// how many commits ahead we are from the remote branch (how many commits we can push)
+	Pushables string
+	// how many commits behind we are from the remote branch (how many commits we can pull)
+	Pullables string
+	// whether the remote branch is 'gone' i.e. we're tracking a remote branch that has been deleted
 	UpstreamGone bool
+	// whether this is the current branch. Exactly one branch should have this be true
 	Head         bool
 	DetachedHead bool
 	// if we have a named remote locally this will be the name of that remote e.g.
@@ -17,6 +22,10 @@ type Branch struct {
 	// 'git@github.com:tiwood/lazygit.git'
 	UpstreamRemote string
 	UpstreamBranch string
+	// subject line in commit message
+	Subject string
+	// commit hash
+	CommitHash string
 }
 
 func (b *Branch) FullRefName() string {

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -49,6 +49,7 @@ type GuiConfig struct {
 	ShowCommandLog              bool               `yaml:"showCommandLog"`
 	ShowBottomLine              bool               `yaml:"showBottomLine"`
 	ShowIcons                   bool               `yaml:"showIcons"`
+	ShowBranchCommitHash        bool               `yaml:"showBranchCommitHash"`
 	ExperimentalShowBranchHeads bool               `yaml:"experimentalShowBranchHeads"`
 	CommandLogSize              int                `yaml:"commandLogSize"`
 	SplitDiff                   string             `yaml:"splitDiff"`
@@ -426,6 +427,7 @@ func GetDefaultConfig() *UserConfig {
 			ShowRandomTip:               true,
 			ShowIcons:                   false,
 			ExperimentalShowBranchHeads: false,
+			ShowBranchCommitHash:        false,
 			CommandLogSize:              8,
 			SplitDiff:                   "auto",
 			SkipRewordInEditorWarning:   false,

--- a/pkg/gui/context/branches_context.go
+++ b/pkg/gui/context/branches_context.go
@@ -25,6 +25,7 @@ func NewBranchesContext(c *ContextCommon) *BranchesContext {
 			c.State().GetRepoState().GetScreenMode() != types.SCREEN_NORMAL,
 			c.Modes().Diffing.Ref,
 			c.Tr,
+			c.UserConfig,
 		)
 	}
 

--- a/pkg/utils/formatting.go
+++ b/pkg/utils/formatting.go
@@ -149,9 +149,11 @@ func SafeTruncate(str string, limit int) string {
 	}
 }
 
+const COMMIT_HASH_SHORT_SIZE = 8
+
 func ShortSha(sha string) string {
-	if len(sha) < 8 {
+	if len(sha) < COMMIT_HASH_SHORT_SIZE {
 		return sha
 	}
-	return sha[:8]
+	return sha[:COMMIT_HASH_SHORT_SIZE]
 }


### PR DESCRIPTION
- **PR Description**

* adds commit hashes against branches
* adds commit subject lines against branches when in full-screen mode
* adds shortened timestamps against commits

It can be useful to know what commit your branch is on if only for the sake of comparison with another branch. It's also useful to see if fast-forwarding a branch other than the checked-out branch actually did anything (you'll know because the commit hash against the branch changes).

I tried out uniquely colouring each hash in the same way we uniquely colour author names, to make it easier to spot if two hashes were the same, but it looked too noisy.

before:
![image](https://user-images.githubusercontent.com/8456633/201609989-b24954f9-9143-4caa-9311-6cc679447877.png)


after:
![image](https://user-images.githubusercontent.com/8456633/201609912-d3e5705c-746f-44d3-894c-a49a2a891463.png)

in full view:
![image](https://user-images.githubusercontent.com/8456633/201611990-bab2e724-e4cf-4f84-84b7-046f1d5b8506.png)



- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
