### PR TITLE
Make "merged" take precedence over "unpushed"

### DIFF
--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -357,7 +357,7 @@ func (self *CommitLoader) setCommitMergedStatuses(refName string, commits []*mod
 		if strings.HasPrefix(ancestor, commit.Sha) {
 			passedAncestor = true
 		}
-		if commit.Status != models.StatusPushed {
+		if commit.Status != models.StatusPushed && commit.Status != models.StatusUnpushed {
 			continue
 		}
 		if passedAncestor {


### PR DESCRIPTION
- **PR Description**

Previously, when rebasing a branch onto a newer master, all commits from the previous fork point up to its head were marked red (unpushed), including the commits that are on master already. While this is technically correct from the perspective of the current branch's upstream, it's not what most people expect, intuitively; they want to see where the current branch starts, relative to master. So all commits of master should be green, and then the commits of the current branch in red.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
