### PR TITLE
feat: added a possibility to copy commit's summary to a clipboard

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -64,6 +64,7 @@ gui:
   splitDiff: 'auto' # one of 'auto' | 'always'
   skipRewordInEditorWarning: false # for skipping the confirmation before launching the reword editor
   border: 'single' # one of 'single' | 'double' | 'rounded' | 'hidden'
+  commitSummaryFormat: 'SHA: %H%nDate: %aD%nAuthor: %aN <%aE>%n%n%B' # for copying into clipboard a summary of a commit
 git:
   paging:
     colorArg: always
@@ -344,6 +345,15 @@ The available attributes are:
 - default
 - reverse # useful for high-contrast
 - underline
+
+## Commit summary format for copying into clipboard
+
+Copying commit's summary to a clipboard invokes the following git command under the hood:
+```
+git show --no-patch --format=<format> <SHA>
+```
+For all possible values `<format>` might be, please refere to the [manual](https://git-scm.com/docs/git-show#_pretty_formats).
+
 
 ## Highlighting the selected line
 

--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -124,6 +124,19 @@ func (self *CommitCommands) GetCommitAuthor(commitSha string) (Author, error) {
 	return author, err
 }
 
+func (self *CommitCommands) GetCommitSummary(commitSha string, summaryFormat string) (string, error) {
+	//this relies on the logic described in https://git-scm.com/docs/git-show#Documentation/git-show.txt---formatltformatgt
+	//'When <format> is none of the above, and has %placeholder in it, it acts as if --pretty=tformat:<format> were given'
+	//in other words it's possible to pass not only a format string with %placeholder, but also pre-defined
+	//'oneline', 'short', 'medium', 'full', etc.
+	cmdStr := fmt.Sprintf("git show --no-patch --format=%s %s", self.cmd.Quote(summaryFormat), commitSha)
+
+	var output string
+	output, err := self.cmd.New(cmdStr).DontLog().RunWithOutput()
+	output = strings.TrimSpace(output)
+	return output, err
+}
+
 func (self *CommitCommands) GetCommitMessageFirstLine(sha string) (string, error) {
 	return self.GetCommitMessagesFirstLine([]string{sha})
 }

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -53,6 +53,7 @@ type GuiConfig struct {
 	SkipRewordInEditorWarning bool               `yaml:"skipRewordInEditorWarning"`
 	WindowSize                string             `yaml:"windowSize"`
 	Border                    string             `yaml:"border"`
+	CommitSummaryFormat       string             `yaml:"commitSummaryFormat"`
 }
 
 type ThemeConfig struct {
@@ -420,6 +421,7 @@ func GetDefaultConfig() *UserConfig {
 			SplitDiff:                 "auto",
 			SkipRewordInEditorWarning: false,
 			Border:                    "single",
+			CommitSummaryFormat:       "SHA: %H%nDate: %aD%nAuthor: %aN <%aE>%n%n%B",
 		},
 		Git: GitConfig{
 			Paging: PagingConfig{

--- a/pkg/gui/controllers/basic_commits_controller.go
+++ b/pkg/gui/controllers/basic_commits_controller.go
@@ -135,6 +135,13 @@ func (self *BasicCommitsController) copyCommitAttribute(commit *models.Commit) e
 				},
 				Key: 'a',
 			},
+			{
+				Label: self.c.Tr.LcCommitSummary,
+				OnPress: func() error {
+					return self.copySummaryToClipboard(commit)
+				},
+				Key: 'S',
+			},
 		},
 	})
 }
@@ -189,6 +196,21 @@ func (self *BasicCommitsController) copyAuthorToClipboard(commit *models.Commit)
 
 	self.c.LogAction(self.c.Tr.Actions.CopyCommitAuthorToClipboard)
 	if err := self.os.CopyToClipboard(formattedAuthor); err != nil {
+		return self.c.Error(err)
+	}
+
+	self.c.Toast(self.c.Tr.CommitAuthorCopiedToClipboard)
+	return nil
+}
+
+func (self *BasicCommitsController) copySummaryToClipboard(commit *models.Commit) error {
+	summary, err := self.git.Commit.GetCommitSummary(commit.Sha, self.c.UserConfig.Gui.CommitSummaryFormat)
+	if err != nil {
+		return self.c.Error(err)
+	}
+
+	self.c.LogAction(self.c.Tr.Actions.CopyCommitSummaryToClipboard)
+	if err := self.os.CopyToClipboard(summary); err != nil {
 		return self.c.Error(err)
 	}
 

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -411,6 +411,7 @@ type TranslationSet struct {
 	LcCopyCommitMessageToClipboard      string
 	LcCommitMessage                     string
 	LcCommitAuthor                      string
+	LcCommitSummary                     string
 	LcCopyCommitAttributeToClipboard    string
 	LcCopyBranchNameToClipboard         string
 	LcCopyFileNameToClipboard           string
@@ -469,6 +470,7 @@ type TranslationSet struct {
 	CommitURLCopiedToClipboard          string
 	CommitMessageCopiedToClipboard      string
 	CommitAuthorCopiedToClipboard       string
+	CommitSummaryCopiedToClipboard      string
 	PatchCopiedToClipboard              string
 	LcCopiedToClipboard                 string
 	ErrCannotEditDirectory              string
@@ -572,6 +574,7 @@ type Actions struct {
 	CopyCommitSHAToClipboard          string
 	CopyCommitURLToClipboard          string
 	CopyCommitAuthorToClipboard       string
+	CopyCommitSummaryToClipboard      string
 	CopyCommitAttributeToClipboard    string
 	CopyPatchToClipboard              string
 	CustomCommand                     string
@@ -1083,6 +1086,7 @@ func EnglishTranslationSet() TranslationSet {
 		LcCopyCommitMessageToClipboard:      "copy commit message to clipboard",
 		LcCommitMessage:                     "commit message",
 		LcCommitAuthor:                      "commit author",
+		LcCommitSummary:                     "commit summary",
 		LcCopyCommitAttributeToClipboard:    "copy commit attribute",
 		LcCopyBranchNameToClipboard:         "copy branch name to clipboard",
 		LcCopyFileNameToClipboard:           "copy the file name to the clipboard",
@@ -1140,6 +1144,7 @@ func EnglishTranslationSet() TranslationSet {
 		CommitURLCopiedToClipboard:          "Commit URL copied to clipboard",
 		CommitMessageCopiedToClipboard:      "Commit message copied to clipboard",
 		CommitAuthorCopiedToClipboard:       "Commit author copied to clipboard",
+		CommitSummaryCopiedToClipboard:      "Commit summary copied to clipboard",
 		PatchCopiedToClipboard:              "Patch copied to clipboard",
 		LcCopiedToClipboard:                 "copied to clipboard",
 		ErrCannotEditDirectory:              "Cannot edit directory: you can only edit individual files",
@@ -1224,6 +1229,7 @@ func EnglishTranslationSet() TranslationSet {
 			CopyCommitSHAToClipboard:          "Copy commit SHA to clipboard",
 			CopyCommitURLToClipboard:          "Copy commit URL to clipboard",
 			CopyCommitAuthorToClipboard:       "Copy commit author to clipboard",
+			CopyCommitSummaryToClipboard:      "Copy summary to clipboard",
 			CopyCommitAttributeToClipboard:    "Copy to clipboard",
 			CopyPatchToClipboard:              "Copy patch to clipboard",
 			MoveCommitUp:                      "Move commit up",


### PR DESCRIPTION
- **PR Description**

This adds another menu option to 'Copy attribute' menu list.
Bound to `S` key, 'Copy summary' menu entry, it would copy the commit's summary formatted according to `gui.commitSummaryFormat` to the clipboard.

supported placeholders:
`{{sha}}`, `{{date}}`, `{{authorName}}`, `{{authorEmail}}`, `{{message}}`, `{{shortSha}}`, `{{name}}`, `{{extraInfo}}`

Default format string:
"SHA: {{sha}}\nDate: {{date}}\nAuthor: {{authorName}} <{{authorEmail}}>\n\n{{message}}"

added documentation for 'copy commit summary to cliboard' functionality


- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc \
