### PR TITLE
Fix yellow/red coloring of pushed/unpushed commits in branch commits panel

### DIFF
--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -401,7 +401,9 @@ func ignoringWarnings(commandOutput string) string {
 func (self *CommitLoader) getFirstPushedCommit(refName string) (string, error) {
 	output, err := self.cmd.
 		New(
-			fmt.Sprintf("git merge-base %s %s@{u}", self.cmd.Quote(refName), self.cmd.Quote(refName)),
+			fmt.Sprintf("git merge-base %s %s@{u}",
+				self.cmd.Quote(refName),
+				self.cmd.Quote(strings.TrimPrefix(refName, "refs/heads/"))),
 		).
 		DontLog().
 		RunWithOutput()

--- a/pkg/commands/git_commands/commit_loader_test.go
+++ b/pkg/commands/git_commands/commit_loader_test.go
@@ -48,6 +48,22 @@ func TestGetCommits(t *testing.T) {
 			expectedError:   nil,
 		},
 		{
+			testName:          "should use proper upstream name for branch",
+			logOrder:          "topo-order",
+			rebaseMode:        enums.REBASE_MODE_NONE,
+			currentBranchName: "mybranch",
+			opts:              GetCommitsOptions{RefName: "refs/heads/mybranch", IncludeRebaseCommits: false},
+			runner: oscommands.NewFakeRunner(t).
+				/* EXPECTED:
+				Expect(`git merge-base "refs/heads/mybranch" "mybranch"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ACTUAL: */
+				Expect(`git merge-base "refs/heads/mybranch" "refs/heads/mybranch"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				Expect(`git -c log.showSignature=false log "refs/heads/mybranch" --topo-order --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40`, "", nil),
+
+			expectedCommits: []*models.Commit{},
+			expectedError:   nil,
+		},
+		{
 			testName:          "should return commits if they are present",
 			logOrder:          "topo-order",
 			rebaseMode:        enums.REBASE_MODE_NONE,

--- a/pkg/commands/git_commands/commit_loader_test.go
+++ b/pkg/commands/git_commands/commit_loader_test.go
@@ -54,10 +54,7 @@ func TestGetCommits(t *testing.T) {
 			currentBranchName: "mybranch",
 			opts:              GetCommitsOptions{RefName: "refs/heads/mybranch", IncludeRebaseCommits: false},
 			runner: oscommands.NewFakeRunner(t).
-				/* EXPECTED:
 				Expect(`git merge-base "refs/heads/mybranch" "mybranch"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
-				ACTUAL: */
-				Expect(`git merge-base "refs/heads/mybranch" "refs/heads/mybranch"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				Expect(`git -c log.showSignature=false log "refs/heads/mybranch" --topo-order --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40`, "", nil),
 
 			expectedCommits: []*models.Commit{},


### PR DESCRIPTION
- **PR Description**

The detection of the first pushed commit (commits above this are colored red,
below this yellow) didn't work for the sub-commits view of the branches panel.

In the following picture, the coloring is correct for the local commits panel,
but not for the branches panel when showing the same branch. This PR fixes that.

<img width="354" alt="image" src="https://user-images.githubusercontent.com/1225667/219851977-467edecc-d60e-49cb-b7d4-61ade4c97cb6.png">

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
