### PR TITLE
Revert "feat: support for `push --force-if-includes`"

### DIFF
--- a/pkg/commands/git_commands/deps_test.go
+++ b/pkg/commands/git_commands/deps_test.go
@@ -15,7 +15,6 @@ import (
 type commonDeps struct {
 	runner     *oscommands.FakeCmdObjRunner
 	userConfig *config.UserConfig
-	gitVersion *GitVersion
 	gitConfig  *git_config.FakeGitConfig
 	getenv     func(string) string
 	removeFile func(string) error
@@ -47,11 +46,6 @@ func buildGitCommon(deps commonDeps) *GitCommon {
 	gitCommon.Common.UserConfig = deps.userConfig
 	if gitCommon.Common.UserConfig == nil {
 		gitCommon.Common.UserConfig = config.GetDefaultConfig()
-	}
-
-	gitCommon.version = deps.gitVersion
-	if gitCommon.version == nil {
-		gitCommon.version = &GitVersion{2, 0, 0, ""}
 	}
 
 	gitConfig := deps.gitConfig

--- a/pkg/commands/git_commands/sync.go
+++ b/pkg/commands/git_commands/sync.go
@@ -29,11 +29,7 @@ func (self *SyncCommands) PushCmdObj(opts PushOpts) (oscommands.ICmdObj, error) 
 	cmdStr := "git push"
 
 	if opts.Force {
-		if self.version.IsOlderThan(2, 30, 0) {
-			cmdStr += " --force-with-lease"
-		} else {
-			cmdStr += " --force-with-lease --force-if-includes"
-		}
+		cmdStr += " --force-with-lease"
 	}
 
 	if opts.SetUpstream {

--- a/pkg/commands/git_commands/sync_test.go
+++ b/pkg/commands/git_commands/sync_test.go
@@ -10,7 +10,6 @@ import (
 func TestSyncPush(t *testing.T) {
 	type scenario struct {
 		testName string
-		version  *GitVersion
 		opts     PushOpts
 		test     func(oscommands.ICmdObj, error)
 	}
@@ -18,7 +17,6 @@ func TestSyncPush(t *testing.T) {
 	scenarios := []scenario{
 		{
 			testName: "Push with force disabled",
-			version:  &GitVersion{2, 29, 3, ""},
 			opts:     PushOpts{Force: false},
 			test: func(cmdObj oscommands.ICmdObj, err error) {
 				assert.Equal(t, cmdObj.ToString(), "git push")
@@ -27,7 +25,6 @@ func TestSyncPush(t *testing.T) {
 		},
 		{
 			testName: "Push with force enabled",
-			version:  &GitVersion{2, 29, 3, ""},
 			opts:     PushOpts{Force: true},
 			test: func(cmdObj oscommands.ICmdObj, err error) {
 				assert.Equal(t, cmdObj.ToString(), "git push --force-with-lease")
@@ -35,17 +32,7 @@ func TestSyncPush(t *testing.T) {
 			},
 		},
 		{
-			testName: "Push with force enabled (>= 2.30.0)",
-			version:  &GitVersion{2, 30, 0, ""},
-			opts:     PushOpts{Force: true},
-			test: func(cmdObj oscommands.ICmdObj, err error) {
-				assert.Equal(t, cmdObj.ToString(), "git push --force-with-lease --force-if-includes")
-				assert.NoError(t, err)
-			},
-		},
-		{
 			testName: "Push with force disabled, upstream supplied",
-			version:  &GitVersion{2, 29, 3, ""},
 			opts: PushOpts{
 				Force:          false,
 				UpstreamRemote: "origin",
@@ -58,7 +45,6 @@ func TestSyncPush(t *testing.T) {
 		},
 		{
 			testName: "Push with force disabled, setting upstream",
-			version:  &GitVersion{2, 29, 3, ""},
 			opts: PushOpts{
 				Force:          false,
 				UpstreamRemote: "origin",
@@ -72,7 +58,6 @@ func TestSyncPush(t *testing.T) {
 		},
 		{
 			testName: "Push with force enabled, setting upstream",
-			version:  &GitVersion{2, 29, 3, ""},
 			opts: PushOpts{
 				Force:          true,
 				UpstreamRemote: "origin",
@@ -85,22 +70,7 @@ func TestSyncPush(t *testing.T) {
 			},
 		},
 		{
-			testName: "Push with force enabled, setting upstream (>= 2.30.0)",
-			version:  &GitVersion{2, 30, 0, ""},
-			opts: PushOpts{
-				Force:          true,
-				UpstreamRemote: "origin",
-				UpstreamBranch: "master",
-				SetUpstream:    true,
-			},
-			test: func(cmdObj oscommands.ICmdObj, err error) {
-				assert.Equal(t, cmdObj.ToString(), `git push --force-with-lease --force-if-includes --set-upstream "origin" "master"`)
-				assert.NoError(t, err)
-			},
-		},
-		{
 			testName: "Push with remote branch but no origin",
-			version:  &GitVersion{2, 29, 3, ""},
 			opts: PushOpts{
 				Force:          true,
 				UpstreamRemote: "",
@@ -117,7 +87,7 @@ func TestSyncPush(t *testing.T) {
 	for _, s := range scenarios {
 		s := s
 		t.Run(s.testName, func(t *testing.T) {
-			instance := buildSyncCommands(commonDeps{gitVersion: s.version})
+			instance := buildSyncCommands(commonDeps{})
 			s.test(instance.PushCmdObj(s.opts))
 		})
 	}


### PR DESCRIPTION
- **PR Description**

revert e00f248cf72785429e2bafc4bcd7bf39528163a5 (#2333)

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
