### PR TITLE
investigate intermittent rebase continue prompt failure

### DIFF
--- a/pkg/gui/command_log_panel.go
+++ b/pkg/gui/command_log_panel.go
@@ -30,6 +30,7 @@ func (gui *Gui) LogAction(action string) {
 
 	gui.Views.Extras.Autoscroll = true
 
+	gui.GuiLog = append(gui.GuiLog, action)
 	fmt.Fprint(gui.Views.Extras, "\n"+style.FgYellow.Sprint(action))
 }
 
@@ -46,7 +47,7 @@ func (gui *Gui) LogCommand(cmdStr string, commandLine bool) {
 		// we style it differently to communicate that
 		textStyle = style.FgMagenta
 	}
-	gui.CmdLog = append(gui.CmdLog, cmdStr)
+	gui.GuiLog = append(gui.GuiLog, cmdStr)
 	indentedCmdStr := "  " + strings.Replace(cmdStr, "\n", "\n  ", -1)
 	fmt.Fprint(gui.Views.Extras, "\n"+textStyle.Sprint(indentedCmdStr))
 }

--- a/pkg/gui/context.go
+++ b/pkg/gui/context.go
@@ -105,7 +105,9 @@ func (self *ContextMgr) pushToContextStack(c types.Context) ([]types.Context, ty
 		self.ContextStack = append(self.ContextStack, c)
 	} else if c.GetKind() == types.SIDE_CONTEXT {
 		// if we are switching to a side context, remove all other contexts in the stack
-		contextsToDeactivate = self.ContextStack
+		contextsToDeactivate = lo.Filter(self.ContextStack, func(context types.Context, _ int) bool {
+			return context.GetKey() != c.GetKey()
+		})
 		self.ContextStack = []types.Context{c}
 	} else if c.GetKind() == types.MAIN_CONTEXT {
 		// if we're switching to a main context, remove all other main contexts in the stack

--- a/pkg/gui/context.go
+++ b/pkg/gui/context.go
@@ -95,7 +95,7 @@ func (self *ContextMgr) pushToContextStack(c types.Context) ([]types.Context, ty
 	defer self.Unlock()
 
 	if len(self.ContextStack) > 0 &&
-		c == self.ContextStack[len(self.ContextStack)-1] {
+		c.GetKey() == self.ContextStack[len(self.ContextStack)-1].GetKey() {
 		// Context being pushed is already on top of the stack: nothing to
 		// deactivate or activate
 		return contextsToDeactivate, nil

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -93,8 +93,8 @@ type Gui struct {
 
 	Views types.Views
 
-	// Log of the commands that get run, to be displayed to the user.
-	CmdLog []string
+	// Log of the commands/actions logged in the Command Log panel.
+	GuiLog []string
 
 	// the extras window contains things like the command log
 	ShowExtrasWindow bool
@@ -440,7 +440,7 @@ func NewGui(
 		showRecentRepos:      showRecentRepos,
 		RepoPathStack:        &utils.StringStack{},
 		RepoStateMap:         map[Repo]*GuiRepoState{},
-		CmdLog:               []string{},
+		GuiLog:               []string{},
 
 		// originally we could only hide the command log permanently via the config
 		// but now we do it via state. So we need to still support the config for the

--- a/pkg/gui/gui_driver.go
+++ b/pkg/gui/gui_driver.go
@@ -64,7 +64,7 @@ func (self *GuiDriver) Fail(message string) {
 		"%s\nFinal Lazygit state:\n%s\nUpon failure, focused view was '%s'.\nLog:\n%s", message,
 		self.gui.g.Snapshot(),
 		currentView.Name(),
-		strings.Join(self.gui.CmdLog, "\n"),
+		strings.Join(self.gui.GuiLog, "\n"),
 	)
 
 	self.gui.g.Close()


### PR DESCRIPTION
- **PR Description**

Sometimes we fail to prompt the user to continue a merge/rebase after a conflict is resolved (see example in this failing [integration test](https://github.com/jesseduffield/lazygit/actions/runs/4947331950/jobs/8847541659)).

This is caused by a race condition:

Our refresh code may try to push a context. It does this in two places:
1) when all merge conflicts are resolved, we push a 'continue merge?' confirmation context
2) when all conflicts of a given file are resolved and we're in the merge conflicts context,
   we push the files context.

Sometimes we push the confirmation context and then push the files context over it, so the user
never sees the confirmation context.

This PR fixes the race condition by adding a check to ensure that we're still in the
merge conflicts panel before we try escaping from it.

I've also added a couple other 'fixes' along the way (though they didn't actually cause the original issue).

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
