### PR TITLE
Do not autosquash in regular rebase

### DIFF
--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -129,7 +129,7 @@ func (self *RebaseCommands) PrepareInteractiveRebaseCommand(baseSha string, todo
 		debug = "TRUE"
 	}
 
-	cmdStr := fmt.Sprintf("git rebase --interactive --autostash --keep-empty %s", baseSha)
+	cmdStr := fmt.Sprintf("git rebase --interactive --autostash --keep-empty --no-autosquash %s", baseSha)
 	self.Log.WithField("command", cmdStr).Debug("RunCommand")
 
 	cmdObj := self.cmd.New(cmdStr)

--- a/pkg/commands/git_commands/rebase_test.go
+++ b/pkg/commands/git_commands/rebase_test.go
@@ -26,7 +26,7 @@ func TestRebaseRebaseBranch(t *testing.T) {
 			testName: "successful rebase",
 			arg:      "master",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git rebase --interactive --autostash --keep-empty master`, "", nil),
+				Expect(`git rebase --interactive --autostash --keep-empty --no-autosquash master`, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -35,7 +35,7 @@ func TestRebaseRebaseBranch(t *testing.T) {
 			testName: "unsuccessful rebase",
 			arg:      "master",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git rebase --interactive --autostash --keep-empty master`, "", errors.New("error")),
+				Expect(`git rebase --interactive --autostash --keep-empty --no-autosquash master`, "", errors.New("error")),
 			test: func(err error) {
 				assert.Error(t, err)
 			},
@@ -125,7 +125,7 @@ func TestRebaseDiscardOldFileChanges(t *testing.T) {
 			commitIndex: 0,
 			fileName:    "test999.txt",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git rebase --interactive --autostash --keep-empty abcdef`, "", nil).
+				Expect(`git rebase --interactive --autostash --keep-empty --no-autosquash abcdef`, "", nil).
 				Expect(`git cat-file -e HEAD^:"test999.txt"`, "", nil).
 				Expect(`git checkout HEAD^ -- "test999.txt"`, "", nil).
 				Expect(`git commit --amend --no-edit --allow-empty`, "", nil).

--- a/pkg/integration/tests/branch/rebase_does_not_autosquash.go
+++ b/pkg/integration/tests/branch/rebase_does_not_autosquash.go
@@ -45,9 +45,7 @@ var RebaseDoesNotAutosquash = NewIntegrationTest(NewIntegrationTestArgs{
 			Confirm()
 
 		t.Views().Commits().Lines(
-			/* Expected the fixup to be kept, but it's gone:
 			Contains("fixup! branch commit"),
-			*/
 			Contains("branch commit"),
 			Contains("master commit"),
 			Contains("base"),

--- a/pkg/integration/tests/branch/rebase_does_not_autosquash.go
+++ b/pkg/integration/tests/branch/rebase_does_not_autosquash.go
@@ -1,0 +1,56 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var RebaseDoesNotAutosquash = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Rebase a branch that has fixups onto another branch, and verify that the fixups are not squashed even if rebase.autoSquash is enabled globally.",
+	ExtraCmdArgs: "",
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.SetConfig("rebase.autoSquash", "true")
+
+		shell.
+			EmptyCommit("base").
+			NewBranch("my-branch").
+			Checkout("master").
+			EmptyCommit("master commit").
+			Checkout("my-branch").
+			EmptyCommit("branch commit").
+			EmptyCommit("fixup! branch commit")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Lines(
+				Contains("fixup! branch commit"),
+				Contains("branch commit"),
+				Contains("base"),
+			)
+
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("my-branch").IsSelected(),
+				Contains("master"),
+			).
+			SelectNextItem().
+			Press(keys.Branches.RebaseBranch)
+
+		t.ExpectPopup().Confirmation().
+			Title(Equals("Rebasing")).
+			Content(Contains("Are you sure you want to rebase 'my-branch' on top of 'master'?")).
+			Confirm()
+
+		t.Views().Commits().Lines(
+			/* Expected the fixup to be kept, but it's gone:
+			Contains("fixup! branch commit"),
+			*/
+			Contains("branch commit"),
+			Contains("master commit"),
+			Contains("base"),
+		)
+	},
+})

--- a/pkg/integration/tests/tests.go
+++ b/pkg/integration/tests/tests.go
@@ -37,6 +37,7 @@ var tests = []*components.IntegrationTest{
 	branch.Delete,
 	branch.Rebase,
 	branch.RebaseAndDrop,
+	branch.RebaseDoesNotAutosquash,
 	branch.Suggestions,
 	branch.Reset,
 	branch.DetachedHead,


### PR DESCRIPTION
- **PR Description**

For users who have the `rebase.autoSquash` git config set to true (like me :), any regular rebase would squash fixups in addition to rebasing. That's undesirable, squashing fixups should be a deliberate action. This PR fixes that.

@jesseduffield I'm not sure if you appreciate this style of adding a "failing" test first to demonstrate a bug. We use this pattern a lot at work, and I find it useful.