### PR TITLE
change `git.commit.verbose` to accept "default"

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -67,7 +67,7 @@ git:
     useConfig: false
   commit:
     signOff: false
-    verbose: false
+    verbose: default # one of 'default' | 'always' | 'never'
   merging:
     # only applicable to unix users
     manualCommit: false

--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -74,9 +74,12 @@ func (self *CommitCommands) signoffFlag() string {
 }
 
 func (self *CommitCommands) verboseFlag() string {
-	if self.UserConfig.Git.Commit.Verbose {
+	switch self.config.UserConfig.Git.Commit.Verbose {
+	case "always":
 		return " --verbose"
-	} else {
+	case "never":
+		return " --no-verbose"
+	default:
 		return ""
 	}
 }

--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -446,14 +446,4 @@ func (self *CommitLoader) getLogCmd(opts GetCommitsOptions) oscommands.ICmdObj {
 	).DontLog()
 }
 
-var prettyFormat = fmt.Sprintf(
-	"--pretty=format:\"%%H%s%%at%s%%aN%s%%ae%s%%d%s%%p%s%%s\"",
-	NULL_CODE,
-	NULL_CODE,
-	NULL_CODE,
-	NULL_CODE,
-	NULL_CODE,
-	NULL_CODE,
-)
-
-const NULL_CODE = "%x00"
+const prettyFormat = `--pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s"`

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -93,8 +93,8 @@ type PagingConfig struct {
 }
 
 type CommitConfig struct {
-	SignOff bool `yaml:"signOff"`
-	Verbose bool `yaml:"verbose"`
+	SignOff bool   `yaml:"signOff"`
+	Verbose string `yaml:"verbose"`
 }
 
 type MergingConfig struct {
@@ -387,7 +387,7 @@ func GetDefaultConfig() *UserConfig {
 			},
 			Commit: CommitConfig{
 				SignOff: false,
-				Verbose: false,
+				Verbose: "default",
 			},
 			Merging: MergingConfig{
 				ManualCommit: false,


### PR DESCRIPTION
- **PR Description**

ref: https://github.com/jesseduffield/lazygit/pull/2341

change to ignore `git config commit.verbose` if `git.commit.verbose` is `never`.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
