### PR TITLE
Implement "Edit commit" by breaking after current commit

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -123,7 +123,7 @@ func (app *App) validateGitVersion() (*git_commands.GitVersion, error) {
 		return nil, minVersionError
 	}
 
-	if version.IsOlderThan(2, 0, 0) {
+	if version.IsOlderThan(2, 20, 0) {
 		return nil, minVersionError
 	}
 

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -133,7 +133,7 @@ func NewGitCommandAux(
 	reflogCommitLoader := git_commands.NewReflogCommitLoader(cmn, cmd)
 	remoteLoader := git_commands.NewRemoteLoader(cmn, cmd, repo.Remotes)
 	stashLoader := git_commands.NewStashLoader(cmn, cmd)
-	tagLoader := git_commands.NewTagLoader(cmn, version, cmd)
+	tagLoader := git_commands.NewTagLoader(cmn, cmd)
 
 	return &GitCommand{
 		Branch:      branchCommands,

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -117,6 +117,16 @@ func (self *RebaseCommands) InteractiveRebase(commits []*models.Commit, index in
 	return self.PrepareInteractiveRebaseCommand(sha, todo, true).Run()
 }
 
+func (self *RebaseCommands) InteractiveRebaseBreakAfter(commits []*models.Commit, index int) error {
+	todo, sha, err := self.BuildSingleActionTodo(commits, index-1, "pick")
+	if err != nil {
+		return err
+	}
+
+	todo = append(todo, TodoLine{Action: "break", Commit: nil})
+	return self.PrepareInteractiveRebaseCommand(sha, todo, true).Run()
+}
+
 // PrepareInteractiveRebaseCommand returns the cmd for an interactive rebase
 // we tell git to run lazygit to edit the todo list, and we pass the client
 // lazygit a todo string to write to the todo file
@@ -400,5 +410,9 @@ type TodoLine struct {
 }
 
 func (self *TodoLine) ToString() string {
-	return self.Action + " " + self.Commit.Sha + " " + self.Commit.Name + "\n"
+	if self.Action == "break" {
+		return self.Action + "\n"
+	} else {
+		return self.Action + " " + self.Commit.Sha + " " + self.Commit.Name + "\n"
+	}
 }

--- a/pkg/commands/git_commands/tag_loader.go
+++ b/pkg/commands/git_commands/tag_loader.go
@@ -1,8 +1,6 @@
 package git_commands
 
 import (
-	"fmt"
-
 	"github.com/jesseduffield/generics/slices"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
@@ -12,31 +10,23 @@ import (
 
 type TagLoader struct {
 	*common.Common
-	version *GitVersion
-	cmd     oscommands.ICmdObjBuilder
+	cmd oscommands.ICmdObjBuilder
 }
 
 func NewTagLoader(
 	common *common.Common,
-	version *GitVersion,
 	cmd oscommands.ICmdObjBuilder,
 ) *TagLoader {
 	return &TagLoader{
-		Common:  common,
-		version: version,
-		cmd:     cmd,
+		Common: common,
+		cmd:    cmd,
 	}
 }
 
 func (self *TagLoader) GetTags() ([]*models.Tag, error) {
 	// get remote branches, sorted  by creation date (descending)
 	// see: https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---sortltkeygt
-	sortKey := "-creatordate"
-	if self.version.IsOlderThan(2, 7, 0) {
-		sortKey = "-v:refname"
-	}
-
-	tagsOutput, err := self.cmd.New(fmt.Sprintf(`git tag --list --sort=%s`, sortKey)).DontLog().RunWithOutput()
+	tagsOutput, err := self.cmd.New(`git tag --list --sort=-creatordate`).DontLog().RunWithOutput()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/git_commands/tag_loader_test.go
+++ b/pkg/commands/git_commands/tag_loader_test.go
@@ -20,7 +20,6 @@ testtag
 func TestGetTags(t *testing.T) {
 	type scenario struct {
 		testName      string
-		gitVersion    *GitVersion
 		runner        *oscommands.FakeCmdObjRunner
 		expectedTags  []*models.Tag
 		expectedError error
@@ -28,41 +27,16 @@ func TestGetTags(t *testing.T) {
 
 	scenarios := []scenario{
 		{
-			testName:   "should return no tags if there are none",
-			gitVersion: &GitVersion{2, 7, 0, ""},
+			testName: "should return no tags if there are none",
 			runner: oscommands.NewFakeRunner(t).
 				Expect(`git tag --list --sort=-creatordate`, "", nil),
 			expectedTags:  []*models.Tag{},
 			expectedError: nil,
 		},
 		{
-			testName:   "should return no tags if there are none (< 2.7.0)",
-			gitVersion: &GitVersion{2, 6, 7, ""},
-			runner: oscommands.NewFakeRunner(t).
-				Expect(`git tag --list --sort=-v:refname`, "", nil),
-			expectedTags:  []*models.Tag{},
-			expectedError: nil,
-		},
-		{
-			testName:   "should return tags if present",
-			gitVersion: &GitVersion{2, 7, 0, ""},
+			testName: "should return tags if present",
 			runner: oscommands.NewFakeRunner(t).
 				Expect(`git tag --list --sort=-creatordate`, tagsOutput, nil),
-			expectedTags: []*models.Tag{
-				{Name: "v0.34"},
-				{Name: "v0.33"},
-				{Name: "v0.32.2"},
-				{Name: "v0.32.1"},
-				{Name: "v0.32"},
-				{Name: "testtag"},
-			},
-			expectedError: nil,
-		},
-		{
-			testName:   "should return tags if present (< 2.7.0)",
-			gitVersion: &GitVersion{2, 6, 7, ""},
-			runner: oscommands.NewFakeRunner(t).
-				Expect(`git tag --list --sort=-v:refname`, tagsOutput, nil),
 			expectedTags: []*models.Tag{
 				{Name: "v0.34"},
 				{Name: "v0.33"},
@@ -78,11 +52,10 @@ func TestGetTags(t *testing.T) {
 	for _, scenario := range scenarios {
 		scenario := scenario
 		t.Run(scenario.testName, func(t *testing.T) {
-			loader := NewTagLoader(
-				utils.NewDummyCommon(),
-				scenario.gitVersion,
-				oscommands.NewDummyCmdObjBuilder(scenario.runner),
-			)
+			loader := &TagLoader{
+				Common: utils.NewDummyCommon(),
+				cmd:    oscommands.NewDummyCmdObjBuilder(scenario.runner),
+			}
 
 			tags, err := loader.GetTags()
 

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -298,7 +298,8 @@ func (self *LocalCommitsController) edit(commit *models.Commit) error {
 
 	return self.c.WithWaitingStatus(self.c.Tr.RebasingStatus, func() error {
 		self.c.LogAction(self.c.Tr.Actions.EditCommit)
-		return self.interactiveRebase("edit")
+		err := self.git.Rebase.InteractiveRebaseBreakAfter(self.model.Commits, self.context().GetSelectedLineIdx())
+		return self.helpers.MergeAndRebase.CheckMergeOrRebase(err)
 	})
 }
 

--- a/pkg/i18n/chinese.go
+++ b/pkg/i18n/chinese.go
@@ -395,7 +395,7 @@ func chineseTranslationSet() TranslationSet {
 		LcCreateNewBranchFromCommit:         "从提交创建新分支",
 		LcBuildingPatch:                     "正在构建补丁",
 		LcViewCommits:                       "查看提交",
-		MinGitVersionError:                  "Git 版本必须至少为 2.0（即从 2014 年开始的版本）。请更新 git。或者在 https://github.com/jesseduffield/lazygit/issues 上提出一个问题，以使 lazygit 更加向后兼容。",
+		MinGitVersionError:                  "Git 版本必须至少为 2.20（即从 2018 年开始的版本）。请更新 git。或者在 https://github.com/jesseduffield/lazygit/issues 上提出一个问题，以使 lazygit 更加向后兼容。",
 		LcRunningCustomCommandStatus:        "正在运行自定义命令",
 		LcSubmoduleStashAndReset:            "存放未提交的子模块更改和更新",
 		LcAndResetSubmodules:                "和重置子模块",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1072,7 +1072,7 @@ func EnglishTranslationSet() TranslationSet {
 		LcCreateNewBranchFromCommit:         "create new branch off of commit",
 		LcBuildingPatch:                     "building patch",
 		LcViewCommits:                       "view commits",
-		MinGitVersionError:                  "Git version must be at least 2.0 (i.e. from 2014 onwards). Please upgrade your git version. Alternatively raise an issue at https://github.com/jesseduffield/lazygit/issues for lazygit to be more backwards compatible.",
+		MinGitVersionError:                  "Git version must be at least 2.20 (i.e. from 2018 onwards). Please upgrade your git version. Alternatively raise an issue at https://github.com/jesseduffield/lazygit/issues for lazygit to be more backwards compatible.",
 		LcRunningCustomCommandStatus:        "running custom command",
 		LcSubmoduleStashAndReset:            "stash uncommitted submodule changes and update",
 		LcAndResetSubmodules:                "and reset submodules",

--- a/pkg/i18n/japanese.go
+++ b/pkg/i18n/japanese.go
@@ -405,7 +405,7 @@ func japaneseTranslationSet() TranslationSet {
 		LcCreateNewBranchFromCommit:  "コミットにブランチを作成",
 		LcBuildingPatch:              "パッチを構築",
 		LcViewCommits:                "コミットを閲覧",
-		MinGitVersionError:           "lazygitの実行にはGit 2.0以降のバージョンが必要です。Gitを更新してください。もしくは、lazygitの後方互換性を改善するために https://github.com/jesseduffield/lazygit/issues にissueを作成してください。",
+		MinGitVersionError:           "lazygitの実行にはGit 2.20以降のバージョンが必要です。Gitを更新してください。もしくは、lazygitの後方互換性を改善するために https://github.com/jesseduffield/lazygit/issues にissueを作成してください。",
 		LcRunningCustomCommandStatus: "カスタムコマンドを実行",
 		// LcSubmoduleStashAndReset:            "stash uncommitted submodule changes and update",
 		// LcAndResetSubmodules:                "and reset submodules",

--- a/pkg/i18n/korean.go
+++ b/pkg/i18n/korean.go
@@ -406,7 +406,7 @@ func koreanTranslationSet() TranslationSet {
 		LcCreateNewBranchFromCommit:         "커밋에서 새 브랜치를 만듭니다.",
 		LcBuildingPatch:                     "building patch",
 		LcViewCommits:                       "커밋 보기",
-		MinGitVersionError:                  "lazygit 실행을 위해서는 Git 2.0 이후의 버전(2014년 이후의)이 필요합니다. Git를 업데이트 해주세요. 아니면 lazygit이 이전 버전과 더 잘 호환되도록 https://github.com/jesseduffield/lazygit/issues 에 issue를 작성해 주세요.",
+		MinGitVersionError:                  "lazygit 실행을 위해서는 Git 2.20 이후의 버전(2018년 이후의)이 필요합니다. Git를 업데이트 해주세요. 아니면 lazygit이 이전 버전과 더 잘 호환되도록 https://github.com/jesseduffield/lazygit/issues 에 issue를 작성해 주세요.",
 		LcRunningCustomCommandStatus:        "커스텀 명령어 실행",
 		LcSubmoduleStashAndReset:            "stash uncommitted submodule changes and update",
 		LcAndResetSubmodules:                "and reset submodules",


### PR DESCRIPTION
- **PR Description**

Instead of rebasing from the commit below the current one and then setting the
current one to "edit", we rebase from the current one and insert a "break" after
it. In most cases the behavior is exactly the same as before, except that the
new method also works if the current commit is a merge commit. This is useful if
you want to create a new commit at the very beginning of your branch (before the
first commit of your branch), if the last commit before that is a merge.
- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
   * I didn't add or adapt any tests, because for the normal cases the behavior should be unchanged
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
