### PR TITLE
keybind 'D' for discard all in files menu

### DIFF
--- a/pkg/gui/controllers/files_remove_controller.go
+++ b/pkg/gui/controllers/files_remove_controller.go
@@ -51,7 +51,7 @@ func (self *FilesRemoveController) remove(node *filetree.FileNode) error {
 					}
 					return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}})
 				},
-				Key: 'd',
+				Key: 'D',
 			},
 		}
 
@@ -95,7 +95,7 @@ func (self *FilesRemoveController) remove(node *filetree.FileNode) error {
 						}
 						return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}})
 					},
-					Key: 'd',
+					Key: 'D',
 				},
 			}
 


### PR DESCRIPTION
- **PR Description**
The keybind combination is now 'd'->'D' to discard all files.
Closes https://github.com/jesseduffield/lazygit/issues/2291

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
