### PR TITLE
Add config for main branches

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -88,6 +88,9 @@ git:
     # displays the whole git graph by default in the commits panel (equivalent to passing the `--all` argument to `git log`)
     showWholeGraph: false
   skipHookPrefix: WIP
+  # The main branches. We colour commits green if they belong to one of these branches, 
+  # so that you can easily see which commits are unique to your branch (coloured in yellow)
+  mainBranches: [master, main]
   autoFetch: true
   autoRefresh: true
   branchLogCmd: 'git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --'

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -129,7 +129,7 @@ func NewGitCommandAux(
 
 	branchLoader := git_commands.NewBranchLoader(cmn, branchCommands.GetRawBranches, branchCommands.CurrentBranchInfo, configCommands)
 	commitFileLoader := git_commands.NewCommitFileLoader(cmn, cmd)
-	commitLoader := git_commands.NewCommitLoader(cmn, cmd, dotGitDir, branchCommands.CurrentBranchInfo, statusCommands.RebaseMode)
+	commitLoader := git_commands.NewCommitLoader(cmn, cmd, dotGitDir, statusCommands.RebaseMode)
 	reflogCommitLoader := git_commands.NewReflogCommitLoader(cmn, cmd)
 	remoteLoader := git_commands.NewRemoteLoader(cmn, cmd, repo.Remotes)
 	stashLoader := git_commands.NewStashLoader(cmn, cmd)

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -76,6 +76,7 @@ type GitConfig struct {
 	Paging              PagingConfig                  `yaml:"paging"`
 	Commit              CommitConfig                  `yaml:"commit"`
 	Merging             MergingConfig                 `yaml:"merging"`
+	MainBranches        []string                      `yaml:"mainBranches"`
 	SkipHookPrefix      string                        `yaml:"skipHookPrefix"`
 	AutoFetch           bool                          `yaml:"autoFetch"`
 	AutoRefresh         bool                          `yaml:"autoRefresh"`
@@ -443,6 +444,7 @@ func GetDefaultConfig() *UserConfig {
 				ShowWholeGraph: false,
 			},
 			SkipHookPrefix:      "WIP",
+			MainBranches:        []string{"master", "main"},
 			AutoFetch:           true,
 			AutoRefresh:         true,
 			BranchLogCmd:        "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",


### PR DESCRIPTION
- **PR Description**

Add config git.baseBranches

It defaults to ["master", "main"], but can be set to whatever branch names
are used as base branches, e.g. ["master", "devel", "v1.0-hotfixes"]. It is
used for color-coding the shas in the commit list, i.e. to decide whether
commits are green or yellow.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc
