### PR TITLE
fix RefName of detached HEAD to works in Chinese

### DIFF
--- a/pkg/integration/tests/branch/detached_head.go
+++ b/pkg/integration/tests/branch/detached_head.go
@@ -1,0 +1,40 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var DetachedHead = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Create a new branch on detached head",
+	ExtraCmdArgs: "",
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			CreateNCommits(10).
+			Checkout("HEAD^")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Lines(
+				MatchesRegexp(`\*.*HEAD`).IsSelected(),
+				MatchesRegexp(`master`),
+			).
+			Press(keys.Universal.New)
+
+		t.ExpectPopup().Prompt().
+			Title(MatchesRegexp(`^New Branch Name \(Branch is off of '[0-9a-f]+'\)$`)).
+			Type("new-branch").
+			Confirm()
+
+		t.Views().Branches().
+			Lines(
+				MatchesRegexp(`\* new-branch`).IsSelected(),
+				MatchesRegexp(`master`),
+			)
+
+		t.Git().CurrentBranchName("new-branch")
+	},
+})

--- a/pkg/integration/tests/tests.go
+++ b/pkg/integration/tests/tests.go
@@ -38,6 +38,7 @@ var tests = []*components.IntegrationTest{
 	branch.RebaseAndDrop,
 	branch.Suggestions,
 	branch.Reset,
+	branch.DetachedHead,
 	cherry_pick.CherryPick,
 	cherry_pick.CherryPickConflicts,
 	commit.Commit,


### PR DESCRIPTION
- **PR Description**

fix https://github.com/jesseduffield/lazygit/issues/1467

1. `git switch --detach`
2. `LANG=zh_CN.UTF-8 lazygit branch`
3. `n` (new branch) and type something
4. `enter`

<table>
<tr>
	<td>before
	<td><img width="920" alt="スクリーンショット 2023-01-27 20 15 27" src="https://user-images.githubusercontent.com/10097437/215073791-2ea90ca5-6a66-48b6-a96e-328b9e8f94ef.png">
	<td><img width="859" alt="スクリーンショット 2023-01-27 20 15 35" src="https://user-images.githubusercontent.com/10097437/215073815-d5a3e9fb-ebc2-422f-b48b-fd9fef4b08c0.png">
<tr>
	<td>after
	<td><img width="939" alt="スクリーンショット 2023-01-27 20 15 59" src="https://user-images.githubusercontent.com/10097437/215073890-04ba4110-0a8a-4937-bdc5-f5fd6880079f.png">
	<td><img width="1053" alt="スクリーンショット 2023-01-27 20 16 10" src="https://user-images.githubusercontent.com/10097437/215073915-e5dba937-846f-4730-8cc3-b6dd130d8a77.png">
</table>

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
