### PR TITLE
Fix setting gui.selectedLineBgColor as a hex value

### DIFF
--- a/pkg/theme/style.go
+++ b/pkg/theme/style.go
@@ -30,9 +30,9 @@ func GetTextStyle(keys []string, background bool) style.TextStyle {
 			} else if utils.IsValidHexValue(key) {
 				c := style.NewRGBColor(color.HEX(key, background))
 				if background {
-					s.SetBg(c)
+					s = s.SetBg(c)
 				} else {
-					s.SetFg(c)
+					s = s.SetFg(c)
 				}
 			}
 		}

--- a/pkg/theme/style_test.go
+++ b/pkg/theme/style_test.go
@@ -1,0 +1,65 @@
+package theme
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gookit/color"
+	"github.com/jesseduffield/lazygit/pkg/gui/style"
+)
+
+func TestGetTextStyle(t *testing.T) {
+	scenarios := []struct {
+		name       string
+		keys       []string
+		background bool
+		expected   style.TextStyle
+	}{
+		{
+			name:       "empty",
+			keys:       []string{""},
+			background: true,
+			expected:   style.New(),
+		},
+		{
+			name:       "named color, fg",
+			keys:       []string{"blue"},
+			background: false,
+			expected:   style.New().SetFg(style.NewBasicColor(color.FgBlue)),
+		},
+		{
+			name:       "named color, bg",
+			keys:       []string{"blue"},
+			background: true,
+			expected:   style.New().SetBg(style.NewBasicColor(color.BgBlue)),
+		},
+		{
+			name:       "hex color, fg",
+			keys:       []string{"#123456"},
+			background: false,
+			/* EXPECTED:
+			expected:   style.New().SetFg(style.NewRGBColor(color.RGBColor{0x12, 0x34, 0x56, 0})),
+			ACTUAL:
+			*/
+			expected:   style.New(),
+		},
+		{
+			name:       "hex color, bg",
+			keys:       []string{"#abcdef"},
+			background: true,
+			/* EXPECTED:
+			expected:   style.New().SetBg(style.NewRGBColor(color.RGBColor{0xab, 0xcd, 0xef, 1})),
+			ACTUAL:
+			*/
+			expected:   style.New(),
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			if actual := GetTextStyle(scenario.keys, scenario.background); !reflect.DeepEqual(actual, scenario.expected) {
+				t.Errorf("GetTextStyle() = %v, expected %v", actual, scenario.expected)
+			}
+		})
+	}
+}

--- a/pkg/theme/style_test.go
+++ b/pkg/theme/style_test.go
@@ -37,21 +37,13 @@ func TestGetTextStyle(t *testing.T) {
 			name:       "hex color, fg",
 			keys:       []string{"#123456"},
 			background: false,
-			/* EXPECTED:
 			expected:   style.New().SetFg(style.NewRGBColor(color.RGBColor{0x12, 0x34, 0x56, 0})),
-			ACTUAL:
-			*/
-			expected:   style.New(),
 		},
 		{
 			name:       "hex color, bg",
 			keys:       []string{"#abcdef"},
 			background: true,
-			/* EXPECTED:
 			expected:   style.New().SetBg(style.NewRGBColor(color.RGBColor{0xab, 0xcd, 0xef, 1})),
-			ACTUAL:
-			*/
-			expected:   style.New(),
 		},
 	}
 


### PR DESCRIPTION
- **PR Description**

When trying to set `gui.selectedRangeBgColor` to a hex value, it would get set to nothing instead. Named colors worked though.

I don't understand why this didn't seem to affect any of the other colors that are set with `GetTextStyle`, e.g. `selectedLineBgColor`. But the fix here still seems right to me.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
