### PR TITLE
allow verbose diff in rebase commit editor

### DIFF
--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -191,8 +191,13 @@ func (self *RebaseCommands) PrepareInteractiveRebaseCommand(opts PrepareInteract
 		rebaseMergesArg = ""
 	}
 
-	cmdStr := fmt.Sprintf("git rebase --interactive --autostash --keep-empty%s --no-autosquash%s %s",
-		emptyArg, rebaseMergesArg, opts.baseShaOrRoot)
+	verboseArg := " -c commit.verbose=true"
+	if self.UserConfig.Git.Commit.Verbose != "always" {
+		verboseArg = ""
+	}
+
+	cmdStr := fmt.Sprintf("git%s rebase --interactive --autostash --keep-empty%s --no-autosquash%s %s",
+		verboseArg, emptyArg, rebaseMergesArg, opts.baseShaOrRoot)
 	self.Log.WithField("command", cmdStr).Debug("RunCommand")
 
 	cmdObj := self.cmd.New(cmdStr)

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -235,11 +235,22 @@ func (self *LocalCommitsController) handleReword(message string) error {
 	return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})
 }
 
+func (self *LocalCommitsController) verboseFlag() string {
+	switch self.c.UserConfig.Git.Commit.Verbose {
+	case "always":
+		return " --verbose"
+	case "never":
+		return " --no-verbose"
+	default:
+		return ""
+	}
+}
+
 func (self *LocalCommitsController) doRewordEditor() error {
 	self.c.LogAction(self.c.Tr.Actions.RewordCommit)
 
 	if self.isHeadCommit() {
-		return self.c.RunSubprocessAndRefresh(self.os.Cmd.New("git commit --allow-empty --amend --only"))
+		return self.c.RunSubprocessAndRefresh(self.os.Cmd.New(fmt.Sprintf("git commit --allow-empty --amend --only%s", self.verboseFlag())))
 	}
 
 	subProcess, err := self.git.Rebase.RewordCommitInEditor(


### PR DESCRIPTION
There currently exists a "verbose" flag in the config that a user can enable in order to show the diff when writing a commit message in the editor of their choice. However, I discovered that this isn't the case when you're rewording an existing commit through a rebase.

I find it's much easier to write meaningful commit messages during a rebase if the diff is right there in front of you, so this commit adds the ability for that verbose flag to affect the rebase commit editing as well.

I thought about adding another flag to the config, but figured that was a bit overkill since this is still to do with commit messages.

---

I've copied the `verboseFlag()` method from `CommitCommands` into `LocalCommitsController` as there was no relation between the two (and it's a very useful convenience method). This also means that it can be used in `RebaseCommands` due to their relationship.