### PR TITLE
appease golangci-lint

### DIFF
--- a/pkg/commands/oscommands/cmd_obj_builder.go
+++ b/pkg/commands/oscommands/cmd_obj_builder.go
@@ -52,7 +52,7 @@ func (self *CmdObjBuilder) NewFromArgs(args []string) ICmdObj {
 }
 
 func (self *CmdObjBuilder) NewShell(commandStr string) ICmdObj {
-	quotedCommand := ""
+	var quotedCommand string
 	// Windows does not seem to like quotes around the command
 	if self.platform.OS == "windows" {
 		quotedCommand = strings.NewReplacer(

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -23,7 +23,7 @@ func (gui *Gui) getCurrentBranch(path string) string {
 		if err == nil {
 			content := strings.TrimSpace(string(headFile))
 			refsPrefix := "ref: refs/heads/"
-			branchDisplay := ""
+			var branchDisplay string
 			if strings.HasPrefix(content, refsPrefix) {
 				// is a branch
 				branchDisplay = strings.TrimPrefix(content, refsPrefix)


### PR DESCRIPTION
- **PR Description**

It's very annoying when the linter is updated and all of a sudden all CI builds start breaking. Alas, this was an easy fix.

This lint rule is borderline too strict but it DOES make the code more expressive, so long as you don't have other places in the code that make use of the zero value from a `var` declaration.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
