### PR TITLE
Allow resetting author during rebase

### DIFF
--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -79,7 +79,7 @@ func (self *RebaseCommands) SetCommitAuthor(commits []*models.Commit, index int,
 }
 
 func (self *RebaseCommands) GenericAmend(commits []*models.Commit, index int, f func() error) error {
-	if index == 0 {
+	if models.IsHeadCommit(commits, index) {
 		// we've selected the top commit so no rebase is required
 		return f()
 	}

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -474,6 +474,10 @@ func (self *LocalCommitsController) amendTo(commit *models.Commit) error {
 }
 
 func (self *LocalCommitsController) amendAttribute(commit *models.Commit) error {
+	if self.git.Status.WorkingTreeState() != enums.REBASE_MODE_NONE && !self.isHeadCommit() {
+		return self.c.ErrorMsg(self.c.Tr.AlreadyRebasing)
+	}
+
 	return self.c.Menu(types.CreateMenuOptions{
 		Title: "Amend commit attribute",
 		Items: []*types.MenuItem{


### PR DESCRIPTION
- **PR Description**

Allow resetting the author of the HEAD commit while in a rebase, and disallow resetting the author for any other commit during a rebase.

We somehow missed that in #2485.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
