### PR TITLE
Add `-M` flag for main panel git diffs

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -160,7 +160,7 @@ func (self *CommitCommands) ShowCmdObj(sha string, filterPath string, ignoreWhit
 		ignoreWhitespaceArg = " --ignore-all-space"
 	}
 
-	cmdStr := fmt.Sprintf("git show --submodule --color=%s --unified=%d --no-renames --stat -p %s%s%s",
+	cmdStr := fmt.Sprintf("git show --submodule --color=%s --unified=%d --stat -p %s%s%s",
 		self.UserConfig.Git.Paging.ColorArg, contextSize, sha, ignoreWhitespaceArg, filterPathArg)
 	return self.cmd.New(cmdStr).DontLog()
 }

--- a/pkg/commands/git_commands/commit_test.go
+++ b/pkg/commands/git_commands/commit_test.go
@@ -196,8 +196,8 @@ func TestCommitShowCmdObj(t *testing.T) {
 			testName:         "Default case with filter path",
 			filterPath:       "file.txt",
 			contextSize:      3,
-			ignoreWhitespace: true,
-			expected:         `git show --submodule --color=always --unified=3 --no-renames --stat -p 1234567890 --ignore-all-space -- "file.txt"`,
+			ignoreWhitespace: false,
+			expected:         `git show --submodule --color=always --unified=3 --no-renames --stat -p 1234567890 -- "file.txt"`,
 		},
 		{
 			testName:         "Show diff with custom context size",
@@ -205,6 +205,13 @@ func TestCommitShowCmdObj(t *testing.T) {
 			contextSize:      77,
 			ignoreWhitespace: false,
 			expected:         "git show --submodule --color=always --unified=77 --no-renames --stat -p 1234567890",
+		},
+		{
+			testName:         "Show diff, ignoring whitespace",
+			filterPath:       "",
+			contextSize:      77,
+			ignoreWhitespace: true,
+			expected:         "git show --submodule --color=always --unified=77 --no-renames --stat -p 1234567890 --ignore-all-space",
 		},
 	}
 

--- a/pkg/commands/git_commands/commit_test.go
+++ b/pkg/commands/git_commands/commit_test.go
@@ -190,28 +190,28 @@ func TestCommitShowCmdObj(t *testing.T) {
 			filterPath:       "",
 			contextSize:      3,
 			ignoreWhitespace: false,
-			expected:         "git show --submodule --color=always --unified=3 --no-renames --stat -p 1234567890",
+			expected:         "git show --submodule --color=always --unified=3 --stat -p 1234567890",
 		},
 		{
 			testName:         "Default case with filter path",
 			filterPath:       "file.txt",
 			contextSize:      3,
 			ignoreWhitespace: false,
-			expected:         `git show --submodule --color=always --unified=3 --no-renames --stat -p 1234567890 -- "file.txt"`,
+			expected:         `git show --submodule --color=always --unified=3 --stat -p 1234567890 -- "file.txt"`,
 		},
 		{
 			testName:         "Show diff with custom context size",
 			filterPath:       "",
 			contextSize:      77,
 			ignoreWhitespace: false,
-			expected:         "git show --submodule --color=always --unified=77 --no-renames --stat -p 1234567890",
+			expected:         "git show --submodule --color=always --unified=77 --stat -p 1234567890",
 		},
 		{
 			testName:         "Show diff, ignoring whitespace",
 			filterPath:       "",
 			contextSize:      77,
 			ignoreWhitespace: true,
-			expected:         "git show --submodule --color=always --unified=77 --no-renames --stat -p 1234567890 --ignore-all-space",
+			expected:         "git show --submodule --color=always --unified=77 --stat -p 1234567890 --ignore-all-space",
 		},
 	}
 


### PR DESCRIPTION
This PR adds the ability to specify, through the config file, whether `lazygit` should simplify the diffs in the main panel through the use of the `-M` flag.

This makes it so that `git` will output a line change count of 0 for files that are moved/renamed, rather than

	-{file_length}
	+{file_length}

This cleans up the diff significantly when making lots of sweeping changes to codebases, as well as unifying the line count change in `lazygit` to that of Github (since that ignores moved files by default).

---

The first commit in here cleans up the test file that I was working in, so that the application of the second commit makes more sense.