### PR TITLE
Introduce more alternate keybinding slots for quit.

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -115,6 +115,7 @@ keybinding:
   universal:
     quit: 'q'
     quit-alt1: '<c-c>' # alternative/alias of quit
+    # quit-alt(N) # continuation to 5.
     return: '<esc>' # return to previous menu, will quit if there's nowhere to return
     quitWithoutChangingDirectory: 'Q'
     togglePanel: '<tab>' # goto the next panel

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -137,6 +137,10 @@ type KeybindingConfig struct {
 type KeybindingUniversalConfig struct {
 	Quit                         string   `yaml:"quit"`
 	QuitAlt1                     string   `yaml:"quit-alt1"`
+	QuitAlt2                     string   `yaml:"quit-alt2"`
+	QuitAlt3                     string   `yaml:"quit-alt3"`
+	QuitAlt4                     string   `yaml:"quit-alt4"`
+	QuitAlt5                     string   `yaml:"quit-alt5"`
 	Return                       string   `yaml:"return"`
 	QuitWithoutChangingDirectory string   `yaml:"quitWithoutChangingDirectory"`
 	TogglePanel                  string   `yaml:"togglePanel"`

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -70,6 +70,30 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 		},
 		{
 			ViewName: "",
+			Key:      opts.GetKey(opts.Config.Universal.QuitAlt2),
+			Modifier: gocui.ModNone,
+			Handler:  self.handleQuit,
+		},
+		{
+			ViewName: "",
+			Key:      opts.GetKey(opts.Config.Universal.QuitAlt3),
+			Modifier: gocui.ModNone,
+			Handler:  self.handleQuit,
+		},
+		{
+			ViewName: "",
+			Key:      opts.GetKey(opts.Config.Universal.QuitAlt4),
+			Modifier: gocui.ModNone,
+			Handler:  self.handleQuit,
+		},
+		{
+			ViewName: "",
+			Key:      opts.GetKey(opts.Config.Universal.QuitAlt5),
+			Modifier: gocui.ModNone,
+			Handler:  self.handleQuit,
+		},
+		{
+			ViewName: "",
 			Key:      opts.GetKey(opts.Config.Universal.Return),
 			Modifier: gocui.ModNone,
 			Handler:  self.handleTopLevelReturn,


### PR DESCRIPTION
I'd like to be able to quit with all of:
 - <kbd>C-c</kbd>
 - <kbd>C-d</kbd>
 - <kbd>q</kbd>

Apologies, This implementation is ugly because I haven't had a chance to learn go. Maybe a good samaritan could DRY up the alternate keybindings pattern in the future so that it may scale infinitely based on user config.

I tried to chuck a for loop at the end of the bindings slice and append to it but it appears I'd need to reflect (in a compiled language? _I guess go has a runtime more extensive than it's famous GC?_) in order to dynamically access `opts.GetKey(opts.Config.Universal.QuitAlt(N))`, by name. Too much go'iness and reflection ugliness for me 😅 I'm sure there is a better data layout than that.

But hey if it's not DRY at least it's declarative and maintainable 😉