### PR TITLE
fix: fix `default` color

### DIFF
--- a/pkg/gui/style/basic_styles.go
+++ b/pkg/gui/style/basic_styles.go
@@ -39,7 +39,7 @@ var (
 		Foreground TextStyle
 		Background TextStyle
 	}{
-		"default": {FgWhite, BgBlack},
+		"default": {FgDefault, BgDefault},
 		"black":   {FgBlack, BgBlack},
 		"red":     {FgRed, BgRed},
 		"green":   {FgGreen, BgGreen},


### PR DESCRIPTION
- **PR Description**

fix: https://github.com/jesseduffield/lazygit/issues/2410

<table>
<tr>
	<th>before
	<td><img width="569" alt="スクリーンショット 2023-02-03 19 48 50" src="https://user-images.githubusercontent.com/10097437/216582651-64e519d7-9494-4d8e-a88d-908523c4ffc1.png">
<tr>
	<th>after
	<td><img width="567" alt="スクリーンショット 2023-02-03 19 49 03" src="https://user-images.githubusercontent.com/10097437/216582668-81f971f5-55e1-4309-b2ca-550d3318f3d2.png">
</table>

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
