### PR TITLE
Fix checking for credentials performance

### DIFF
--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -338,6 +338,8 @@ func (self *cmdObjRunner) getCheckForCredentialRequestFunc() func([]byte) (Crede
 		compiledPrompts[compiledPattern] = askFor
 	}
 
+	newlineRegex := regexp.MustCompile("\n")
+
 	// this function takes each word of output from the command and builds up a string to see if we're being asked for a password
 	return func(newBytes []byte) (CredentialType, bool) {
 		_, err := ttyText.Write(newBytes)
@@ -352,10 +354,10 @@ func (self *cmdObjRunner) getCheckForCredentialRequestFunc() func([]byte) (Crede
 			}
 		}
 
-		if match, _ := regexp.MatchString("\n", ttyText.String()); match {
-			newText := strings.Split(ttyText.String(), "\n")
+		if indices := newlineRegex.FindIndex([]byte(ttyText.String())); indices != nil {
+			newText := []byte(ttyText.String()[indices[1]:])
 			ttyText.Reset()
-			ttyText.Write([]byte(newText[len(newText)-1]))
+			ttyText.Write(newText)
 		}
 		return 0, false
 	}

--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -346,6 +346,11 @@ func (self *cmdObjRunner) getCheckForCredentialRequestFunc() func([]byte) (Crede
 			}
 		}
 
+		if match, _ := regexp.MatchString("\n", ttyText.String()); match {
+			newText := strings.Split(ttyText.String(), "\n")
+			ttyText.Reset()
+			ttyText.Write([]byte(newText[len(newText)-1]))
+		}
 		return 0, false
 	}
 }

--- a/pkg/commands/oscommands/cmd_obj_runner_test.go
+++ b/pkg/commands/oscommands/cmd_obj_runner_test.go
@@ -1,0 +1,26 @@
+package oscommands
+
+import (
+	//"github.com/jesseduffield/lazygit/pkg/common"
+	//"github.com/jesseduffield/lazygit/pkg/config"
+	"github.com/jesseduffield/lazygit/pkg/utils"
+	"testing"
+)
+
+func TestProcessOutput(t *testing.T) {
+	dummyLog := utils.NewDummyLog()
+	scenarios := []struct {
+		name   string
+		runner ICmdObjRunner
+	}{
+		{
+			name:   "hi",
+			runner: cmdObjRunner{dummyLog, NewNullGuiIO(utils.NewDummyLog())},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+		})
+	}
+}

--- a/pkg/commands/oscommands/cmd_obj_runner_test.go
+++ b/pkg/commands/oscommands/cmd_obj_runner_test.go
@@ -1,26 +1,109 @@
 package oscommands
 
 import (
-	//"github.com/jesseduffield/lazygit/pkg/common"
-	//"github.com/jesseduffield/lazygit/pkg/config"
-	"github.com/jesseduffield/lazygit/pkg/utils"
+	"strings"
 	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
+func getRunner() *cmdObjRunner {
+	log := utils.NewDummyLog()
+	return &cmdObjRunner{
+		log:   log,
+		guiIO: NewNullGuiIO(log),
+	}
+}
+
 func TestProcessOutput(t *testing.T) {
-	dummyLog := utils.NewDummyLog()
+	defaultPromptUserForCredential := func(ct CredentialType) string {
+		switch ct {
+		case Password:
+			return "password"
+		case Username:
+			return "username"
+		case Passphrase:
+			return "passphrase"
+		case PIN:
+			return "pin"
+		default:
+			panic("unexpected credential type")
+		}
+	}
+
 	scenarios := []struct {
-		name   string
-		runner ICmdObjRunner
+		name                    string
+		promptUserForCredential func(CredentialType) string
+		output                  string
+		expectedToWrite         string
 	}{
 		{
-			name:   "hi",
-			runner: cmdObjRunner{dummyLog, NewNullGuiIO(utils.NewDummyLog())},
+			name:                    "no output",
+			promptUserForCredential: defaultPromptUserForCredential,
+			output:                  "",
+			expectedToWrite:         "",
+		},
+		{
+			name:                    "password prompt",
+			promptUserForCredential: defaultPromptUserForCredential,
+			output:                  "Password:",
+			expectedToWrite:         "password",
+		},
+		{
+			name:                    "password prompt 2",
+			promptUserForCredential: defaultPromptUserForCredential,
+			output:                  "Bill's password:",
+			expectedToWrite:         "password",
+		},
+		{
+			name:                    "password prompt 3",
+			promptUserForCredential: defaultPromptUserForCredential,
+			output:                  "Password for 'Bill':",
+			expectedToWrite:         "password",
+		},
+		{
+			name:                    "username prompt",
+			promptUserForCredential: defaultPromptUserForCredential,
+			output:                  "Username for 'Bill':",
+			expectedToWrite:         "username",
+		},
+		{
+			name:                    "passphrase prompt",
+			promptUserForCredential: defaultPromptUserForCredential,
+			output:                  "Enter passphrase for key '123':",
+			expectedToWrite:         "passphrase",
+		},
+		{
+			name:                    "pin prompt",
+			promptUserForCredential: defaultPromptUserForCredential,
+			output:                  "Enter PIN for key '123':",
+			expectedToWrite:         "pin",
+		},
+		{
+			name:                    "username and password prompt",
+			promptUserForCredential: defaultPromptUserForCredential,
+			output:                  "Password:\nUsername for 'Alice':\n",
+			expectedToWrite:         "passwordusername",
+		},
+		{
+			name:                    "user submits empty credential",
+			promptUserForCredential: func(ct CredentialType) string { return "" },
+			output:                  "Password:\n",
+			expectedToWrite:         "",
 		},
 	}
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
+			runner := getRunner()
+			reader := strings.NewReader(scenario.output)
+			writer := &strings.Builder{}
+
+			runner.processOutput(reader, writer, scenario.promptUserForCredential)
+
+			if writer.String() != scenario.expectedToWrite {
+				t.Errorf("expected to write '%s' but got '%s'", scenario.expectedToWrite, writer.String())
+			}
 		})
 	}
 }


### PR DESCRIPTION
None of the patterns spill over multiple lines so if we haven't matched the output so far, and we have received a newline, we can disregard everything before the last newline.

Also it's faster if we compile the `regex` patterns ahead of time instead of compiling them just in time because that's what `regexp.MatchString` was doing internally.

I know the sample size is 1, but I've tried fetching `970` commits (from `v0.32` to current `master`) and it cuts down from `>35mins` (that's when I gave up looking at the stopwatch) on `master` to `5s` on this branch.

- **PR Description**

There is the issue of the `Command Log` being cut off, but I'm not entirely sure if that's caused by this PR. I'll leave the current `master` fetch running to see if it results in the same thing.

![image](https://user-images.githubusercontent.com/8365241/219945964-11aec1c5-11d0-4006-bfec-95e5c264134d.png)


- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
