### PR TITLE
Only use --empty=keep option with git versions that support it

### DIFF
--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -181,12 +181,18 @@ func (self *RebaseCommands) PrepareInteractiveRebaseCommand(opts PrepareInteract
 		debug = "TRUE"
 	}
 
+	emptyArg := " --empty=keep"
+	if self.version.IsOlderThan(2, 26, 0) {
+		emptyArg = ""
+	}
+
 	rebaseMergesArg := " --rebase-merges"
 	if self.version.IsOlderThan(2, 22, 0) {
 		rebaseMergesArg = ""
 	}
-	cmdStr := fmt.Sprintf("git rebase --interactive --autostash --keep-empty --empty=keep --no-autosquash%s %s",
-		rebaseMergesArg, opts.baseShaOrRoot)
+
+	cmdStr := fmt.Sprintf("git rebase --interactive --autostash --keep-empty%s --no-autosquash%s %s",
+		emptyArg, rebaseMergesArg, opts.baseShaOrRoot)
 	self.Log.WithField("command", cmdStr).Debug("RunCommand")
 
 	cmdObj := self.cmd.New(cmdStr)

--- a/pkg/commands/git_commands/rebase_test.go
+++ b/pkg/commands/git_commands/rebase_test.go
@@ -16,29 +16,52 @@ import (
 
 func TestRebaseRebaseBranch(t *testing.T) {
 	type scenario struct {
-		testName string
-		arg      string
-		runner   *oscommands.FakeCmdObjRunner
-		test     func(error)
+		testName   string
+		arg        string
+		gitVersion *GitVersion
+		runner     *oscommands.FakeCmdObjRunner
+		test       func(error)
 	}
 
 	scenarios := []scenario{
 		{
-			testName: "successful rebase",
-			arg:      "master",
+			testName:   "successful rebase",
+			arg:        "master",
+			gitVersion: &GitVersion{2, 26, 0, ""},
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git rebase --interactive --autostash --keep-empty --empty=keep --no-autosquash master`, "", nil),
+				Expect(`git rebase --interactive --autostash --keep-empty --empty=keep --no-autosquash --rebase-merges master`, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
 		},
 		{
-			testName: "unsuccessful rebase",
-			arg:      "master",
+			testName:   "unsuccessful rebase",
+			arg:        "master",
+			gitVersion: &GitVersion{2, 26, 0, ""},
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git rebase --interactive --autostash --keep-empty --empty=keep --no-autosquash master`, "", errors.New("error")),
+				Expect(`git rebase --interactive --autostash --keep-empty --empty=keep --no-autosquash --rebase-merges master`, "", errors.New("error")),
 			test: func(err error) {
 				assert.Error(t, err)
+			},
+		},
+		{
+			testName:   "successful rebase (< 2.26.0)",
+			arg:        "master",
+			gitVersion: &GitVersion{2, 25, 5, ""},
+			runner: oscommands.NewFakeRunner(t).
+				Expect(`git rebase --interactive --autostash --keep-empty --no-autosquash --rebase-merges master`, "", nil),
+			test: func(err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			testName:   "successful rebase (< 2.22.0)",
+			arg:        "master",
+			gitVersion: &GitVersion{2, 21, 9, ""},
+			runner: oscommands.NewFakeRunner(t).
+				Expect(`git rebase --interactive --autostash --keep-empty --no-autosquash master`, "", nil),
+			test: func(err error) {
+				assert.NoError(t, err)
 			},
 		},
 	}
@@ -46,7 +69,7 @@ func TestRebaseRebaseBranch(t *testing.T) {
 	for _, s := range scenarios {
 		s := s
 		t.Run(s.testName, func(t *testing.T) {
-			instance := buildRebaseCommands(commonDeps{runner: s.runner})
+			instance := buildRebaseCommands(commonDeps{runner: s.runner, gitVersion: s.gitVersion})
 			s.test(instance.RebaseBranch(s.arg))
 		})
 	}
@@ -126,7 +149,7 @@ func TestRebaseDiscardOldFileChanges(t *testing.T) {
 			commitIndex: 0,
 			fileName:    "test999.txt",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git rebase --interactive --autostash --keep-empty --empty=keep --no-autosquash abcdef`, "", nil).
+				Expect(`git rebase --interactive --autostash --keep-empty --empty=keep --no-autosquash --rebase-merges abcdef`, "", nil).
 				Expect(`git cat-file -e HEAD^:"test999.txt"`, "", nil).
 				Expect(`git checkout HEAD^ -- "test999.txt"`, "", nil).
 				Expect(`git commit --amend --no-edit --allow-empty`, "", nil).
@@ -143,8 +166,9 @@ func TestRebaseDiscardOldFileChanges(t *testing.T) {
 		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildRebaseCommands(commonDeps{
-				runner:    s.runner,
-				gitConfig: git_config.NewFakeGitConfig(s.gitConfigMockResponses),
+				runner:     s.runner,
+				gitVersion: &GitVersion{2, 26, 0, ""},
+				gitConfig:  git_config.NewFakeGitConfig(s.gitConfigMockResponses),
 			})
 
 			s.test(instance.DiscardOldFileChanges(s.commits, s.commitIndex, s.fileName))

--- a/pkg/integration/components/test.go
+++ b/pkg/integration/components/test.go
@@ -60,7 +60,7 @@ type GitVersionRestriction struct {
 }
 
 // Verifies the version is at least the given version (inclusive)
-func From(version string) GitVersionRestriction {
+func AtLeast(version string) GitVersionRestriction {
 	return GitVersionRestriction{from: version}
 }
 

--- a/pkg/integration/components/test_test.go
+++ b/pkg/integration/components/test_test.go
@@ -96,18 +96,18 @@ func TestGitVersionRestriction(t *testing.T) {
 		expectedShouldRun bool
 	}{
 		{
-			testName:          "From, current is newer",
-			gitVersion:        From("2.24.9"),
+			testName:          "AtLeast, current is newer",
+			gitVersion:        AtLeast("2.24.9"),
 			expectedShouldRun: true,
 		},
 		{
-			testName:          "From, current is same",
-			gitVersion:        From("2.25.0"),
+			testName:          "AtLeast, current is same",
+			gitVersion:        AtLeast("2.25.0"),
 			expectedShouldRun: true,
 		},
 		{
-			testName:          "From, current is older",
-			gitVersion:        From("2.26.0"),
+			testName:          "AtLeast, current is older",
+			gitVersion:        AtLeast("2.26.0"),
 			expectedShouldRun: false,
 		},
 		{

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
@@ -9,7 +9,7 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Drops a commit during interactive rebase when there is an update-ref in the git-rebase-todo file",
 	ExtraCmdArgs: "",
 	Skip:         false,
-	GitVersion:   From("2.38.0"),
+	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref_show_branch_heads.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref_show_branch_heads.go
@@ -9,7 +9,7 @@ var DropTodoCommitWithUpdateRefShowBranchHeads = NewIntegrationTest(NewIntegrati
 	Description:  "Drops a commit during interactive rebase when there is an update-ref in the git-rebase-todo file (with experimentalShowBranchHeads on)",
 	ExtraCmdArgs: "",
 	Skip:         false,
-	GitVersion:   From("2.38.0"),
+	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {
 		config.UserConfig.Gui.ExperimentalShowBranchHeads = true
 	},

--- a/pkg/integration/tests/patch_building/move_to_earlier_commit_no_keep_empty.go
+++ b/pkg/integration/tests/patch_building/move_to_earlier_commit_no_keep_empty.go
@@ -5,11 +5,11 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
-var MoveToEarlierCommit = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Move a patch from a commit to an earlier commit",
+var MoveToEarlierCommitNoKeepEmpty = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Move a patch from a commit to an earlier commit, for older git versions that don't keep the empty commit",
 	ExtraCmdArgs: "",
 	Skip:         false,
-	GitVersion:   AtLeast("2.26.0"),
+	GitVersion:   Before("2.26.0"),
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateDir("dir")
@@ -57,10 +57,10 @@ var MoveToEarlierCommit = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			IsFocused().
 			Lines(
-				Contains("commit to move from"),
-				Contains("destination commit").IsSelected(),
-				Contains("first commit"),
+				Contains("destination commit"),
+				Contains("first commit").IsSelected(),
 			).
+			SelectPreviousItem().
 			PressEnter()
 
 		t.Views().CommitFiles().
@@ -73,17 +73,5 @@ var MoveToEarlierCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("A unrelated-file"),
 			).
 			PressEscape()
-
-		t.Views().Commits().
-			IsFocused().
-			SelectPreviousItem().
-			PressEnter()
-
-		// the original commit has no more files in it
-		t.Views().CommitFiles().
-			IsFocused().
-			Lines(
-				Contains("(none)"),
-			)
 	},
 })

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -117,6 +117,7 @@ var tests = []*components.IntegrationTest{
 	patch_building.ApplyInReverseWithConflict,
 	patch_building.CopyPatchToClipboard,
 	patch_building.MoveToEarlierCommit,
+	patch_building.MoveToEarlierCommitNoKeepEmpty,
 	patch_building.MoveToIndex,
 	patch_building.MoveToIndexPartOfAdjacentAddedLines,
 	patch_building.MoveToIndexPartial,


### PR DESCRIPTION
- **PR Description**

Avoid errors when doing interactive rebases with git versions older than 2.26.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
