### PR TITLE
Add icon for Kotlin files

### DIFF
--- a/pkg/gui/presentation/icons/file_icons.go
+++ b/pkg/gui/presentation/icons/file_icons.go
@@ -179,6 +179,7 @@ var extIconMap = map[string]string{
 	".jsx":            "\ue7ba", // 
 	".jxl":            "\uf1c5", // 
 	".ksh":            "\uf489", // 
+	".kt":             "\ue634", // 
 	".latex":          "\uf034", // 
 	".less":           "\ue758", // 
 	".lhs":            "\ue777", // 

--- a/pkg/gui/presentation/icons/file_icons.go
+++ b/pkg/gui/presentation/icons/file_icons.go
@@ -180,6 +180,7 @@ var extIconMap = map[string]string{
 	".jxl":            "\uf1c5", // 
 	".ksh":            "\uf489", // 
 	".kt":             "\ue634", // 
+	".kts":            "\ue634", // 
 	".latex":          "\uf034", // 
 	".less":           "\ue758", // 
 	".lhs":            "\ue777", // 


### PR DESCRIPTION
- **PR Description**

Icon for files with Kotlin file extension ([`.kt`](https://docs.fileformat.com/programming/kt/)) is being added here.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
