### PR TITLE
gitflow finish command can publish to remote if needed

### DIFF
--- a/pkg/commands/git_commands/flow.go
+++ b/pkg/commands/git_commands/flow.go
@@ -24,7 +24,7 @@ func (self *FlowCommands) GitFlowEnabled() bool {
 	return self.config.GetGitFlowPrefixes() != ""
 }
 
-func (self *FlowCommands) FinishCmdObj(branchName string) (oscommands.ICmdObj, error) {
+func (self *FlowCommands) FinishCmdObj(branchName string, willPush bool) (oscommands.ICmdObj, error) {
 	prefixes := self.config.GetGitFlowPrefixes()
 
 	// need to find out what kind of branch this is
@@ -46,6 +46,10 @@ func (self *FlowCommands) FinishCmdObj(branchName string) (oscommands.ICmdObj, e
 
 	if branchType == "" {
 		return nil, errors.New(self.Tr.NotAGitFlowBranch)
+	}
+
+	if willPush == true {
+		return self.cmd.New("git flow " + branchType + " finish -pm " + suffix), nil
 	}
 
 	return self.cmd.New("git flow " + branchType + " finish " + suffix), nil


### PR DESCRIPTION
Yeah it's me @aleDVirgo with my personal github account, here is the PR as requested... sorry I'm not a Golang programmer but I've experimented with it.

The goal of this PR is to been able to publish/push the git flow finish command output also on remote cuz it's a common practice here in the place where I work.

The new `willPush` boolean var can be triggered by a conf var or maybe by asking the user in a prompt after the finish command has been selected.

Thanks, hoping to not have written some bad s**t