### PR TITLE
Update icons to use Nerd Fonts v3.

### DIFF
--- a/pkg/gui/presentation/icons/file_icons.go
+++ b/pkg/gui/presentation/icons/file_icons.go
@@ -89,13 +89,13 @@ var extIconMap = map[string]string{
 	".cp":             "\ue61d", // 
 	".cpio":           "\uf410", // 
 	".cpp":            "\ue61d", // 
-	".cs":             "\uf81a", // 
+	".cs":             "\U000f031b", // 󰌛
 	".csh":            "\uf489", // 
 	".cshtml":         "\uf1fa", // 
-	".csproj":         "\uf81a", // 
+	".csproj":         "\U000f031b", // 󰌛
 	".css":            "\ue749", // 
 	".csv":            "\uf1c3", // 
-	".csx":            "\uf81a", // 
+	".csx":            "\U000f031b", // 󰌛
 	".cxx":            "\ue61d", // 
 	".d":              "\ue7af", // 
 	".dart":           "\ue798", // 
@@ -184,7 +184,7 @@ var extIconMap = map[string]string{
 	".latex":          "\uf034", // 
 	".less":           "\ue758", // 
 	".lhs":            "\ue777", // 
-	".license":        "\uf718", // 
+	".license":        "\U000f0219", // 󰈙
 	".localized":      "\uf179", // 
 	".lock":           "\uf023", // 
 	".log":            "\uf18d", // 
@@ -210,7 +210,7 @@ var extIconMap = map[string]string{
 	".msi":            "\ue70f", // 
 	".mustache":       "\ue60f", // 
 	".nix":            "\uf313", // 
-	".node":           "\uf898", // 
+	".node":           "\U000f0399", // 󰎙
 	".npmignore":      "\ue71e", // 
 	".odp":            "\uf1c4", // 
 	".ods":            "\uf1c3", // 
@@ -251,7 +251,7 @@ var extIconMap = map[string]string{
 	".rspec_parallel": "\ue21e", // 
 	".rspec_status":   "\ue21e", // 
 	".rss":            "\uf09e", // 
-	".rtf":            "\uf718", // 
+	".rtf":            "\U000f0219", // 󰈙
 	".ru":             "\ue21e", // 
 	".rubydoc":        "\ue73b", // 
 	".sass":           "\ue603", // 
@@ -290,7 +290,7 @@ var extIconMap = map[string]string{
 	".tzo":            "\uf410", // 
 	".video":          "\uf03d", // 
 	".vim":            "\ue62b", // 
-	".vue":            "\ufd42", // ﵂
+	".vue":            "\U000f0844", // 󰡄
 	".war":            "\ue256", // 
 	".wav":            "\uf001", // 
 	".webm":           "\uf03d", // 

--- a/pkg/gui/presentation/icons/git_icons.go
+++ b/pkg/gui/presentation/icons/git_icons.go
@@ -7,12 +7,12 @@ import (
 )
 
 const (
-	BRANCH_ICON         = "\ufb2b" // שׂ
+	BRANCH_ICON         = "\U000f062c" // 󰘬
 	DETACHED_HEAD_ICON  = "\ue729" // 
 	TAG_ICON            = "\uf02b" // 
-	COMMIT_ICON         = "\ufc16" // ﰖ
-	MERGE_COMMIT_ICON   = "\ufb2c" // שּׁ
-	DEFAULT_REMOTE_ICON = "\uf7a1" // 
+	COMMIT_ICON         = "\U000f0718" // 󰜘
+	MERGE_COMMIT_ICON   = "\U000f062d" // 󰘭
+	DEFAULT_REMOTE_ICON = "\U000f02a2" // 󰊢
 	STASH_ICON          = "\uf01c" // 
 )
 
@@ -25,7 +25,7 @@ var remoteIcons = []remoteIcon{
 	{domain: "github.com", icon: "\ue709"},    // 
 	{domain: "bitbucket.org", icon: "\ue703"}, // 
 	{domain: "gitlab.com", icon: "\uf296"},    // 
-	{domain: "dev.azure.com", icon: "\ufd03"}, // ﴃ
+	{domain: "dev.azure.com", icon: "\U000f0805"}, // 󰠅
 }
 
 func IconForBranch(branch *models.Branch) string {


### PR DESCRIPTION
- **PR Description**

This updates icons to use Nerd Fonts v3 which had [breaking changes](https://www.nerdfonts.com/releases). I used all the recommendations from [`nerdfix check`](https://github.com/loichyan/nerdfix) except for the Azure icon, which I changed to `nf-md-microsoft_azure`.

Fixes #2603.

Output from nerdfix

```
note: Found obsolete icon U+F81A
   ┌─ ./pkg/gui/presentation/icons/file_icons.go:92:34
   │
92 │     ".cs":             "\uf81a", // 
   │                                     ^ Icon 'nf-mdi-language_csharp' is marked as obsolete
   │
   = You could replace it with:
         1. 󰌛 U+F031B nf-md-language_csharp
         2. 󰙲 U+F0672 nf-md-language_cpp
         3. 󰙱 U+F0671 nf-md-language_c
         4. 󰌜 U+F031C nf-md-language_css3

note: Found obsolete icon U+F81A
   ┌─ ./pkg/gui/presentation/icons/file_icons.go:95:34
   │
95 │     ".csproj":         "\uf81a", // 
   │                                     ^ Icon 'nf-mdi-language_csharp' is marked as obsolete
   │
   = You could replace it with:
         1. 󰌛 U+F031B nf-md-language_csharp
         2. 󰙲 U+F0672 nf-md-language_cpp
         3. 󰙱 U+F0671 nf-md-language_c
         4. 󰌜 U+F031C nf-md-language_css3

note: Found obsolete icon U+F81A
   ┌─ ./pkg/gui/presentation/icons/file_icons.go:98:34
   │
98 │     ".csx":            "\uf81a", // 
   │                                     ^ Icon 'nf-mdi-language_csharp' is marked as obsolete
   │
   = You could replace it with:
         1. 󰌛 U+F031B nf-md-language_csharp
         2. 󰙲 U+F0672 nf-md-language_cpp
         3. 󰙱 U+F0671 nf-md-language_c
         4. 󰌜 U+F031C nf-md-language_css3

note: Found obsolete icon U+F718
    ┌─ ./pkg/gui/presentation/icons/file_icons.go:187:34
    │
187 │     ".license":        "\uf718", // 
    │                                     ^ Icon 'nf-mdi-file_document' is marked as obsolete
    │
    = You could replace it with:
          1. 󰈙 U+F0219 nf-md-file_document
          2. 󰷈 U+F0DC8 nf-md-file_document_edit
          3. 󱪗 U+F1A97 nf-md-file_document_alert
          4. 󱪝 U+F1A9D nf-md-file_document_plus

note: Found obsolete icon U+F898
    ┌─ ./pkg/gui/presentation/icons/file_icons.go:213:34
    │
213 │     ".node":           "\uf898", // 
    │                                     ^ Icon 'nf-mdi-nodejs' is marked as obsolete
    │
    = You could replace it with:
          1. 󰎙 U+F0399 nf-md-nodejs
          2.  U+E719 nf-dev-nodejs
          3. 󰡄 U+F0844 nf-md-vuejs

note: Found obsolete icon U+F718
    ┌─ ./pkg/gui/presentation/icons/file_icons.go:254:34
    │
254 │     ".rtf":            "\uf718", // 
    │                                     ^ Icon 'nf-mdi-file_document' is marked as obsolete
    │
    = You could replace it with:
          1. 󰈙 U+F0219 nf-md-file_document
          2. 󰷈 U+F0DC8 nf-md-file_document_edit
          3. 󱪗 U+F1A97 nf-md-file_document_alert
          4. 󱪝 U+F1A9D nf-md-file_document_plus

note: Found obsolete icon U+FD42
    ┌─ ./pkg/gui/presentation/icons/file_icons.go:293:34
    │
293 │     ".vue":            "\ufd42", // ﵂
    │                                     ^ Icon 'nf-mdi-vuejs' is marked as obsolete
    │
    = You could replace it with:
          1. 󰡄 U+F0844 nf-md-vuejs
          2. 󰎙 U+F0399 nf-md-nodejs

note: Found obsolete icon U+FB2B
   ┌─ ./pkg/gui/presentation/icons/git_icons.go:10:36
   │
10 │     BRANCH_ICON         = "\ufb2b" // שׂ
   │                                       ^ Icon 'nf-mdi-source_branch' is marked as obsolete
   │
   = You could replace it with:
         1. 󰘬 U+F062C nf-md-source_branch
         2. 󱓊 U+F14CA nf-md-source_branch_plus
         3. 󱓎 U+F14CE nf-md-source_branch_sync
         4. 󱓍 U+F14CD nf-md-source_branch_refresh

note: Found obsolete icon U+FC16
   ┌─ ./pkg/gui/presentation/icons/git_icons.go:13:36
   │
13 │     COMMIT_ICON         = "\ufc16" // ﰖ
   │                                       ^ Icon 'nf-mdi-source_commit' is marked as obsolete
   │
   = You could replace it with:
         1. 󰜘 U+F0718 nf-md-source_commit
         2. 󰜝 U+F071D nf-md-source_commit_start
         3. 󰜙 U+F0719 nf-md-source_commit_end
         4. 󰜛 U+F071B nf-md-source_commit_local

note: Found obsolete icon U+FB2C
   ┌─ ./pkg/gui/presentation/icons/git_icons.go:14:36
   │
14 │     MERGE_COMMIT_ICON   = "\ufb2c" // שּׁ
   │                                       ^ Icon 'nf-mdi-source_merge' is marked as obsolete
   │
   = You could replace it with:
         1. 󰘭 U+F062D nf-md-source_merge
         2. 󰽜 U+F0F5C nf-md-merge
         3. 󱓠 U+F14E0 nf-md-set_merge
         4. 󰃸 U+F00F8 nf-md-call_merge

note: Found obsolete icon U+F7A1
   ┌─ ./pkg/gui/presentation/icons/git_icons.go:15:36
   │
15 │     DEFAULT_REMOTE_ICON = "\uf7a1" // 
   │                                       ^ Icon 'nf-mdi-git' is marked as obsolete
   │
   = You could replace it with:
         1. 󰊢 U+F02A2 nf-md-git
         2.  U+E65D nf-seti-git
         3.  U+F1D3 nf-fa-git
         4.  U+E702 nf-dev-git

note: Found obsolete icon U+FD03
   ┌─ ./pkg/gui/presentation/icons/git_icons.go:28:48
   │
28 │     {domain: "dev.azure.com", icon: "\ufd03"}, // ﴃ
   │                                                   ^ Icon 'nf-mdi-azure' is marked as obsolete
   │
   = You could replace it with:
         1.  U+EBD8 nf-cod-azure
         2. 󰎎 U+F038E nf-md-nature
         3. 󰟋 U+F07CB nf-md-gesture
         4. 󰔌 U+F050C nf-md-texture
```

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting)) **No, this file is not formatted by gofumpt and formatting creates a diff on the whole file.**
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide) **No, I found no tests for these files.**
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
