### PR TITLE
disable help menu key binding on suggestions panel

### DIFF
--- a/pkg/gui/options_menu_panel.go
+++ b/pkg/gui/options_menu_panel.go
@@ -50,8 +50,13 @@ func uniqueBindings(bindings []*types.Binding) []*types.Binding {
 }
 
 func (gui *Gui) handleCreateOptionsMenu() error {
-	context := gui.currentContext()
-	bindings := gui.getBindings(context)
+	ctx := gui.currentContext()
+	// Don't show menu while displaying popup.
+	if ctx.GetKind() == types.PERSISTENT_POPUP || ctx.GetKind() == types.TEMPORARY_POPUP {
+		return nil
+	}
+
+	bindings := gui.getBindings(ctx)
 
 	menuItems := slices.Map(bindings, func(binding *types.Binding) *types.MenuItem {
 		return &types.MenuItem{


### PR DESCRIPTION
- **PR Description**

1. `:`, `<tab>`: focus suggestions panel
2. `x` or `?`: open help menu
3. `<esc>`: close help menu
4. suggestions panel becomes inoperable

<img width="1603" alt="スクリーンショット 2023-02-05 21 01 38" src="https://user-images.githubusercontent.com/10097437/216817523-565800a0-42cf-4450-bf71-a5ffd2227c50.png">

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
