### PR TITLE
Allow multiline commit when rewording commit

### DIFF
--- a/pkg/gui/context/context.go
+++ b/pkg/gui/context/context.go
@@ -37,6 +37,7 @@ const (
 	CONFIRMATION_CONTEXT_KEY   types.ContextKey = "confirmation"
 	SEARCH_CONTEXT_KEY         types.ContextKey = "search"
 	COMMIT_MESSAGE_CONTEXT_KEY types.ContextKey = "commitMessage"
+	REWORD_COMMIT_CONTEXT_KEY  types.ContextKey = "rewordCommit"
 	SUBMODULES_CONTEXT_KEY     types.ContextKey = "submodules"
 	SUGGESTIONS_CONTEXT_KEY    types.ContextKey = "suggestions"
 	COMMAND_LOG_CONTEXT_KEY    types.ContextKey = "cmdLog"
@@ -98,6 +99,7 @@ type ContextTree struct {
 	MergeConflicts              *MergeConflictsContext
 	Confirmation                types.Context
 	CommitMessage               types.Context
+	RewordCommitMessage         types.Context
 	CommandLog                  types.Context
 
 	// display contexts
@@ -146,6 +148,7 @@ func (self *ContextTree) Flatten() []types.Context {
 		self.Search,
 		self.Information,
 		self.Limit,
+		self.RewordCommitMessage,
 	}
 }
 

--- a/pkg/gui/context_config.go
+++ b/pkg/gui/context_config.go
@@ -230,6 +230,19 @@ func (gui *Gui) contextTree() *context.ContextTree {
 				OnFocus: OnFocusWrapper(gui.handleCommitMessageFocused),
 			},
 		),
+		RewordCommitMessage: context.NewSimpleContext(
+			context.NewBaseContext(context.NewBaseContextOpts{
+				Kind:                  types.PERSISTENT_POPUP,
+				View:                  gui.Views.RewordCommitMessage,
+				WindowName:            "rewordCommitMessage",
+				Key:                   context.REWORD_COMMIT_CONTEXT_KEY,
+				Focusable:             true,
+				HasUncontrolledBounds: true,
+			}),
+			context.ContextCallbackOpts{
+				OnFocus: OnFocusWrapper(gui.handleCommitMessageFocused),
+			},
+		),
 		Search: context.NewSimpleContext(
 			context.NewBaseContext(context.NewBaseContextOpts{
 				Kind:       types.PERSISTENT_POPUP,

--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -26,6 +26,7 @@ func (gui *Gui) resetControllers() {
 	rebaseHelper := helpers.NewMergeAndRebaseHelper(helperCommon, gui.State.Contexts, gui.git, refsHelper)
 	suggestionsHelper := helpers.NewSuggestionsHelper(helperCommon, model, gui.refreshSuggestions)
 	setCommitMessage := gui.getSetTextareaTextFn(func() *gocui.View { return gui.Views.CommitMessage })
+	setRewordCommitMessage := gui.getSetTextareaTextFn(func() *gocui.View { return gui.Views.RewordCommitMessage })
 	getSavedCommitMessage := func() string {
 		return gui.State.savedCommitMessage
 	}
@@ -104,7 +105,8 @@ func (gui *Gui) resetControllers() {
 	remoteBranchesController := controllers.NewRemoteBranchesController(common)
 
 	menuController := controllers.NewMenuController(common)
-	localCommitsController := controllers.NewLocalCommitsController(common, syncController.HandlePull)
+	localCommitsController := controllers.NewLocalCommitsController(common, syncController.HandlePull, setRewordCommitMessage)
+	rewordCommitsController := controllers.NewRewordCommitController(common)
 	tagsController := controllers.NewTagsController(common)
 	filesController := controllers.NewFilesController(
 		common,
@@ -237,6 +239,10 @@ func (gui *Gui) resetControllers() {
 
 	controllers.AttachControllers(gui.State.Contexts.CommitMessage,
 		commitMessageController,
+	)
+
+	controllers.AttachControllers(gui.State.Contexts.RewordCommitMessage,
+		rewordCommitsController,
 	)
 
 	controllers.AttachControllers(gui.State.Contexts.RemoteBranches,

--- a/pkg/gui/controllers/reword_commit_controller.go
+++ b/pkg/gui/controllers/reword_commit_controller.go
@@ -1,0 +1,70 @@
+package controllers
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+)
+
+type RewordCommitController struct {
+	baseController
+	*controllerCommon
+}
+
+var _ types.IController = &RewordCommitController{}
+
+func NewRewordCommitController(
+	common *controllerCommon,
+) *RewordCommitController {
+	return &RewordCommitController{
+		baseController:   baseController{},
+		controllerCommon: common,
+	}
+}
+
+func (self *RewordCommitController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
+	bindings := []*types.Binding{
+		{
+			Key:     opts.GetKey(opts.Config.Universal.SubmitEditorText),
+			Handler: self.confirm,
+		},
+		{
+			Key:     opts.GetKey(opts.Config.Universal.Return),
+			Handler: self.close,
+		},
+	}
+
+	return bindings
+}
+
+func (self *RewordCommitController) Context() types.Context {
+	return self.context()
+}
+
+// this method is pointless in this context but I'm keeping it consistent
+// with other contexts so that when generics arrive it's easier to refactor
+func (self *RewordCommitController) context() types.Context {
+	return self.contexts.RewordCommitMessage
+}
+
+func (self *RewordCommitController) confirm() error {
+	message := self.context().GetView().TextArea.GetContent()
+
+	if message == "" {
+		return self.c.ErrorMsg(self.c.Tr.CommitWithoutMessageErr)
+	}
+
+	self.c.LogAction(self.c.Tr.Actions.RewordCommit)
+	if err := self.git.Rebase.RewordCommit(
+		self.model.Commits,
+		self.contexts.LocalCommits.GetSelectedLineIdx(),
+		message,
+	); err != nil {
+		return self.c.Error(err)
+	}
+
+	_ = self.c.PopContext()
+	return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})
+}
+
+func (self *RewordCommitController) close() error {
+	return self.c.PopContext()
+}

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -26,20 +26,21 @@ type Views struct {
 	PatchBuildingSecondary *gocui.View
 	MergeConflicts         *gocui.View
 
-	Options       *gocui.View
-	Confirmation  *gocui.View
-	Menu          *gocui.View
-	CommitMessage *gocui.View
-	CommitFiles   *gocui.View
-	SubCommits    *gocui.View
-	Information   *gocui.View
-	AppStatus     *gocui.View
-	Search        *gocui.View
-	SearchPrefix  *gocui.View
-	Limit         *gocui.View
-	Suggestions   *gocui.View
-	Tooltip       *gocui.View
-	Extras        *gocui.View
+	Options             *gocui.View
+	Confirmation        *gocui.View
+	Menu                *gocui.View
+	CommitMessage       *gocui.View
+	RewordCommitMessage *gocui.View
+	CommitFiles         *gocui.View
+	SubCommits          *gocui.View
+	Information         *gocui.View
+	AppStatus           *gocui.View
+	Search              *gocui.View
+	SearchPrefix        *gocui.View
+	Limit               *gocui.View
+	Suggestions         *gocui.View
+	Tooltip             *gocui.View
+	Extras              *gocui.View
 
 	// for playing the easter egg snake game
 	Snake *gocui.View
@@ -94,6 +95,7 @@ func (gui *Gui) orderedViewNameMappings() []viewNameMapping {
 
 		// popups.
 		{viewPtr: &gui.Views.CommitMessage, name: "commitMessage"},
+		{viewPtr: &gui.Views.RewordCommitMessage, name: "rewordCommitMessage"},
 		{viewPtr: &gui.Views.Menu, name: "menu"},
 		{viewPtr: &gui.Views.Suggestions, name: "suggestions"},
 		{viewPtr: &gui.Views.Confirmation, name: "confirmation"},
@@ -204,6 +206,12 @@ func (gui *Gui) createAllViews() error {
 	gui.Views.CommitMessage.FgColor = theme.GocuiDefaultTextColor
 	gui.Views.CommitMessage.Editable = true
 	gui.Views.CommitMessage.Editor = gocui.EditorFunc(gui.commitMessageEditor)
+
+	gui.Views.RewordCommitMessage.Visible = false
+	gui.Views.RewordCommitMessage.Title = gui.c.Tr.CommitMessage
+	gui.Views.RewordCommitMessage.FgColor = theme.GocuiDefaultTextColor
+	gui.Views.RewordCommitMessage.Editable = true
+	gui.Views.RewordCommitMessage.Editor = gocui.EditorFunc(gui.commitMessageEditor)
 
 	gui.Views.Confirmation.Visible = false
 

--- a/pkg/integration/components/commit_message_panel_driver.go
+++ b/pkg/integration/components/commit_message_panel_driver.go
@@ -1,11 +1,16 @@
 package components
 
 type CommitMessagePanelDriver struct {
-	t *TestDriver
+	t      *TestDriver
+	reword bool
 }
 
 func (self *CommitMessagePanelDriver) getViewDriver() *ViewDriver {
-	return self.t.Views().CommitMessage()
+	if self.reword {
+		return self.t.Views().RewordCommitMessage()
+	} else {
+		return self.t.Views().CommitMessage()
+	}
 }
 
 // asserts on the text initially present in the prompt

--- a/pkg/integration/components/popup.go
+++ b/pkg/integration/components/popup.go
@@ -1,5 +1,7 @@
 package components
 
+import "fmt"
+
 type Popup struct {
 	t *TestDriver
 }
@@ -57,14 +59,20 @@ func (self *Popup) inMenu() {
 }
 
 func (self *Popup) CommitMessagePanel() *CommitMessagePanelDriver {
-	self.inCommitMessagePanel()
+	self.assertCurrentView("commitMessage")
 
 	return &CommitMessagePanelDriver{t: self.t}
 }
 
-func (self *Popup) inCommitMessagePanel() {
+func (self *Popup) RewordCommitPanel() *CommitMessagePanelDriver {
+	self.assertCurrentView("rewordCommitMessage")
+
+	return &CommitMessagePanelDriver{t: self.t, reword: true}
+}
+
+func (self *Popup) assertCurrentView(expectedView string) {
 	self.t.assertWithRetries(func() (bool, string) {
 		currentView := self.t.gui.CurrentContext().GetView()
-		return currentView.Name() == "commitMessage", "Expected commit message panel to be focused"
+		return currentView.Name() == expectedView, fmt.Sprintf("Expected %s panel to be focused", expectedView)
 	})
 }

--- a/pkg/integration/components/views.go
+++ b/pkg/integration/components/views.go
@@ -112,6 +112,10 @@ func (self *Views) CommitMessage() *ViewDriver {
 	return self.byName("commitMessage")
 }
 
+func (self *Views) RewordCommitMessage() *ViewDriver {
+	return self.byName("rewordCommitMessage")
+}
+
 func (self *Views) Suggestions() *ViewDriver {
 	return self.byName("suggestions")
 }

--- a/pkg/integration/tests/commit/commit_reword_multiline.go
+++ b/pkg/integration/tests/commit/commit_reword_multiline.go
@@ -1,0 +1,31 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CommitRewordMultiline = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Reword commit with a multi-line commit message",
+	ExtraCmdArgs: "",
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFile("myfile", "myfile content")
+		shell.GitAddAll()
+		shell.Commit("first line")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("first line"),
+			).
+			Press(keys.Commits.RenameCommit)
+
+		t.ExpectPopup().RewordCommitPanel().AddNewline().Type("second line").Confirm()
+
+		t.Views().Commits().Focus()
+		t.Views().Main().Content(MatchesRegexp("first line\n\\s*second line"))
+	},
+})

--- a/pkg/integration/tests/tests.go
+++ b/pkg/integration/tests/tests.go
@@ -42,6 +42,7 @@ var tests = []*components.IntegrationTest{
 	cherry_pick.CherryPickConflicts,
 	commit.Commit,
 	commit.CommitMultiline,
+	commit.CommitRewordMultiline,
 	commit.Revert,
 	commit.NewBranch,
 	commit.Staged,


### PR DESCRIPTION
- **Allow multiline commit when rewording commit**
- This should fix https://github.com/jesseduffield/lazygit/issues/1344

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
