### PR TITLE
allow to disable `git.log.order`

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -74,7 +74,7 @@ git:
     # extra args passed to `git merge`, e.g. --no-ff
     args: ''
   log:
-    # one of date-order, author-date-order, topo-order.
+    # one of date-order, author-date-order, topo-order or default.
     # topo-order makes it easier to read the git log graph, but commits may not
     # appear chronologically. See https://git-scm.com/docs/git-log#_commit_ordering
     order: 'topo-order'

--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -426,7 +426,10 @@ func (self *CommitLoader) getLogCmd(opts GetCommitsOptions) oscommands.ICmdObj {
 
 	config := self.UserConfig.Git.Log
 
-	orderFlag := "--" + config.Order
+	orderFlag := ""
+	if config.Order != "default" {
+		orderFlag = " --" + config.Order
+	}
 	allFlag := ""
 	if opts.All {
 		allFlag = " --all"
@@ -434,7 +437,7 @@ func (self *CommitLoader) getLogCmd(opts GetCommitsOptions) oscommands.ICmdObj {
 
 	return self.cmd.New(
 		fmt.Sprintf(
-			"git -c log.showSignature=false log %s %s %s --oneline %s%s --abbrev=%d%s",
+			"git -c log.showSignature=false log %s%s%s --oneline %s%s --abbrev=%d%s",
 			self.cmd.Quote(opts.RefName),
 			orderFlag,
 			allFlag,


### PR DESCRIPTION
- **PR Description**

ref: https://github.com/jesseduffield/lazygit/issues/2397

As mentioned in #2397, `log --topo-order` is slow. I think it would be useful for large repositories to disable order.

```sh
$ cd github.com/ruby/ruby
$ for i in "--topo-order" "--date-order" "--author-date-order" ""; do echo "git log $i"; time (git log --oneline -n300 $i >/dev/null); done
git log --topo-order
( git log --oneline -n300 $i > /dev/null; )  0.75s user 0.06s system 93% cpu 0.867 total
git log --date-order
( git log --oneline -n300 $i > /dev/null; )  0.71s user 0.05s system 97% cpu 0.778 total
git log --author-date-order
( git log --oneline -n300 $i > /dev/null; )  0.79s user 0.05s system 97% cpu 0.864 total
git log
( git log --oneline -n300 $i > /dev/null; )  0.01s user 0.01s system 91% cpu 0.024 total
```

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
