### PR TITLE
Fix two issues with the "<-- YOU ARE HERE ---" label

### DIFF
--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -15,7 +15,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 	"github.com/jesseduffield/lazygit/pkg/commands/types/enums"
 	"github.com/jesseduffield/lazygit/pkg/common"
-	"github.com/jesseduffield/lazygit/pkg/gui/style"
 )
 
 // context:
@@ -68,10 +67,6 @@ type GetCommitsOptions struct {
 func (self *CommitLoader) GetCommits(opts GetCommitsOptions) ([]*models.Commit, error) {
 	commits := []*models.Commit{}
 	var rebasingCommits []*models.Commit
-	rebaseMode, err := self.getRebaseMode()
-	if err != nil {
-		return nil, err
-	}
 
 	if opts.IncludeRebaseCommits && opts.FilterPath == "" {
 		var err error
@@ -104,12 +99,6 @@ func (self *CommitLoader) GetCommits(opts GetCommitsOptions) ([]*models.Commit, 
 
 	if len(commits) == 0 {
 		return commits, nil
-	}
-
-	if rebaseMode != enums.REBASE_MODE_NONE {
-		currentCommit := commits[len(rebasingCommits)]
-		youAreHere := style.FgYellow.Sprintf("<-- %s ---", self.Tr.YouAreHere)
-		currentCommit.Name = fmt.Sprintf("%s %s", youAreHere, currentCommit.Name)
 	}
 
 	commits, err = self.setCommitMergedStatuses(opts.RefName, commits)

--- a/pkg/gui/list_context_config.go
+++ b/pkg/gui/list_context_config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jesseduffield/generics/slices"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/jesseduffield/lazygit/pkg/commands/types/enums"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
@@ -118,7 +119,11 @@ func (gui *Gui) branchCommitsListContext() *context.LocalCommitsContext {
 					selectedCommitSha = selectedCommit.Sha
 				}
 			}
+
+			showYouAreHereLabel := gui.git.Status.WorkingTreeState() == enums.REBASE_MODE_REBASING
+
 			return presentation.GetCommitListDisplayStrings(
+				gui.Common,
 				gui.State.Model.Commits,
 				gui.State.ScreenMode != SCREEN_NORMAL,
 				gui.helpers.CherryPick.CherryPickedCommitShaSet(),
@@ -130,6 +135,7 @@ func (gui *Gui) branchCommitsListContext() *context.LocalCommitsContext {
 				length,
 				gui.shouldShowGraph(),
 				gui.State.Model.BisectInfo,
+				showYouAreHereLabel,
 			)
 		},
 		OnFocusWrapper(gui.onCommitFocus),
@@ -152,6 +158,7 @@ func (gui *Gui) subCommitsListContext() *context.SubCommitsContext {
 				}
 			}
 			return presentation.GetCommitListDisplayStrings(
+				gui.Common,
 				gui.State.Model.SubCommits,
 				gui.State.ScreenMode != SCREEN_NORMAL,
 				gui.helpers.CherryPick.CherryPickedCommitShaSet(),
@@ -163,6 +170,7 @@ func (gui *Gui) subCommitsListContext() *context.SubCommitsContext {
 				length,
 				gui.shouldShowGraph(),
 				git_commands.NewNullBisectInfo(),
+				false,
 			)
 		},
 		nil,

--- a/pkg/gui/list_context_config.go
+++ b/pkg/gui/list_context_config.go
@@ -120,7 +120,7 @@ func (gui *Gui) branchCommitsListContext() *context.LocalCommitsContext {
 				}
 			}
 
-			showYouAreHereLabel := gui.git.Status.WorkingTreeState() == enums.REBASE_MODE_REBASING
+			showYouAreHereLabel := gui.State.Model.WorkingTreeStateAtLastCommitRefresh == enums.REBASE_MODE_REBASING
 
 			return presentation.GetCommitListDisplayStrings(
 				gui.Common,

--- a/pkg/gui/refresh.go
+++ b/pkg/gui/refresh.go
@@ -236,6 +236,7 @@ func (gui *Gui) refreshCommitsWithLimit() error {
 		return err
 	}
 	gui.State.Model.Commits = commits
+	gui.State.Model.WorkingTreeStateAtLastCommitRefresh = gui.git.Status.WorkingTreeState()
 
 	return gui.c.PostRefreshUpdate(gui.State.Contexts.LocalCommits)
 }
@@ -264,6 +265,7 @@ func (gui *Gui) refreshRebaseCommits() error {
 		return err
 	}
 	gui.State.Model.Commits = updatedCommits
+	gui.State.Model.WorkingTreeStateAtLastCommitRefresh = gui.git.Status.WorkingTreeState()
 
 	return gui.c.PostRefreshUpdate(gui.State.Contexts.LocalCommits)
 }

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
+	"github.com/jesseduffield/lazygit/pkg/commands/types/enums"
 	"github.com/jesseduffield/lazygit/pkg/common"
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/sasha-s/go-deadlock"
@@ -154,9 +155,10 @@ type Model struct {
 	// one and the same
 	ReflogCommits []*models.Commit
 
-	BisectInfo     *git_commands.BisectInfo
-	RemoteBranches []*models.RemoteBranch
-	Tags           []*models.Tag
+	BisectInfo                          *git_commands.BisectInfo
+	WorkingTreeStateAtLastCommitRefresh enums.RebaseMode
+	RemoteBranches                      []*models.RemoteBranch
+	Tags                                []*models.Tag
 
 	// for displaying suggestions while typing in a file name
 	FilesTrie *patricia.Trie


### PR DESCRIPTION
- **PR Description**

This fixes two issues with the "<-- YOU ARE HERE ---" label:

1. When hitting enter on the "You are here"commit to see its files, there's junk in the frame's title bar:
<img width="586" alt="image" src="https://user-images.githubusercontent.com/1225667/221419663-b8278c2a-d89e-4ace-a751-1c474fb2719c.png">

2. When looking at the commits of a branch or tag while a rebase is ongoing, the top commit will show a bogus "You are here" label:
<img width="377" alt="image" src="https://user-images.githubusercontent.com/1225667/221419674-eeabd6c9-2ecf-4663-86ba-9730349d916d.png">

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
