### PR TITLE
Fix accordion mode when building a custom patch

### DIFF
--- a/pkg/gui/context.go
+++ b/pkg/gui/context.go
@@ -78,12 +78,15 @@ func (gui *Gui) pushToContextStack(c types.Context) []types.Context {
 		gui.State.ContextManager.ContextStack = []types.Context{c}
 	} else if c.GetKind() == types.MAIN_CONTEXT {
 		// if we're switching to a main context, remove all other main contexts in the stack
+		contextsToKeep := []types.Context{}
 		for _, stackContext := range gui.State.ContextManager.ContextStack {
 			if stackContext.GetKind() == types.MAIN_CONTEXT {
 				contextsToDeactivate = append(contextsToDeactivate, stackContext)
+			} else {
+				contextsToKeep = append(contextsToKeep, stackContext)
 			}
 		}
-		gui.State.ContextManager.ContextStack = []types.Context{c}
+		gui.State.ContextManager.ContextStack = append(contextsToKeep, c)
 	} else {
 		topContext := gui.currentContextWithoutLock()
 

--- a/pkg/gui/controllers/helpers/patch_building_helper.go
+++ b/pkg/gui/controllers/helpers/patch_building_helper.go
@@ -38,7 +38,7 @@ func (self *PatchBuildingHelper) ValidateNormalWorkingTreeState() (bool, error) 
 
 // takes us from the patch building panel back to the commit files panel
 func (self *PatchBuildingHelper) Escape() error {
-	return self.c.PushContext(self.contexts.CommitFiles)
+	return self.c.PopContext()
 }
 
 // kills the custom patch and returns us back to the commit files panel if needed

--- a/pkg/gui/controllers/merge_conflicts_controller.go
+++ b/pkg/gui/controllers/merge_conflicts_controller.go
@@ -162,7 +162,7 @@ func (self *MergeConflictsController) context() *context.MergeConflictsContext {
 }
 
 func (self *MergeConflictsController) Escape() error {
-	return self.c.PushContext(self.contexts.Files)
+	return self.c.PopContext()
 }
 
 func (self *MergeConflictsController) HandleEditFile() error {

--- a/pkg/gui/controllers/staging_controller.go
+++ b/pkg/gui/controllers/staging_controller.go
@@ -133,7 +133,7 @@ func (self *StagingController) EditFile() error {
 }
 
 func (self *StagingController) Escape() error {
-	return self.c.PushContext(self.contexts.Files)
+	return self.c.PopContext()
 }
 
 func (self *StagingController) TogglePanel() error {


### PR DESCRIPTION
- **PR Description**

When `gui.expandFocusedSidePanel` is set, the commits panel should be expanded while building a custom patch. However, the files panel was expanded in this case. This PR fixes that.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
