### PR TITLE
Add convenience builder for git commands

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -117,8 +117,7 @@ func NewGitCommandAux(
 	workingTreeCommands := git_commands.NewWorkingTreeCommands(gitCommon, submoduleCommands, fileLoader)
 	rebaseCommands := git_commands.NewRebaseCommands(gitCommon, commitCommands, workingTreeCommands)
 	stashCommands := git_commands.NewStashCommands(gitCommon, fileLoader, workingTreeCommands)
-	// TODO: have patch builder take workingTreeCommands in its entirety
-	patchBuilder := patch.NewPatchBuilder(cmn.Log, workingTreeCommands.ApplyPatch,
+	patchBuilder := patch.NewPatchBuilder(cmn.Log,
 		func(from string, to string, reverse bool, filename string, plain bool) (string, error) {
 			// TODO: make patch builder take Gui.IgnoreWhitespaceInDiffView into
 			// account. For now we just pass false.

--- a/pkg/commands/git_commands/bisect.go
+++ b/pkg/commands/git_commands/bisect.go
@@ -1,7 +1,6 @@
 package git_commands
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -98,13 +97,15 @@ func (self *BisectCommands) GetInfo() *BisectInfo {
 }
 
 func (self *BisectCommands) Reset() error {
-	return self.cmd.New("git bisect reset").StreamOutput().Run()
+	cmdStr := NewGitCmd("bisect").Arg("reset").ToString()
+
+	return self.cmd.New(cmdStr).StreamOutput().Run()
 }
 
 func (self *BisectCommands) Mark(ref string, term string) error {
-	return self.cmd.New(
-		fmt.Sprintf("git bisect %s %s", term, ref),
-	).
+	cmdStr := NewGitCmd("bisect").Arg(term, ref).ToString()
+
+	return self.cmd.New(cmdStr).
 		IgnoreEmptyError().
 		StreamOutput().
 		Run()
@@ -115,7 +116,9 @@ func (self *BisectCommands) Skip(ref string) error {
 }
 
 func (self *BisectCommands) Start() error {
-	return self.cmd.New("git bisect start").StreamOutput().Run()
+	cmdStr := NewGitCmd("bisect").Arg("start").ToString()
+
+	return self.cmd.New(cmdStr).StreamOutput().Run()
 }
 
 // tells us whether we've found our problem commit(s). We return a string slice of
@@ -137,7 +140,8 @@ func (self *BisectCommands) IsDone() (bool, []string, error) {
 	done := false
 	candidates := []string{}
 
-	err := self.cmd.New(fmt.Sprintf("git rev-list %s", newSha)).RunAndProcessLines(func(line string) (bool, error) {
+	cmdStr := NewGitCmd("rev-list").Arg(newSha).ToString()
+	err := self.cmd.New(cmdStr).RunAndProcessLines(func(line string) (bool, error) {
 		sha := strings.TrimSpace(line)
 
 		if status, ok := info.statusMap[sha]; ok {
@@ -167,9 +171,11 @@ func (self *BisectCommands) IsDone() (bool, []string, error) {
 // bisecting is actually a descendant of our current bisect commit. If it's not, we need to
 // render the commits from the bad commit.
 func (self *BisectCommands) ReachableFromStart(bisectInfo *BisectInfo) bool {
-	err := self.cmd.New(
-		fmt.Sprintf("git merge-base --is-ancestor %s %s", bisectInfo.GetNewSha(), bisectInfo.GetStartSha()),
-	).DontLog().Run()
+	cmdStr := NewGitCmd("merge-base").
+		Arg("--is-ancestor", bisectInfo.GetNewSha(), bisectInfo.GetStartSha()).
+		ToString()
+
+	err := self.cmd.New(cmdStr).DontLog().Run()
 
 	return err == nil
 }

--- a/pkg/commands/git_commands/commit_file_loader.go
+++ b/pkg/commands/git_commands/commit_file_loader.go
@@ -1,7 +1,6 @@
 package git_commands
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/jesseduffield/generics/slices"
@@ -25,12 +24,18 @@ func NewCommitFileLoader(common *common.Common, cmd oscommands.ICmdObjBuilder) *
 
 // GetFilesInDiff get the specified commit files
 func (self *CommitFileLoader) GetFilesInDiff(from string, to string, reverse bool) ([]*models.CommitFile, error) {
-	reverseFlag := ""
-	if reverse {
-		reverseFlag = " -R "
-	}
+	cmdStr := NewGitCmd("diff").
+		Arg("--submodule").
+		Arg("--no-ext-diff").
+		Arg("--name-status").
+		Arg("-z").
+		Arg("--no-renames").
+		ArgIf(reverse, "-R").
+		Arg(from).
+		Arg(to).
+		ToString()
 
-	filenames, err := self.cmd.New(fmt.Sprintf("git diff --submodule --no-ext-diff --name-status -z --no-renames %s %s %s", reverseFlag, from, to)).DontLog().RunWithOutput()
+	filenames, err := self.cmd.New(cmdStr).DontLog().RunWithOutput()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/git_commands/deps_test.go
+++ b/pkg/commands/git_commands/deps_test.go
@@ -150,3 +150,9 @@ func buildBranchCommands(deps commonDeps) *BranchCommands {
 
 	return NewBranchCommands(gitCommon)
 }
+
+func buildFlowCommands(deps commonDeps) *FlowCommands {
+	gitCommon := buildGitCommon(deps)
+
+	return NewFlowCommands(gitCommon)
+}

--- a/pkg/commands/git_commands/deps_test.go
+++ b/pkg/commands/git_commands/deps_test.go
@@ -7,6 +7,7 @@ import (
 	gogit "github.com/jesseduffield/go-git/v5"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_config"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
+	"github.com/jesseduffield/lazygit/pkg/commands/patch"
 	"github.com/jesseduffield/lazygit/pkg/common"
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/utils"
@@ -115,6 +116,26 @@ func buildWorkingTreeCommands(deps commonDeps) *WorkingTreeCommands {
 	fileLoader := buildFileLoader(gitCommon)
 
 	return NewWorkingTreeCommands(gitCommon, submoduleCommands, fileLoader)
+}
+
+func buildPatchCommands(deps commonDeps) *PatchCommands {
+	gitCommon := buildGitCommon(deps)
+	rebaseCommands := buildRebaseCommands(deps)
+	commitCommands := buildCommitCommands(deps)
+	statusCommands := buildStatusCommands(deps)
+	stashCommands := buildStashCommands(deps)
+	loadFileFn := func(from string, to string, reverse bool, filename string, plain bool) (string, error) {
+		return "", nil
+	}
+	patchBuilder := patch.NewPatchBuilder(gitCommon.Log, loadFileFn)
+
+	return NewPatchCommands(gitCommon, rebaseCommands, commitCommands, statusCommands, stashCommands, patchBuilder)
+}
+
+func buildStatusCommands(deps commonDeps) *StatusCommands {
+	gitCommon := buildGitCommon(deps)
+
+	return NewStatusCommands(gitCommon)
 }
 
 func buildStashCommands(deps commonDeps) *StashCommands {

--- a/pkg/commands/git_commands/flow.go
+++ b/pkg/commands/git_commands/flow.go
@@ -34,6 +34,7 @@ func (self *FlowCommands) FinishCmdObj(branchName string) (oscommands.ICmdObj, e
 	branchType := ""
 	for _, line := range strings.Split(strings.TrimSpace(prefixes), "\n") {
 		if strings.HasPrefix(line, "gitflow.prefix.") && strings.HasSuffix(line, prefix) {
+
 			regex := regexp.MustCompile("gitflow.prefix.([^ ]*) .*")
 			matches := regex.FindAllStringSubmatch(line, 1)
 
@@ -48,9 +49,13 @@ func (self *FlowCommands) FinishCmdObj(branchName string) (oscommands.ICmdObj, e
 		return nil, errors.New(self.Tr.NotAGitFlowBranch)
 	}
 
-	return self.cmd.New("git flow " + branchType + " finish " + suffix), nil
+	cmdStr := NewGitCmd("flow").Arg(branchType, "finish", suffix).ToString()
+
+	return self.cmd.New(cmdStr), nil
 }
 
 func (self *FlowCommands) StartCmdObj(branchType string, name string) oscommands.ICmdObj {
-	return self.cmd.New("git flow " + branchType + " start " + name)
+	cmdStr := NewGitCmd("flow").Arg(branchType, "start", name).ToString()
+
+	return self.cmd.New(cmdStr)
 }

--- a/pkg/commands/git_commands/flow_test.go
+++ b/pkg/commands/git_commands/flow_test.go
@@ -1,0 +1,92 @@
+package git_commands
+
+import (
+	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/commands/git_config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartCmdObj(t *testing.T) {
+	scenarios := []struct {
+		testName   string
+		branchType string
+		name       string
+		expected   string
+	}{
+		{
+			testName:   "basic",
+			branchType: "feature",
+			name:       "test",
+			expected:   "git flow feature start test",
+		},
+	}
+
+	for _, s := range scenarios {
+		s := s
+		t.Run(s.testName, func(t *testing.T) {
+			instance := buildFlowCommands(commonDeps{})
+
+			assert.Equal(t,
+				instance.StartCmdObj(s.branchType, s.name).ToString(),
+				s.expected,
+			)
+		})
+	}
+}
+
+func TestFinishCmdObj(t *testing.T) {
+	scenarios := []struct {
+		testName               string
+		branchName             string
+		expected               string
+		expectedError          string
+		gitConfigMockResponses map[string]string
+	}{
+		{
+			testName:               "not a git flow branch",
+			branchName:             "mybranch",
+			expected:               "",
+			expectedError:          "This does not seem to be a git flow branch",
+			gitConfigMockResponses: nil,
+		},
+		{
+			testName:               "feature branch without config",
+			branchName:             "feature/mybranch",
+			expected:               "",
+			expectedError:          "This does not seem to be a git flow branch",
+			gitConfigMockResponses: nil,
+		},
+		{
+			testName:      "feature branch with config",
+			branchName:    "feature/mybranch",
+			expected:      "git flow feature finish mybranch",
+			expectedError: "",
+			gitConfigMockResponses: map[string]string{
+				"--local --get-regexp gitflow.prefix": "gitflow.prefix.feature feature/",
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		s := s
+		t.Run(s.testName, func(t *testing.T) {
+			instance := buildFlowCommands(commonDeps{
+				gitConfig: git_config.NewFakeGitConfig(s.gitConfigMockResponses),
+			})
+
+			cmd, err := instance.FinishCmdObj(s.branchName)
+
+			if s.expectedError != "" {
+				if err == nil {
+					t.Errorf("Expected error, got nil")
+				} else {
+					assert.Equal(t, err.Error(), s.expectedError)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, cmd.ToString(), s.expected)
+			}
+		})
+	}
+}

--- a/pkg/commands/git_commands/git_command_builder.go
+++ b/pkg/commands/git_commands/git_command_builder.go
@@ -1,0 +1,54 @@
+package git_commands
+
+import "strings"
+
+// convenience struct for building git commands. Especially useful when
+// including conditional args
+type GitCommandBuilder struct {
+	// command string
+	args []string
+}
+
+func NewGitCmd(command string) *GitCommandBuilder {
+	return &GitCommandBuilder{args: []string{command}}
+}
+
+func (self *GitCommandBuilder) Arg(args ...string) *GitCommandBuilder {
+	self.args = append(self.args, args...)
+
+	return self
+}
+
+func (self *GitCommandBuilder) ArgIf(condition bool, ifTrue ...string) *GitCommandBuilder {
+	if condition {
+		self.Arg(ifTrue...)
+	}
+
+	return self
+}
+
+func (self *GitCommandBuilder) ArgIfElse(condition bool, ifTrue string, ifFalse string) *GitCommandBuilder {
+	if condition {
+		return self.Arg(ifTrue)
+	} else {
+		return self.Arg(ifFalse)
+	}
+}
+
+func (self *GitCommandBuilder) Config(value string) *GitCommandBuilder {
+	// config settings come before the command
+	self.args = append([]string{"-c", value}, self.args...)
+
+	return self
+}
+
+func (self *GitCommandBuilder) RepoPath(value string) *GitCommandBuilder {
+	// repo path comes before the command
+	self.args = append([]string{"-C", value}, self.args...)
+
+	return self
+}
+
+func (self *GitCommandBuilder) ToString() string {
+	return "git " + strings.Join(self.args, " ")
+}

--- a/pkg/commands/git_commands/git_command_builder_test.go
+++ b/pkg/commands/git_commands/git_command_builder_test.go
@@ -1,0 +1,56 @@
+package git_commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGitCommandBuilder(t *testing.T) {
+	scenarios := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input: NewGitCmd("push").
+				Arg("--force-with-lease").
+				Arg("--set-upstream").
+				Arg("origin").
+				Arg("master").
+				ToString(),
+			expected: "git push --force-with-lease --set-upstream origin master",
+		},
+		{
+			input:    NewGitCmd("push").ArgIf(true, "--test").ToString(),
+			expected: "git push --test",
+		},
+		{
+			input:    NewGitCmd("push").ArgIf(false, "--test").ToString(),
+			expected: "git push",
+		},
+		{
+			input:    NewGitCmd("push").ArgIfElse(true, "-b", "-a").ToString(),
+			expected: "git push -b",
+		},
+		{
+			input:    NewGitCmd("push").ArgIfElse(false, "-a", "-b").ToString(),
+			expected: "git push -b",
+		},
+		{
+			input:    NewGitCmd("push").Arg("-a", "-b").ToString(),
+			expected: "git push -a -b",
+		},
+		{
+			input:    NewGitCmd("push").Config("user.name=foo").Config("user.email=bar").ToString(),
+			expected: "git -c user.email=bar -c user.name=foo push",
+		},
+		{
+			input:    NewGitCmd("push").RepoPath("a/b/c").ToString(),
+			expected: "git -C a/b/c push",
+		},
+	}
+
+	for _, s := range scenarios {
+		assert.Equal(t, s.input, s.expected)
+	}
+}

--- a/pkg/commands/git_commands/patch.go
+++ b/pkg/commands/git_commands/patch.go
@@ -267,5 +267,7 @@ func (self *PatchCommands) PullPatchIntoNewCommit(commits []*models.Commit, comm
 // only some lines of a range of adjacent added lines. To solve this, we
 // get the diff of HEAD and the original commit and then apply that.
 func (self *PatchCommands) diffHeadAgainstCommit(commit *models.Commit) (string, error) {
-	return self.cmd.New(fmt.Sprintf("git diff HEAD..%s", commit.Sha)).RunWithOutput()
+	cmdStr := NewGitCmd("diff").Arg("HEAD.." + commit.Sha).ToString()
+
+	return self.cmd.New(cmdStr).RunWithOutput()
 }

--- a/pkg/commands/git_commands/patch.go
+++ b/pkg/commands/git_commands/patch.go
@@ -2,6 +2,8 @@ package git_commands
 
 import (
 	"fmt"
+	"path/filepath"
+	"time"
 
 	"github.com/fsmiamoto/git-todo-parser/todo"
 	"github.com/go-errors/errors"
@@ -9,6 +11,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/commands/patch"
 	"github.com/jesseduffield/lazygit/pkg/commands/types/enums"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 type PatchCommands struct {
@@ -39,6 +42,53 @@ func NewPatchCommands(
 	}
 }
 
+type ApplyPatchOpts struct {
+	ThreeWay bool
+	Cached   bool
+	Index    bool
+	Reverse  bool
+}
+
+func (self *PatchCommands) ApplyCustomPatch(reverse bool) error {
+	patch := self.PatchBuilder.PatchToApply(reverse)
+
+	return self.ApplyPatch(patch, ApplyPatchOpts{
+		Index:    true,
+		ThreeWay: true,
+		Reverse:  reverse,
+	})
+}
+
+func (self *PatchCommands) ApplyPatch(patch string, opts ApplyPatchOpts) error {
+	filepath, err := self.SaveTemporaryPatch(patch)
+	if err != nil {
+		return err
+	}
+
+	return self.applyPatchFile(filepath, opts)
+}
+
+func (self *PatchCommands) applyPatchFile(filepath string, opts ApplyPatchOpts) error {
+	cmdStr := NewGitCmd("apply").
+		ArgIf(opts.ThreeWay, "--3way").
+		ArgIf(opts.Cached, "--cached").
+		ArgIf(opts.Index, "--index").
+		ArgIf(opts.Reverse, "--reverse").
+		Arg(self.cmd.Quote(filepath)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
+}
+
+func (self *PatchCommands) SaveTemporaryPatch(patch string) (string, error) {
+	filepath := filepath.Join(self.os.GetTempDir(), utils.GetCurrentRepoName(), time.Now().Format("Jan _2 15.04.05.000000000")+".patch")
+	self.Log.Infof("saving temporary patch to %s", filepath)
+	if err := self.os.CreateFileWithContent(filepath, patch); err != nil {
+		return "", err
+	}
+	return filepath, nil
+}
+
 // DeletePatchesFromCommit applies a patch in reverse for a commit
 func (self *PatchCommands) DeletePatchesFromCommit(commits []*models.Commit, commitIndex int) error {
 	if err := self.rebase.BeginInteractiveRebaseForCommit(commits, commitIndex); err != nil {
@@ -46,7 +96,7 @@ func (self *PatchCommands) DeletePatchesFromCommit(commits []*models.Commit, com
 	}
 
 	// apply each patch in reverse
-	if err := self.PatchBuilder.ApplyPatches(true); err != nil {
+	if err := self.ApplyCustomPatch(true); err != nil {
 		_ = self.rebase.AbortRebase()
 		return err
 	}
@@ -72,7 +122,7 @@ func (self *PatchCommands) MovePatchToSelectedCommit(commits []*models.Commit, s
 		}
 
 		// apply each patch forward
-		if err := self.PatchBuilder.ApplyPatches(false); err != nil {
+		if err := self.ApplyCustomPatch(false); err != nil {
 			// Don't abort the rebase here; this might cause conflicts, so give
 			// the user a chance to resolve them
 			return err
@@ -121,7 +171,7 @@ func (self *PatchCommands) MovePatchToSelectedCommit(commits []*models.Commit, s
 	}
 
 	// apply each patch in reverse
-	if err := self.PatchBuilder.ApplyPatches(true); err != nil {
+	if err := self.ApplyCustomPatch(true); err != nil {
 		_ = self.rebase.AbortRebase()
 		return err
 	}
@@ -144,7 +194,7 @@ func (self *PatchCommands) MovePatchToSelectedCommit(commits []*models.Commit, s
 	self.rebase.onSuccessfulContinue = func() error {
 		// now we should be up to the destination, so let's apply forward these patches to that.
 		// ideally we would ensure we're on the right commit but I'm not sure if that check is necessary
-		if err := self.rebase.workingTree.ApplyPatch(patch, "index", "3way"); err != nil {
+		if err := self.ApplyPatch(patch, ApplyPatchOpts{Index: true, ThreeWay: true}); err != nil {
 			// Don't abort the rebase here; this might cause conflicts, so give
 			// the user a chance to resolve them
 			return err
@@ -177,7 +227,7 @@ func (self *PatchCommands) MovePatchIntoIndex(commits []*models.Commit, commitId
 		return err
 	}
 
-	if err := self.PatchBuilder.ApplyPatches(true); err != nil {
+	if err := self.ApplyCustomPatch(true); err != nil {
 		if self.status.WorkingTreeState() == enums.REBASE_MODE_REBASING {
 			_ = self.rebase.AbortRebase()
 		}
@@ -201,7 +251,7 @@ func (self *PatchCommands) MovePatchIntoIndex(commits []*models.Commit, commitId
 
 	self.rebase.onSuccessfulContinue = func() error {
 		// add patches to index
-		if err := self.rebase.workingTree.ApplyPatch(patch, "index", "3way"); err != nil {
+		if err := self.ApplyPatch(patch, ApplyPatchOpts{Index: true, ThreeWay: true}); err != nil {
 			if self.status.WorkingTreeState() == enums.REBASE_MODE_REBASING {
 				_ = self.rebase.AbortRebase()
 			}
@@ -226,7 +276,7 @@ func (self *PatchCommands) PullPatchIntoNewCommit(commits []*models.Commit, comm
 		return err
 	}
 
-	if err := self.PatchBuilder.ApplyPatches(true); err != nil {
+	if err := self.ApplyCustomPatch(true); err != nil {
 		_ = self.rebase.AbortRebase()
 		return err
 	}
@@ -242,7 +292,7 @@ func (self *PatchCommands) PullPatchIntoNewCommit(commits []*models.Commit, comm
 		return err
 	}
 
-	if err := self.rebase.workingTree.ApplyPatch(patch, "index", "3way"); err != nil {
+	if err := self.ApplyPatch(patch, ApplyPatchOpts{Index: true, ThreeWay: true}); err != nil {
 		_ = self.rebase.AbortRebase()
 		return err
 	}

--- a/pkg/commands/git_commands/patch_test.go
+++ b/pkg/commands/git_commands/patch_test.go
@@ -1,0 +1,66 @@
+package git_commands
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/go-errors/errors"
+	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorkingTreeApplyPatch(t *testing.T) {
+	type scenario struct {
+		testName string
+		runner   *oscommands.FakeCmdObjRunner
+		test     func(error)
+	}
+
+	expectFn := func(regexStr string, errToReturn error) func(cmdObj oscommands.ICmdObj) (string, error) {
+		return func(cmdObj oscommands.ICmdObj) (string, error) {
+			re := regexp.MustCompile(regexStr)
+			cmdStr := cmdObj.ToString()
+			matches := re.FindStringSubmatch(cmdStr)
+			assert.Equal(t, 2, len(matches), fmt.Sprintf("unexpected command: %s", cmdStr))
+
+			filename := matches[1]
+
+			content, err := os.ReadFile(filename)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "test", string(content))
+
+			return "", errToReturn
+		}
+	}
+
+	scenarios := []scenario{
+		{
+			testName: "valid case",
+			runner: oscommands.NewFakeRunner(t).
+				ExpectFunc(expectFn(`git apply --cached "(.*)"`, nil)),
+			test: func(err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			testName: "command returns error",
+			runner: oscommands.NewFakeRunner(t).
+				ExpectFunc(expectFn(`git apply --cached "(.*)"`, errors.New("error"))),
+			test: func(err error) {
+				assert.Error(t, err)
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		s := s
+		t.Run(s.testName, func(t *testing.T) {
+			instance := buildPatchCommands(commonDeps{runner: s.runner})
+			s.test(instance.ApplyPatch("test", ApplyPatchOpts{Cached: true}))
+			s.runner.CheckForMissingCalls()
+		})
+	}
+}

--- a/pkg/commands/git_commands/remote.go
+++ b/pkg/commands/git_commands/remote.go
@@ -15,44 +15,52 @@ func NewRemoteCommands(gitCommon *GitCommon) *RemoteCommands {
 }
 
 func (self *RemoteCommands) AddRemote(name string, url string) error {
-	return self.cmd.
-		New(fmt.Sprintf("git remote add %s %s", self.cmd.Quote(name), self.cmd.Quote(url))).
-		Run()
+	cmdStr := NewGitCmd("remote").
+		Arg("add", self.cmd.Quote(name), self.cmd.Quote(url)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *RemoteCommands) RemoveRemote(name string) error {
-	return self.cmd.
-		New(fmt.Sprintf("git remote remove %s", self.cmd.Quote(name))).
-		Run()
+	cmdStr := NewGitCmd("remote").
+		Arg("remove", self.cmd.Quote(name)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *RemoteCommands) RenameRemote(oldRemoteName string, newRemoteName string) error {
-	return self.cmd.
-		New(fmt.Sprintf("git remote rename %s %s", self.cmd.Quote(oldRemoteName), self.cmd.Quote(newRemoteName))).
-		Run()
+	cmdStr := NewGitCmd("remote").
+		Arg("rename", self.cmd.Quote(oldRemoteName), self.cmd.Quote(newRemoteName)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *RemoteCommands) UpdateRemoteUrl(remoteName string, updatedUrl string) error {
-	return self.cmd.
-		New(fmt.Sprintf("git remote set-url %s %s", self.cmd.Quote(remoteName), self.cmd.Quote(updatedUrl))).
-		Run()
+	cmdStr := NewGitCmd("remote").
+		Arg("set-url", self.cmd.Quote(remoteName), self.cmd.Quote(updatedUrl)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *RemoteCommands) DeleteRemoteBranch(remoteName string, branchName string) error {
-	command := fmt.Sprintf("git push %s --delete %s", self.cmd.Quote(remoteName), self.cmd.Quote(branchName))
-	return self.cmd.New(command).PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
+	cmdStr := NewGitCmd("push").
+		Arg(self.cmd.Quote(remoteName), "--delete", self.cmd.Quote(branchName)).
+		ToString()
+
+	return self.cmd.New(cmdStr).PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
 }
 
 // CheckRemoteBranchExists Returns remote branch
 func (self *RemoteCommands) CheckRemoteBranchExists(branchName string) bool {
-	_, err := self.cmd.
-		New(
-			fmt.Sprintf("git show-ref --verify -- refs/remotes/origin/%s",
-				self.cmd.Quote(branchName),
-			),
-		).
-		DontLog().
-		RunWithOutput()
+	cmdStr := NewGitCmd("show-ref").
+		Arg("--verify", "--", fmt.Sprintf("refs/remotes/origin/%s", self.cmd.Quote(branchName))).
+		ToString()
+
+	_, err := self.cmd.New(cmdStr).DontLog().RunWithOutput()
 
 	return err == nil
 }

--- a/pkg/commands/git_commands/remote_loader.go
+++ b/pkg/commands/git_commands/remote_loader.go
@@ -31,7 +31,8 @@ func NewRemoteLoader(
 }
 
 func (self *RemoteLoader) GetRemotes() ([]*models.Remote, error) {
-	remoteBranchesStr, err := self.cmd.New("git branch -r").DontLog().RunWithOutput()
+	cmdStr := NewGitCmd("branch").Arg("-r").ToString()
+	remoteBranchesStr, err := self.cmd.New(cmdStr).DontLog().RunWithOutput()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/git_commands/stash.go
+++ b/pkg/commands/git_commands/stash.go
@@ -26,68 +26,94 @@ func NewStashCommands(
 }
 
 func (self *StashCommands) DropNewest() error {
-	return self.cmd.New("git stash drop").Run()
+	cmdStr := NewGitCmd("stash").Arg("drop").ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *StashCommands) Drop(index int) error {
-	return self.cmd.New(fmt.Sprintf("git stash drop stash@{%d}", index)).Run()
+	cmdStr := NewGitCmd("stash").Arg("drop", fmt.Sprintf("stash@{%d}", index)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *StashCommands) Pop(index int) error {
-	return self.cmd.New(fmt.Sprintf("git stash pop stash@{%d}", index)).Run()
+	cmdStr := NewGitCmd("stash").Arg("pop", fmt.Sprintf("stash@{%d}", index)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *StashCommands) Apply(index int) error {
-	return self.cmd.New(fmt.Sprintf("git stash apply stash@{%d}", index)).Run()
+	cmdStr := NewGitCmd("stash").Arg("apply", fmt.Sprintf("stash@{%d}", index)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 // Save save stash
 func (self *StashCommands) Save(message string) error {
-	return self.cmd.New("git stash save " + self.cmd.Quote(message)).Run()
+	cmdStr := NewGitCmd("stash").Arg("save", self.cmd.Quote(message)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *StashCommands) Store(sha string, message string) error {
 	trimmedMessage := strings.Trim(message, " \t")
-	if len(trimmedMessage) > 0 {
-		return self.cmd.New(fmt.Sprintf("git stash store %s -m %s", self.cmd.Quote(sha), self.cmd.Quote(trimmedMessage))).Run()
-	}
-	return self.cmd.New(fmt.Sprintf("git stash store %s", self.cmd.Quote(sha))).Run()
+
+	cmdStr := NewGitCmd("stash").Arg("store", self.cmd.Quote(sha)).
+		ArgIf(trimmedMessage != "", "-m", self.cmd.Quote(trimmedMessage)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *StashCommands) Sha(index int) (string, error) {
-	sha, _, err := self.cmd.New(fmt.Sprintf("git rev-parse refs/stash@{%d}", index)).DontLog().RunWithOutputs()
+	cmdStr := NewGitCmd("rev-parse").
+		Arg(fmt.Sprintf("refs/stash@{%d}", index)).
+		ToString()
+
+	sha, _, err := self.cmd.New(cmdStr).DontLog().RunWithOutputs()
 	return strings.Trim(sha, "\r\n"), err
 }
 
 func (self *StashCommands) ShowStashEntryCmdObj(index int, ignoreWhitespace bool) oscommands.ICmdObj {
-	ignoreWhitespaceFlag := ""
-	if ignoreWhitespace {
-		ignoreWhitespaceFlag = " --ignore-all-space"
-	}
-
-	cmdStr := fmt.Sprintf(
-		"git stash show -p --stat --color=%s --unified=%d%s stash@{%d}",
-		self.UserConfig.Git.Paging.ColorArg,
-		self.UserConfig.Git.DiffContextSize,
-		ignoreWhitespaceFlag,
-		index,
-	)
+	cmdStr := NewGitCmd("stash").Arg("show").
+		Arg("-p").
+		Arg("--stat").
+		Arg(fmt.Sprintf("--color=%s", self.UserConfig.Git.Paging.ColorArg)).
+		Arg(fmt.Sprintf("--unified=%d", self.UserConfig.Git.DiffContextSize)).
+		ArgIf(ignoreWhitespace, "--ignore-all-space").
+		Arg(fmt.Sprintf("stash@{%d}", index)).
+		ToString()
 
 	return self.cmd.New(cmdStr).DontLog()
 }
 
 func (self *StashCommands) StashAndKeepIndex(message string) error {
-	return self.cmd.New(fmt.Sprintf("git stash save %s --keep-index", self.cmd.Quote(message))).Run()
+	cmdStr := NewGitCmd("stash").Arg("save", self.cmd.Quote(message), "--keep-index").
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *StashCommands) StashUnstagedChanges(message string) error {
-	if err := self.cmd.New("git commit --no-verify -m \"[lazygit] stashing unstaged changes\"").Run(); err != nil {
+	if err := self.cmd.New(
+		NewGitCmd("commit").
+			Arg("--no-verify", "-m", self.cmd.Quote("[lazygit] stashing unstaged changes")).
+			ToString(),
+	).Run(); err != nil {
 		return err
 	}
 	if err := self.Save(message); err != nil {
 		return err
 	}
-	if err := self.cmd.New("git reset --soft HEAD^").Run(); err != nil {
+
+	if err := self.cmd.New(
+		NewGitCmd("reset").Arg("--soft", "HEAD^").ToString(),
+	).Run(); err != nil {
 		return err
 	}
 	return nil
@@ -97,7 +123,9 @@ func (self *StashCommands) StashUnstagedChanges(message string) error {
 // shoutouts to Joe on https://stackoverflow.com/questions/14759748/stashing-only-staged-changes-in-git-is-it-possible
 func (self *StashCommands) SaveStagedChanges(message string) error {
 	// wrap in 'writing', which uses a mutex
-	if err := self.cmd.New("git stash --keep-index").Run(); err != nil {
+	if err := self.cmd.New(
+		NewGitCmd("stash").Arg("--keep-index").ToString(),
+	).Run(); err != nil {
 		return err
 	}
 
@@ -105,15 +133,22 @@ func (self *StashCommands) SaveStagedChanges(message string) error {
 		return err
 	}
 
-	if err := self.cmd.New("git stash apply stash@{1}").Run(); err != nil {
+	if err := self.cmd.New(
+		NewGitCmd("stash").Arg("apply", "stash@{1}").ToString(),
+	).Run(); err != nil {
 		return err
 	}
 
-	if err := self.os.PipeCommands("git stash show -p", "git apply -R"); err != nil {
+	if err := self.os.PipeCommands(
+		NewGitCmd("stash").Arg("show", "-p").ToString(),
+		NewGitCmd("apply").Arg("-R").ToString(),
+	); err != nil {
 		return err
 	}
 
-	if err := self.cmd.New("git stash drop stash@{1}").Run(); err != nil {
+	if err := self.cmd.New(
+		NewGitCmd("stash").Arg("drop", "stash@{1}").ToString(),
+	).Run(); err != nil {
 		return err
 	}
 
@@ -135,7 +170,10 @@ func (self *StashCommands) SaveStagedChanges(message string) error {
 }
 
 func (self *StashCommands) StashIncludeUntrackedChanges(message string) error {
-	return self.cmd.New(fmt.Sprintf("git stash save %s --include-untracked", self.cmd.Quote(message))).Run()
+	return self.cmd.New(
+		NewGitCmd("stash").Arg("save", self.cmd.Quote(message), "--include-untracked").
+			ToString(),
+	).Run()
 }
 
 func (self *StashCommands) Rename(index int, message string) error {

--- a/pkg/commands/git_commands/stash_loader.go
+++ b/pkg/commands/git_commands/stash_loader.go
@@ -32,7 +32,8 @@ func (self *StashLoader) GetStashEntries(filterPath string) []*models.StashEntry
 		return self.getUnfilteredStashEntries()
 	}
 
-	rawString, err := self.cmd.New("git stash list --name-only").DontLog().RunWithOutput()
+	cmdStr := NewGitCmd("stash").Arg("list", "--name-only").ToString()
+	rawString, err := self.cmd.New(cmdStr).DontLog().RunWithOutput()
 	if err != nil {
 		return self.getUnfilteredStashEntries()
 	}
@@ -65,7 +66,9 @@ outer:
 }
 
 func (self *StashLoader) getUnfilteredStashEntries() []*models.StashEntry {
-	rawString, _ := self.cmd.New("git stash list -z --pretty='%gs'").DontLog().RunWithOutput()
+	cmdStr := NewGitCmd("stash").Arg("list", "-z", "--pretty='%gs'").ToString()
+
+	rawString, _ := self.cmd.New(cmdStr).DontLog().RunWithOutput()
 	return slices.MapWithIndex(utils.SplitNul(rawString), func(line string, index int) *models.StashEntry {
 		return self.stashEntryFromLine(line, index)
 	})

--- a/pkg/commands/git_commands/status.go
+++ b/pkg/commands/git_commands/status.go
@@ -56,7 +56,9 @@ func (self *StatusCommands) IsBareRepo() (bool, error) {
 }
 
 func IsBareRepo(osCommand *oscommands.OSCommand) (bool, error) {
-	res, err := osCommand.Cmd.New("git rev-parse --is-bare-repository").DontLog().RunWithOutput()
+	res, err := osCommand.Cmd.New(
+		NewGitCmd("rev-parse").Arg("--is-bare-repository").ToString(),
+	).DontLog().RunWithOutput()
 	if err != nil {
 		return false, err
 	}

--- a/pkg/commands/git_commands/submodule.go
+++ b/pkg/commands/git_commands/submodule.go
@@ -2,7 +2,6 @@ package git_commands
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -82,38 +81,60 @@ func (self *SubmoduleCommands) Stash(submodule *models.SubmoduleConfig) error {
 		return nil
 	}
 
-	return self.cmd.New("git -C " + self.cmd.Quote(submodule.Path) + " stash --include-untracked").Run()
+	cmdStr := NewGitCmd("stash").
+		RepoPath(self.cmd.Quote(submodule.Path)).
+		Arg("--include-untracked").
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *SubmoduleCommands) Reset(submodule *models.SubmoduleConfig) error {
-	return self.cmd.New("git submodule update --init --force -- " + self.cmd.Quote(submodule.Path)).Run()
+	cmdStr := NewGitCmd("submodule").
+		Arg("update", "--init", "--force", "--", self.cmd.Quote(submodule.Path)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *SubmoduleCommands) UpdateAll() error {
 	// not doing an --init here because the user probably doesn't want that
-	return self.cmd.New("git submodule update --force").Run()
+	cmdStr := NewGitCmd("submodule").Arg("update", "--force").ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *SubmoduleCommands) Delete(submodule *models.SubmoduleConfig) error {
 	// based on https://gist.github.com/myusuf3/7f645819ded92bda6677
 
-	if err := self.cmd.New("git submodule deinit --force -- " + self.cmd.Quote(submodule.Path)).Run(); err != nil {
-		if strings.Contains(err.Error(), "did not match any file(s) known to git") {
-			if err := self.cmd.New("git config --file .gitmodules --remove-section submodule." + self.cmd.Quote(submodule.Name)).Run(); err != nil {
-				return err
-			}
+	if err := self.cmd.New(
+		NewGitCmd("submodule").
+			Arg("deinit", "--force", "--", self.cmd.Quote(submodule.Path)).ToString(),
+	).Run(); err != nil {
+		if !strings.Contains(err.Error(), "did not match any file(s) known to git") {
+			return err
+		}
 
-			if err := self.cmd.New("git config --remove-section submodule." + self.cmd.Quote(submodule.Name)).Run(); err != nil {
-				return err
-			}
+		if err := self.cmd.New(
+			NewGitCmd("config").
+				Arg("--file", ".gitmodules", "--remove-section", "submodule."+self.cmd.Quote(submodule.Path)).
+				ToString(),
+		).Run(); err != nil {
+			return err
+		}
 
-			// if there's an error here about it not existing then we'll just continue to do `git rm`
-		} else {
+		if err := self.cmd.New(
+			NewGitCmd("config").
+				Arg("--remove-section", "submodule."+self.cmd.Quote(submodule.Path)).
+				ToString(),
+		).Run(); err != nil {
 			return err
 		}
 	}
 
-	if err := self.cmd.New("git rm --force -r " + submodule.Path).Run(); err != nil {
+	if err := self.cmd.New(
+		NewGitCmd("rm").Arg("--force", "-r", submodule.Path).ToString(),
+	).Run(); err != nil {
 		// if the directory isn't there then that's fine
 		self.Log.Error(err)
 	}
@@ -122,24 +143,35 @@ func (self *SubmoduleCommands) Delete(submodule *models.SubmoduleConfig) error {
 }
 
 func (self *SubmoduleCommands) Add(name string, path string, url string) error {
-	return self.cmd.
-		New(
-			fmt.Sprintf(
-				"git submodule add --force --name %s -- %s %s ",
-				self.cmd.Quote(name),
-				self.cmd.Quote(url),
-				self.cmd.Quote(path),
-			)).
-		Run()
+	cmdStr := NewGitCmd("submodule").
+		Arg("add").
+		Arg("--force").
+		Arg("--name").
+		Arg(self.cmd.Quote(name)).
+		Arg("--").
+		Arg(self.cmd.Quote(url)).
+		Arg(self.cmd.Quote(path)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *SubmoduleCommands) UpdateUrl(name string, path string, newUrl string) error {
+	setUrlCmdStr := NewGitCmd("config").
+		Arg(
+			"--file", ".gitmodules", "submodule."+self.cmd.Quote(name)+".url", self.cmd.Quote(newUrl),
+		).
+		ToString()
+
 	// the set-url command is only for later git versions so we're doing it manually here
-	if err := self.cmd.New("git config --file .gitmodules submodule." + self.cmd.Quote(name) + ".url " + self.cmd.Quote(newUrl)).Run(); err != nil {
+	if err := self.cmd.New(setUrlCmdStr).Run(); err != nil {
 		return err
 	}
 
-	if err := self.cmd.New("git submodule sync -- " + self.cmd.Quote(path)).Run(); err != nil {
+	syncCmdStr := NewGitCmd("submodule").Arg("sync", "--", self.cmd.Quote(path)).
+		ToString()
+
+	if err := self.cmd.New(syncCmdStr).Run(); err != nil {
 		return err
 	}
 
@@ -147,27 +179,45 @@ func (self *SubmoduleCommands) UpdateUrl(name string, path string, newUrl string
 }
 
 func (self *SubmoduleCommands) Init(path string) error {
-	return self.cmd.New("git submodule init -- " + self.cmd.Quote(path)).Run()
+	cmdStr := NewGitCmd("submodule").Arg("init", "--", self.cmd.Quote(path)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *SubmoduleCommands) Update(path string) error {
-	return self.cmd.New("git submodule update --init -- " + self.cmd.Quote(path)).Run()
+	cmdStr := NewGitCmd("submodule").Arg("update", "--init", "--", self.cmd.Quote(path)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *SubmoduleCommands) BulkInitCmdObj() oscommands.ICmdObj {
-	return self.cmd.New("git submodule init")
+	cmdStr := NewGitCmd("submodule").Arg("init").
+		ToString()
+
+	return self.cmd.New(cmdStr)
 }
 
 func (self *SubmoduleCommands) BulkUpdateCmdObj() oscommands.ICmdObj {
-	return self.cmd.New("git submodule update")
+	cmdStr := NewGitCmd("submodule").Arg("update").
+		ToString()
+
+	return self.cmd.New(cmdStr)
 }
 
 func (self *SubmoduleCommands) ForceBulkUpdateCmdObj() oscommands.ICmdObj {
-	return self.cmd.New("git submodule update --force")
+	cmdStr := NewGitCmd("submodule").Arg("update", "--force").
+		ToString()
+
+	return self.cmd.New(cmdStr)
 }
 
 func (self *SubmoduleCommands) BulkDeinitCmdObj() oscommands.ICmdObj {
-	return self.cmd.New("git submodule deinit --all --force")
+	cmdStr := NewGitCmd("submodule").Arg("deinit", "--all", "--force").
+		ToString()
+
+	return self.cmd.New(cmdStr)
 }
 
 func (self *SubmoduleCommands) ResetSubmodules(submodules []*models.SubmoduleConfig) error {

--- a/pkg/commands/git_commands/tag.go
+++ b/pkg/commands/git_commands/tag.go
@@ -1,9 +1,5 @@
 package git_commands
 
-import (
-	"fmt"
-)
-
 type TagCommands struct {
 	*GitCommon
 }
@@ -15,25 +11,32 @@ func NewTagCommands(gitCommon *GitCommon) *TagCommands {
 }
 
 func (self *TagCommands) CreateLightweight(tagName string, ref string) error {
-	if len(ref) > 0 {
-		return self.cmd.New(fmt.Sprintf("git tag -- %s %s", self.cmd.Quote(tagName), self.cmd.Quote(ref))).Run()
-	} else {
-		return self.cmd.New(fmt.Sprintf("git tag -- %s", self.cmd.Quote(tagName))).Run()
-	}
+	cmdStr := NewGitCmd("tag").Arg("--", self.cmd.Quote(tagName)).
+		ArgIf(len(ref) > 0, self.cmd.Quote(ref)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *TagCommands) CreateAnnotated(tagName, ref, msg string) error {
-	if len(ref) > 0 {
-		return self.cmd.New(fmt.Sprintf("git tag %s %s -m %s", self.cmd.Quote(tagName), self.cmd.Quote(ref), self.cmd.Quote(msg))).Run()
-	} else {
-		return self.cmd.New(fmt.Sprintf("git tag %s -m %s", self.cmd.Quote(tagName), self.cmd.Quote(msg))).Run()
-	}
+	cmdStr := NewGitCmd("tag").Arg(self.cmd.Quote(tagName)).
+		ArgIf(len(ref) > 0, self.cmd.Quote(ref)).
+		Arg("-m", self.cmd.Quote(msg)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *TagCommands) Delete(tagName string) error {
-	return self.cmd.New(fmt.Sprintf("git tag -d %s", self.cmd.Quote(tagName))).Run()
+	cmdStr := NewGitCmd("tag").Arg("-d", self.cmd.Quote(tagName)).
+		ToString()
+
+	return self.cmd.New(cmdStr).Run()
 }
 
 func (self *TagCommands) Push(remoteName string, tagName string) error {
-	return self.cmd.New(fmt.Sprintf("git push %s tag %s", self.cmd.Quote(remoteName), self.cmd.Quote(tagName))).PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
+	cmdStr := NewGitCmd("push").Arg(self.cmd.Quote(remoteName), "tag", self.cmd.Quote(tagName)).
+		ToString()
+
+	return self.cmd.New(cmdStr).PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
 }

--- a/pkg/commands/git_commands/tag_loader.go
+++ b/pkg/commands/git_commands/tag_loader.go
@@ -28,7 +28,8 @@ func NewTagLoader(
 func (self *TagLoader) GetTags() ([]*models.Tag, error) {
 	// get remote branches, sorted  by creation date (descending)
 	// see: https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---sortltkeygt
-	tagsOutput, err := self.cmd.New(`git tag --list -n --sort=-creatordate`).DontLog().RunWithOutput()
+	cmdStr := NewGitCmd("tag").Arg("--list", "-n", "--sort=-creatordate").ToString()
+	tagsOutput, err := self.cmd.New(cmdStr).DontLog().RunWithOutput()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/git_commands/version.go
+++ b/pkg/commands/git_commands/version.go
@@ -15,7 +15,7 @@ type GitVersion struct {
 }
 
 func GetGitVersion(osCommand *oscommands.OSCommand) (*GitVersion, error) {
-	versionStr, _, err := osCommand.Cmd.New("git --version").RunWithOutputs()
+	versionStr, _, err := osCommand.Cmd.New(NewGitCmd("--version").ToString()).RunWithOutputs()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -3,14 +3,11 @@ package git_commands
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"time"
 
 	"github.com/go-errors/errors"
 	"github.com/jesseduffield/generics/slices"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
-	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 type WorkingTreeCommands struct {
@@ -271,33 +268,6 @@ func (self *WorkingTreeCommands) WorktreeFileDiffCmdObj(node models.IFile, plain
 		ToString()
 
 	return self.cmd.New(cmdStr).DontLog()
-}
-
-func (self *WorkingTreeCommands) ApplyPatch(patch string, flags ...string) error {
-	filepath, err := self.SaveTemporaryPatch(patch)
-	if err != nil {
-		return err
-	}
-
-	return self.ApplyPatchFile(filepath, flags...)
-}
-
-func (self *WorkingTreeCommands) ApplyPatchFile(filepath string, flags ...string) error {
-	flagStr := ""
-	for _, flag := range flags {
-		flagStr += " --" + flag
-	}
-
-	return self.cmd.New(fmt.Sprintf("git apply%s %s", flagStr, self.cmd.Quote(filepath))).Run()
-}
-
-func (self *WorkingTreeCommands) SaveTemporaryPatch(patch string) (string, error) {
-	filepath := filepath.Join(self.os.GetTempDir(), utils.GetCurrentRepoName(), time.Now().Format("Jan _2 15.04.05.000000000")+".patch")
-	self.Log.Infof("saving temporary patch to %s", filepath)
-	if err := self.os.CreateFileWithContent(filepath, patch); err != nil {
-		return "", err
-	}
-	return filepath, nil
 }
 
 // ShowFileDiff get the diff of specified from and to. Typically this will be used for a single commit so it'll be 123abc^..123abc

--- a/pkg/commands/git_commands/working_tree_test.go
+++ b/pkg/commands/git_commands/working_tree_test.go
@@ -2,8 +2,6 @@ package git_commands
 
 import (
 	"fmt"
-	"os"
-	"regexp"
 	"testing"
 
 	"github.com/go-errors/errors"
@@ -425,60 +423,6 @@ func TestWorkingTreeCheckoutFile(t *testing.T) {
 			instance := buildWorkingTreeCommands(commonDeps{runner: s.runner})
 
 			s.test(instance.CheckoutFile(s.commitSha, s.fileName))
-			s.runner.CheckForMissingCalls()
-		})
-	}
-}
-
-func TestWorkingTreeApplyPatch(t *testing.T) {
-	type scenario struct {
-		testName string
-		runner   *oscommands.FakeCmdObjRunner
-		test     func(error)
-	}
-
-	expectFn := func(regexStr string, errToReturn error) func(cmdObj oscommands.ICmdObj) (string, error) {
-		return func(cmdObj oscommands.ICmdObj) (string, error) {
-			re := regexp.MustCompile(regexStr)
-			cmdStr := cmdObj.ToString()
-			matches := re.FindStringSubmatch(cmdStr)
-			assert.Equal(t, 2, len(matches), fmt.Sprintf("unexpected command: %s", cmdStr))
-
-			filename := matches[1]
-
-			content, err := os.ReadFile(filename)
-			assert.NoError(t, err)
-
-			assert.Equal(t, "test", string(content))
-
-			return "", errToReturn
-		}
-	}
-
-	scenarios := []scenario{
-		{
-			testName: "valid case",
-			runner: oscommands.NewFakeRunner(t).
-				ExpectFunc(expectFn(`git apply --cached "(.*)"`, nil)),
-			test: func(err error) {
-				assert.NoError(t, err)
-			},
-		},
-		{
-			testName: "command returns error",
-			runner: oscommands.NewFakeRunner(t).
-				ExpectFunc(expectFn(`git apply --cached "(.*)"`, errors.New("error"))),
-			test: func(err error) {
-				assert.Error(t, err)
-			},
-		},
-	}
-
-	for _, s := range scenarios {
-		s := s
-		t.Run(s.testName, func(t *testing.T) {
-			instance := buildWorkingTreeCommands(commonDeps{runner: s.runner})
-			s.test(instance.ApplyPatch("test", "cached"))
 			s.runner.CheckForMissingCalls()
 		})
 	}

--- a/pkg/gui/controllers/custom_patch_options_menu_action.go
+++ b/pkg/gui/controllers/custom_patch_options_menu_action.go
@@ -199,7 +199,7 @@ func (self *CustomPatchOptionsMenuAction) handleApplyPatch(reverse bool) error {
 		action = "Apply patch in reverse"
 	}
 	self.c.LogAction(action)
-	if err := self.c.Git().Patch.PatchBuilder.ApplyPatches(reverse); err != nil {
+	if err := self.c.Git().Patch.ApplyCustomPatch(reverse); err != nil {
 		return self.c.Error(err)
 	}
 	return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})

--- a/pkg/gui/presentation/files_test.go
+++ b/pkg/gui/presentation/files_test.go
@@ -136,7 +136,6 @@ M file1
 			}
 			patchBuilder := patch.NewPatchBuilder(
 				utils.NewDummyLog(),
-				func(patch string, flags ...string) error { return nil },
 				func(from string, to string, reverse bool, filename string, plain bool) (string, error) {
 					return "", nil
 				},


### PR DESCRIPTION
- **PR Description**

This PR adds a convenience builder for git commands. It particularly comes in handy when you want a concise way of conditionally adding arguments to a git command.

The PR currently applies this new pattern across all of git_commands, but I'd like to get feedback on whether that's a good idea.

Benefits of the new pattern:
* conditionally adding args is easy and concise
* less risk of double-spaces in git commands

Downsides of the new pattern:
* much more verbose for the typical case where you're just appending a bunch of args unconditionally
* harder to CTRL+F

So I'm thinking we have a few options:
### make use of this pattern everywhere and stop using plain strings

* reduces cognitive overhead that you'd get from working with multiple patterns
* spares us from needing to switch from one pattern to another when say you need to add a conditional argument.
* (speculative, probably not a thing) easier to apply some flag to all git commands in future (because they are all constructed by the same code). Example would be passing a '-C' argument for when working with a remote or submodule

### make use of this pattern only when we need to add conditional args

This is less consistent but it means in the places where you have a sequence of static git commands (no conditional args) it's a lot easier to read, and there's less vertical space being used. It also means when you need the new pattern, it results in much cleaner code.

### ditch it entirely

This also benefits from consistency, and spares us having to tell new contributors about our pattern for expressing git commands.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc
