### PR TITLE
Fix to show commitPrefixes in commit message with a new blank commit

### DIFF
--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -160,7 +160,7 @@ func (self *WorkingTreeHelper) HandleWIPCommitPress() error {
 func (self *WorkingTreeHelper) HandleCommitPress() error {
 	message := self.contexts.CommitMessage.GetPreservedMessage()
 
-	if message != "" {
+	if message == "" {
 		commitPrefixConfig := self.commitPrefixConfigForRepo()
 		if commitPrefixConfig != nil {
 			prefixPattern := commitPrefixConfig.Pattern

--- a/pkg/integration/tests/commit/commit_wip_with_prefix.go
+++ b/pkg/integration/tests/commit/commit_wip_with_prefix.go
@@ -1,0 +1,57 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CommitWipWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Commit with skip hook and config commitPrefix is defined. Prefix is ignored when creating WIP commits.",
+	ExtraCmdArgs: "",
+	Skip:         false,
+	SetupConfig: func(testConfig *config.AppConfig) {
+		testConfig.UserConfig.Git.CommitPrefixes = map[string]config.CommitPrefixConfig{"repo": {Pattern: "^\\w+\\/(\\w+-\\w+).*", Replace: "[$1]: "}}
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.NewBranch("feature/TEST-002")
+		shell.CreateFile("test-wip-commit-prefix", "This is foo bar")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			IsEmpty()
+
+		t.Views().Files().
+			IsFocused().
+			PressPrimaryAction().
+			Press(keys.Files.CommitChangesWithoutHook)
+
+		t.ExpectPopup().CommitMessagePanel().
+			Title(Equals("Commit summary")).
+			InitialText(Equals("WIP")).
+			Type(" foo").
+			Cancel()
+
+		t.Views().Files().
+			IsFocused().
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			Title(Equals("Commit summary")).
+			InitialText(Equals("WIP foo")).
+			Type(" bar").
+			Cancel()
+
+		t.Views().Files().
+			IsFocused().
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			Title(Equals("Commit summary")).
+			InitialText(Equals("WIP foo bar")).
+			Type(". Added something else").
+			Confirm()
+
+		t.Views().Commits().Focus()
+		t.Views().Main().Content(Contains("WIP foo bar. Added something else"))
+	},
+})

--- a/pkg/integration/tests/commit/commit_with_prefix.go
+++ b/pkg/integration/tests/commit/commit_with_prefix.go
@@ -1,0 +1,47 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CommitWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Commit with defined config commitPrefix",
+	ExtraCmdArgs: "",
+	Skip:         false,
+	SetupConfig: func(testConfig *config.AppConfig) {
+		testConfig.UserConfig.Git.CommitPrefixes = map[string]config.CommitPrefixConfig{"repo": {Pattern: "^\\w+\\/(\\w+-\\w+).*", Replace: "[$1]: "}}
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.NewBranch("feature/TEST-001")
+		shell.CreateFile("test-commit-prefix", "This is foo bar")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			IsEmpty()
+
+		t.Views().Files().
+			IsFocused().
+			PressPrimaryAction().
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			Title(Equals("Commit summary")).
+			InitialText(Equals("[TEST-001]: ")).
+			Type("my commit message").
+			Cancel()
+
+		t.Views().Files().
+			IsFocused().
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			Title(Equals("Commit summary")).
+			InitialText(Equals("[TEST-001]: my commit message")).
+			Type(". Added something else").
+			Confirm()
+
+		t.Views().Commits().Focus()
+		t.Views().Main().Content(Contains("[TEST-001]: my commit message. Added something else"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -47,6 +47,8 @@ var tests = []*components.IntegrationTest{
 	commit.Amend,
 	commit.Commit,
 	commit.CommitMultiline,
+	commit.CommitWipWithPrefix,
+	commit.CommitWithPrefix,
 	commit.CreateTag,
 	commit.DiscardOldFileChange,
 	commit.History,


### PR DESCRIPTION
- **PR Description**

Yesterday, when I updated lazygit to the newest version, my commitPrefixes is not working anymore. Actually, it's not working when I start lazygit and start a new commit with blank message. If I commit it as WIP or add some text and cancel and recommit again prefix will show.

It was working perfectly fine in old version (I couldn't remember which one).

The fix is: 
  - remove the check message != ""
  - check if message doesn't contain prefix => add prefix in front of message
  - add tests

I commented on this issue #2215 however I don't know if they have same issue as me.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
