### PR TITLE
[#2279] defaultFgColor entry in theme config

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -46,6 +46,8 @@ gui:
       - blue
     unstagedChangesColor:
       - red
+    defaultFgColor:
+      - white
   commitLength:
     show: true
   mouseEvents: true

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -47,7 +47,7 @@ gui:
     unstagedChangesColor:
       - red
     defaultFgColor:
-      - white
+      - default
   commitLength:
     show: true
   mouseEvents: true

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -63,6 +63,7 @@ type ThemeConfig struct {
 	CherryPickedCommitBgColor []string `yaml:"cherryPickedCommitBgColor"`
 	CherryPickedCommitFgColor []string `yaml:"cherryPickedCommitFgColor"`
 	UnstagedChangesColor      []string `yaml:"unstagedChangesColor"`
+	DefaultFgColor            []string `yaml:"defaultFgColor"`
 }
 
 type CommitLengthConfig struct {
@@ -365,6 +366,7 @@ func GetDefaultConfig() *UserConfig {
 				CherryPickedCommitBgColor: []string{"cyan"},
 				CherryPickedCommitFgColor: []string{"blue"},
 				UnstagedChangesColor:      []string{"red"},
+				DefaultFgColor:            []string{"default"},
 			},
 			CommitLength:             CommitLengthConfig{Show: true},
 			SkipNoStagedFilesWarning: false,

--- a/pkg/theme/theme.go
+++ b/pkg/theme/theme.go
@@ -58,6 +58,6 @@ func UpdateTheme(themeConfig config.ThemeConfig) {
 	OptionsColor = GetGocuiStyle(themeConfig.OptionsTextColor)
 	OptionsFgColor = GetTextStyle(themeConfig.OptionsTextColor, false)
 
-	DefaultTextColor = style.FgDefault
-	GocuiDefaultTextColor = gocui.ColorDefault
+	DefaultTextColor = GetTextStyle(themeConfig.DefaultFgColor, false)
+	GocuiDefaultTextColor = GetGocuiStyle(themeConfig.DefaultFgColor)
 }


### PR DESCRIPTION
- **PR Description**

Add defaultFgColor entry in theme config.
Closes #2279.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
