### PR TITLE
Add config gui.experimentalShowBranchHeads

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -57,6 +57,7 @@ gui:
   showFileTree: true # for rendering changes files in a tree format
   showListFooter: true # for seeing the '5 of 20' message in list panels
   showRandomTip: true
+  experimentalShowBranchHeads: false # visualize branch heads with (*) in commits list
   showBottomLine: true # for hiding the bottom information line (unless it has important information to tell you)
   showCommandLog: true
   showIcons: false

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -27,32 +27,33 @@ type RefresherConfig struct {
 }
 
 type GuiConfig struct {
-	AuthorColors              map[string]string  `yaml:"authorColors"`
-	BranchColors              map[string]string  `yaml:"branchColors"`
-	ScrollHeight              int                `yaml:"scrollHeight"`
-	ScrollPastBottom          bool               `yaml:"scrollPastBottom"`
-	MouseEvents               bool               `yaml:"mouseEvents"`
-	SkipUnstageLineWarning    bool               `yaml:"skipUnstageLineWarning"`
-	SkipStashWarning          bool               `yaml:"skipStashWarning"`
-	SidePanelWidth            float64            `yaml:"sidePanelWidth"`
-	ExpandFocusedSidePanel    bool               `yaml:"expandFocusedSidePanel"`
-	MainPanelSplitMode        string             `yaml:"mainPanelSplitMode"`
-	Language                  string             `yaml:"language"`
-	TimeFormat                string             `yaml:"timeFormat"`
-	Theme                     ThemeConfig        `yaml:"theme"`
-	CommitLength              CommitLengthConfig `yaml:"commitLength"`
-	SkipNoStagedFilesWarning  bool               `yaml:"skipNoStagedFilesWarning"`
-	ShowListFooter            bool               `yaml:"showListFooter"`
-	ShowFileTree              bool               `yaml:"showFileTree"`
-	ShowRandomTip             bool               `yaml:"showRandomTip"`
-	ShowCommandLog            bool               `yaml:"showCommandLog"`
-	ShowBottomLine            bool               `yaml:"showBottomLine"`
-	ShowIcons                 bool               `yaml:"showIcons"`
-	CommandLogSize            int                `yaml:"commandLogSize"`
-	SplitDiff                 string             `yaml:"splitDiff"`
-	SkipRewordInEditorWarning bool               `yaml:"skipRewordInEditorWarning"`
-	WindowSize                string             `yaml:"windowSize"`
-	Border                    string             `yaml:"border"`
+	AuthorColors                map[string]string  `yaml:"authorColors"`
+	BranchColors                map[string]string  `yaml:"branchColors"`
+	ScrollHeight                int                `yaml:"scrollHeight"`
+	ScrollPastBottom            bool               `yaml:"scrollPastBottom"`
+	MouseEvents                 bool               `yaml:"mouseEvents"`
+	SkipUnstageLineWarning      bool               `yaml:"skipUnstageLineWarning"`
+	SkipStashWarning            bool               `yaml:"skipStashWarning"`
+	SidePanelWidth              float64            `yaml:"sidePanelWidth"`
+	ExpandFocusedSidePanel      bool               `yaml:"expandFocusedSidePanel"`
+	MainPanelSplitMode          string             `yaml:"mainPanelSplitMode"`
+	Language                    string             `yaml:"language"`
+	TimeFormat                  string             `yaml:"timeFormat"`
+	Theme                       ThemeConfig        `yaml:"theme"`
+	CommitLength                CommitLengthConfig `yaml:"commitLength"`
+	SkipNoStagedFilesWarning    bool               `yaml:"skipNoStagedFilesWarning"`
+	ShowListFooter              bool               `yaml:"showListFooter"`
+	ShowFileTree                bool               `yaml:"showFileTree"`
+	ShowRandomTip               bool               `yaml:"showRandomTip"`
+	ShowCommandLog              bool               `yaml:"showCommandLog"`
+	ShowBottomLine              bool               `yaml:"showBottomLine"`
+	ShowIcons                   bool               `yaml:"showIcons"`
+	ExperimentalShowBranchHeads bool               `yaml:"experimentalShowBranchHeads"`
+	CommandLogSize              int                `yaml:"commandLogSize"`
+	SplitDiff                   string             `yaml:"splitDiff"`
+	SkipRewordInEditorWarning   bool               `yaml:"skipRewordInEditorWarning"`
+	WindowSize                  string             `yaml:"windowSize"`
+	Border                      string             `yaml:"border"`
 }
 
 type ThemeConfig struct {
@@ -408,18 +409,19 @@ func GetDefaultConfig() *UserConfig {
 				UnstagedChangesColor:      []string{"red"},
 				DefaultFgColor:            []string{"default"},
 			},
-			CommitLength:              CommitLengthConfig{Show: true},
-			SkipNoStagedFilesWarning:  false,
-			ShowListFooter:            true,
-			ShowCommandLog:            true,
-			ShowBottomLine:            true,
-			ShowFileTree:              true,
-			ShowRandomTip:             true,
-			ShowIcons:                 false,
-			CommandLogSize:            8,
-			SplitDiff:                 "auto",
-			SkipRewordInEditorWarning: false,
-			Border:                    "single",
+			CommitLength:                CommitLengthConfig{Show: true},
+			SkipNoStagedFilesWarning:    false,
+			ShowListFooter:              true,
+			ShowCommandLog:              true,
+			ShowBottomLine:              true,
+			ShowFileTree:                true,
+			ShowRandomTip:               true,
+			ShowIcons:                   false,
+			ExperimentalShowBranchHeads: false,
+			CommandLogSize:              8,
+			SplitDiff:                   "auto",
+			SkipRewordInEditorWarning:   false,
+			Border:                      "single",
 		},
 		Git: GitConfig{
 			Paging: PagingConfig{

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -277,7 +277,7 @@ func displayCommit(
 	} else {
 		if len(commit.Tags) > 0 {
 			tagString = theme.DiffTerminalColor.SetBold().Sprint(strings.Join(commit.Tags, " ")) + " "
-		} else if commit.ExtraInfo != "" {
+		} else if common.UserConfig.Gui.ExperimentalShowBranchHeads && commit.ExtraInfo != "" {
 			tagString = style.FgMagenta.SetBold().Sprint("(*)") + " "
 		}
 	}

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref_show_branch_heads.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref_show_branch_heads.go
@@ -5,12 +5,14 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
-var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Drops a commit during interactive rebase when there is an update-ref in the git-rebase-todo file",
+var DropTodoCommitWithUpdateRefShowBranchHeads = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Drops a commit during interactive rebase when there is an update-ref in the git-rebase-todo file (with experimentalShowBranchHeads on)",
 	ExtraCmdArgs: "",
 	Skip:         false,
 	GitVersion:   From("2.38.0"),
-	SetupConfig:  func(config *config.AppConfig) {},
+	SetupConfig: func(config *config.AppConfig) {
+		config.UserConfig.Gui.ExperimentalShowBranchHeads = true
+	},
 	SetupRepo: func(shell *Shell) {
 		shell.
 			CreateNCommits(3).
@@ -23,10 +25,10 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 06").IsSelected(),
+				Contains("(*) commit 06").IsSelected(),
 				Contains("commit 05"),
 				Contains("commit 04"),
-				Contains("commit 03"),
+				Contains("(*) commit 03"),
 				Contains("commit 02"),
 				Contains("commit 01"),
 			).
@@ -34,11 +36,11 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Universal.Edit).
 			Focus().
 			Lines(
-				Contains("pick").Contains("commit 06"),
+				Contains("pick").Contains("(*) commit 06"),
 				Contains("pick").Contains("commit 05"),
 				Contains("pick").Contains("commit 04"),
 				Contains("update-ref").Contains("master"),
-				Contains("pick").Contains("commit 03"),
+				Contains("pick").Contains("(*) commit 03"),
 				Contains("pick").Contains("commit 02"),
 				Contains("<-- YOU ARE HERE --- commit 01"),
 			).
@@ -50,9 +52,9 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			IsFocused().
 			Lines(
-				Contains("commit 06"),
+				Contains("(*) commit 06"),
 				Contains("commit 04"),
-				Contains("commit 03"),
+				Contains("(*) commit 03"),
 				Contains("commit 02"),
 				Contains("commit 01"),
 			)

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -93,6 +93,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.AmendMerge,
 	interactive_rebase.AmendNonHeadCommitDuringRebase,
 	interactive_rebase.DropTodoCommitWithUpdateRef,
+	interactive_rebase.DropTodoCommitWithUpdateRefShowBranchHeads,
 	interactive_rebase.EditFirstCommit,
 	interactive_rebase.EditNonTodoCommitDuringRebase,
 	interactive_rebase.FixupFirstCommit,


### PR DESCRIPTION
People find the new (*) display for branch heads in the commits list confusing, so make it opt-in for now.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
