### PR TITLE
Reduce memory consumption when loading large number of commits

### DIFF
--- a/pkg/gui/context/base_context.go
+++ b/pkg/gui/context/base_context.go
@@ -20,11 +20,12 @@ type BaseContext struct {
 	onFocusFn           onFocusFn
 	onFocusLostFn       onFocusLostFn
 
-	focusable                  bool
-	transient                  bool
-	hasControlledBounds        bool
-	needsRerenderOnWidthChange bool
-	highlightOnFocus           bool
+	focusable                   bool
+	transient                   bool
+	hasControlledBounds         bool
+	needsRerenderOnWidthChange  bool
+	needsRerenderOnHeightChange bool
+	highlightOnFocus            bool
 
 	*ParentContextMgr
 }
@@ -37,15 +38,16 @@ type (
 var _ types.IBaseContext = &BaseContext{}
 
 type NewBaseContextOpts struct {
-	Kind                       types.ContextKind
-	Key                        types.ContextKey
-	View                       *gocui.View
-	WindowName                 string
-	Focusable                  bool
-	Transient                  bool
-	HasUncontrolledBounds      bool // negating for the sake of making false the default
-	HighlightOnFocus           bool
-	NeedsRerenderOnWidthChange bool
+	Kind                        types.ContextKind
+	Key                         types.ContextKey
+	View                        *gocui.View
+	WindowName                  string
+	Focusable                   bool
+	Transient                   bool
+	HasUncontrolledBounds       bool // negating for the sake of making false the default
+	HighlightOnFocus            bool
+	NeedsRerenderOnWidthChange  bool
+	NeedsRerenderOnHeightChange bool
 
 	OnGetOptionsMap func() map[string]string
 }
@@ -56,18 +58,19 @@ func NewBaseContext(opts NewBaseContextOpts) *BaseContext {
 	hasControlledBounds := !opts.HasUncontrolledBounds
 
 	return &BaseContext{
-		kind:                       opts.Kind,
-		key:                        opts.Key,
-		view:                       opts.View,
-		windowName:                 opts.WindowName,
-		onGetOptionsMap:            opts.OnGetOptionsMap,
-		focusable:                  opts.Focusable,
-		transient:                  opts.Transient,
-		hasControlledBounds:        hasControlledBounds,
-		highlightOnFocus:           opts.HighlightOnFocus,
-		needsRerenderOnWidthChange: opts.NeedsRerenderOnWidthChange,
-		ParentContextMgr:           &ParentContextMgr{},
-		viewTrait:                  viewTrait,
+		kind:                        opts.Kind,
+		key:                         opts.Key,
+		view:                        opts.View,
+		windowName:                  opts.WindowName,
+		onGetOptionsMap:             opts.OnGetOptionsMap,
+		focusable:                   opts.Focusable,
+		transient:                   opts.Transient,
+		hasControlledBounds:         hasControlledBounds,
+		highlightOnFocus:            opts.HighlightOnFocus,
+		needsRerenderOnWidthChange:  opts.NeedsRerenderOnWidthChange,
+		needsRerenderOnHeightChange: opts.NeedsRerenderOnHeightChange,
+		ParentContextMgr:            &ParentContextMgr{},
+		viewTrait:                   viewTrait,
 	}
 }
 
@@ -195,6 +198,10 @@ func (self *BaseContext) HasControlledBounds() bool {
 
 func (self *BaseContext) NeedsRerenderOnWidthChange() bool {
 	return self.needsRerenderOnWidthChange
+}
+
+func (self *BaseContext) NeedsRerenderOnHeightChange() bool {
+	return self.needsRerenderOnHeightChange
 }
 
 func (self *BaseContext) Title() string {

--- a/pkg/gui/context/branches_context.go
+++ b/pkg/gui/context/branches_context.go
@@ -24,7 +24,7 @@ func NewBranchesContext(c *ContextCommon) *BranchesContext {
 		},
 	)
 
-	getDisplayStrings := func(_ int, _ int) [][]string {
+	getDisplayStrings := func(startIdx int, endIdx int) [][]string {
 		return presentation.GetBranchListDisplayStrings(
 			viewModel.GetItems(),
 			c.State().GetItemOperation,
@@ -34,6 +34,9 @@ func NewBranchesContext(c *ContextCommon) *BranchesContext {
 			c.Tr,
 			c.UserConfig,
 			c.Model().Worktrees,
+			startIdx,
+			endIdx,
+			viewModel.GetSelectedLineIdx(),
 		)
 	}
 
@@ -52,7 +55,8 @@ func NewBranchesContext(c *ContextCommon) *BranchesContext {
 				list:              viewModel,
 				getDisplayStrings: getDisplayStrings,
 			},
-			c: c,
+			c:                       c,
+			refreshViewportOnChange: true,
 		},
 	}
 

--- a/pkg/gui/context/commit_files_context.go
+++ b/pkg/gui/context/commit_files_context.go
@@ -64,10 +64,7 @@ func NewCommitFilesContext(c *ContextCommon) *CommitFilesContext {
 		},
 	}
 
-	ctx.GetView().SetOnSelectItem(ctx.SearchTrait.onSelectItemWrapper(func(selectedLineIdx int) error {
-		ctx.GetList().SetSelection(selectedLineIdx)
-		return ctx.HandleFocus(types.OnFocusOpts{})
-	}))
+	ctx.GetView().SetOnSelectItem(ctx.SearchTrait.onSelectItemWrapper(ctx.OnSearchSelect))
 
 	return ctx
 }

--- a/pkg/gui/context/commit_files_context.go
+++ b/pkg/gui/context/commit_files_context.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/filetree"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
@@ -72,4 +73,8 @@ func NewCommitFilesContext(c *ContextCommon) *CommitFilesContext {
 
 func (self *CommitFilesContext) GetDiffTerminals() []string {
 	return []string{self.GetRef().RefName()}
+}
+
+func (self *CommitFilesContext) ModelSearchResults(searchStr string, caseSensitive bool) []gocui.SearchPosition {
+	return nil
 }

--- a/pkg/gui/context/commit_files_context.go
+++ b/pkg/gui/context/commit_files_context.go
@@ -18,8 +18,9 @@ type CommitFilesContext struct {
 }
 
 var (
-	_ types.IListContext    = (*CommitFilesContext)(nil)
-	_ types.DiffableContext = (*CommitFilesContext)(nil)
+	_ types.IListContext       = (*CommitFilesContext)(nil)
+	_ types.DiffableContext    = (*CommitFilesContext)(nil)
+	_ types.ISearchableContext = (*CommitFilesContext)(nil)
 )
 
 func NewCommitFilesContext(c *ContextCommon) *CommitFilesContext {

--- a/pkg/gui/context/list_context_trait.go
+++ b/pkg/gui/context/list_context_trait.go
@@ -102,7 +102,7 @@ func (self *ListContextTrait) HandleRender() error {
 }
 
 func (self *ListContextTrait) OnSearchSelect(selectedLineIdx int) error {
-	self.GetList().SetSelection(selectedLineIdx)
+	self.GetList().SetSelection(self.ViewIndexToModelIndex(selectedLineIdx))
 	return self.HandleFocus(types.OnFocusOpts{})
 }
 

--- a/pkg/gui/context/list_context_trait.go
+++ b/pkg/gui/context/list_context_trait.go
@@ -136,3 +136,7 @@ func (self *ListContextTrait) IsItemVisible(item types.HasUrn) bool {
 func (self *ListContextTrait) RangeSelectEnabled() bool {
 	return true
 }
+
+func (self *ListContextTrait) RenderOnlyVisibleLines() bool {
+	return self.renderOnlyVisibleLines
+}

--- a/pkg/gui/context/list_context_trait.go
+++ b/pkg/gui/context/list_context_trait.go
@@ -25,10 +25,9 @@ func (self *ListContextTrait) IsListContext() {}
 func (self *ListContextTrait) FocusLine() {
 	// Doing this at the end of the layout function because we need the view to be
 	// resized before we focus the line, otherwise if we're in accordion mode
-	// the view could be squashed and won't how to adjust the cursor/origin
+	// the view could be squashed and won't how to adjust the cursor/origin.
+	// Also, refreshing the viewport needs to happen after the view has been resized.
 	self.c.AfterLayout(func() error {
-		oldOrigin, _ := self.GetViewTrait().ViewPortYBounds()
-
 		self.GetViewTrait().FocusPoint(
 			self.ModelIndexToViewIndex(self.list.GetSelectedLineIdx()))
 
@@ -40,22 +39,13 @@ func (self *ListContextTrait) FocusLine() {
 			self.GetViewTrait().CancelRangeSelect()
 		}
 
-		// If FocusPoint() caused the view to scroll (because the selected line
-		// was out of view before), we need to rerender the view port again.
-		// This can happen when pressing , or . to scroll by pages, or < or > to
-		// jump to the top or bottom.
-		newOrigin, _ := self.GetViewTrait().ViewPortYBounds()
-		if self.refreshViewportOnChange && oldOrigin != newOrigin {
+		if self.refreshViewportOnChange {
 			self.refreshViewport()
 		}
 		return nil
 	})
 
 	self.setFooter()
-
-	if self.refreshViewportOnChange {
-		self.refreshViewport()
-	}
 }
 
 func (self *ListContextTrait) refreshViewport() {

--- a/pkg/gui/context/list_renderer.go
+++ b/pkg/gui/context/list_renderer.go
@@ -35,6 +35,7 @@ type ListRenderer struct {
 	numNonModelItems        int
 	viewIndicesByModelIndex []int
 	modelIndicesByViewIndex []int
+	columnPositions         []int
 }
 
 func (self *ListRenderer) GetList() types.IList {
@@ -57,6 +58,10 @@ func (self *ListRenderer) ViewIndexToModelIndex(viewIndex int) int {
 	}
 
 	return viewIndex
+}
+
+func (self *ListRenderer) ColumnPositions() []int {
+	return self.columnPositions
 }
 
 // startIdx and endIdx are view indices, not model indices. If you want to
@@ -87,6 +92,7 @@ func (self *ListRenderer) renderLines(startIdx int, endIdx int) string {
 	lines, columnPositions := utils.RenderDisplayStrings(
 		self.getDisplayStrings(startModelIdx, endModelIdx),
 		columnAlignments)
+	self.columnPositions = columnPositions
 	lines = self.insertNonModelItems(nonModelItems, endIdx, startIdx, lines, columnPositions)
 	return strings.Join(lines, "\n")
 }

--- a/pkg/gui/context/local_commits_context.go
+++ b/pkg/gui/context/local_commits_context.go
@@ -72,12 +72,13 @@ func NewLocalCommitsContext(c *ContextCommon) *LocalCommitsContext {
 		SearchTrait:           NewSearchTrait(c),
 		ListContextTrait: &ListContextTrait{
 			Context: NewSimpleContext(NewBaseContext(NewBaseContextOpts{
-				View:                       c.Views().Commits,
-				WindowName:                 "commits",
-				Key:                        LOCAL_COMMITS_CONTEXT_KEY,
-				Kind:                       types.SIDE_CONTEXT,
-				Focusable:                  true,
-				NeedsRerenderOnWidthChange: true,
+				View:                        c.Views().Commits,
+				WindowName:                  "commits",
+				Key:                         LOCAL_COMMITS_CONTEXT_KEY,
+				Kind:                        types.SIDE_CONTEXT,
+				Focusable:                   true,
+				NeedsRerenderOnWidthChange:  true,
+				NeedsRerenderOnHeightChange: true,
 			})),
 			ListRenderer: ListRenderer{
 				list:              viewModel,
@@ -85,6 +86,7 @@ func NewLocalCommitsContext(c *ContextCommon) *LocalCommitsContext {
 			},
 			c:                       c,
 			refreshViewportOnChange: true,
+			renderOnlyVisibleLines:  true,
 		},
 	}
 

--- a/pkg/gui/context/local_commits_context.go
+++ b/pkg/gui/context/local_commits_context.go
@@ -18,8 +18,9 @@ type LocalCommitsContext struct {
 }
 
 var (
-	_ types.IListContext    = (*LocalCommitsContext)(nil)
-	_ types.DiffableContext = (*LocalCommitsContext)(nil)
+	_ types.IListContext       = (*LocalCommitsContext)(nil)
+	_ types.DiffableContext    = (*LocalCommitsContext)(nil)
+	_ types.ISearchableContext = (*LocalCommitsContext)(nil)
 )
 
 func NewLocalCommitsContext(c *ContextCommon) *LocalCommitsContext {

--- a/pkg/gui/context/local_commits_context.go
+++ b/pkg/gui/context/local_commits_context.go
@@ -85,10 +85,7 @@ func NewLocalCommitsContext(c *ContextCommon) *LocalCommitsContext {
 		},
 	}
 
-	ctx.GetView().SetOnSelectItem(ctx.SearchTrait.onSelectItemWrapper(func(selectedLineIdx int) error {
-		ctx.GetList().SetSelection(selectedLineIdx)
-		return ctx.HandleFocus(types.OnFocusOpts{})
-	}))
+	ctx.GetView().SetOnSelectItem(ctx.SearchTrait.onSelectItemWrapper(ctx.OnSearchSelect))
 
 	return ctx
 }

--- a/pkg/gui/context/patch_explorer_context.go
+++ b/pkg/gui/context/patch_explorer_context.go
@@ -142,3 +142,7 @@ func (self *PatchExplorerContext) NavigateTo(isFocused bool, selectedLineIdx int
 func (self *PatchExplorerContext) GetMutex() *deadlock.Mutex {
 	return self.mutex
 }
+
+func (self *PatchExplorerContext) ModelSearchResults(searchStr string, caseSensitive bool) []gocui.SearchPosition {
+	return nil
+}

--- a/pkg/gui/context/patch_explorer_context.go
+++ b/pkg/gui/context/patch_explorer_context.go
@@ -18,7 +18,10 @@ type PatchExplorerContext struct {
 	mutex                  *deadlock.Mutex
 }
 
-var _ types.IPatchExplorerContext = (*PatchExplorerContext)(nil)
+var (
+	_ types.IPatchExplorerContext = (*PatchExplorerContext)(nil)
+	_ types.ISearchableContext    = (*PatchExplorerContext)(nil)
+)
 
 func NewPatchExplorerContext(
 	view *gocui.View,

--- a/pkg/gui/context/remote_branches_context.go
+++ b/pkg/gui/context/remote_branches_context.go
@@ -37,13 +37,14 @@ func NewRemoteBranchesContext(
 		DynamicTitleBuilder:   NewDynamicTitleBuilder(c.Tr.RemoteBranchesDynamicTitle),
 		ListContextTrait: &ListContextTrait{
 			Context: NewSimpleContext(NewBaseContext(NewBaseContextOpts{
-				View:                       c.Views().RemoteBranches,
-				WindowName:                 "branches",
-				Key:                        REMOTE_BRANCHES_CONTEXT_KEY,
-				Kind:                       types.SIDE_CONTEXT,
-				Focusable:                  true,
-				Transient:                  true,
-				NeedsRerenderOnWidthChange: true,
+				View:                        c.Views().RemoteBranches,
+				WindowName:                  "branches",
+				Key:                         REMOTE_BRANCHES_CONTEXT_KEY,
+				Kind:                        types.SIDE_CONTEXT,
+				Focusable:                   true,
+				Transient:                   true,
+				NeedsRerenderOnWidthChange:  true,
+				NeedsRerenderOnHeightChange: true,
 			})),
 			ListRenderer: ListRenderer{
 				list:              viewModel,

--- a/pkg/gui/context/remote_branches_context.go
+++ b/pkg/gui/context/remote_branches_context.go
@@ -28,8 +28,8 @@ func NewRemoteBranchesContext(
 		},
 	)
 
-	getDisplayStrings := func(_ int, _ int) [][]string {
-		return presentation.GetRemoteBranchListDisplayStrings(viewModel.GetItems(), c.Modes().Diffing.Ref)
+	getDisplayStrings := func(startIdx int, endIdx int) [][]string {
+		return presentation.GetRemoteBranchListDisplayStrings(viewModel.GetItems(), startIdx, endIdx, c.Modes().Diffing.Ref)
 	}
 
 	return &RemoteBranchesContext{
@@ -50,7 +50,8 @@ func NewRemoteBranchesContext(
 				list:              viewModel,
 				getDisplayStrings: getDisplayStrings,
 			},
-			c: c,
+			c:                      c,
+			renderOnlyVisibleLines: true,
 		},
 	}
 }

--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -73,8 +73,6 @@ func NewSubCommitsContext(
 			selectedCommitHash,
 			startIdx,
 			endIdx,
-			// Don't show the graph in the left/right view; we'd like to, but
-			// it's too complicated:
 			shouldShowGraph(c),
 			git_commands.NewNullBisectInfo(),
 			false,

--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
@@ -199,4 +200,8 @@ func (self *SubCommitsContext) GetDiffTerminals() []string {
 	itemId := self.GetSelectedItemId()
 
 	return []string{itemId}
+}
+
+func (self *SubCommitsContext) ModelSearchResults(searchStr string, caseSensitive bool) []gocui.SearchPosition {
+	return searchModelCommits(caseSensitive, self.GetCommits(), self.ColumnPositions(), searchStr)
 }

--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -21,8 +21,9 @@ type SubCommitsContext struct {
 }
 
 var (
-	_ types.IListContext    = (*SubCommitsContext)(nil)
-	_ types.DiffableContext = (*SubCommitsContext)(nil)
+	_ types.IListContext       = (*SubCommitsContext)(nil)
+	_ types.DiffableContext    = (*SubCommitsContext)(nil)
+	_ types.ISearchableContext = (*SubCommitsContext)(nil)
 )
 
 func NewSubCommitsContext(

--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -133,10 +133,7 @@ func NewSubCommitsContext(
 		},
 	}
 
-	ctx.GetView().SetOnSelectItem(ctx.SearchTrait.onSelectItemWrapper(func(selectedLineIdx int) error {
-		ctx.GetList().SetSelection(selectedLineIdx)
-		return ctx.HandleFocus(types.OnFocusOpts{})
-	}))
+	ctx.GetView().SetOnSelectItem(ctx.SearchTrait.onSelectItemWrapper(ctx.OnSearchSelect))
 
 	return ctx
 }

--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -115,13 +115,14 @@ func NewSubCommitsContext(
 		DynamicTitleBuilder: NewDynamicTitleBuilder(c.Tr.SubCommitsDynamicTitle),
 		ListContextTrait: &ListContextTrait{
 			Context: NewSimpleContext(NewBaseContext(NewBaseContextOpts{
-				View:                       c.Views().SubCommits,
-				WindowName:                 "branches",
-				Key:                        SUB_COMMITS_CONTEXT_KEY,
-				Kind:                       types.SIDE_CONTEXT,
-				Focusable:                  true,
-				Transient:                  true,
-				NeedsRerenderOnWidthChange: true,
+				View:                        c.Views().SubCommits,
+				WindowName:                  "branches",
+				Key:                         SUB_COMMITS_CONTEXT_KEY,
+				Kind:                        types.SIDE_CONTEXT,
+				Focusable:                   true,
+				Transient:                   true,
+				NeedsRerenderOnWidthChange:  true,
+				NeedsRerenderOnHeightChange: true,
 			})),
 			ListRenderer: ListRenderer{
 				list:              viewModel,
@@ -130,6 +131,7 @@ func NewSubCommitsContext(
 			},
 			c:                       c,
 			refreshViewportOnChange: true,
+			renderOnlyVisibleLines:  true,
 		},
 	}
 

--- a/pkg/gui/context/view_trait.go
+++ b/pkg/gui/context/view_trait.go
@@ -34,6 +34,15 @@ func (self *ViewTrait) SetViewPortContent(content string) {
 	self.view.OverwriteLines(y, content)
 }
 
+func (self *ViewTrait) SetViewPortContentAndClearEverythingElse(content string) {
+	_, y := self.view.Origin()
+	self.view.OverwriteLinesAndClearEverythingElse(y, content)
+}
+
+func (self *ViewTrait) SetContentLineCount(lineCount int) {
+	self.view.SetContentLineCount(lineCount)
+}
+
 func (self *ViewTrait) SetContent(content string) {
 	self.view.SetContent(content)
 }

--- a/pkg/gui/context/working_tree_context.go
+++ b/pkg/gui/context/working_tree_context.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/filetree"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
@@ -57,4 +58,8 @@ func NewWorkingTreeContext(c *ContextCommon) *WorkingTreeContext {
 	ctx.GetView().SetOnSelectItem(ctx.SearchTrait.onSelectItemWrapper(ctx.OnSearchSelect))
 
 	return ctx
+}
+
+func (self *WorkingTreeContext) ModelSearchResults(searchStr string, caseSensitive bool) []gocui.SearchPosition {
+	return nil
 }

--- a/pkg/gui/context/working_tree_context.go
+++ b/pkg/gui/context/working_tree_context.go
@@ -51,10 +51,7 @@ func NewWorkingTreeContext(c *ContextCommon) *WorkingTreeContext {
 		},
 	}
 
-	ctx.GetView().SetOnSelectItem(ctx.SearchTrait.onSelectItemWrapper(func(selectedLineIdx int) error {
-		ctx.GetList().SetSelection(selectedLineIdx)
-		return ctx.HandleFocus(types.OnFocusOpts{})
-	}))
+	ctx.GetView().SetOnSelectItem(ctx.SearchTrait.onSelectItemWrapper(ctx.OnSearchSelect))
 
 	return ctx
 }

--- a/pkg/gui/context/working_tree_context.go
+++ b/pkg/gui/context/working_tree_context.go
@@ -15,7 +15,10 @@ type WorkingTreeContext struct {
 	*SearchTrait
 }
 
-var _ types.IListContext = (*WorkingTreeContext)(nil)
+var (
+	_ types.IListContext       = (*WorkingTreeContext)(nil)
+	_ types.ISearchableContext = (*WorkingTreeContext)(nil)
+)
 
 func NewWorkingTreeContext(c *ContextCommon) *WorkingTreeContext {
 	viewModel := filetree.NewFileTreeViewModel(

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -759,6 +759,14 @@ func (self *RefreshHelper) refForLog() string {
 }
 
 func (self *RefreshHelper) refreshView(context types.Context) error {
+	// Re-applying the filter must be done before re-rendering the view, so that
+	// the filtered list model is up to date for rendering.
 	self.searchHelper.ReApplyFilter(context)
-	return self.c.PostRefreshUpdate(context)
+
+	err := self.c.PostRefreshUpdate(context)
+
+	// Re-applying the search must be done after re-rendering the view though,
+	// so that the "x of y" status is shown correctly.
+	self.searchHelper.ReApplySearch(context)
+	return err
 }

--- a/pkg/gui/controllers/helpers/search_helper.go
+++ b/pkg/gui/controllers/helpers/search_helper.go
@@ -162,10 +162,10 @@ func (self *SearchHelper) ConfirmSearch() error {
 		return err
 	}
 
-	return search(context)
+	return context.GetView().Search(searchString, modelSearchResults(context))
 }
 
-func search(context types.ISearchableContext) error {
+func modelSearchResults(context types.ISearchableContext) []gocui.SearchPosition {
 	searchString := context.GetSearchString()
 
 	var normalizedSearchStr string
@@ -177,7 +177,7 @@ func search(context types.ISearchableContext) error {
 		normalizedSearchStr = strings.ToLower(searchString)
 	}
 
-	return context.GetView().Search(searchString, context.ModelSearchResults(normalizedSearchStr, caseSensitive))
+	return context.ModelSearchResults(normalizedSearchStr, caseSensitive)
 }
 
 func (self *SearchHelper) CancelPrompt() error {
@@ -254,12 +254,12 @@ func (self *SearchHelper) ReApplySearch(ctx types.Context) {
 	// Reapply the search if the model has changed. This is needed for contexts
 	// that use the model for searching, to pass the new model search positions
 	// to the view.
-	state := self.searchState()
-	if ctx == state.Context {
-		searchableContext, ok := ctx.(types.ISearchableContext)
-		if ok {
-			_ = search(searchableContext)
+	searchableContext, ok := ctx.(types.ISearchableContext)
+	if ok {
+		ctx.GetView().UpdateSearchResults(searchableContext.GetSearchString(), modelSearchResults(searchableContext))
 
+		state := self.searchState()
+		if ctx == state.Context {
 			// Re-render the "x of y" search status, unless the search prompt is
 			// open for typing.
 			if self.c.CurrentContext().GetKey() != context.SEARCH_CONTEXT_KEY {

--- a/pkg/gui/controllers/helpers/search_helper.go
+++ b/pkg/gui/controllers/helpers/search_helper.go
@@ -2,12 +2,14 @@ package helpers
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/theme"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 // NOTE: this helper supports both filtering and searching. Filtering is when
@@ -156,17 +158,26 @@ func (self *SearchHelper) ConfirmSearch() error {
 		context.GetSearchHistory().Push(searchString)
 	}
 
-	view := context.GetView()
-
 	if err := self.c.PopContext(); err != nil {
 		return err
 	}
 
-	if err := view.Search(searchString); err != nil {
-		return err
+	return search(context)
+}
+
+func search(context types.ISearchableContext) error {
+	searchString := context.GetSearchString()
+
+	var normalizedSearchStr string
+	// if we have any uppercase characters we'll do a case-sensitive search
+	caseSensitive := utils.ContainsUppercase(searchString)
+	if caseSensitive {
+		normalizedSearchStr = searchString
+	} else {
+		normalizedSearchStr = strings.ToLower(searchString)
 	}
 
-	return nil
+	return context.GetView().Search(searchString, context.ModelSearchResults(normalizedSearchStr, caseSensitive))
 }
 
 func (self *SearchHelper) CancelPrompt() error {
@@ -235,6 +246,25 @@ func (self *SearchHelper) ReApplyFilter(context types.Context) {
 			filterableContext.SetSelection(0)
 			_ = filterableContext.GetView().SetOriginY(0)
 			filterableContext.ReApplyFilter(self.c.UserConfig.Gui.UseFuzzySearch())
+		}
+	}
+}
+
+func (self *SearchHelper) ReApplySearch(ctx types.Context) {
+	// Reapply the search if the model has changed. This is needed for contexts
+	// that use the model for searching, to pass the new model search positions
+	// to the view.
+	state := self.searchState()
+	if ctx == state.Context {
+		searchableContext, ok := ctx.(types.ISearchableContext)
+		if ok {
+			_ = search(searchableContext)
+
+			// Re-render the "x of y" search status, unless the search prompt is
+			// open for typing.
+			if self.c.CurrentContext().GetKey() != context.SEARCH_CONTEXT_KEY {
+				self.RenderSearchStatus(searchableContext)
+			}
 		}
 	}
 }

--- a/pkg/gui/controllers/list_controller.go
+++ b/pkg/gui/controllers/list_controller.go
@@ -53,6 +53,9 @@ func (self *ListController) HandleScrollRight() error {
 func (self *ListController) HandleScrollUp() error {
 	scrollHeight := self.c.UserConfig.Gui.ScrollHeight
 	self.context.GetViewTrait().ScrollUp(scrollHeight)
+	if self.context.RenderOnlyVisibleLines() {
+		return self.context.HandleRender()
+	}
 
 	return nil
 }
@@ -60,6 +63,9 @@ func (self *ListController) HandleScrollUp() error {
 func (self *ListController) HandleScrollDown() error {
 	scrollHeight := self.c.UserConfig.Gui.ScrollHeight
 	self.context.GetViewTrait().ScrollDown(scrollHeight)
+	if self.context.RenderOnlyVisibleLines() {
+		return self.context.HandleRender()
+	}
 
 	return nil
 }

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -72,13 +72,25 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			frameOffset = 0
 		}
 
+		mustRerender := false
 		if context.NeedsRerenderOnWidthChange() {
 			// view.Width() returns the width -1 for some reason
 			oldWidth := view.Width() + 1
 			newWidth := dimensionsObj.X1 - dimensionsObj.X0 + 2*frameOffset
 			if oldWidth != newWidth {
-				contextsToRerender = append(contextsToRerender, context)
+				mustRerender = true
 			}
+		}
+		if context.NeedsRerenderOnHeightChange() {
+			// view.Height() returns the height -1 for some reason
+			oldHeight := view.Height() + 1
+			newHeight := dimensionsObj.Y1 - dimensionsObj.Y0 + 2*frameOffset
+			if oldHeight != newHeight {
+				mustRerender = true
+			}
+		}
+		if mustRerender {
+			contextsToRerender = append(contextsToRerender, context)
 		}
 
 		_, err = g.SetView(

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -29,10 +29,13 @@ func GetBranchListDisplayStrings(
 	tr *i18n.TranslationSet,
 	userConfig *config.UserConfig,
 	worktrees []*models.Worktree,
+	startIdx int,
+	endIdx int,
+	selectedBranchIdx int,
 ) [][]string {
-	return lo.Map(branches, func(branch *models.Branch, _ int) []string {
+	return lo.Map(branches[startIdx:endIdx], func(branch *models.Branch, idx int) []string {
 		diffed := branch.Name == diffName
-		return getBranchDisplayStrings(branch, getItemOperation(branch), fullDescription, diffed, viewWidth, tr, userConfig, worktrees, time.Now())
+		return getBranchDisplayStrings(branch, getItemOperation(branch), fullDescription, diffed, viewWidth, tr, userConfig, worktrees, time.Now(), selectedBranchIdx == startIdx+idx)
 	})
 }
 
@@ -47,6 +50,7 @@ func getBranchDisplayStrings(
 	userConfig *config.UserConfig,
 	worktrees []*models.Worktree,
 	now time.Time,
+	isSelected bool,
 ) []string {
 	checkedOutByWorkTree := git_commands.CheckedOutByOtherWorktree(b, worktrees)
 	showCommitHash := fullDescription || userConfig.Gui.ShowBranchCommitHash
@@ -74,7 +78,9 @@ func getBranchDisplayStrings(
 	}
 
 	nameTextStyle := GetBranchTextStyle(b.Name)
-	if diffed {
+	if isSelected {
+		nameTextStyle = style.FgYellow
+	} else if diffed {
 		nameTextStyle = theme.DiffTerminalColor
 	}
 

--- a/pkg/gui/presentation/branches_test.go
+++ b/pkg/gui/presentation/branches_test.go
@@ -312,7 +312,7 @@ func Test_getBranchDisplayStrings(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("getBranchDisplayStrings_%d", i), func(t *testing.T) {
-			strings := getBranchDisplayStrings(s.branch, s.itemOperation, s.fullDescription, false, s.viewWidth, c.Tr, c.UserConfig, worktrees, time.Time{})
+			strings := getBranchDisplayStrings(s.branch, s.itemOperation, s.fullDescription, false, s.viewWidth, c.Tr, c.UserConfig, worktrees, time.Time{}, false)
 			assert.Equal(t, s.expected, strings)
 		})
 	}

--- a/pkg/gui/presentation/remote_branches.go
+++ b/pkg/gui/presentation/remote_branches.go
@@ -7,8 +7,8 @@ import (
 	"github.com/samber/lo"
 )
 
-func GetRemoteBranchListDisplayStrings(branches []*models.RemoteBranch, diffName string) [][]string {
-	return lo.Map(branches, func(branch *models.RemoteBranch, _ int) []string {
+func GetRemoteBranchListDisplayStrings(branches []*models.RemoteBranch, startIdx, endIdx int, diffName string) [][]string {
+	return lo.Map(branches[startIdx:endIdx], func(branch *models.RemoteBranch, _ int) []string {
 		diffed := branch.FullName() == diffName
 		return getRemoteBranchDisplayStrings(branch, diffed)
 	})

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -63,6 +63,9 @@ type IBaseContext interface {
 	// true if the view needs to be rerendered when its width changes
 	NeedsRerenderOnWidthChange() bool
 
+	// true if the view needs to be rerendered when its height changes
+	NeedsRerenderOnHeightChange() bool
+
 	// returns the desired title for the view upon activation. If there is no desired title (returns empty string), then
 	// no title will be set
 	Title() string
@@ -172,6 +175,8 @@ type IViewTrait interface {
 	SetRangeSelectStart(yIdx int)
 	CancelRangeSelect()
 	SetViewPortContent(content string)
+	SetViewPortContentAndClearEverythingElse(content string)
+	SetContentLineCount(lineCount int)
 	SetContent(content string)
 	SetFooter(value string)
 	SetOriginX(value int)

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -153,6 +153,7 @@ type IListContext interface {
 	FocusLine()
 	IsListContext() // used for type switch
 	RangeSelectEnabled() bool
+	RenderOnlyVisibleLines() bool
 }
 
 type IPatchExplorerContext interface {

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -114,12 +114,16 @@ type ISearchableContext interface {
 	Context
 	ISearchHistoryContext
 
+	// These are all implemented by SearchTrait
 	SetSearchString(string)
 	GetSearchString() string
 	ClearSearchString()
 	IsSearching() bool
 	IsSearchableContext()
 	RenderSearchStatus(int, int)
+
+	// This must be implemented by each concrete context. Return nil if not searching the model.
+	ModelSearchResults(searchStr string, caseSensitive bool) []gocui.SearchPosition
 }
 
 type DiffableContext interface {

--- a/pkg/integration/components/view_driver.go
+++ b/pkg/integration/components/view_driver.go
@@ -431,6 +431,11 @@ func (self *ViewDriver) SelectPreviousItem() *ViewDriver {
 	return self.PressFast(self.t.keys.Universal.PrevItem)
 }
 
+// i.e. pressing '<'
+func (self *ViewDriver) GotoTop() *ViewDriver {
+	return self.PressFast(self.t.keys.Universal.GotoTop)
+}
+
 // i.e. pressing space
 func (self *ViewDriver) PressPrimaryAction() *ViewDriver {
 	return self.Press(self.t.keys.Universal.Select)
@@ -457,21 +462,15 @@ func (self *ViewDriver) PressEscape() *ViewDriver {
 // - the user is not in a list item
 // - no list item is found containing the given text
 // - multiple list items are found containing the given text in the initial page of items
-//
-// NOTE: this currently assumes that BufferLines returns all the lines that can be accessed.
-// If this changes in future, we'll need to update this code to first attempt to find the item
-// in the current page and failing that, jump to the top of the view and iterate through all of it,
-// looking for the item.
 func (self *ViewDriver) NavigateToLine(matcher *TextMatcher) *ViewDriver {
 	self.IsFocused()
 
 	view := self.getView()
 	lines := view.BufferLines()
 
-	var matchIndex int
+	matchIndex := -1
 
 	self.t.assertWithRetries(func() (bool, string) {
-		matchIndex = -1
 		var matches []string
 		// first we look for a duplicate on the current screen. We won't bother looking beyond that though.
 		for i, line := range lines {
@@ -483,12 +482,18 @@ func (self *ViewDriver) NavigateToLine(matcher *TextMatcher) *ViewDriver {
 		}
 		if len(matches) > 1 {
 			return false, fmt.Sprintf("Found %d matches for `%s`, expected only a single match. Matching lines:\n%s", len(matches), matcher.name(), strings.Join(matches, "\n"))
-		} else if len(matches) == 0 {
-			return false, fmt.Sprintf("Could not find item matching: %s. Lines:\n%s", matcher.name(), strings.Join(lines, "\n"))
-		} else {
-			return true, ""
 		}
+		return true, ""
 	})
+
+	// If no match was found, it could be that this is a view that renders only
+	// the visible lines. In that case, we jump to the top and then press
+	// down-arrow until we found the match. We simply return the first match we
+	// find, so we have no way to assert that there are no duplicates.
+	if matchIndex == -1 {
+		self.GotoTop()
+		matchIndex = len(lines)
+	}
 
 	selectedLineIdx := self.getSelectedLineIdx()
 	if selectedLineIdx == matchIndex {
@@ -514,12 +519,14 @@ func (self *ViewDriver) NavigateToLine(matcher *TextMatcher) *ViewDriver {
 	for i := 0; i < maxNumKeyPresses; i++ {
 		keyPress()
 		idx := self.getSelectedLineIdx()
-		if ok, _ := matcher.test(lines[idx]); ok {
+		// It is important to use view.BufferLines() here and not lines, because it
+		// could change with every keypress.
+		if ok, _ := matcher.test(view.BufferLines()[idx]); ok {
 			return self
 		}
 	}
 
-	self.t.fail(fmt.Sprintf("Could not navigate to item matching: %s. Lines:\n%s", matcher.name(), strings.Join(lines, "\n")))
+	self.t.fail(fmt.Sprintf("Could not navigate to item matching: %s. Lines:\n%s", matcher.name(), strings.Join(view.BufferLines(), "\n")))
 	return self
 }
 

--- a/pkg/integration/tests/commit/search.go
+++ b/pkg/integration/tests/commit/search.go
@@ -31,7 +31,7 @@ var Search = NewIntegrationTest(NewIntegrationTestArgs{
 					Type("two").
 					Confirm()
 
-				t.Views().Search().Content(Contains("matches for 'two' (1 of 1)"))
+				t.Views().Search().IsVisible().Content(Contains("matches for 'two' (1 of 1)"))
 			}).
 			Lines(
 				Contains("four"),
@@ -46,7 +46,7 @@ var Search = NewIntegrationTest(NewIntegrationTestArgs{
 					Type("o").
 					Confirm()
 
-				t.Views().Search().Content(Contains("matches for 'o' (2 of 3)"))
+				t.Views().Search().IsVisible().Content(Contains("matches for 'o' (2 of 3)"))
 			}).
 			Lines(
 				Contains("four"),
@@ -56,7 +56,7 @@ var Search = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			Press("n").
 			Tap(func() {
-				t.Views().Search().Content(Contains("matches for 'o' (3 of 3)"))
+				t.Views().Search().IsVisible().Content(Contains("matches for 'o' (3 of 3)"))
 			}).
 			Lines(
 				Contains("four"),
@@ -66,7 +66,7 @@ var Search = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			Press("n").
 			Tap(func() {
-				t.Views().Search().Content(Contains("matches for 'o' (1 of 3)"))
+				t.Views().Search().IsVisible().Content(Contains("matches for 'o' (1 of 3)"))
 			}).
 			Lines(
 				Contains("four").IsSelected(),
@@ -76,7 +76,7 @@ var Search = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			Press("n").
 			Tap(func() {
-				t.Views().Search().Content(Contains("matches for 'o' (2 of 3)"))
+				t.Views().Search().IsVisible().Content(Contains("matches for 'o' (2 of 3)"))
 			}).
 			Lines(
 				Contains("four"),
@@ -86,7 +86,7 @@ var Search = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			Press("N").
 			Tap(func() {
-				t.Views().Search().Content(Contains("matches for 'o' (1 of 3)"))
+				t.Views().Search().IsVisible().Content(Contains("matches for 'o' (1 of 3)"))
 			}).
 			Lines(
 				Contains("four").IsSelected(),
@@ -96,7 +96,7 @@ var Search = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			Press("N").
 			Tap(func() {
-				t.Views().Search().Content(Contains("matches for 'o' (3 of 3)"))
+				t.Views().Search().IsVisible().Content(Contains("matches for 'o' (3 of 3)"))
 			}).
 			Lines(
 				Contains("four"),

--- a/pkg/integration/tests/staging/search.go
+++ b/pkg/integration/tests/staging/search.go
@@ -29,7 +29,7 @@ var Search = NewIntegrationTest(NewIntegrationTestArgs{
 					Type("four").
 					Confirm()
 
-				t.Views().Search().Content(Contains("matches for 'four' (1 of 1)"))
+				t.Views().Search().IsVisible().Content(Contains("matches for 'four' (1 of 1)"))
 			}).
 			SelectedLine(Contains("+four")). // stage the line
 			PressPrimaryAction().

--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -1596,6 +1596,11 @@ func (v *View) OverwriteLines(y int, content string) {
 	v.wy = y
 
 	lines := strings.Replace(content, "\n", "\x1b[K\n", -1)
+	// If the last line doesn't end with a linefeed, add the erase command at
+	// the end too
+	if !strings.HasSuffix(lines, "\n") {
+		lines += "\x1b[K"
+	}
 	v.writeString(lines)
 }
 

--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -968,7 +968,9 @@ func (v *View) updateSearchPositions() {
 		}
 
 		v.searcher.searchPositions = []cellPos{}
-		for y, line := range v.lines {
+
+		searchPositionsForLine := func(line []cell, y int) []cellPos {
+			var result []cellPos
 			x := 0
 			for startIdx, c := range line {
 				found := true
@@ -985,10 +987,15 @@ func (v *View) updateSearchPositions() {
 					offset += 1
 				}
 				if found {
-					v.searcher.searchPositions = append(v.searcher.searchPositions, cellPos{x: x, y: y})
+					result = append(result, cellPos{x: x, y: y})
 				}
 				x += runewidth.RuneWidth(c.chr)
 			}
+			return result
+		}
+
+		for y, line := range v.lines {
+			v.searcher.searchPositions = append(v.searcher.searchPositions, searchPositionsForLine(line, y)...)
 		}
 	}
 }

--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -489,6 +489,14 @@ func (v *View) setRune(x, y int, ch rune, fgColor, bgColor Attribute) error {
 		}
 	}
 
+	if matched, selected := v.isPatternMatchedRune(x, y); matched {
+		if selected {
+			bgColor = ColorCyan
+		} else {
+			bgColor = ColorYellow
+		}
+	}
+
 	// Don't display NUL characters
 	if ch == 0 {
 		ch = ' '
@@ -1102,13 +1110,6 @@ func (v *View) draw() error {
 			bgColor := c.bgColor
 			if bgColor == ColorDefault {
 				bgColor = v.BgColor
-			}
-			if matched, selected := v.isPatternMatchedRune(x, y); matched {
-				if selected {
-					bgColor = ColorCyan
-				} else {
-					bgColor = ColorYellow
-				}
 			}
 
 			if err := v.setRune(x, y, c.chr, fgColor, bgColor); err != nil {

--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -1604,6 +1604,13 @@ func (v *View) OverwriteLines(y int, content string) {
 	v.writeString(lines)
 }
 
+func (v *View) SetContentLineCount(lineCount int) {
+	if lineCount > 0 {
+		v.makeWriteable(0, lineCount-1)
+	}
+	v.lines = v.lines[:lineCount]
+}
+
 func (v *View) ScrollUp(amount int) {
 	if amount > v.oy {
 		amount = v.oy

--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -760,6 +760,8 @@ func (v *View) writeRunes(p []rune) {
 			}
 		}
 	}
+
+	v.updateSearchPositions()
 }
 
 // exported functions use the mutex. Non-exported functions are for internal use
@@ -1007,7 +1009,6 @@ func (v *View) draw() error {
 
 	v.clearRunes()
 
-	v.updateSearchPositions()
 	maxX, maxY := v.Size()
 
 	if v.Wrap {

--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -1586,11 +1586,7 @@ func (v *View) ClearTextArea() {
 	_ = v.SetCursor(0, 0)
 }
 
-// only call this function if you don't care where v.wx and v.wy end up
-func (v *View) OverwriteLines(y int, content string) {
-	v.writeMutex.Lock()
-	defer v.writeMutex.Unlock()
-
+func (v *View) overwriteLines(y int, content string) {
 	// break by newline, then for each line, write it, then add that erase command
 	v.wx = 0
 	v.wy = y
@@ -1602,6 +1598,30 @@ func (v *View) OverwriteLines(y int, content string) {
 		lines += "\x1b[K"
 	}
 	v.writeString(lines)
+}
+
+// only call this function if you don't care where v.wx and v.wy end up
+func (v *View) OverwriteLines(y int, content string) {
+	v.writeMutex.Lock()
+	defer v.writeMutex.Unlock()
+
+	v.overwriteLines(y, content)
+}
+
+// only call this function if you don't care where v.wx and v.wy end up
+func (v *View) OverwriteLinesAndClearEverythingElse(y int, content string) {
+	v.writeMutex.Lock()
+	defer v.writeMutex.Unlock()
+
+	v.overwriteLines(y, content)
+
+	for i := 0; i < y; i += 1 {
+		v.lines[i] = nil
+	}
+
+	for i := v.wy + 1; i < len(v.lines); i += 1 {
+		v.lines[i] = nil
+	}
 }
 
 func (v *View) SetContentLineCount(lineCount int) {


### PR DESCRIPTION
When pressing `>` in the commits panel to trigger loading all the remaining commits past the initial 300, memory consumption is a pretty big problem for larger repositories.

The two main causes seem to be
1. the cell memory from rendering the entire list of commits into the gocui view
2. the pipe sets when git.log.showGraph is on

This PR addresses only the first of these problems, by not rendering the entire view, but only the visible portion of it. Since we already re-render the visible portion of the view on every layout call, this was relatively easy to do.

Below are some measurements for our repository at work (261.985 commits):

|               | master | this PR |
| ------------- | ------ | ------- |
| without Graph | 855 MB | 360 MB  |
| with Graph    | 3.1 GB | 770 MB  |

And for the linux kernel repo (1.170.387 commits):

|               | master                                    | this PR |
| ------------- | ----------------------------------------- | ------- |
| without Graph | 5.8 GB                                    | 1.2G    |
| with Graph    | Killed by the OS after it reached 86.9 GB | 39.9 GB |

The measurements were taken after scrolling all the way down in the list of commits. They have to be taken with a grain of salt, as memory consumption fluctuates quite a bit in ways that I find hard to make sense of.

As you can see, there's more work to do to reduce the memory usage for the graph, but for our repo at work this PR makes it usable already, which it wasn't really before.

The commits prefixed with `[gocui]` are meant to go into a PR on the gocui repo, and will be replaced with a single "bump gocui" commit here.