### PR TITLE
Secondary panel scrolling

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -154,6 +154,8 @@ keybinding:
     scrollDownMain-alt1: 'J' # main panel scroll down
     scrollUpMain-alt2: '<c-u>' # main panel scroll up
     scrollDownMain-alt2: '<c-d>' # main panel scroll down
+    scrollUpSecondary:  '<c-h>' # secondary panel scroll up
+    scrollDownSecondary: '<c-l>' # secondary panel scroll down
     executeCustomCommand: ':'
     createRebaseOptionsMenu: 'm'
     pushFiles: 'P'
@@ -446,6 +448,8 @@ keybinding:
     scrollDownMain-alt1: 'E'
     scrollUpMain-alt2: '<c-u>'
     scrollDownMain-alt2: '<c-e>'
+    scrollUpSecondary: '<c-h>'
+    scrollDownSecondary: '<c-l>'
     undo: 'l'
     redo: '<c-r>'
     diffingMenu: 'M'

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -175,6 +175,8 @@ type KeybindingUniversalConfig struct {
 	ScrollDownMainAlt1           string   `yaml:"scrollDownMain-alt1"`
 	ScrollUpMainAlt2             string   `yaml:"scrollUpMain-alt2"`
 	ScrollDownMainAlt2           string   `yaml:"scrollDownMain-alt2"`
+	ScrollUpSecondary            string   `yaml:"scrollUpSecondary"`
+	ScrollDownSecondary          string   `yaml:"scrollDownSecondary"`
 	ExecuteCustomCommand         string   `yaml:"executeCustomCommand"`
 	CreateRebaseOptionsMenu      string   `yaml:"createRebaseOptionsMenu"`
 	Push                         string   `yaml:"pushFiles"` // 'Files' appended for legacy reasons
@@ -301,6 +303,7 @@ type OSConfig struct {
 	// Same as EditAtLine, except that the command needs to wait until the
 	// window is closed.
 	EditAtLineAndWait string `yaml:"editAtLineAndWait,omitempty"`
+
 
 	// Whether the given edit commands use the terminal. Used to decide whether
 	// lazygit needs to suspend to the background before calling the editor.
@@ -503,6 +506,8 @@ func GetDefaultConfig() *UserConfig {
 				ScrollDownMainAlt1:           "J",
 				ScrollUpMainAlt2:             "<c-u>",
 				ScrollDownMainAlt2:           "<c-d>",
+				ScrollUpSecondary:            "<c-h>",
+				ScrollDownSecondary:          "<c-l>",
 				ExecuteCustomCommand:         ":",
 				CreateRebaseOptionsMenu:      "m",
 				Push:                         "P",

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -120,6 +120,16 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 		},
 		{
 			ViewName:    "",
+			Key:         opts.GetKey(opts.Config.Universal.ScrollUpSecondary),
+			Handler:     self.scrollUpSecondary,
+		},
+		{
+			ViewName:    "",
+			Key:         opts.GetKey(opts.Config.Universal.ScrollDownSecondary),
+			Handler:     self.scrollDownSecondary,
+		},
+		{
+			ViewName:    "",
 			Key:         opts.GetKey(opts.Config.Universal.CreateRebaseOptionsMenu),
 			Handler:     self.helpers.MergeAndRebase.CreateRebaseOptionsMenu,
 			Description: self.c.Tr.ViewMergeRebaseOptions,


### PR DESCRIPTION
- **PR Description**
Hello, I spent some time trying to find keybinding option for scrolling secondary window when there are more than one main view window (like with diff or patch building) but couldn't find a way to do it. I have added new options (ScrollUpSecondary/ScrollDownSecondary) to allow the behaviour.

- **Please check if the PR fulfills these requirements**

* [y ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [y] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [na] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [na] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [y ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [y] You've read through your own file changes for silly mistakes etc
