### PR TITLE
Add the return alternative key to return in the input box

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -113,6 +113,7 @@ keybinding:
     quit: 'q'
     quit-alt1: '<c-c>' # alternative/alias of quit
     return: '<esc>' # return to previous menu, will quit if there's nowhere to return
+    return-alt1: ';' # Can be set as a single character key to return to the previous menu level
     quitWithoutChangingDirectory: 'Q'
     togglePanel: '<tab>' # goto the next panel
     prevItem: '<up>' # go one line up

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -113,7 +113,8 @@ keybinding:
     quit: 'q'
     quit-alt1: '<c-c>' # alternative/alias of quit
     return: '<esc>' # return to previous menu, will quit if there's nowhere to return
-    return-alt1: ';' # When set to a printable character, this will work for returning from non-prompt panels
+    # When set to a printable character, this will work for returning from non-prompt panels
+    return-alt1: null
     quitWithoutChangingDirectory: 'Q'
     togglePanel: '<tab>' # goto the next panel
     prevItem: '<up>' # go one line up

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -113,7 +113,7 @@ keybinding:
     quit: 'q'
     quit-alt1: '<c-c>' # alternative/alias of quit
     return: '<esc>' # return to previous menu, will quit if there's nowhere to return
-    return-alt1: ';' # Can be set as a single character key to return to the previous menu level
+    return-alt1: ';' # When set to a printable character, this will work for returning from non-prompt panels
     quitWithoutChangingDirectory: 'Q'
     togglePanel: '<tab>' # goto the next panel
     prevItem: '<up>' # go one line up

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -425,6 +425,7 @@ func GetDefaultConfig() *UserConfig {
 				Quit:                         "q",
 				QuitAlt1:                     "<c-c>",
 				Return:                       "<esc>",
+				ReturnAlt1:                   "",
 				QuitWithoutChangingDirectory: "Q",
 				TogglePanel:                  "<tab>",
 				PrevItem:                     "<up>",

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -136,6 +136,7 @@ type KeybindingUniversalConfig struct {
 	Quit                         string   `yaml:"quit"`
 	QuitAlt1                     string   `yaml:"quit-alt1"`
 	Return                       string   `yaml:"return"`
+	ReturnAlt1                   string   `yaml:"return-alt1"`
 	QuitWithoutChangingDirectory string   `yaml:"quitWithoutChangingDirectory"`
 	TogglePanel                  string   `yaml:"togglePanel"`
 	PrevItem                     string   `yaml:"prevItem"`

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -75,6 +75,12 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 			Handler:  self.handleTopLevelReturn,
 		},
 		{
+			ViewName: "",
+			Key:      opts.GetKey(opts.Config.Universal.ReturnAlt1),
+			Modifier: gocui.ModNone,
+			Handler:  self.handleTopLevelReturn,
+		},
+		{
 			ViewName:    "",
 			Key:         opts.GetKey(opts.Config.Universal.OpenRecentRepos),
 			Handler:     self.handleCreateRecentReposMenu,


### PR DESCRIPTION
- **PR Description**
Since the `esc` key is far away from me, I set the return key to `q` for convenience, but I can't return to the top-level menu in the input box due to a hard-coded key issue in the code.

```yaml
keybinding:
  universal:
    quit: '<esc>'
    quit-alt1: '<c-c>' # alternative/alias of quit
    return: '<c-q>' # return to previous menu, will quit if there's nowhere to return
    return-alt1: 'q' # return to previous menu, will quit if there's nowhere to return
```
So I added a return alternative `returnAlt1` which can be set to a single character, so that to return in the input box you can use the `return` key binding, and a normal menu return can use the `returnAlt1` key binding.
```yaml
keybinding:
  universal:
    quit: '<esc>'
    quit-alt1: '<c-c>' # alternative/alias of quit
    return: '<c-q>' # return to previous menu, will quit if there's nowhere to return
    return-alt1: 'q' # Can be set as a single character key to return to the previous menu level
```

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
