### PR TITLE
Make arrows consistent

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -143,8 +143,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>e</kbd>: edit file
   <kbd>o</kbd>: open file
-  <kbd>◄</kbd>: select previous conflict
-  <kbd>►</kbd>: select next conflict
+  <kbd>◀</kbd>: select previous conflict
+  <kbd>▶</kbd>: select next conflict
   <kbd>▲</kbd>: select previous hunk
   <kbd>▼</kbd>: select next hunk
   <kbd>z</kbd>: undo
@@ -164,8 +164,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Main Panel (Patch Building)
 
 <pre>
-  <kbd>◄</kbd>: select previous hunk
-  <kbd>►</kbd>: select next hunk
+  <kbd>◀</kbd>: select previous hunk
+  <kbd>▶</kbd>: select next hunk
   <kbd>v</kbd>: toggle drag select
   <kbd>V</kbd>: toggle drag select
   <kbd>a</kbd>: toggle select hunk
@@ -179,8 +179,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Main Panel (Staging)
 
 <pre>
-  <kbd>◄</kbd>: select previous hunk
-  <kbd>►</kbd>: select next hunk
+  <kbd>◀</kbd>: select previous hunk
+  <kbd>▶</kbd>: select next hunk
   <kbd>v</kbd>: toggle drag select
   <kbd>V</kbd>: toggle drag select
   <kbd>a</kbd>: toggle select hunk

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -203,8 +203,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>e</kbd>: ファイルを編集
   <kbd>o</kbd>: ファイルを開く
-  <kbd>◄</kbd>: 前のコンフリクトを選択
-  <kbd>►</kbd>: 次のコンフリクトを選択
+  <kbd>◀</kbd>: 前のコンフリクトを選択
+  <kbd>▶</kbd>: 次のコンフリクトを選択
   <kbd>▲</kbd>: 前のhunkを選択
   <kbd>▼</kbd>: 次のhunkを選択
   <kbd>z</kbd>: アンドゥ
@@ -224,8 +224,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## メインパネル (Patch Building)
 
 <pre>
-  <kbd>◄</kbd>: 前のhunkを選択
-  <kbd>►</kbd>: 次のhunkを選択
+  <kbd>◀</kbd>: 前のhunkを選択
+  <kbd>▶</kbd>: 次のhunkを選択
   <kbd>v</kbd>: 範囲選択を切り替え
   <kbd>V</kbd>: 範囲選択を切り替え
   <kbd>a</kbd>: hunk選択を切り替え
@@ -239,8 +239,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## メインパネル (Staging)
 
 <pre>
-  <kbd>◄</kbd>: 前のhunkを選択
-  <kbd>►</kbd>: 次のhunkを選択
+  <kbd>◀</kbd>: 前のhunkを選択
+  <kbd>▶</kbd>: 次のhunkを選択
   <kbd>v</kbd>: 範囲選択を切り替え
   <kbd>V</kbd>: 範囲選択を切り替え
   <kbd>a</kbd>: hunk選択を切り替え

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -88,8 +88,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>e</kbd>: 파일 편집
   <kbd>o</kbd>: 파일 닫기
-  <kbd>◄</kbd>: 이전 충돌을 선택
-  <kbd>►</kbd>: 다음 충돌을 선택
+  <kbd>◀</kbd>: 이전 충돌을 선택
+  <kbd>▶</kbd>: 다음 충돌을 선택
   <kbd>▲</kbd>: 이전 hunk를 선택
   <kbd>▼</kbd>: 다음 hunk를 선택
   <kbd>z</kbd>: 되돌리기
@@ -109,8 +109,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## 메인 패널 (Patch Building)
 
 <pre>
-  <kbd>◄</kbd>: 이전 hunk를 선택
-  <kbd>►</kbd>: 다음 hunk를 선택
+  <kbd>◀</kbd>: 이전 hunk를 선택
+  <kbd>▶</kbd>: 다음 hunk를 선택
   <kbd>v</kbd>: 드래그 선택 전환
   <kbd>V</kbd>: 드래그 선택 전환
   <kbd>a</kbd>: toggle select hunk
@@ -124,8 +124,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## 메인 패널 (Staging)
 
 <pre>
-  <kbd>◄</kbd>: 이전 hunk를 선택
-  <kbd>►</kbd>: 다음 hunk를 선택
+  <kbd>◀</kbd>: 이전 hunk를 선택
+  <kbd>▶</kbd>: 다음 hunk를 선택
   <kbd>v</kbd>: 드래그 선택 전환
   <kbd>V</kbd>: 드래그 선택 전환
   <kbd>a</kbd>: toggle select hunk

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -143,8 +143,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>e</kbd>: verander bestand
   <kbd>o</kbd>: open bestand
-  <kbd>◄</kbd>: selecteer voorgaand conflict
-  <kbd>►</kbd>: selecteer volgende conflict
+  <kbd>◀</kbd>: selecteer voorgaand conflict
+  <kbd>▶</kbd>: selecteer volgende conflict
   <kbd>▲</kbd>: selecteer bovenste hunk
   <kbd>▼</kbd>: selecteer onderste hunk
   <kbd>z</kbd>: ongedaan maken
@@ -164,8 +164,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Patch Bouwen
 
 <pre>
-  <kbd>◄</kbd>: selecteer de vorige hunk
-  <kbd>►</kbd>: selecteer de volgende hunk
+  <kbd>◀</kbd>: selecteer de vorige hunk
+  <kbd>▶</kbd>: selecteer de volgende hunk
   <kbd>v</kbd>: toggle drag selecteer
   <kbd>V</kbd>: toggle drag selecteer
   <kbd>a</kbd>: toggle selecteer hunk
@@ -218,8 +218,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Staging
 
 <pre>
-  <kbd>◄</kbd>: selecteer de vorige hunk
-  <kbd>►</kbd>: selecteer de volgende hunk
+  <kbd>◀</kbd>: selecteer de vorige hunk
+  <kbd>▶</kbd>: selecteer de volgende hunk
   <kbd>v</kbd>: toggle drag selecteer
   <kbd>V</kbd>: toggle drag selecteer
   <kbd>a</kbd>: toggle selecteer hunk

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -101,8 +101,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Main Panel (Patch Building)
 
 <pre>
-  <kbd>◄</kbd>: poprzedni kawałek
-  <kbd>►</kbd>: następny kawałek
+  <kbd>◀</kbd>: poprzedni kawałek
+  <kbd>▶</kbd>: następny kawałek
   <kbd>v</kbd>: toggle drag select
   <kbd>V</kbd>: toggle drag select
   <kbd>a</kbd>: toggle select hunk
@@ -156,8 +156,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Poczekalnia
 
 <pre>
-  <kbd>◄</kbd>: poprzedni kawałek
-  <kbd>►</kbd>: następny kawałek
+  <kbd>◀</kbd>: poprzedni kawałek
+  <kbd>▶</kbd>: następny kawałek
   <kbd>v</kbd>: toggle drag select
   <kbd>V</kbd>: toggle drag select
   <kbd>a</kbd>: toggle select hunk
@@ -218,8 +218,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>e</kbd>: edytuj plik
   <kbd>o</kbd>: otwórz plik
-  <kbd>◄</kbd>: poprzedni konflikt
-  <kbd>►</kbd>: następny konflikt
+  <kbd>◀</kbd>: poprzedni konflikt
+  <kbd>▶</kbd>: następny konflikt
   <kbd>▲</kbd>: wybierz poprzedni kawałek
   <kbd>▼</kbd>: wybierz następny kawałek
   <kbd>z</kbd>: cofnij

--- a/docs/keybindings/Keybindings_zh.md
+++ b/docs/keybindings/Keybindings_zh.md
@@ -184,8 +184,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## 构建补丁中
 
 <pre>
-  <kbd>◄</kbd>: 选择上一个区块
-  <kbd>►</kbd>: 选择下一个区块
+  <kbd>◀</kbd>: 选择上一个区块
+  <kbd>▶</kbd>: 选择下一个区块
   <kbd>v</kbd>: 切换拖动选择
   <kbd>V</kbd>: 切换拖动选择
   <kbd>a</kbd>: 切换选择区块
@@ -212,8 +212,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>e</kbd>: 编辑文件
   <kbd>o</kbd>: 打开文件
-  <kbd>◄</kbd>: 选择上一个冲突
-  <kbd>►</kbd>: 选择下一个冲突
+  <kbd>◀</kbd>: 选择上一个冲突
+  <kbd>▶</kbd>: 选择下一个冲突
   <kbd>▲</kbd>: 选择顶部块
   <kbd>▼</kbd>: 选择底部块
   <kbd>z</kbd>: 撤销
@@ -226,8 +226,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## 正在暂存
 
 <pre>
-  <kbd>◄</kbd>: 选择上一个区块
-  <kbd>►</kbd>: 选择下一个区块
+  <kbd>◀</kbd>: 选择上一个区块
+  <kbd>▶</kbd>: 选择下一个区块
   <kbd>v</kbd>: 切换拖动选择
   <kbd>V</kbd>: 切换拖动选择
   <kbd>a</kbd>: 切换选择区块

--- a/pkg/gui/keybindings/keybindings.go
+++ b/pkg/gui/keybindings/keybindings.go
@@ -32,8 +32,8 @@ var keyMapReversed = map[gocui.Key]string{
 	gocui.KeyPgdn:        "pgdown",
 	gocui.KeyArrowUp:     "▲",
 	gocui.KeyArrowDown:   "▼",
-	gocui.KeyArrowLeft:   "◄",
-	gocui.KeyArrowRight:  "►",
+	gocui.KeyArrowLeft:   "◀",
+	gocui.KeyArrowRight:  "▶",
 	gocui.KeyTab:         "tab", // ctrl+i
 	gocui.KeyBacktab:     "shift+tab",
 	gocui.KeyEnter:       "enter", // ctrl+m

--- a/pkg/gui/presentation/files.go
+++ b/pkg/gui/presentation/files.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	EXPANDED_ARROW  = "▼"
-	COLLAPSED_ARROW = "►"
+	COLLAPSED_ARROW = "▶"
 )
 
 // keeping these here as individual constants in case later on people want the old tree shape

--- a/pkg/gui/presentation/files_test.go
+++ b/pkg/gui/presentation/files_test.go
@@ -53,7 +53,7 @@ func TestRenderFileTree(t *testing.T) {
 			},
 			expected: toStringSlice(
 				`
-► dir1
+▶ dir1
 ▼ dir2
   ▼ dir2
      M file3
@@ -112,7 +112,7 @@ func TestRenderCommitFileTree(t *testing.T) {
 			},
 			expected: toStringSlice(
 				`
-► dir1
+▶ dir1
 ▼ dir2
   ▼ dir2
     D file3


### PR DESCRIPTION
**PR Description**

The arrow key symbols shown in the UI were inconsistent. For the up/down keys, the characters for

- U+25B2 BLACK UP-POINTING TRIANGLE
- U+25BC BLACK DOWN-POINTING TRIANGLE

were used, but the left/right keys used

- U+25C4 BLACK LEFT-POINTING POINTER
- U+25BA BLACK RIGHT-POINTING POINTER

Those look different depending on the terminal font:

![Bildschirm­foto 2023-03-14 um 10 54 39](https://user-images.githubusercontent.com/3185950/224965358-beb3e0e5-217b-4692-957d-34d710067ea1.png)

This PR uses the matching triangle characters for left/right:

- U+25C0 BLACK LEFT-POINTING TRIANGLE
- U+25B6 BLACK RIGHT-POINTING TRIANGLE

![Bildschirm­foto 2023-03-14 um 11 07 59](https://user-images.githubusercontent.com/3185950/224967335-c9f66bcd-3293-473f-906a-f9e63e9fe1bc.png)

**Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc
