### PR TITLE
Support stacked branches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cli/safeexec v1.0.0
 	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21
 	github.com/creack/pty v1.1.11
-	github.com/fsmiamoto/git-todo-parser v0.0.4-0.20230403011024-617a5a7ce980
+	github.com/fsmiamoto/git-todo-parser v0.0.4
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/gdamore/tcell/v2 v2.6.0
 	github.com/go-errors/errors v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/fatih/color v1.7.1-0.20180516100307-2d684516a886/go.mod h1:Zm6kSWBoL9
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
-github.com/fsmiamoto/git-todo-parser v0.0.4-0.20230403011024-617a5a7ce980 h1:ay9aM+Ay9I4LJttUVF4EFVmeNUkS9/snYVFK6lwieVQ=
-github.com/fsmiamoto/git-todo-parser v0.0.4-0.20230403011024-617a5a7ce980/go.mod h1:B+AgTbNE2BARvJqzXygThzqxLIaEWvwr2sxKYYb0Fas=
+github.com/fsmiamoto/git-todo-parser v0.0.4 h1:fzcGaoAFDHWzJRKw//CSZFrXucsLKplIvOSab3FtWWM=
+github.com/fsmiamoto/git-todo-parser v0.0.4/go.mod h1:B+AgTbNE2BARvJqzXygThzqxLIaEWvwr2sxKYYb0Fas=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=

--- a/pkg/app/daemon/rebase.go
+++ b/pkg/app/daemon/rebase.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsmiamoto/git-todo-parser/todo"
+	"github.com/jesseduffield/generics/slices"
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/jesseduffield/lazygit/pkg/common"
+	"github.com/jesseduffield/lazygit/pkg/env"
+)
+
+type TodoLine struct {
+	Action string
+	Commit *models.Commit
+}
+
+func (self *TodoLine) ToString() string {
+	if self.Action == "break" {
+		return self.Action + "\n"
+	} else {
+		return self.Action + " " + self.Commit.Sha + " " + self.Commit.Name + "\n"
+	}
+}
+
+func TodoLinesToString(todoLines []TodoLine) string {
+	lines := slices.Map(todoLines, func(todoLine TodoLine) string {
+		return todoLine.ToString()
+	})
+
+	return strings.Join(slices.Reverse(lines), "")
+}
+
+type ChangeTodoAction struct {
+	Sha       string
+	NewAction todo.TodoCommand
+}
+
+func handleInteractiveRebase(common *common.Common, f func(path string) error) error {
+	common.Log.Info("Lazygit invoked as interactive rebase demon")
+	common.Log.Info("args: ", os.Args)
+	path := os.Args[1]
+
+	if strings.HasSuffix(path, "git-rebase-todo") {
+		return f(path)
+	} else if strings.HasSuffix(path, filepath.Join(gitDir(), "COMMIT_EDITMSG")) { // TODO: test
+		// if we are rebasing and squashing, we'll see a COMMIT_EDITMSG
+		// but in this case we don't need to edit it, so we'll just return
+	} else {
+		common.Log.Info("Lazygit demon did not match on any use cases")
+	}
+
+	return nil
+}
+
+func gitDir() string {
+	dir := env.GetGitDirEnv()
+	if dir == "" {
+		return ".git"
+	}
+	return dir
+}

--- a/pkg/commands/git_commands/deps_test.go
+++ b/pkg/commands/git_commands/deps_test.go
@@ -15,6 +15,7 @@ import (
 type commonDeps struct {
 	runner     *oscommands.FakeCmdObjRunner
 	userConfig *config.UserConfig
+	gitVersion *GitVersion
 	gitConfig  *git_config.FakeGitConfig
 	getenv     func(string) string
 	removeFile func(string) error
@@ -46,6 +47,11 @@ func buildGitCommon(deps commonDeps) *GitCommon {
 	gitCommon.Common.UserConfig = deps.userConfig
 	if gitCommon.Common.UserConfig == nil {
 		gitCommon.Common.UserConfig = config.GetDefaultConfig()
+	}
+
+	gitCommon.version = deps.gitVersion
+	if gitCommon.version == nil {
+		gitCommon.version = &GitVersion{2, 0, 0, ""}
 	}
 
 	gitConfig := deps.gitConfig

--- a/pkg/commands/git_commands/patch.go
+++ b/pkg/commands/git_commands/patch.go
@@ -105,15 +105,16 @@ func (self *PatchCommands) MovePatchToSelectedCommit(commits []*models.Commit, s
 
 	baseIndex := sourceCommitIdx + 1
 
+	changes := []daemon.ChangeTodoAction{
+		{Sha: commits[sourceCommitIdx].Sha, NewAction: todo.Edit},
+		{Sha: commits[destinationCommitIdx].Sha, NewAction: todo.Edit},
+	}
+	self.os.LogCommand(logTodoChanges(changes), false)
+
 	err := self.rebase.PrepareInteractiveRebaseCommand(PrepareInteractiveRebaseCommandOpts{
 		baseShaOrRoot:  commits[baseIndex].Sha,
 		overrideEditor: true,
-		instruction: ChangeTodoActionsInstruction{
-			actions: []daemon.ChangeTodoAction{
-				{Sha: commits[sourceCommitIdx].Sha, NewAction: todo.Edit},
-				{Sha: commits[destinationCommitIdx].Sha, NewAction: todo.Edit},
-			},
-		},
+		instruction:    daemon.NewChangeTodoActionsInstruction(changes),
 	}).Run()
 	if err != nil {
 		return err

--- a/pkg/commands/git_commands/patch.go
+++ b/pkg/commands/git_commands/patch.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fsmiamoto/git-todo-parser/todo"
 	"github.com/go-errors/errors"
+	"github.com/jesseduffield/lazygit/pkg/app/daemon"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/commands/patch"
 	"github.com/jesseduffield/lazygit/pkg/commands/types/enums"
@@ -107,9 +108,11 @@ func (self *PatchCommands) MovePatchToSelectedCommit(commits []*models.Commit, s
 	err := self.rebase.PrepareInteractiveRebaseCommand(PrepareInteractiveRebaseCommandOpts{
 		baseShaOrRoot:  commits[baseIndex].Sha,
 		overrideEditor: true,
-		changeTodoActions: []ChangeTodoAction{
-			{sha: commits[sourceCommitIdx].Sha, newAction: todo.Edit},
-			{sha: commits[destinationCommitIdx].Sha, newAction: todo.Edit},
+		instruction: ChangeTodoActionsInstruction{
+			actions: []daemon.ChangeTodoAction{
+				{Sha: commits[sourceCommitIdx].Sha, NewAction: todo.Edit},
+				{Sha: commits[destinationCommitIdx].Sha, NewAction: todo.Edit},
+			},
 		},
 	}).Run()
 	if err != nil {

--- a/pkg/commands/git_commands/patch.go
+++ b/pkg/commands/git_commands/patch.go
@@ -3,6 +3,7 @@ package git_commands
 import (
 	"fmt"
 
+	"github.com/fsmiamoto/git-todo-parser/todo"
 	"github.com/go-errors/errors"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/commands/patch"
@@ -103,18 +104,13 @@ func (self *PatchCommands) MovePatchToSelectedCommit(commits []*models.Commit, s
 
 	baseIndex := sourceCommitIdx + 1
 
-	todoLines := self.rebase.BuildTodoLines(commits[0:baseIndex], func(commit *models.Commit, i int) string {
-		if i == sourceCommitIdx || i == destinationCommitIdx {
-			return "edit"
-		} else {
-			return "pick"
-		}
-	})
-
 	err := self.rebase.PrepareInteractiveRebaseCommand(PrepareInteractiveRebaseCommandOpts{
 		baseShaOrRoot:  commits[baseIndex].Sha,
-		todoLines:      todoLines,
 		overrideEditor: true,
+		changeTodoActions: []ChangeTodoAction{
+			{sha: commits[sourceCommitIdx].Sha, newAction: todo.Edit},
+			{sha: commits[destinationCommitIdx].Sha, newAction: todo.Edit},
+		},
 	}).Run()
 	if err != nil {
 		return err

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -127,20 +127,6 @@ func (self *RebaseCommands) InteractiveRebase(commits []*models.Commit, index in
 	}).Run()
 }
 
-func (self *RebaseCommands) InteractiveRebaseBreakAfter(commits []*models.Commit, index int) error {
-	todo, sha, err := self.BuildSingleActionTodo(commits, index-1, "pick")
-	if err != nil {
-		return err
-	}
-
-	todo = append(todo, TodoLine{Action: "break", Commit: nil})
-	return self.PrepareInteractiveRebaseCommand(PrepareInteractiveRebaseCommandOpts{
-		baseShaOrRoot:  sha,
-		todoLines:      todo,
-		overrideEditor: true,
-	}).Run()
-}
-
 func (self *RebaseCommands) EditRebase(branchRef string) error {
 	commands := []TodoLine{{Action: "break"}}
 	return self.PrepareInteractiveRebaseCommand(PrepareInteractiveRebaseCommandOpts{

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -173,7 +173,12 @@ func (self *RebaseCommands) PrepareInteractiveRebaseCommand(opts PrepareInteract
 		debug = "TRUE"
 	}
 
-	cmdStr := fmt.Sprintf("git rebase --interactive --autostash --keep-empty --empty=keep --no-autosquash %s", opts.baseShaOrRoot)
+	rebaseMergesArg := " --rebase-merges"
+	if self.version.IsOlderThan(2, 22, 0) {
+		rebaseMergesArg = ""
+	}
+	cmdStr := fmt.Sprintf("git rebase --interactive --autostash --keep-empty --empty=keep --no-autosquash%s %s",
+		rebaseMergesArg, opts.baseShaOrRoot)
 	self.Log.WithField("command", cmdStr).Debug("RunCommand")
 
 	cmdObj := self.cmd.New(cmdStr)

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -231,25 +231,8 @@ func (self *RebaseCommands) AmendTo(commit *models.Commit) error {
 
 // EditRebaseTodo sets the action for a given rebase commit in the git-rebase-todo file
 func (self *RebaseCommands) EditRebaseTodo(commit *models.Commit, action todo.TodoCommand) error {
-	fileName := filepath.Join(self.dotGitDir, "rebase-merge/git-rebase-todo")
-	todos, err := utils.ReadRebaseTodoFile(fileName)
-	if err != nil {
-		return err
-	}
-
-	for i := range todos {
-		t := &todos[i]
-		// Comparing just the sha is not enough; we need to compare both the
-		// action and the sha, as the sha could appear multiple times (e.g. in a
-		// pick and later in a merge)
-		if t.Command == commit.Action && t.Commit == commit.Sha {
-			t.Command = action
-			return utils.WriteRebaseTodoFile(fileName, todos)
-		}
-	}
-
-	// Should never get here
-	return fmt.Errorf("Todo %s not found in git-rebase-todo", commit.Sha)
+	return utils.EditRebaseTodo(
+		filepath.Join(self.dotGitDir, "rebase-merge/git-rebase-todo"), commit.Sha, commit.Action, action)
 }
 
 // MoveTodoDown moves a rebase todo item down by one position

--- a/pkg/commands/git_commands/rebase_test.go
+++ b/pkg/commands/git_commands/rebase_test.go
@@ -2,6 +2,7 @@ package git_commands
 
 import (
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/go-errors/errors"
@@ -63,7 +64,7 @@ func TestRebaseSkipEditorCommand(t *testing.T) {
 			`^EDITOR=.*$`,
 			`^GIT_EDITOR=.*$`,
 			`^GIT_SEQUENCE_EDITOR=.*$`,
-			"^" + daemon.DaemonKindEnvKey + "=" + string(daemon.ExitImmediately) + "$",
+			"^" + daemon.DaemonKindEnvKey + "=" + strconv.Itoa(int(daemon.DaemonKindExitImmediately)) + "$",
 		} {
 			regexStr := regexStr
 			foundMatch := lo.ContainsBy(envVars, func(envVar string) bool {

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -169,7 +169,7 @@ func (self *LocalCommitsController) squashDown(commit *models.Commit) error {
 		HandleConfirm: func() error {
 			return self.c.WithWaitingStatus(self.c.Tr.SquashingStatus, func() error {
 				self.c.LogAction(self.c.Tr.Actions.SquashCommitDown)
-				return self.interactiveRebase("squash")
+				return self.interactiveRebase(todo.Squash)
 			})
 		},
 	})
@@ -194,7 +194,7 @@ func (self *LocalCommitsController) fixup(commit *models.Commit) error {
 		HandleConfirm: func() error {
 			return self.c.WithWaitingStatus(self.c.Tr.FixingStatus, func() error {
 				self.c.LogAction(self.c.Tr.Actions.FixupCommit)
-				return self.interactiveRebase("fixup")
+				return self.interactiveRebase(todo.Fixup)
 			})
 		},
 	})
@@ -284,7 +284,7 @@ func (self *LocalCommitsController) drop(commit *models.Commit) error {
 		HandleConfirm: func() error {
 			return self.c.WithWaitingStatus(self.c.Tr.DeletingStatus, func() error {
 				self.c.LogAction(self.c.Tr.Actions.DropCommit)
-				return self.interactiveRebase("drop")
+				return self.interactiveRebase(todo.Drop)
 			})
 		},
 	})
@@ -320,7 +320,7 @@ func (self *LocalCommitsController) pick(commit *models.Commit) error {
 	return self.pullFiles()
 }
 
-func (self *LocalCommitsController) interactiveRebase(action string) error {
+func (self *LocalCommitsController) interactiveRebase(action todo.TodoCommand) error {
 	err := self.git.Rebase.InteractiveRebase(self.model.Commits, self.context().GetSelectedLineIdx(), action)
 	return self.helpers.MergeAndRebase.CheckMergeOrRebase(err)
 }

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -466,7 +466,7 @@ func (self *LocalCommitsController) amendTo(commit *models.Commit) error {
 		HandleConfirm: func() error {
 			return self.c.WithWaitingStatus(self.c.Tr.AmendingStatus, func() error {
 				self.c.LogAction(self.c.Tr.Actions.AmendCommit)
-				err := self.git.Rebase.AmendTo(commit)
+				err := self.git.Rebase.AmendTo(self.model.Commits, self.context().GetView().SelectedLineIdx())
 				return self.helpers.MergeAndRebase.CheckMergeOrRebase(err)
 			})
 		},

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -301,7 +301,7 @@ func (self *LocalCommitsController) edit(commit *models.Commit) error {
 
 	return self.c.WithWaitingStatus(self.c.Tr.RebasingStatus, func() error {
 		self.c.LogAction(self.c.Tr.Actions.EditCommit)
-		err := self.git.Rebase.InteractiveRebaseBreakAfter(self.model.Commits, self.context().GetSelectedLineIdx())
+		err := self.git.Rebase.EditRebase(commit.Sha)
 		return self.helpers.MergeAndRebase.CheckMergeOrRebase(err)
 	})
 }

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -440,7 +440,7 @@ func (self *LocalCommitsController) moveUp(commit *models.Commit) error {
 
 	return self.c.WithWaitingStatus(self.c.Tr.MovingStatus, func() error {
 		self.c.LogAction(self.c.Tr.Actions.MoveCommitUp)
-		err := self.git.Rebase.MoveCommitDown(self.model.Commits, index-1)
+		err := self.git.Rebase.MoveCommitUp(self.model.Commits, index)
 		if err == nil {
 			self.context().MoveSelectedLine(-1)
 		}

--- a/pkg/integration/tests/interactive_rebase/amend_fixup_commit.go
+++ b/pkg/integration/tests/interactive_rebase/amend_fixup_commit.go
@@ -1,0 +1,50 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var AmendFixupCommit = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Amends a staged file to a fixup commit, and checks that other unrelated fixup commits are not auto-squashed.",
+	ExtraCmdArgs: "",
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			CreateNCommits(1).
+			CreateFileAndAdd("first-fixup-file", "").Commit("fixup! commit 01").
+			CreateNCommitsStartingAt(2, 2).
+			CreateFileAndAdd("unrelated-fixup-file", "fixup 03").Commit("fixup! commit 03").
+			CreateFileAndAdd("fixup-file", "fixup 01")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("fixup! commit 03"),
+				Contains("commit 03"),
+				Contains("commit 02"),
+				Contains("fixup! commit 01"),
+				Contains("commit 01"),
+			).
+			NavigateToLine(Contains("fixup! commit 01")).
+			Press(keys.Commits.AmendToCommit).
+			Tap(func() {
+				t.ExpectPopup().Confirmation().
+					Title(Equals("Amend Commit")).
+					Content(Contains("Are you sure you want to amend this commit with your staged files?")).
+					Confirm()
+			}).
+			Lines(
+				Contains("fixup! commit 03"),
+				Contains("commit 03"),
+				Contains("commit 02"),
+				Contains("fixup! commit 01").IsSelected(),
+				Contains("commit 01"),
+			)
+
+		t.Views().Main().
+			Content(Contains("fixup 01"))
+	},
+})

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
@@ -30,17 +30,8 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit 02"),
 				Contains("commit 01"),
 			).
-			// Once "e" is fixed we can just hit "e", but for now we need to
-			// manually do a command-line rebase
-			// NavigateToLine(Contains("commit 01")).
-			// Press(keys.Universal.Edit).
-			Tap(func() {
-				t.GlobalPress(keys.Universal.ExecuteCustomCommand)
-				t.ExpectPopup().Prompt().
-					Title(Equals("Custom Command:")).
-					Type(`git -c core.editor="perl -i -lpe 'print \"break\" if $.==1'" rebase -i HEAD~5`).
-					Confirm()
-			}).
+			NavigateToLine(Contains("commit 01")).
+			Press(keys.Universal.Edit).
 			Focus().
 			Lines(
 				Contains("pick").Contains("(*) commit 06"),

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -85,6 +85,7 @@ var tests = []*components.IntegrationTest{
 	filter_by_path.TypeFile,
 	interactive_rebase.AdvancedInteractiveRebase,
 	interactive_rebase.AmendFirstCommit,
+	interactive_rebase.AmendFixupCommit,
 	interactive_rebase.AmendHeadCommitDuringRebase,
 	interactive_rebase.AmendMerge,
 	interactive_rebase.AmendNonHeadCommitDuringRebase,

--- a/pkg/utils/rebase_todo.go
+++ b/pkg/utils/rebase_todo.go
@@ -63,6 +63,16 @@ func WriteRebaseTodoFile(fileName string, todos []todo.Todo) error {
 	return err
 }
 
+func PrependStrToTodoFile(filePath string, linesToPrepend []byte) error {
+	existingContent, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	linesToPrepend = append(linesToPrepend, existingContent...)
+	return os.WriteFile(filePath, linesToPrepend, 0o644)
+}
+
 func MoveTodoDown(fileName string, sha string, action todo.TodoCommand) error {
 	todos, err := ReadRebaseTodoFile(fileName)
 	if err != nil {

--- a/pkg/utils/rebase_todo_test.go
+++ b/pkg/utils/rebase_todo_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/fsmiamoto/git-todo-parser/todo"
@@ -226,5 +227,112 @@ func TestRebaseCommands_moveTodoUp(t *testing.T) {
 			assert.Equal(t, s.expectedTodos, rearrangedTodos)
 		},
 		)
+	}
+}
+
+func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
+	scenarios := []struct {
+		name          string
+		todos         []todo.Todo
+		originalSha   string
+		fixupSha      string
+		expectedTodos []todo.Todo
+		expectedErr   error
+	}{
+		{
+			name: "fixup commit is the last commit",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "original"},
+				{Command: todo.Pick, Commit: "fixup"},
+			},
+			originalSha: "original",
+			fixupSha:    "fixup",
+			expectedTodos: []todo.Todo{
+				{Command: todo.Pick, Commit: "original"},
+				{Command: todo.Fixup, Commit: "fixup"},
+			},
+			expectedErr: nil,
+		},
+		{
+			// TODO: is this something we actually want to support?
+			name: "fixup commit is separated from original commit",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "original"},
+				{Command: todo.Pick, Commit: "other"},
+				{Command: todo.Pick, Commit: "fixup"},
+			},
+			originalSha: "original",
+			fixupSha:    "fixup",
+			expectedTodos: []todo.Todo{
+				{Command: todo.Pick, Commit: "original"},
+				{Command: todo.Fixup, Commit: "fixup"},
+				{Command: todo.Pick, Commit: "other"},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "More original SHAs than expected",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "original"},
+				{Command: todo.Pick, Commit: "original"},
+				{Command: todo.Pick, Commit: "fixup"},
+			},
+			originalSha:   "original",
+			fixupSha:      "fixup",
+			expectedTodos: nil,
+			expectedErr:   errors.New("Expected exactly one original SHA, found 2"),
+		},
+		{
+			name: "More fixup SHAs than expected",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "original"},
+				{Command: todo.Pick, Commit: "fixup"},
+				{Command: todo.Pick, Commit: "fixup"},
+			},
+			originalSha:   "original",
+			fixupSha:      "fixup",
+			expectedTodos: nil,
+			expectedErr:   errors.New("Expected exactly one fixup SHA, found 2"),
+		},
+		{
+			name: "No fixup SHAs found",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "original"},
+			},
+			originalSha:   "original",
+			fixupSha:      "fixup",
+			expectedTodos: nil,
+			expectedErr:   errors.New("Expected exactly one fixup SHA, found 0"),
+		},
+		{
+			name: "No original SHAs found",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "fixup"},
+			},
+			originalSha:   "original",
+			fixupSha:      "fixup",
+			expectedTodos: nil,
+			expectedErr:   errors.New("Expected exactly one original SHA, found 0"),
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			actualTodos, actualErr := moveFixupCommitDown(scenario.todos, scenario.originalSha, scenario.fixupSha)
+
+			if scenario.expectedErr == nil {
+				if !assert.NoError(t, actualErr) {
+					t.Errorf("Expected no error, got: %v", actualErr)
+				}
+			} else {
+				if !assert.EqualError(t, actualErr, scenario.expectedErr.Error()) {
+					t.Errorf("Expected err: %v, got: %v", scenario.expectedErr, actualErr)
+				}
+			}
+
+			if !assert.EqualValues(t, actualTodos, scenario.expectedTodos) {
+				t.Errorf("Expected todos: %v, got: %v", scenario.expectedTodos, actualTodos)
+			}
+		})
 	}
 }

--- a/vendor/github.com/fsmiamoto/git-todo-parser/todo/parse.go
+++ b/vendor/github.com/fsmiamoto/git-todo-parser/todo/parse.go
@@ -56,9 +56,11 @@ func parseLine(line string) (Todo, error) {
 
 	fields := strings.Fields(line)
 
+	var commandLen int
 	for i := Pick; i < Comment; i++ {
 		if isCommand(i, fields[0]) {
 			todo.Command = i
+			commandLen = len(fields[0])
 			fields = fields[1:]
 			break
 		}
@@ -74,10 +76,14 @@ func parseLine(line string) (Todo, error) {
 	}
 
 	if todo.Command == Label || todo.Command == Reset {
-		if len(fields) == 0 {
+		restOfLine := strings.TrimSpace(line[commandLen:])
+		if todo.Command == Reset && restOfLine == "[new root]" {
+			todo.Label = restOfLine
+		} else if len(fields) == 0 {
 			return todo, ErrMissingLabel
+		} else {
+			todo.Label = fields[0]
 		}
-		todo.Label = fields[0]
 		return todo, nil
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -30,7 +30,7 @@ github.com/emirpasic/gods/utils
 # github.com/fatih/color v1.9.0
 ## explicit; go 1.13
 github.com/fatih/color
-# github.com/fsmiamoto/git-todo-parser v0.0.4-0.20230403011024-617a5a7ce980
+# github.com/fsmiamoto/git-todo-parser v0.0.4
 ## explicit; go 1.13
 github.com/fsmiamoto/git-todo-parser/todo
 # github.com/fsnotify/fsnotify v1.4.7


### PR DESCRIPTION
- **PR Description**

If the user has `rebase.updateRefs` in their git config, working with stacked branches behaves as expected now. For example, pressing "e" or "d" in a lower branch now preserves the stack.

Fixes most of #2527.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
