### PR TITLE
Add option to allow --verbose commit in editor commits

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -67,6 +67,7 @@ git:
     useConfig: false
   commit:
     signOff: false
+    verbose: false
   merging:
     # only applicable to unix users
     manualCommit: false

--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -62,12 +62,20 @@ func (self *CommitCommands) CommitCmdObj(message string) oscommands.ICmdObj {
 
 // runs git commit without the -m argument meaning it will invoke the user's editor
 func (self *CommitCommands) CommitEditorCmdObj() oscommands.ICmdObj {
-	return self.cmd.New(fmt.Sprintf("git commit%s", self.signoffFlag()))
+	return self.cmd.New(fmt.Sprintf("git commit%s%s", self.signoffFlag(), self.verboseFlag()))
 }
 
 func (self *CommitCommands) signoffFlag() string {
 	if self.UserConfig.Git.Commit.SignOff {
 		return " --signoff"
+	} else {
+		return ""
+	}
+}
+
+func (self *CommitCommands) verboseFlag() string {
+	if self.UserConfig.Git.Commit.Verbose {
+		return " --verbose"
 	} else {
 		return ""
 	}

--- a/pkg/commands/git_commands/commit_test.go
+++ b/pkg/commands/git_commands/commit_test.go
@@ -32,6 +32,7 @@ func TestCommitCommitObj(t *testing.T) {
 		testName             string
 		message              string
 		configSignoff        bool
+		configVerbose        bool
 		configSkipHookPrefix string
 		expected             string
 	}
@@ -41,6 +42,7 @@ func TestCommitCommitObj(t *testing.T) {
 			testName:             "Commit",
 			message:              "test",
 			configSignoff:        false,
+			configVerbose:        false,
 			configSkipHookPrefix: "",
 			expected:             `git commit -m "test"`,
 		},
@@ -48,6 +50,7 @@ func TestCommitCommitObj(t *testing.T) {
 			testName:             "Commit with --no-verify flag",
 			message:              "WIP: test",
 			configSignoff:        false,
+			configVerbose:        false,
 			configSkipHookPrefix: "WIP",
 			expected:             `git commit --no-verify -m "WIP: test"`,
 		},
@@ -55,6 +58,7 @@ func TestCommitCommitObj(t *testing.T) {
 			testName:             "Commit with multiline message",
 			message:              "line1\nline2",
 			configSignoff:        false,
+			configVerbose:        false,
 			configSkipHookPrefix: "",
 			expected:             `git commit -m "line1" -m "line2"`,
 		},
@@ -62,13 +66,23 @@ func TestCommitCommitObj(t *testing.T) {
 			testName:             "Commit with signoff",
 			message:              "test",
 			configSignoff:        true,
+			configVerbose:        false,
 			configSkipHookPrefix: "",
 			expected:             `git commit --signoff -m "test"`,
+		},
+		{
+			testName:             "Commit with message ignores verbose flag",
+			message:              "test",
+			configSignoff:        false,
+			configVerbose:        true,
+			configSkipHookPrefix: "",
+			expected:             `git commit -m "test"`,
 		},
 		{
 			testName:             "Commit with signoff and no-verify",
 			message:              "WIP: test",
 			configSignoff:        true,
+			configVerbose:        false,
 			configSkipHookPrefix: "WIP",
 			expected:             `git commit --no-verify --signoff -m "WIP: test"`,
 		},
@@ -79,6 +93,7 @@ func TestCommitCommitObj(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			userConfig := config.GetDefaultConfig()
 			userConfig.Git.Commit.SignOff = s.configSignoff
+			userConfig.Git.Commit.Verbose = s.configVerbose
 			userConfig.Git.SkipHookPrefix = s.configSkipHookPrefix
 
 			instance := buildCommitCommands(commonDeps{userConfig: userConfig})

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -94,6 +94,7 @@ type PagingConfig struct {
 
 type CommitConfig struct {
 	SignOff bool `yaml:"signOff"`
+	Verbose bool `yaml:"verbose"`
 }
 
 type MergingConfig struct {
@@ -386,6 +387,7 @@ func GetDefaultConfig() *UserConfig {
 			},
 			Commit: CommitConfig{
 				SignOff: false,
+				Verbose: false,
 			},
 			Merging: MergingConfig{
 				ManualCommit: false,


### PR DESCRIPTION
- **Add option to allow --verbose commit in editor commits**

This PR adds a config option that, when enabled, passes the `--verbose` flag
to `git commit` when committing from the editor.

Since the `--verbose` option is only useful for the editor provided messages,
the flag is not set when using the lazygit native prompt.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

I was playing around with adding an integration test for this, but I'm not sure
how I would configure git to use a non-interactive editor for the test.
Maybe I can set $GIT_EDITOR just for the scope of a test?
Do you have any suggestions?
