### PR TITLE
Disable ~/.gitconfig when running integration tests

### DIFF
--- a/pkg/integration/components/runner.go
+++ b/pkg/integration/components/runner.go
@@ -165,6 +165,8 @@ func getLazygitCommand(test *IntegrationTest, paths Paths, rootDir string, sandb
 		cmdObj.AddEnvVars(fmt.Sprintf("KEY_PRESS_DELAY=%d", keyPressDelay))
 	}
 
+	cmdObj.AddEnvVars("GIT_CONFIG_GLOBAL=/dev/null")
+
 	return cmdObj.GetCmd(), nil
 }
 


### PR DESCRIPTION
A global ~/.gitconfig file can have influence on how integration tests behave; in my case, I had the option "merge.conflictStyle" set to "diff3", which made the integration test "cherry_pick_conflict" fail because the diff was different from what the test expected.

Make this more robust by telling git to ignore the global config file when running tests.