### PR TITLE
Ensure trailing LF when copying diff lines to clipboard

### DIFF
--- a/pkg/commands/patch/patch_parser.go
+++ b/pkg/commands/patch/patch_parser.go
@@ -210,10 +210,10 @@ func (p *PatchParser) RenderLinesPlain(firstLineIndex, lastLineIndex int) string
 
 func renderLinesPlain(lines []*PatchLine) string {
 	renderedLines := slices.Map(lines, func(line *PatchLine) string {
-		return line.Content
+		return line.Content + "\n"
 	})
 
-	return strings.Join(renderedLines, "\n")
+	return strings.Join(renderedLines, "")
 }
 
 // GetNextStageableLineIndex takes a line index and returns the line index of the next stageable line

--- a/pkg/commands/patch/patch_parser.go
+++ b/pkg/commands/patch/patch_parser.go
@@ -202,10 +202,6 @@ func (p *PatchParser) Render(isFocused bool, firstLineIndex int, lastLineIndex i
 	return result
 }
 
-func (p *PatchParser) RenderPlain() string {
-	return renderLinesPlain(p.PatchLines)
-}
-
 // RenderLinesPlain returns the non-coloured string of diff part from firstLineIndex to
 // lastLineIndex
 func (p *PatchParser) RenderLinesPlain(firstLineIndex, lastLineIndex int) string {


### PR DESCRIPTION
- **PR Description**

When copying a range of diff lines to the clipboard, the last line wouldn't end with a line feed. This made it inconvenient to paste the copied block into a text document. Ensure that the last line ends with a LF too.

I didn't add a test for this, let me know if you think it's worth doing that.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
