### PR TITLE
always refresh the staging panel

### DIFF
--- a/pkg/gui/refresh.go
+++ b/pkg/gui/refresh.go
@@ -73,13 +73,14 @@ func (gui *Gui) Refresh(options types.RefreshOptions) error {
 	f := func() {
 		var scopeSet *set.Set[types.RefreshableView]
 		if len(options.Scope) == 0 {
-			// not refreshing staging/patch-building unless explicitly requested because we only need
+			// not refreshing patch-building unless explicitly requested because we only need
 			// to refresh those while focused.
 			scopeSet = set.NewFromSlice([]types.RefreshableView{
 				types.COMMITS,
 				types.BRANCHES,
 				types.FILES,
 				types.STASH,
+				types.STAGING,
 				types.REFLOG,
 				types.TAGS,
 				types.REMOTES,


### PR DESCRIPTION
- **PR Description**
fixes #2363 
always rerender the staging panel in order to correctly clear the `Staged Changes` panel when commiting from the staging panel

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
