### PR TITLE
Allow the selected line of a list view to be outside the visible area

### DIFF
--- a/pkg/gui/controllers/filtering_menu_action.go
+++ b/pkg/gui/controllers/filtering_menu_action.go
@@ -74,5 +74,6 @@ func (self *FilteringMenuAction) setFiltering(path string) error {
 
 	return self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.COMMITS}, Then: func() {
 		self.c.Contexts().LocalCommits.SetSelectedLineIdx(0)
+		self.c.Contexts().LocalCommits.FocusLine()
 	}})
 }

--- a/pkg/gui/controllers/list_controller.go
+++ b/pkg/gui/controllers/list_controller.go
@@ -54,12 +54,6 @@ func (self *ListController) HandleScrollUp() error {
 	scrollHeight := self.c.UserConfig.Gui.ScrollHeight
 	self.context.GetViewTrait().ScrollUp(scrollHeight)
 
-	// we only need to do a line change if our line has been pushed out of the viewport, because
-	// at the moment much logic depends on the selected line always being visible
-	if !self.isSelectedLineInViewPort() {
-		return self.handleLineChange(-scrollHeight)
-	}
-
 	return nil
 }
 
@@ -67,17 +61,7 @@ func (self *ListController) HandleScrollDown() error {
 	scrollHeight := self.c.UserConfig.Gui.ScrollHeight
 	self.context.GetViewTrait().ScrollDown(scrollHeight)
 
-	if !self.isSelectedLineInViewPort() {
-		return self.handleLineChange(scrollHeight)
-	}
-
 	return nil
-}
-
-func (self *ListController) isSelectedLineInViewPort() bool {
-	selectedLineIdx := self.context.GetList().GetSelectedLineIdx()
-	startIdx, length := self.context.GetViewTrait().ViewPortYBounds()
-	return selectedLineIdx >= startIdx && selectedLineIdx < startIdx+length
 }
 
 func (self *ListController) scrollHorizontal(scrollFunc func()) error {

--- a/pkg/gui/controllers/stash_controller.go
+++ b/pkg/gui/controllers/stash_controller.go
@@ -187,6 +187,7 @@ func (self *StashController) handleRenameStashEntry(stashEntry *models.StashEntr
 				return err
 			}
 			self.context().SetSelectedLineIdx(0) // Select the renamed stash
+			self.context().FocusLine()
 			return nil
 		},
 	})

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -131,8 +131,6 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			continue
 		}
 
-		listContext.FocusLine()
-
 		view.SelBgColor = theme.GocuiSelectedLineBgColor
 
 		// I doubt this is expensive though it's admittedly redundant after the first render

--- a/pkg/integration/tests/filter_by_path/select_file.go
+++ b/pkg/integration/tests/filter_by_path/select_file.go
@@ -18,10 +18,12 @@ var SelectFile = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains(`only filterFile`).IsSelected(),
+				Contains(`none of the two`).IsSelected(),
+				Contains(`only filterFile`),
 				Contains(`only otherFile`),
 				Contains(`both files`),
 			).
+			SelectNextItem().
 			PressEnter()
 
 		// when you click into the commit itself, you see all files from that commit

--- a/pkg/integration/tests/filter_by_path/shared.go
+++ b/pkg/integration/tests/filter_by_path/shared.go
@@ -14,6 +14,8 @@ func commonSetup(shell *Shell) {
 
 	shell.UpdateFileAndAdd("filterFile", "new filterFile content")
 	shell.Commit("only filterFile")
+
+	shell.EmptyCommit("none of the two")
 }
 
 func postFilterTest(t *TestDriver) {


### PR DESCRIPTION
I don't see a reason why this restriction to have the selection be always visible was necessary. Removing it has two benefits:

1. Scrolling a list view doesn't change the selection. A common scenario: you look at one of the commits of your current branch; you want to see the how many'th commit this is, but the beginning of the branch is scrolled off the bottom of the commits panel. You scroll down to find the beginning of your branch, but this changes the selection and shows a different commit now - not what you want.

2. It is possible to scroll a panel that is not the current one without changing the focus to it. That's how windows in other GUIs usually behave.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
