### PR TITLE
Include "nvim" and "kakoune" in supported edit presets

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -285,7 +285,7 @@ os:
   editPreset: 'vscode'
 ```
 
-Supported presets are `vim`, `emacs`, `nano`, `vscode`, `sublime`, `bbedit`, and
+Supported presets are `vim`, `nvim`, `emacs`, `nano`, `vscode`, `sublime`, `bbedit`, and
 `xcode`. In many cases lazygit will be able to guess the right preset from your
 $(git config core.editor), or an environment variable such as $VISUAL or $EDITOR.
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -285,9 +285,9 @@ os:
   editPreset: 'vscode'
 ```
 
-Supported presets are `vim`, `nvim`, `emacs`, `nano`, `vscode`, `sublime`, `bbedit`, and
-`xcode`. In many cases lazygit will be able to guess the right preset from your
-$(git config core.editor), or an environment variable such as $VISUAL or $EDITOR.
+Supported presets are `vim`, `nvim`, `emacs`, `nano`, `vscode`, `sublime`, `bbedit`,
+`kakoune` and `xcode`. In many cases lazygit will be able to guess the right preset
+from your $(git config core.editor), or an environment variable such as $VISUAL or $EDITOR.
 
 If for some reason you are not happy with the default commands from a preset, or
 there simply is no preset for your editor, you can customize the commands by

--- a/pkg/config/editor_presets.go
+++ b/pkg/config/editor_presets.go
@@ -35,6 +35,7 @@ type editPreset struct {
 	editInTerminal            bool
 }
 
+// IF YOU ADD A PRESET TO THIS FUNCTION YOU MUST UPDATE THE `Supported presets` SECTION OF docs/Config.md
 func getPreset(osConfig *OSConfig, guessDefaultEditor func() string) *editPreset {
 	presets := map[string]*editPreset{
 		"vi":      standardTerminalEditorPreset("vi"),


### PR DESCRIPTION
- **PR Description**

Include `nvim` and `kakoune` in supported [edit presets](https://github.com/jesseduffield/lazygit/blob/5149b24ab3dfad3860e2300519c7c583dcc8c9ff/pkg/config/editor_presets.go#L42)

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
