### PR TITLE
Improve custom patch conflict handling

### DIFF
--- a/pkg/commands/patch/hunk.go
+++ b/pkg/commands/patch/hunk.go
@@ -45,7 +45,7 @@ func headerInfo(header string) (int, int, string) {
 	return oldStart, newStart, heading
 }
 
-func (hunk *PatchHunk) updatedLines(lineIndices []int, willBeAppliedReverse bool) []string {
+func (hunk *PatchHunk) updatedLines(lineIndices []int, reverse bool) []string {
 	skippedNewlineMessageIndex := -1
 	newLines := []string{}
 
@@ -58,7 +58,7 @@ func (hunk *PatchHunk) updatedLines(lineIndices []int, willBeAppliedReverse bool
 		isLineSelected := lo.Contains(lineIndices, lineIdx)
 
 		firstChar, content := line[:1], line[1:]
-		transformedFirstChar := transformedFirstChar(firstChar, willBeAppliedReverse, isLineSelected)
+		transformedFirstChar := transformedFirstChar(firstChar, reverse, isLineSelected)
 
 		if isLineSelected || (transformedFirstChar == "\\" && skippedNewlineMessageIndex != lineIdx) || transformedFirstChar == " " {
 			newLines = append(newLines, transformedFirstChar+content)
@@ -74,9 +74,9 @@ func (hunk *PatchHunk) updatedLines(lineIndices []int, willBeAppliedReverse bool
 	return newLines
 }
 
-func transformedFirstChar(firstChar string, willBeAppliedReverse bool, isLineSelected bool) string {
+func transformedFirstChar(firstChar string, reverse bool, isLineSelected bool) string {
 	linesToKeepInPatchContext := "-"
-	if willBeAppliedReverse {
+	if reverse {
 		linesToKeepInPatchContext = "+"
 	}
 	if !isLineSelected && firstChar == linesToKeepInPatchContext {
@@ -90,8 +90,8 @@ func (hunk *PatchHunk) formatHeader(oldStart int, oldLength int, newStart int, n
 	return fmt.Sprintf("@@ -%d,%d +%d,%d @@%s\n", oldStart, oldLength, newStart, newLength, heading)
 }
 
-func (hunk *PatchHunk) formatWithChanges(lineIndices []int, willBeAppliedReverse bool, startOffset int) (int, string) {
-	bodyLines := hunk.updatedLines(lineIndices, willBeAppliedReverse)
+func (hunk *PatchHunk) formatWithChanges(lineIndices []int, reverse bool, startOffset int) (int, string) {
+	bodyLines := hunk.updatedLines(lineIndices, reverse)
 	startOffset, header, ok := hunk.updatedHeader(bodyLines, startOffset)
 	if !ok {
 		return startOffset, ""

--- a/pkg/commands/patch/patch_manager.go
+++ b/pkg/commands/patch/patch_manager.go
@@ -162,7 +162,7 @@ func (p *PatchManager) RemoveFileLineRange(filename string, firstLineIdx, lastLi
 	return nil
 }
 
-func (p *PatchManager) renderPlainPatchForFile(filename string, reverse bool, keepOriginalHeader bool) string {
+func (p *PatchManager) renderPlainPatchForFile(filename string, reverse bool, willBeAppliedReverse bool, keepOriginalHeader bool) string {
 	info, err := p.getFileInfo(filename)
 	if err != nil {
 		p.Log.Error(err)
@@ -177,14 +177,18 @@ func (p *PatchManager) renderPlainPatchForFile(filename string, reverse bool, ke
 	case PART:
 		// generate a new diff with just the selected lines
 		return ModifiedPatchForLines(p.Log, filename, info.diff, info.includedLineIndices,
-			PatchOptions{Reverse: reverse, KeepOriginalHeader: keepOriginalHeader})
+			PatchOptions{
+				Reverse:              reverse,
+				WillBeAppliedReverse: willBeAppliedReverse,
+				KeepOriginalHeader:   keepOriginalHeader,
+			})
 	default:
 		return ""
 	}
 }
 
-func (p *PatchManager) RenderPatchForFile(filename string, plain bool, reverse bool, keepOriginalHeader bool) string {
-	patch := p.renderPlainPatchForFile(filename, reverse, keepOriginalHeader)
+func (p *PatchManager) RenderPatchForFile(filename string, plain bool, reverse bool, willBeAppliedReverse bool, keepOriginalHeader bool) string {
+	patch := p.renderPlainPatchForFile(filename, reverse, willBeAppliedReverse, keepOriginalHeader)
 	if plain {
 		return patch
 	}
@@ -200,7 +204,7 @@ func (p *PatchManager) renderEachFilePatch(plain bool) []string {
 
 	sort.Strings(filenames)
 	patches := slices.Map(filenames, func(filename string) string {
-		return p.RenderPatchForFile(filename, plain, false, true)
+		return p.RenderPatchForFile(filename, plain, false, false, true)
 	})
 	output := slices.Filter(patches, func(patch string) bool {
 		return patch != ""
@@ -241,27 +245,20 @@ func (p *PatchManager) GetFileIncLineIndices(filename string) ([]int, error) {
 }
 
 func (p *PatchManager) ApplyPatches(reverse bool) error {
-	// for whole patches we'll apply the patch in reverse
-	// but for part patches we'll apply a reverse patch forwards
+	applyFlags := []string{"index", "3way"}
+	if reverse {
+		applyFlags = append(applyFlags, "reverse")
+	}
+
 	for filename, info := range p.fileInfoMap {
 		if info.mode == UNSELECTED {
 			continue
 		}
 
-		applyFlags := []string{"index", "3way"}
-		reverseOnGenerate := false
-		if reverse {
-			if info.mode == WHOLE {
-				applyFlags = append(applyFlags, "reverse")
-			} else {
-				reverseOnGenerate = true
-			}
-		}
-
 		var err error
 		// first run we try with the original header, then without
 		for _, keepOriginalHeader := range []bool{true, false} {
-			patch := p.RenderPatchForFile(filename, true, reverseOnGenerate, keepOriginalHeader)
+			patch := p.RenderPatchForFile(filename, true, false, reverse, keepOriginalHeader)
 			if patch == "" {
 				continue
 			}

--- a/pkg/commands/patch/patch_manager.go
+++ b/pkg/commands/patch/patch_manager.go
@@ -178,7 +178,6 @@ func (p *PatchManager) renderPlainPatchForFile(filename string, willBeAppliedRev
 		// generate a new diff with just the selected lines
 		return ModifiedPatchForLines(p.Log, filename, info.diff, info.includedLineIndices,
 			PatchOptions{
-				Reverse:              false,
 				WillBeAppliedReverse: willBeAppliedReverse,
 				KeepOriginalHeader:   true,
 			})

--- a/pkg/commands/patch/patch_manager.go
+++ b/pkg/commands/patch/patch_manager.go
@@ -162,7 +162,7 @@ func (p *PatchManager) RemoveFileLineRange(filename string, firstLineIdx, lastLi
 	return nil
 }
 
-func (p *PatchManager) renderPlainPatchForFile(filename string, willBeAppliedReverse bool) string {
+func (p *PatchManager) renderPlainPatchForFile(filename string, reverse bool) string {
 	info, err := p.getFileInfo(filename)
 	if err != nil {
 		p.Log.Error(err)
@@ -178,16 +178,16 @@ func (p *PatchManager) renderPlainPatchForFile(filename string, willBeAppliedRev
 		// generate a new diff with just the selected lines
 		return ModifiedPatchForLines(p.Log, filename, info.diff, info.includedLineIndices,
 			PatchOptions{
-				WillBeAppliedReverse: willBeAppliedReverse,
-				KeepOriginalHeader:   true,
+				Reverse:            reverse,
+				KeepOriginalHeader: true,
 			})
 	default:
 		return ""
 	}
 }
 
-func (p *PatchManager) RenderPatchForFile(filename string, plain bool, willBeAppliedReverse bool) string {
-	patch := p.renderPlainPatchForFile(filename, willBeAppliedReverse)
+func (p *PatchManager) RenderPatchForFile(filename string, plain bool, reverse bool) string {
+	patch := p.renderPlainPatchForFile(filename, reverse)
 	if plain {
 		return patch
 	}

--- a/pkg/commands/patch/patch_manager.go
+++ b/pkg/commands/patch/patch_manager.go
@@ -245,6 +245,8 @@ func (p *PatchManager) GetFileIncLineIndices(filename string) ([]int, error) {
 }
 
 func (p *PatchManager) ApplyPatches(reverse bool) error {
+	patch := ""
+
 	applyFlags := []string{"index", "3way"}
 	if reverse {
 		applyFlags = append(applyFlags, "reverse")
@@ -255,16 +257,10 @@ func (p *PatchManager) ApplyPatches(reverse bool) error {
 			continue
 		}
 
-		patch := p.RenderPatchForFile(filename, true, reverse)
-		if patch != "" {
-			err := p.applyPatch(patch, applyFlags...)
-			if err != nil {
-				return err
-			}
-		}
+		patch += p.RenderPatchForFile(filename, true, reverse)
 	}
 
-	return nil
+	return p.applyPatch(patch, applyFlags...)
 }
 
 // clears the patch

--- a/pkg/commands/patch/patch_manager.go
+++ b/pkg/commands/patch/patch_manager.go
@@ -176,7 +176,8 @@ func (p *PatchManager) renderPlainPatchForFile(filename string, reverse bool, ke
 		return info.diff
 	case PART:
 		// generate a new diff with just the selected lines
-		return ModifiedPatchForLines(p.Log, filename, info.diff, info.includedLineIndices, reverse, keepOriginalHeader)
+		return ModifiedPatchForLines(p.Log, filename, info.diff, info.includedLineIndices,
+			PatchOptions{Reverse: reverse, KeepOriginalHeader: keepOriginalHeader})
 	default:
 		return ""
 	}

--- a/pkg/commands/patch/patch_manager.go
+++ b/pkg/commands/patch/patch_manager.go
@@ -162,7 +162,7 @@ func (p *PatchManager) RemoveFileLineRange(filename string, firstLineIdx, lastLi
 	return nil
 }
 
-func (p *PatchManager) renderPlainPatchForFile(filename string, reverse bool, willBeAppliedReverse bool, keepOriginalHeader bool) string {
+func (p *PatchManager) renderPlainPatchForFile(filename string, willBeAppliedReverse bool) string {
 	info, err := p.getFileInfo(filename)
 	if err != nil {
 		p.Log.Error(err)
@@ -178,17 +178,17 @@ func (p *PatchManager) renderPlainPatchForFile(filename string, reverse bool, wi
 		// generate a new diff with just the selected lines
 		return ModifiedPatchForLines(p.Log, filename, info.diff, info.includedLineIndices,
 			PatchOptions{
-				Reverse:              reverse,
+				Reverse:              false,
 				WillBeAppliedReverse: willBeAppliedReverse,
-				KeepOriginalHeader:   keepOriginalHeader,
+				KeepOriginalHeader:   true,
 			})
 	default:
 		return ""
 	}
 }
 
-func (p *PatchManager) RenderPatchForFile(filename string, plain bool, reverse bool, willBeAppliedReverse bool, keepOriginalHeader bool) string {
-	patch := p.renderPlainPatchForFile(filename, reverse, willBeAppliedReverse, keepOriginalHeader)
+func (p *PatchManager) RenderPatchForFile(filename string, plain bool, willBeAppliedReverse bool) string {
+	patch := p.renderPlainPatchForFile(filename, willBeAppliedReverse)
 	if plain {
 		return patch
 	}
@@ -204,7 +204,7 @@ func (p *PatchManager) renderEachFilePatch(plain bool) []string {
 
 	sort.Strings(filenames)
 	patches := slices.Map(filenames, func(filename string) string {
-		return p.RenderPatchForFile(filename, plain, false, false, true)
+		return p.RenderPatchForFile(filename, plain, false)
 	})
 	output := slices.Filter(patches, func(patch string) bool {
 		return patch != ""
@@ -255,7 +255,7 @@ func (p *PatchManager) ApplyPatches(reverse bool) error {
 			continue
 		}
 
-		patch := p.RenderPatchForFile(filename, true, false, reverse, true)
+		patch := p.RenderPatchForFile(filename, true, reverse)
 		if patch != "" {
 			err := p.applyPatch(patch, applyFlags...)
 			if err != nil {

--- a/pkg/commands/patch/patch_manager.go
+++ b/pkg/commands/patch/patch_manager.go
@@ -255,21 +255,12 @@ func (p *PatchManager) ApplyPatches(reverse bool) error {
 			continue
 		}
 
-		var err error
-		// first run we try with the original header, then without
-		for _, keepOriginalHeader := range []bool{true, false} {
-			patch := p.RenderPatchForFile(filename, true, false, reverse, keepOriginalHeader)
-			if patch == "" {
-				continue
+		patch := p.RenderPatchForFile(filename, true, false, reverse, true)
+		if patch != "" {
+			err := p.applyPatch(patch, applyFlags...)
+			if err != nil {
+				return err
 			}
-			if err = p.applyPatch(patch, applyFlags...); err != nil {
-				continue
-			}
-			break
-		}
-
-		if err != nil {
-			return err
 		}
 	}
 

--- a/pkg/commands/patch/patch_modifier.go
+++ b/pkg/commands/patch/patch_modifier.go
@@ -96,6 +96,10 @@ func NewPatchModifier(log *logrus.Entry, filename string, diffText string) *Patc
 }
 
 func (d *PatchModifier) ModifiedPatchForLines(lineIndices []int, opts PatchOptions) string {
+	if opts.Reverse && opts.KeepOriginalHeader {
+		panic("reverse and keepOriginalHeader are not compatible")
+	}
+
 	// step one is getting only those hunks which we care about
 	hunksInRange := []*PatchHunk{}
 outer:

--- a/pkg/commands/patch/patch_modifier.go
+++ b/pkg/commands/patch/patch_modifier.go
@@ -14,17 +14,11 @@ var (
 )
 
 type PatchOptions struct {
-	// Create a reverse patch; in other words, flip all the '+' and '-' while
-	// generating the patch.
-	Reverse bool
-
 	// If true, we're building a patch that we are going to apply using
 	// "git apply --reverse". In other words, we are not flipping the '+' and
 	// '-' ourselves while creating the patch, but git is going to do that when
 	// applying. This has consequences for which lines we need to keep or
 	// discard when filtering lines from partial hunks.
-	//
-	// Currently incompatible with Reverse.
 	WillBeAppliedReverse bool
 
 	// Whether to keep or discard the original diff header including the
@@ -96,10 +90,6 @@ func NewPatchModifier(log *logrus.Entry, filename string, diffText string) *Patc
 }
 
 func (d *PatchModifier) ModifiedPatchForLines(lineIndices []int, opts PatchOptions) string {
-	if opts.Reverse && opts.KeepOriginalHeader {
-		panic("reverse and keepOriginalHeader are not compatible")
-	}
-
 	// step one is getting only those hunks which we care about
 	hunksInRange := []*PatchHunk{}
 outer:
@@ -119,7 +109,7 @@ outer:
 	var formattedHunk string
 	for _, hunk := range hunksInRange {
 		startOffset, formattedHunk = hunk.formatWithChanges(
-			lineIndices, opts.Reverse, opts.WillBeAppliedReverse, startOffset)
+			lineIndices, opts.WillBeAppliedReverse, startOffset)
 		formattedHunks += formattedHunk
 	}
 

--- a/pkg/commands/patch/patch_modifier.go
+++ b/pkg/commands/patch/patch_modifier.go
@@ -18,6 +18,15 @@ type PatchOptions struct {
 	// generating the patch.
 	Reverse bool
 
+	// If true, we're building a patch that we are going to apply using
+	// "git apply --reverse". In other words, we are not flipping the '+' and
+	// '-' ourselves while creating the patch, but git is going to do that when
+	// applying. This has consequences for which lines we need to keep or
+	// discard when filtering lines from partial hunks.
+	//
+	// Currently incompatible with Reverse.
+	WillBeAppliedReverse bool
+
 	// Whether to keep or discard the original diff header including the
 	// "index deadbeef..fa1afe1 100644" line.
 	KeepOriginalHeader bool
@@ -105,7 +114,8 @@ outer:
 	formattedHunks := ""
 	var formattedHunk string
 	for _, hunk := range hunksInRange {
-		startOffset, formattedHunk = hunk.formatWithChanges(lineIndices, opts.Reverse, startOffset)
+		startOffset, formattedHunk = hunk.formatWithChanges(
+			lineIndices, opts.Reverse, opts.WillBeAppliedReverse, startOffset)
 		formattedHunks += formattedHunk
 	}
 

--- a/pkg/commands/patch/patch_modifier.go
+++ b/pkg/commands/patch/patch_modifier.go
@@ -14,12 +14,12 @@ var (
 )
 
 type PatchOptions struct {
-	// If true, we're building a patch that we are going to apply using
-	// "git apply --reverse". In other words, we are not flipping the '+' and
-	// '-' ourselves while creating the patch, but git is going to do that when
-	// applying. This has consequences for which lines we need to keep or
-	// discard when filtering lines from partial hunks.
-	WillBeAppliedReverse bool
+	// Create a patch that will applied in reverse with `git apply --reverse`.
+	// This affects how unselected lines are treated when only parts of a hunk
+	// are selected: usually, for unselected lines we change '-' lines to
+	// context lines and remove '+' lines, but when Reverse is true we need to
+	// turn '+' lines into context lines and remove '-' lines.
+	Reverse bool
 
 	// Whether to keep or discard the original diff header including the
 	// "index deadbeef..fa1afe1 100644" line.
@@ -109,7 +109,7 @@ outer:
 	var formattedHunk string
 	for _, hunk := range hunksInRange {
 		startOffset, formattedHunk = hunk.formatWithChanges(
-			lineIndices, opts.WillBeAppliedReverse, startOffset)
+			lineIndices, opts.Reverse, startOffset)
 		formattedHunks += formattedHunk
 	}
 

--- a/pkg/commands/patch/patch_modifier_test.go
+++ b/pkg/commands/patch/patch_modifier_test.go
@@ -120,7 +120,6 @@ func TestModifyPatchForRange(t *testing.T) {
 		diffText             string
 		firstLineIndex       int
 		lastLineIndex        int
-		reverse              bool
 		willBeAppliedReverse bool
 		expected             string
 	}
@@ -131,7 +130,6 @@ func TestModifyPatchForRange(t *testing.T) {
 			filename:       "filename",
 			firstLineIndex: -1,
 			lastLineIndex:  -1,
-			reverse:        false,
 			diffText:       simpleDiff,
 			expected:       "",
 		},
@@ -140,7 +138,6 @@ func TestModifyPatchForRange(t *testing.T) {
 			filename:       "filename",
 			firstLineIndex: 5,
 			lastLineIndex:  5,
-			reverse:        false,
 			diffText:       simpleDiff,
 			expected:       "",
 		},
@@ -149,7 +146,6 @@ func TestModifyPatchForRange(t *testing.T) {
 			filename:       "filename",
 			firstLineIndex: 0,
 			lastLineIndex:  11,
-			reverse:        false,
 			diffText:       simpleDiff,
 			expected: `--- a/filename
 +++ b/filename
@@ -167,7 +163,6 @@ func TestModifyPatchForRange(t *testing.T) {
 			filename:       "filename",
 			firstLineIndex: 6,
 			lastLineIndex:  6,
-			reverse:        false,
 			diffText:       simpleDiff,
 			expected: `--- a/filename
 +++ b/filename
@@ -184,7 +179,6 @@ func TestModifyPatchForRange(t *testing.T) {
 			filename:       "filename",
 			firstLineIndex: 7,
 			lastLineIndex:  7,
-			reverse:        false,
 			diffText:       simpleDiff,
 			expected: `--- a/filename
 +++ b/filename
@@ -202,7 +196,6 @@ func TestModifyPatchForRange(t *testing.T) {
 			filename:       "filename",
 			firstLineIndex: -100,
 			lastLineIndex:  100,
-			reverse:        false,
 			diffText:       simpleDiff,
 			expected: `--- a/filename
 +++ b/filename
@@ -216,64 +209,10 @@ func TestModifyPatchForRange(t *testing.T) {
 `,
 		},
 		{
-			testName:       "whole range reversed",
-			filename:       "filename",
-			firstLineIndex: 0,
-			lastLineIndex:  11,
-			reverse:        true,
-			diffText:       simpleDiff,
-			expected: `--- a/filename
-+++ b/filename
-@@ -1,5 +1,5 @@
- apple
-+orange
--grape
- ...
- ...
- ...
-`,
-		},
-		{
-			testName:       "removal reversed",
-			filename:       "filename",
-			firstLineIndex: 6,
-			lastLineIndex:  6,
-			reverse:        true,
-			diffText:       simpleDiff,
-			expected: `--- a/filename
-+++ b/filename
-@@ -1,5 +1,6 @@
- apple
-+orange
- grape
- ...
- ...
- ...
-`,
-		},
-		{
-			testName:       "removal reversed",
-			filename:       "filename",
-			firstLineIndex: 7,
-			lastLineIndex:  7,
-			reverse:        true,
-			diffText:       simpleDiff,
-			expected: `--- a/filename
-+++ b/filename
-@@ -1,5 +1,4 @@
- apple
--grape
- ...
- ...
- ...
-`,
-		},
-		{
 			testName:       "add newline to end of file",
 			filename:       "filename",
 			firstLineIndex: -100,
 			lastLineIndex:  100,
-			reverse:        false,
 			diffText:       addNewlineToEndOfFile,
 			expected: `--- a/filename
 +++ b/filename
@@ -287,45 +226,10 @@ func TestModifyPatchForRange(t *testing.T) {
 `,
 		},
 		{
-			testName:       "add newline to end of file, addition only",
-			filename:       "filename",
-			firstLineIndex: 8,
-			lastLineIndex:  8,
-			reverse:        true,
-			diffText:       addNewlineToEndOfFile,
-			expected: `--- a/filename
-+++ b/filename
-@@ -60,4 +60,5 @@ grape
- ...
- ...
- ...
-+last line
-\ No newline at end of file
- last line
-`,
-		},
-		{
-			testName:       "add newline to end of file, removal only",
-			filename:       "filename",
-			firstLineIndex: 10,
-			lastLineIndex:  10,
-			reverse:        true,
-			diffText:       addNewlineToEndOfFile,
-			expected: `--- a/filename
-+++ b/filename
-@@ -60,4 +60,3 @@ grape
- ...
- ...
- ...
--last line
-`,
-		},
-		{
 			testName:       "remove newline from end of file",
 			filename:       "filename",
 			firstLineIndex: -100,
 			lastLineIndex:  100,
-			reverse:        false,
 			diffText:       removeNewlinefromEndOfFile,
 			expected: `--- a/filename
 +++ b/filename
@@ -343,7 +247,6 @@ func TestModifyPatchForRange(t *testing.T) {
 			filename:       "filename",
 			firstLineIndex: 8,
 			lastLineIndex:  8,
-			reverse:        false,
 			diffText:       removeNewlinefromEndOfFile,
 			expected: `--- a/filename
 +++ b/filename
@@ -359,7 +262,6 @@ func TestModifyPatchForRange(t *testing.T) {
 			filename:       "filename",
 			firstLineIndex: 9,
 			lastLineIndex:  9,
-			reverse:        false,
 			diffText:       removeNewlinefromEndOfFile,
 			expected: `--- a/filename
 +++ b/filename
@@ -377,7 +279,6 @@ func TestModifyPatchForRange(t *testing.T) {
 			filename:       "filename",
 			firstLineIndex: -100,
 			lastLineIndex:  100,
-			reverse:        false,
 			diffText:       twoHunks,
 			expected: `--- a/filename
 +++ b/filename
@@ -404,7 +305,6 @@ func TestModifyPatchForRange(t *testing.T) {
 			filename:       "filename",
 			firstLineIndex: 7,
 			lastLineIndex:  15,
-			reverse:        false,
 			diffText:       twoHunks,
 			expected: `--- a/filename
 +++ b/filename
@@ -426,37 +326,10 @@ func TestModifyPatchForRange(t *testing.T) {
 `,
 		},
 		{
-			testName:       "staging part of both hunks, reversed",
-			filename:       "filename",
-			firstLineIndex: 7,
-			lastLineIndex:  15,
-			reverse:        true,
-			diffText:       twoHunks,
-			expected: `--- a/filename
-+++ b/filename
-@@ -1,5 +1,4 @@
- apple
--orange
- ...
- ...
- ...
-@@ -8,8 +7,7 @@ grape
- ...
- ...
- ...
--pear
- lemon
- ...
- ...
- ...
-`,
-		},
-		{
 			testName:       "adding a new file",
 			filename:       "newfile",
 			firstLineIndex: -100,
 			lastLineIndex:  100,
-			reverse:        false,
 			diffText:       newFile,
 			expected: `--- a/newfile
 +++ b/newfile
@@ -471,7 +344,6 @@ func TestModifyPatchForRange(t *testing.T) {
 			filename:       "newfile",
 			firstLineIndex: 6,
 			lastLineIndex:  7,
-			reverse:        false,
 			diffText:       newFile,
 			expected: `--- a/newfile
 +++ b/newfile
@@ -481,26 +353,10 @@ func TestModifyPatchForRange(t *testing.T) {
 `,
 		},
 		{
-			testName:       "adding a new file, reversed",
-			filename:       "newfile",
-			firstLineIndex: -100,
-			lastLineIndex:  100,
-			reverse:        true,
-			diffText:       newFile,
-			expected: `--- a/newfile
-+++ b/newfile
-@@ -1,3 +0,0 @@
--apple
--orange
--grape
-`,
-		},
-		{
 			testName:       "adding a new line to a previously empty file",
 			filename:       "newfile",
 			firstLineIndex: -100,
 			lastLineIndex:  100,
-			reverse:        false,
 			diffText:       addNewlineToPreviouslyEmptyFile,
 			expected: `--- a/newfile
 +++ b/newfile
@@ -510,25 +366,10 @@ func TestModifyPatchForRange(t *testing.T) {
 `,
 		},
 		{
-			testName:       "adding a new line to a previously empty file, reversed",
-			filename:       "newfile",
-			firstLineIndex: -100,
-			lastLineIndex:  100,
-			reverse:        true,
-			diffText:       addNewlineToPreviouslyEmptyFile,
-			expected: `--- a/newfile
-+++ b/newfile
-@@ -1,1 +0,0 @@
--new line
-\ No newline at end of file
-`,
-		},
-		{
 			testName:             "adding part of a hunk",
 			filename:             "filename",
 			firstLineIndex:       6,
 			lastLineIndex:        7,
-			reverse:              false,
 			willBeAppliedReverse: false,
 			diffText:             twoChangesInOneHunk,
 			expected: `--- a/filename
@@ -547,7 +388,6 @@ func TestModifyPatchForRange(t *testing.T) {
 			filename:             "filename",
 			firstLineIndex:       6,
 			lastLineIndex:        7,
-			reverse:              false,
 			willBeAppliedReverse: true,
 			diffText:             twoChangesInOneHunk,
 			expected: `--- a/filename
@@ -568,7 +408,6 @@ func TestModifyPatchForRange(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			result := ModifiedPatchForRange(nil, s.filename, s.diffText, s.firstLineIndex, s.lastLineIndex,
 				PatchOptions{
-					Reverse:              s.reverse,
 					WillBeAppliedReverse: s.willBeAppliedReverse,
 					KeepOriginalHeader:   false,
 				})

--- a/pkg/commands/patch/patch_modifier_test.go
+++ b/pkg/commands/patch/patch_modifier_test.go
@@ -226,10 +226,46 @@ func TestModifyPatchForRange(t *testing.T) {
 `,
 		},
 		{
+			testName:       "add newline to end of file, reversed",
+			filename:       "filename",
+			firstLineIndex: -100,
+			lastLineIndex:  100,
+			reverse:        true,
+			diffText:       addNewlineToEndOfFile,
+			expected: `--- a/filename
++++ b/filename
+@@ -60,4 +60,4 @@ grape
+ ...
+ ...
+ ...
+-last line
+\ No newline at end of file
++last line
+`,
+		},
+		{
 			testName:       "remove newline from end of file",
 			filename:       "filename",
 			firstLineIndex: -100,
 			lastLineIndex:  100,
+			diffText:       removeNewlinefromEndOfFile,
+			expected: `--- a/filename
++++ b/filename
+@@ -60,4 +60,4 @@ grape
+ ...
+ ...
+ ...
+-last line
++last line
+\ No newline at end of file
+`,
+		},
+		{
+			testName:       "remove newline from end of file, reversed",
+			filename:       "filename",
+			firstLineIndex: -100,
+			lastLineIndex:  100,
+			reverse:        true,
 			diffText:       removeNewlinefromEndOfFile,
 			expected: `--- a/filename
 +++ b/filename
@@ -258,6 +294,24 @@ func TestModifyPatchForRange(t *testing.T) {
 `,
 		},
 		{
+			testName:       "remove newline from end of file, removal only, reversed",
+			filename:       "filename",
+			firstLineIndex: 8,
+			lastLineIndex:  8,
+			reverse:        true,
+			diffText:       removeNewlinefromEndOfFile,
+			expected: `--- a/filename
++++ b/filename
+@@ -60,5 +60,4 @@ grape
+ ...
+ ...
+ ...
+-last line
+ last line
+\ No newline at end of file
+`,
+		},
+		{
 			testName:       "remove newline from end of file, addition only",
 			filename:       "filename",
 			firstLineIndex: 9,
@@ -270,6 +324,23 @@ func TestModifyPatchForRange(t *testing.T) {
  ...
  ...
  last line
++last line
+\ No newline at end of file
+`,
+		},
+		{
+			testName:       "remove newline from end of file, addition only, reversed",
+			filename:       "filename",
+			firstLineIndex: 9,
+			lastLineIndex:  9,
+			reverse:        true,
+			diffText:       removeNewlinefromEndOfFile,
+			expected: `--- a/filename
++++ b/filename
+@@ -60,3 +60,4 @@ grape
+ ...
+ ...
+ ...
 +last line
 \ No newline at end of file
 `,
@@ -358,6 +429,20 @@ func TestModifyPatchForRange(t *testing.T) {
 			firstLineIndex: -100,
 			lastLineIndex:  100,
 			diffText:       addNewlineToPreviouslyEmptyFile,
+			expected: `--- a/newfile
++++ b/newfile
+@@ -0,0 +1,1 @@
++new line
+\ No newline at end of file
+`,
+		},
+		{
+			testName:       "adding a new line to a previously empty file, reversed",
+			filename:       "newfile",
+			firstLineIndex: -100,
+			lastLineIndex:  100,
+			diffText:       addNewlineToPreviouslyEmptyFile,
+			reverse:        true,
 			expected: `--- a/newfile
 +++ b/newfile
 @@ -0,0 +1,1 @@

--- a/pkg/commands/patch/patch_modifier_test.go
+++ b/pkg/commands/patch/patch_modifier_test.go
@@ -115,13 +115,13 @@ const exampleHunk = `@@ -1,5 +1,5 @@
 // TestModifyPatchForRange is a function.
 func TestModifyPatchForRange(t *testing.T) {
 	type scenario struct {
-		testName             string
-		filename             string
-		diffText             string
-		firstLineIndex       int
-		lastLineIndex        int
-		willBeAppliedReverse bool
-		expected             string
+		testName       string
+		filename       string
+		diffText       string
+		firstLineIndex int
+		lastLineIndex  int
+		reverse        bool
+		expected       string
 	}
 
 	scenarios := []scenario{
@@ -366,12 +366,12 @@ func TestModifyPatchForRange(t *testing.T) {
 `,
 		},
 		{
-			testName:             "adding part of a hunk",
-			filename:             "filename",
-			firstLineIndex:       6,
-			lastLineIndex:        7,
-			willBeAppliedReverse: false,
-			diffText:             twoChangesInOneHunk,
+			testName:       "adding part of a hunk",
+			filename:       "filename",
+			firstLineIndex: 6,
+			lastLineIndex:  7,
+			reverse:        false,
+			diffText:       twoChangesInOneHunk,
 			expected: `--- a/filename
 +++ b/filename
 @@ -1,5 +1,5 @@
@@ -384,12 +384,12 @@ func TestModifyPatchForRange(t *testing.T) {
 `,
 		},
 		{
-			testName:             "adding part of a hunk, will-be-applied-reverse",
-			filename:             "filename",
-			firstLineIndex:       6,
-			lastLineIndex:        7,
-			willBeAppliedReverse: true,
-			diffText:             twoChangesInOneHunk,
+			testName:       "adding part of a hunk, reverse",
+			filename:       "filename",
+			firstLineIndex: 6,
+			lastLineIndex:  7,
+			reverse:        true,
+			diffText:       twoChangesInOneHunk,
 			expected: `--- a/filename
 +++ b/filename
 @@ -1,5 +1,5 @@
@@ -408,8 +408,8 @@ func TestModifyPatchForRange(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			result := ModifiedPatchForRange(nil, s.filename, s.diffText, s.firstLineIndex, s.lastLineIndex,
 				PatchOptions{
-					WillBeAppliedReverse: s.willBeAppliedReverse,
-					KeepOriginalHeader:   false,
+					Reverse:            s.reverse,
+					KeepOriginalHeader: false,
 				})
 			if !assert.Equal(t, s.expected, result) {
 				fmt.Println(result)

--- a/pkg/commands/patch/patch_modifier_test.go
+++ b/pkg/commands/patch/patch_modifier_test.go
@@ -513,7 +513,8 @@ func TestModifyPatchForRange(t *testing.T) {
 	for _, s := range scenarios {
 		s := s
 		t.Run(s.testName, func(t *testing.T) {
-			result := ModifiedPatchForRange(nil, s.filename, s.diffText, s.firstLineIndex, s.lastLineIndex, s.reverse, false)
+			result := ModifiedPatchForRange(nil, s.filename, s.diffText, s.firstLineIndex, s.lastLineIndex,
+				PatchOptions{Reverse: s.reverse, KeepOriginalHeader: false})
 			if !assert.Equal(t, s.expected, result) {
 				fmt.Println(result)
 			}

--- a/pkg/commands/patch/patch_modifier_test.go
+++ b/pkg/commands/patch/patch_modifier_test.go
@@ -69,6 +69,20 @@ index e48a11c..b2ab81b 100644
  ...
 `
 
+const twoChangesInOneHunk = `diff --git a/filename b/filename
+index 9320895..6d79956 100644
+--- a/filename
++++ b/filename
+@@ -1,5 +1,5 @@
+ apple
+-grape
++kiwi
+ orange
+-pear
++banana
+ lemon
+`
+
 const newFile = `diff --git a/newfile b/newfile
 new file mode 100644
 index 0000000..4e680cc
@@ -101,13 +115,14 @@ const exampleHunk = `@@ -1,5 +1,5 @@
 // TestModifyPatchForRange is a function.
 func TestModifyPatchForRange(t *testing.T) {
 	type scenario struct {
-		testName       string
-		filename       string
-		diffText       string
-		firstLineIndex int
-		lastLineIndex  int
-		reverse        bool
-		expected       string
+		testName             string
+		filename             string
+		diffText             string
+		firstLineIndex       int
+		lastLineIndex        int
+		reverse              bool
+		willBeAppliedReverse bool
+		expected             string
 	}
 
 	scenarios := []scenario{
@@ -508,13 +523,55 @@ func TestModifyPatchForRange(t *testing.T) {
 \ No newline at end of file
 `,
 		},
+		{
+			testName:             "adding part of a hunk",
+			filename:             "filename",
+			firstLineIndex:       6,
+			lastLineIndex:        7,
+			reverse:              false,
+			willBeAppliedReverse: false,
+			diffText:             twoChangesInOneHunk,
+			expected: `--- a/filename
++++ b/filename
+@@ -1,5 +1,5 @@
+ apple
+-grape
++kiwi
+ orange
+ pear
+ lemon
+`,
+		},
+		{
+			testName:             "adding part of a hunk, will-be-applied-reverse",
+			filename:             "filename",
+			firstLineIndex:       6,
+			lastLineIndex:        7,
+			reverse:              false,
+			willBeAppliedReverse: true,
+			diffText:             twoChangesInOneHunk,
+			expected: `--- a/filename
++++ b/filename
+@@ -1,5 +1,5 @@
+ apple
+-grape
++kiwi
+ orange
+ banana
+ lemon
+`,
+		},
 	}
 
 	for _, s := range scenarios {
 		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			result := ModifiedPatchForRange(nil, s.filename, s.diffText, s.firstLineIndex, s.lastLineIndex,
-				PatchOptions{Reverse: s.reverse, KeepOriginalHeader: false})
+				PatchOptions{
+					Reverse:              s.reverse,
+					WillBeAppliedReverse: s.willBeAppliedReverse,
+					KeepOriginalHeader:   false,
+				})
 			if !assert.Equal(t, s.expected, result) {
 				fmt.Println(result)
 			}

--- a/pkg/gui/controllers/staging_controller.go
+++ b/pkg/gui/controllers/staging_controller.go
@@ -182,7 +182,7 @@ func (self *StagingController) applySelection(reverse bool) error {
 
 	firstLineIdx, lastLineIdx := state.SelectedRange()
 	patch := patch.ModifiedPatchForRange(self.c.Log, path, state.GetDiff(), firstLineIdx, lastLineIdx,
-		patch.PatchOptions{Reverse: false, WillBeAppliedReverse: reverse, KeepOriginalHeader: false})
+		patch.PatchOptions{WillBeAppliedReverse: reverse, KeepOriginalHeader: false})
 
 	if patch == "" {
 		return nil
@@ -232,7 +232,7 @@ func (self *StagingController) editHunk() error {
 	hunk := state.CurrentHunk()
 	patchText := patch.ModifiedPatchForRange(
 		self.c.Log, path, state.GetDiff(), hunk.FirstLineIdx, hunk.LastLineIdx(),
-		patch.PatchOptions{Reverse: false, WillBeAppliedReverse: self.staged, KeepOriginalHeader: false},
+		patch.PatchOptions{WillBeAppliedReverse: self.staged, KeepOriginalHeader: false},
 	)
 	patchFilepath, err := self.git.WorkingTree.SaveTemporaryPatch(patchText)
 	if err != nil {
@@ -255,7 +255,7 @@ func (self *StagingController) editHunk() error {
 	lineCount := strings.Count(editedPatchText, "\n") + 1
 	newPatchText := patch.ModifiedPatchForRange(
 		self.c.Log, path, editedPatchText, 0, lineCount,
-		patch.PatchOptions{Reverse: false, KeepOriginalHeader: false},
+		patch.PatchOptions{KeepOriginalHeader: false},
 	)
 
 	applyFlags := []string{"cached"}

--- a/pkg/gui/controllers/staging_controller.go
+++ b/pkg/gui/controllers/staging_controller.go
@@ -182,7 +182,7 @@ func (self *StagingController) applySelection(reverse bool) error {
 
 	firstLineIdx, lastLineIdx := state.SelectedRange()
 	patch := patch.ModifiedPatchForRange(self.c.Log, path, state.GetDiff(), firstLineIdx, lastLineIdx,
-		patch.PatchOptions{Reverse: reverse, KeepOriginalHeader: false})
+		patch.PatchOptions{Reverse: false, WillBeAppliedReverse: reverse, KeepOriginalHeader: false})
 
 	if patch == "" {
 		return nil
@@ -191,6 +191,9 @@ func (self *StagingController) applySelection(reverse bool) error {
 	// apply the patch then refresh this panel
 	// create a new temp file with the patch, then call git apply with that patch
 	applyFlags := []string{}
+	if reverse {
+		applyFlags = append(applyFlags, "reverse")
+	}
 	if !reverse || self.staged {
 		applyFlags = append(applyFlags, "cached")
 	}
@@ -229,7 +232,7 @@ func (self *StagingController) editHunk() error {
 	hunk := state.CurrentHunk()
 	patchText := patch.ModifiedPatchForRange(
 		self.c.Log, path, state.GetDiff(), hunk.FirstLineIdx, hunk.LastLineIdx(),
-		patch.PatchOptions{Reverse: self.staged, KeepOriginalHeader: false},
+		patch.PatchOptions{Reverse: false, WillBeAppliedReverse: self.staged, KeepOriginalHeader: false},
 	)
 	patchFilepath, err := self.git.WorkingTree.SaveTemporaryPatch(patchText)
 	if err != nil {
@@ -254,7 +257,12 @@ func (self *StagingController) editHunk() error {
 		self.c.Log, path, editedPatchText, 0, lineCount,
 		patch.PatchOptions{Reverse: false, KeepOriginalHeader: false},
 	)
-	if err := self.git.WorkingTree.ApplyPatch(newPatchText, "cached"); err != nil {
+
+	applyFlags := []string{"cached"}
+	if self.staged {
+		applyFlags = append(applyFlags, "reverse")
+	}
+	if err := self.git.WorkingTree.ApplyPatch(newPatchText, applyFlags...); err != nil {
 		return self.c.Error(err)
 	}
 

--- a/pkg/gui/controllers/staging_controller.go
+++ b/pkg/gui/controllers/staging_controller.go
@@ -182,7 +182,7 @@ func (self *StagingController) applySelection(reverse bool) error {
 
 	firstLineIdx, lastLineIdx := state.SelectedRange()
 	patch := patch.ModifiedPatchForRange(self.c.Log, path, state.GetDiff(), firstLineIdx, lastLineIdx,
-		patch.PatchOptions{WillBeAppliedReverse: reverse, KeepOriginalHeader: false})
+		patch.PatchOptions{Reverse: reverse, KeepOriginalHeader: false})
 
 	if patch == "" {
 		return nil
@@ -232,7 +232,7 @@ func (self *StagingController) editHunk() error {
 	hunk := state.CurrentHunk()
 	patchText := patch.ModifiedPatchForRange(
 		self.c.Log, path, state.GetDiff(), hunk.FirstLineIdx, hunk.LastLineIdx(),
-		patch.PatchOptions{WillBeAppliedReverse: self.staged, KeepOriginalHeader: false},
+		patch.PatchOptions{Reverse: self.staged, KeepOriginalHeader: false},
 	)
 	patchFilepath, err := self.git.WorkingTree.SaveTemporaryPatch(patchText)
 	if err != nil {

--- a/pkg/gui/controllers/staging_controller.go
+++ b/pkg/gui/controllers/staging_controller.go
@@ -181,7 +181,8 @@ func (self *StagingController) applySelection(reverse bool) error {
 	}
 
 	firstLineIdx, lastLineIdx := state.SelectedRange()
-	patch := patch.ModifiedPatchForRange(self.c.Log, path, state.GetDiff(), firstLineIdx, lastLineIdx, reverse, false)
+	patch := patch.ModifiedPatchForRange(self.c.Log, path, state.GetDiff(), firstLineIdx, lastLineIdx,
+		patch.PatchOptions{Reverse: reverse, KeepOriginalHeader: false})
 
 	if patch == "" {
 		return nil
@@ -227,7 +228,8 @@ func (self *StagingController) editHunk() error {
 
 	hunk := state.CurrentHunk()
 	patchText := patch.ModifiedPatchForRange(
-		self.c.Log, path, state.GetDiff(), hunk.FirstLineIdx, hunk.LastLineIdx(), self.staged, false,
+		self.c.Log, path, state.GetDiff(), hunk.FirstLineIdx, hunk.LastLineIdx(),
+		patch.PatchOptions{Reverse: self.staged, KeepOriginalHeader: false},
 	)
 	patchFilepath, err := self.git.WorkingTree.SaveTemporaryPatch(patchText)
 	if err != nil {
@@ -249,7 +251,8 @@ func (self *StagingController) editHunk() error {
 
 	lineCount := strings.Count(editedPatchText, "\n") + 1
 	newPatchText := patch.ModifiedPatchForRange(
-		self.c.Log, path, editedPatchText, 0, lineCount, false, false,
+		self.c.Log, path, editedPatchText, 0, lineCount,
+		patch.PatchOptions{Reverse: false, KeepOriginalHeader: false},
 	)
 	if err := self.git.WorkingTree.ApplyPatch(newPatchText, "cached"); err != nil {
 		return self.c.Error(err)

--- a/pkg/gui/refresh.go
+++ b/pkg/gui/refresh.go
@@ -672,7 +672,7 @@ func (gui *Gui) refreshPatchBuildingPanel(opts types.OnFocusOpts) error {
 		return err
 	}
 
-	secondaryDiff := gui.git.Patch.PatchManager.RenderPatchForFile(path, false, false, true)
+	secondaryDiff := gui.git.Patch.PatchManager.RenderPatchForFile(path, false, false, false, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/gui/refresh.go
+++ b/pkg/gui/refresh.go
@@ -672,7 +672,7 @@ func (gui *Gui) refreshPatchBuildingPanel(opts types.OnFocusOpts) error {
 		return err
 	}
 
-	secondaryDiff := gui.git.Patch.PatchManager.RenderPatchForFile(path, false, false, false, true)
+	secondaryDiff := gui.git.Patch.PatchManager.RenderPatchForFile(path, false, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/integration/clients/tui.go
+++ b/pkg/integration/clients/tui.go
@@ -121,7 +121,7 @@ func RunTUI() {
 			return nil
 		}
 
-		cmd := secureexec.Command("sh", "-c", fmt.Sprintf("code -r pkg/integration/tests/%s", currentTest.Name()))
+		cmd := secureexec.Command("sh", "-c", fmt.Sprintf("code -r pkg/integration/tests/%s.go", currentTest.Name()))
 		if err := cmd.Run(); err != nil {
 			return err
 		}

--- a/pkg/integration/tests/patch_building/apply_in_reverse_with_conflict.go
+++ b/pkg/integration/tests/patch_building/apply_in_reverse_with_conflict.go
@@ -1,0 +1,91 @@
+package patch_building
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ApplyInReverseWithConflict = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Apply a custom patch in reverse, resulting in a conflict",
+	ExtraCmdArgs: "",
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file1", "file1 content\n")
+		shell.CreateFileAndAdd("file2", "file2 content\n")
+		shell.Commit("first commit")
+		shell.UpdateFileAndAdd("file1", "file1 content\nmore file1 content\n")
+		shell.UpdateFileAndAdd("file2", "file2 content\nmore file2 content\n")
+		shell.Commit("second commit")
+		shell.UpdateFileAndAdd("file1", "file1 content\nmore file1 content\neven more file1\n")
+		shell.Commit("third commit")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("third commit").IsSelected(),
+				Contains("second commit"),
+				Contains("first commit"),
+			).
+			NavigateToLine(Contains("second commit")).
+			PressEnter()
+
+		t.Views().CommitFiles().
+			IsFocused().
+			Lines(
+				Contains("M").Contains("file1").IsSelected(),
+				Contains("M").Contains("file2"),
+			).
+			// Add both files to the patch; the first will conflict, the second won't
+			PressPrimaryAction().
+			SelectNextItem().
+			PressPrimaryAction()
+
+		t.Views().Information().Content(Contains("building patch"))
+
+		t.Views().PatchBuildingSecondary().Content(
+			Contains("+more file1 content").Contains("+more file2 content"))
+
+		t.Common().SelectPatchOption(Contains("apply patch in reverse"))
+
+		t.ExpectPopup().Alert().
+			Title(Equals("Error")).
+			Content(Contains("Applied patch to 'file1' with conflicts.").
+				DoesNotContain("Applied patch to 'file2' cleanly.")).
+			Confirm()
+
+		t.Views().Files().
+			Focus().
+			Lines(
+				Contains("UU").Contains("file1").IsSelected(),
+			).
+			PressPrimaryAction()
+
+		t.Views().MergeConflicts().
+			IsFocused().
+			ContainsLines(
+				Contains("file1 content"),
+				Contains("<<<<<<< ours").IsSelected(),
+				Contains("more file1 content").IsSelected(),
+				Contains("even more file1").IsSelected(),
+				Contains("=======").IsSelected(),
+				Contains(">>>>>>> theirs"),
+			).
+			SelectNextItem().
+			PressPrimaryAction()
+
+		t.Views().Files().
+			Focus().
+			Lines(
+				Contains("M").Contains("file1").IsSelected(),
+			)
+
+		t.Views().Main().
+			ContainsLines(
+				Contains(" file1 content"),
+				Contains("-more file1 content"),
+				Contains("-even more file1"),
+			)
+	},
+})

--- a/pkg/integration/tests/patch_building/apply_in_reverse_with_conflict.go
+++ b/pkg/integration/tests/patch_building/apply_in_reverse_with_conflict.go
@@ -52,7 +52,7 @@ var ApplyInReverseWithConflict = NewIntegrationTest(NewIntegrationTestArgs{
 		t.ExpectPopup().Alert().
 			Title(Equals("Error")).
 			Content(Contains("Applied patch to 'file1' with conflicts.").
-				DoesNotContain("Applied patch to 'file2' cleanly.")).
+				Contains("Applied patch to 'file2' cleanly.")).
 			Confirm()
 
 		t.Views().Files().
@@ -79,6 +79,7 @@ var ApplyInReverseWithConflict = NewIntegrationTest(NewIntegrationTestArgs{
 			Focus().
 			Lines(
 				Contains("M").Contains("file1").IsSelected(),
+				Contains("M").Contains("file2"),
 			)
 
 		t.Views().Main().

--- a/pkg/integration/tests/patch_building/move_to_index_with_conflict.go
+++ b/pkg/integration/tests/patch_building/move_to_index_with_conflict.go
@@ -8,7 +8,7 @@ import (
 var MoveToIndexWithConflict = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Move a patch from a commit to the index, causing a conflict",
 	ExtraCmdArgs: "",
-	Skip:         true, // Skipping until https://github.com/jesseduffield/lazygit/pull/2471 is merged
+	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateFileAndAdd("file1", "file1 content")

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -99,6 +99,7 @@ var tests = []*components.IntegrationTest{
 	misc.InitialOpen,
 	patch_building.Apply,
 	patch_building.ApplyInReverse,
+	patch_building.ApplyInReverseWithConflict,
 	patch_building.CopyPatchToClipboard,
 	patch_building.MoveToIndex,
 	patch_building.MoveToIndexPartial,


### PR DESCRIPTION
- **PR Description**

Fix several problems with applying custom patches when there are conflicts. See the individual commit messages for details.

@jesseduffield Still a draft because I didn't add any tests. I wasn't sure how much they would overlap with the ones that are yet to be migrated. Feel free to cherry-pick these if you want to integrate them in the migration right away.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
