### PR TITLE
Show the selected item on the outer frame

### DIFF
--- a/vendor/github.com/jesseduffield/gocui/gui.go
+++ b/vendor/github.com/jesseduffield/gocui/gui.go
@@ -737,7 +737,11 @@ func (g *Gui) clear(fg, bg Attribute) (int, int) {
 
 // drawFrameEdges draws the horizontal and vertical edges of a view.
 func (g *Gui) drawFrameEdges(v *View, fgColor, bgColor Attribute) error {
-	runeH, runeV := '─', '│'
+	runeH, runeV, runeT := '─', '│', '│'
+	if v.Highlight {
+		runeT = '╡'
+	}
+
 	if len(v.FrameRunes) >= 2 {
 		runeH, runeV = v.FrameRunes[0], v.FrameRunes[1]
 	}
@@ -764,8 +768,14 @@ func (g *Gui) drawFrameEdges(v *View, fgColor, bgColor Attribute) error {
 			continue
 		}
 		if v.x0 > -1 && v.x0 < g.maxX {
-			if err := g.SetRune(v.x0, y, runeV, fgColor, bgColor); err != nil {
-				return err
+			if y == v.cy+v.y0+1 {
+				if err := g.SetRune(v.x0, y, runeT, fgColor, bgColor); err != nil {
+					return err
+				}
+			} else {
+				if err := g.SetRune(v.x0, y, runeV, fgColor, bgColor); err != nil {
+					return err
+				}
 			}
 		}
 		if v.x1 > -1 && v.x1 < g.maxX {


### PR DESCRIPTION
With this update the border is ╡ where the current selection is. It looks a bit like = .

This is very useful in some cases on windows where the terminal by default uses "all bold colors" therefore making the selection indistinguishable from the non selected items.

The change is applied only on the currently selected frame.

Images from mac's terminal shown below.

The following image shows where exactly the change is affecting (annotated)
<img width="1368" alt="Screenshot_2023_03_28_00_05_57@2x2" src="https://user-images.githubusercontent.com/1496933/228081336-85cf02f6-a393-4d14-ac93-8ab006e268f1.png">

And the following 3 screenshots are different scenarios un-annotated
<img width="1368" alt="Screenshot_2023_03_28_00_05_57@2x" src="https://user-images.githubusercontent.com/1496933/228077929-9a16ea9f-d5cb-43ed-ac41-3a99faf294b3.png">
<img width="1368" alt="Screenshot_2023_03_28_00_06_08@2x" src="https://user-images.githubusercontent.com/1496933/228077937-d37fb60e-322c-4933-acc3-0a714e1c806f.png">
<img width="1368" alt="Screenshot_2023_03_28_00_06_22@2x" src="https://user-images.githubusercontent.com/1496933/228077949-c069cc0f-23b8-433b-bb1b-ccd9f222284f.png">


- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide) [IMO no tests necessary for this, the screenshots are evident]
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
