### PR TITLE
fix(icons): replace deprecated nerd-fonts icons

### DIFF
--- a/pkg/gui/presentation/icons/file_icons.go
+++ b/pkg/gui/presentation/icons/file_icons.go
@@ -89,13 +89,13 @@ var extIconMap = map[string]string{
 	".cp":             "\ue61d", // 
 	".cpio":           "\uf410", // 
 	".cpp":            "\ue61d", // 
-	".cs":             "\uf81a", // 
+	".cs":             "\udb80\udf1b", // 
 	".csh":            "\uf489", // 
 	".cshtml":         "\uf1fa", // 
-	".csproj":         "\uf81a", // 
+	".csproj":         "\udb80\udf1b", // 
 	".css":            "\ue749", // 
 	".csv":            "\uf1c3", // 
-	".csx":            "\uf81a", // 
+	".csx":            "\udb80\udf1b", // 
 	".cxx":            "\ue61d", // 
 	".d":              "\ue7af", // 
 	".dart":           "\ue798", // 
@@ -184,7 +184,7 @@ var extIconMap = map[string]string{
 	".latex":          "\uf034", // 
 	".less":           "\ue758", // 
 	".lhs":            "\ue777", // 
-	".license":        "\uf718", // 
+	".license":        "\udb80\ude19", // 
 	".localized":      "\uf179", // 
 	".lock":           "\uf023", // 
 	".log":            "\uf18d", // 
@@ -210,7 +210,7 @@ var extIconMap = map[string]string{
 	".msi":            "\ue70f", // 
 	".mustache":       "\ue60f", // 
 	".nix":            "\uf313", // 
-	".node":           "\uf898", // 
+	".node":           "\udb80\udf99", // 󰎙
 	".npmignore":      "\ue71e", // 
 	".odp":            "\uf1c4", // 
 	".ods":            "\uf1c3", // 
@@ -251,7 +251,7 @@ var extIconMap = map[string]string{
 	".rspec_parallel": "\ue21e", // 
 	".rspec_status":   "\ue21e", // 
 	".rss":            "\uf09e", // 
-	".rtf":            "\uf718", // 
+	".rtf":            "\udb80\ude19", // 󰈙
 	".ru":             "\ue21e", // 
 	".rubydoc":        "\ue73b", // 
 	".sass":           "\ue603", // 
@@ -290,7 +290,7 @@ var extIconMap = map[string]string{
 	".tzo":            "\uf410", // 
 	".video":          "\uf03d", // 
 	".vim":            "\ue62b", // 
-	".vue":            "\ufd42", // ﵂
+	".vue":            "\udb82\udc44", // 󰡄
 	".war":            "\ue256", // 
 	".wav":            "\uf001", // 
 	".webm":           "\uf03d", // 

--- a/pkg/gui/presentation/icons/git_icons.go
+++ b/pkg/gui/presentation/icons/git_icons.go
@@ -7,12 +7,12 @@ import (
 )
 
 const (
-	BRANCH_ICON         = "\ufb2b" // שׂ
+	BRANCH_ICON         = "\udb81\ude2c" // 󰘬
 	DETACHED_HEAD_ICON  = "\ue729" // 
 	TAG_ICON            = "\uf02b" // 
-	COMMIT_ICON         = "\ufc16" // ﰖ
-	MERGE_COMMIT_ICON   = "\ufb2c" // שּׁ
-	DEFAULT_REMOTE_ICON = "\uf7a1" // 
+	COMMIT_ICON         = "\udb81\udf18" // 󰜘
+	MERGE_COMMIT_ICON   = "\udb81\ude2d" // 󰘭
+	DEFAULT_REMOTE_ICON = "\udb80\udea2" // 󰊢
 	STASH_ICON          = "\uf01c" // 
 )
 
@@ -25,7 +25,7 @@ var remoteIcons = []remoteIcon{
 	{domain: "github.com", icon: "\ue709"},    // 
 	{domain: "bitbucket.org", icon: "\ue703"}, // 
 	{domain: "gitlab.com", icon: "\uf296"},    // 
-	{domain: "dev.azure.com", icon: "\ufd03"}, // ﴃ
+	{domain: "dev.azure.com", icon: "\uebd8"}, // 
 }
 
 func IconForBranch(branch *models.Branch) string {


### PR DESCRIPTION
- **PR Description**
Replace deprecated nerd-fonts icons from v3 on.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
