### PR TITLE
Fix initial context activation

### DIFF
--- a/pkg/gui/gui_common.go
+++ b/pkg/gui/gui_common.go
@@ -70,6 +70,10 @@ func (self *guiCommon) IsCurrentContext(c types.Context) bool {
 	return self.CurrentContext().GetKey() == c.GetKey()
 }
 
+func (self *guiCommon) ActivateContext(context types.Context) error {
+	return self.gui.activateContext(context, types.OnFocusOpts{})
+}
+
 func (self *guiCommon) GetAppState() *config.AppState {
 	return self.gui.Config.GetAppState()
 }

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -182,7 +182,7 @@ func (gui *Gui) onInitialViewsCreationForRepo() error {
 	}
 
 	initialContext := gui.currentSideContext()
-	if err := gui.c.PushContext(initialContext); err != nil {
+	if err := gui.c.ActivateContext(initialContext); err != nil {
 		return err
 	}
 

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -45,6 +45,7 @@ type IGuiCommon interface {
 	CurrentContext() Context
 	CurrentStaticContext() Context
 	IsCurrentContext(Context) bool
+	ActivateContext(context Context) error
 	// enters search mode for the current view
 	OpenSearch()
 


### PR DESCRIPTION
- **PR Description**

This broke with 40f6767cfc77; the symptom is that starting lazygit with a git
arg (e.g. "lazygit log") wouldn't activate the requested panel correctly. While
it would show in the expanded view, it didn't have a green frame, and keyboard
events would go to the files panel.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
