### PR TITLE
Indicate reserved menu keybindings to reduce confusion

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,8 +5,8 @@
   "tasks": [
     {
       "label": "Generate cheatsheet",
-      "type": "process",
-      "command": "go run scripts/cheatsheet/main.go ",
+      "type": "shell",
+      "command": "go run scripts/cheatsheet/main.go generate",
       "problemMatcher": [],
     },
     {

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -88,7 +88,7 @@ git:
     # displays the whole git graph by default in the commits panel (equivalent to passing the `--all` argument to `git log`)
     showWholeGraph: false
   skipHookPrefix: WIP
-  # The main branches. We colour commits green if they belong to one of these branches, 
+  # The main branches. We colour commits green if they belong to one of these branches,
   # so that you can easily see which commits are unique to your branch (coloured in yellow)
   mainBranches: [master, main]
   autoFetch: true
@@ -347,6 +347,7 @@ The available attributes are:
 - default
 - reverse # useful for high-contrast
 - underline
+- strikethrough
 
 ## Highlighting the selected line
 

--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -2,28 +2,30 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 # Lazygit Keybindings
 
+_Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
+
 ## Global Keybindings
 
 <pre>
-  <kbd>ctrl+r</kbd>: switch to a recent repo
-  <kbd>pgup</kbd>: scroll up main panel (fn+up/shift+k)
-  <kbd>pgdown</kbd>: scroll down main panel (fn+down/shift+j)
+  <kbd>&lt;c-r&gt;</kbd>: switch to a recent repo
+  <kbd>&lt;pgup&gt;</kbd>: scroll up main panel (fn+up/shift+k)
+  <kbd>&lt;pgdown&gt;</kbd>: scroll down main panel (fn+down/shift+j)
   <kbd>@</kbd>: open command log menu
   <kbd>}</kbd>: Increase the size of the context shown around changes in the diff view
   <kbd>{</kbd>: Decrease the size of the context shown around changes in the diff view
   <kbd>:</kbd>: execute custom command
-  <kbd>ctrl+p</kbd>: view custom patch options
+  <kbd>&lt;c-p&gt;</kbd>: view custom patch options
   <kbd>m</kbd>: view merge/rebase options
   <kbd>R</kbd>: refresh
   <kbd>+</kbd>: next screen mode (normal/half/fullscreen)
   <kbd>_</kbd>: prev screen mode
   <kbd>?</kbd>: open menu
-  <kbd>ctrl+s</kbd>: view filter-by-path options
+  <kbd>&lt;c-s&gt;</kbd>: view filter-by-path options
   <kbd>W</kbd>: open diff menu
-  <kbd>ctrl+e</kbd>: open diff menu
-  <kbd>ctrl+w</kbd>: Toggle whether or not whitespace changes are shown in the diff view
+  <kbd>&lt;c-e&gt;</kbd>: open diff menu
+  <kbd>&lt;c-w&gt;</kbd>: Toggle whether or not whitespace changes are shown in the diff view
   <kbd>z</kbd>: undo (via reflog) (experimental)
-  <kbd>ctrl+z</kbd>: redo (via reflog) (experimental)
+  <kbd>&lt;c-z&gt;</kbd>: redo (via reflog) (experimental)
   <kbd>P</kbd>: push
   <kbd>p</kbd>: pull
 </pre>
@@ -33,9 +35,9 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>,</kbd>: previous page
   <kbd>.</kbd>: next page
-  <kbd><</kbd>: scroll to top
+  <kbd>&lt;</kbd>: scroll to top
   <kbd>/</kbd>: start search
-  <kbd>></kbd>: scroll to bottom
+  <kbd>&gt;</kbd>: scroll to bottom
   <kbd>H</kbd>: scroll left
   <kbd>L</kbd>: scroll right
   <kbd>]</kbd>: next tab
@@ -45,29 +47,29 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Commit Files
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy the committed file name to the clipboard
+  <kbd>&lt;c-o&gt;</kbd>: copy the committed file name to the clipboard
   <kbd>c</kbd>: checkout file
   <kbd>d</kbd>: discard this commit's changes to this file
   <kbd>o</kbd>: open file
   <kbd>e</kbd>: edit file
-  <kbd>space</kbd>: toggle file included in patch
+  <kbd>&lt;space&gt;</kbd>: toggle file included in patch
   <kbd>a</kbd>: toggle all files included in patch
-  <kbd>enter</kbd>: enter file to add selected lines to the patch (or toggle directory collapsed)
+  <kbd>&lt;enter&gt;</kbd>: enter file to add selected lines to the patch (or toggle directory collapsed)
   <kbd>`</kbd>: toggle file tree view
 </pre>
 
 ## Commit Summary
 
 <pre>
-  <kbd>enter</kbd>: confirm
-  <kbd>esc</kbd>: close
+  <kbd>&lt;enter&gt;</kbd>: confirm
+  <kbd>&lt;esc&gt;</kbd>: close
 </pre>
 
 ## Commits
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy commit SHA to clipboard
-  <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
+  <kbd>&lt;c-o&gt;</kbd>: copy commit SHA to clipboard
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (copied) commits selection
   <kbd>b</kbd>: view bisect options
   <kbd>s</kbd>: squash down
   <kbd>f</kbd>: fixup commit
@@ -78,38 +80,38 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>p</kbd>: pick commit (when mid-rebase)
   <kbd>F</kbd>: create fixup commit for this commit
   <kbd>S</kbd>: squash all 'fixup!' commits above selected commit (autosquash)
-  <kbd>ctrl+j</kbd>: move commit down one
-  <kbd>ctrl+k</kbd>: move commit up one
+  <kbd>&lt;c-j&gt;</kbd>: move commit down one
+  <kbd>&lt;c-k&gt;</kbd>: move commit up one
   <kbd>v</kbd>: paste commits (cherry-pick)
   <kbd>A</kbd>: amend commit with staged changes
   <kbd>a</kbd>: reset commit author
   <kbd>t</kbd>: revert commit
   <kbd>T</kbd>: tag commit
-  <kbd>ctrl+l</kbd>: open log menu
-  <kbd>space</kbd>: checkout commit
+  <kbd>&lt;c-l&gt;</kbd>: open log menu
+  <kbd>&lt;space&gt;</kbd>: checkout commit
   <kbd>y</kbd>: copy commit attribute
   <kbd>o</kbd>: open commit in browser
   <kbd>n</kbd>: create new branch off of commit
   <kbd>g</kbd>: view reset options
   <kbd>c</kbd>: copy commit (cherry-pick)
   <kbd>C</kbd>: copy commit range (cherry-pick)
-  <kbd>enter</kbd>: view selected item's files
+  <kbd>&lt;enter&gt;</kbd>: view selected item's files
 </pre>
 
 ## Confirmation Panel
 
 <pre>
-  <kbd>enter</kbd>: confirm
-  <kbd>esc</kbd>: close/cancel
+  <kbd>&lt;enter&gt;</kbd>: confirm
+  <kbd>&lt;esc&gt;</kbd>: close/cancel
 </pre>
 
 ## Files
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy the file name to the clipboard
+  <kbd>&lt;c-o&gt;</kbd>: copy the file name to the clipboard
   <kbd>d</kbd>: view 'discard changes' options
-  <kbd>space</kbd>: toggle staged
-  <kbd>ctrl+b</kbd>: Filter files (staged/unstaged)
+  <kbd>&lt;space&gt;</kbd>: toggle staged
+  <kbd>&lt;c-b&gt;</kbd>: Filter files (staged/unstaged)
   <kbd>c</kbd>: commit changes
   <kbd>w</kbd>: commit changes without pre-commit hook
   <kbd>A</kbd>: amend last commit
@@ -121,7 +123,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>s</kbd>: stash all changes
   <kbd>S</kbd>: view stash options
   <kbd>a</kbd>: stage/unstage all
-  <kbd>enter</kbd>: stage individual hunks/lines for file, or collapse/expand for directory
+  <kbd>&lt;enter&gt;</kbd>: stage individual hunks/lines for file, or collapse/expand for directory
   <kbd>g</kbd>: view upstream reset options
   <kbd>D</kbd>: view reset options
   <kbd>`</kbd>: toggle file tree view
@@ -132,13 +134,13 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Local Branches
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy branch name to clipboard
+  <kbd>&lt;c-o&gt;</kbd>: copy branch name to clipboard
   <kbd>i</kbd>: show git-flow options
-  <kbd>space</kbd>: checkout
+  <kbd>&lt;space&gt;</kbd>: checkout
   <kbd>n</kbd>: new branch
   <kbd>o</kbd>: create pull request
   <kbd>O</kbd>: create pull request options
-  <kbd>ctrl+y</kbd>: copy pull request URL to clipboard
+  <kbd>&lt;c-y&gt;</kbd>: copy pull request URL to clipboard
   <kbd>c</kbd>: checkout by name
   <kbd>F</kbd>: force checkout
   <kbd>d</kbd>: delete branch
@@ -149,7 +151,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>g</kbd>: view reset options
   <kbd>R</kbd>: rename branch
   <kbd>u</kbd>: set/unset upstream
-  <kbd>enter</kbd>: view commits
+  <kbd>&lt;enter&gt;</kbd>: view commits
 </pre>
 
 ## Main Panel (Merging)
@@ -157,53 +159,53 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>e</kbd>: edit file
   <kbd>o</kbd>: open file
-  <kbd>◀</kbd>: select previous conflict
-  <kbd>▶</kbd>: select next conflict
-  <kbd>▲</kbd>: select previous hunk
-  <kbd>▼</kbd>: select next hunk
+  <kbd>&lt;left&gt;</kbd>: select previous conflict
+  <kbd>&lt;right&gt;</kbd>: select next conflict
+  <kbd>&lt;up&gt;</kbd>: select previous hunk
+  <kbd>&lt;down&gt;</kbd>: select next hunk
   <kbd>z</kbd>: undo
   <kbd>M</kbd>: open external merge tool (git mergetool)
-  <kbd>space</kbd>: pick hunk
+  <kbd>&lt;space&gt;</kbd>: pick hunk
   <kbd>b</kbd>: pick all hunks
-  <kbd>esc</kbd>: return to files panel
+  <kbd>&lt;esc&gt;</kbd>: return to files panel
 </pre>
 
 ## Main Panel (Normal)
 
 <pre>
-  <kbd>mouse wheel ▼</kbd>: scroll down (fn+up)
-  <kbd>mouse wheel ▲</kbd>: scroll up (fn+down)
+  <kbd>mouse wheel down</kbd>: scroll down (fn+up)
+  <kbd>mouse wheel up</kbd>: scroll up (fn+down)
 </pre>
 
 ## Main Panel (Patch Building)
 
 <pre>
-  <kbd>◀</kbd>: select previous hunk
-  <kbd>▶</kbd>: select next hunk
+  <kbd>&lt;left&gt;</kbd>: select previous hunk
+  <kbd>&lt;right&gt;</kbd>: select next hunk
   <kbd>v</kbd>: toggle drag select
   <kbd>V</kbd>: toggle drag select
   <kbd>a</kbd>: toggle select hunk
-  <kbd>ctrl+o</kbd>: copy the selected text to the clipboard
+  <kbd>&lt;c-o&gt;</kbd>: copy the selected text to the clipboard
   <kbd>o</kbd>: open file
   <kbd>e</kbd>: edit file
-  <kbd>space</kbd>: add/remove line(s) to patch
-  <kbd>esc</kbd>: exit custom patch builder
+  <kbd>&lt;space&gt;</kbd>: add/remove line(s) to patch
+  <kbd>&lt;esc&gt;</kbd>: exit custom patch builder
 </pre>
 
 ## Main Panel (Staging)
 
 <pre>
-  <kbd>◀</kbd>: select previous hunk
-  <kbd>▶</kbd>: select next hunk
+  <kbd>&lt;left&gt;</kbd>: select previous hunk
+  <kbd>&lt;right&gt;</kbd>: select next hunk
   <kbd>v</kbd>: toggle drag select
   <kbd>V</kbd>: toggle drag select
   <kbd>a</kbd>: toggle select hunk
-  <kbd>ctrl+o</kbd>: copy the selected text to the clipboard
+  <kbd>&lt;c-o&gt;</kbd>: copy the selected text to the clipboard
   <kbd>o</kbd>: open file
   <kbd>e</kbd>: edit file
-  <kbd>esc</kbd>: return to files panel
-  <kbd>tab</kbd>: switch to other panel (staged/unstaged changes)
-  <kbd>space</kbd>: toggle line staged / unstaged
+  <kbd>&lt;esc&gt;</kbd>: return to files panel
+  <kbd>&lt;tab&gt;</kbd>: switch to other panel (staged/unstaged changes)
+  <kbd>&lt;space&gt;</kbd>: toggle line staged / unstaged
   <kbd>d</kbd>: delete change (git reset)
   <kbd>E</kbd>: edit hunk
   <kbd>c</kbd>: commit changes
@@ -214,38 +216,38 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Menu
 
 <pre>
-  <kbd>enter</kbd>: execute
-  <kbd>esc</kbd>: close
+  <kbd>&lt;enter&gt;</kbd>: execute
+  <kbd>&lt;esc&gt;</kbd>: close
 </pre>
 
 ## Reflog
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy commit SHA to clipboard
-  <kbd>space</kbd>: checkout commit
+  <kbd>&lt;c-o&gt;</kbd>: copy commit SHA to clipboard
+  <kbd>&lt;space&gt;</kbd>: checkout commit
   <kbd>y</kbd>: copy commit attribute
   <kbd>o</kbd>: open commit in browser
   <kbd>n</kbd>: create new branch off of commit
   <kbd>g</kbd>: view reset options
   <kbd>c</kbd>: copy commit (cherry-pick)
   <kbd>C</kbd>: copy commit range (cherry-pick)
-  <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
-  <kbd>enter</kbd>: view commits
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (copied) commits selection
+  <kbd>&lt;enter&gt;</kbd>: view commits
 </pre>
 
 ## Remote Branches
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy branch name to clipboard
-  <kbd>space</kbd>: checkout
+  <kbd>&lt;c-o&gt;</kbd>: copy branch name to clipboard
+  <kbd>&lt;space&gt;</kbd>: checkout
   <kbd>n</kbd>: new branch
   <kbd>M</kbd>: merge into currently checked out branch
   <kbd>r</kbd>: rebase checked-out branch onto this branch
   <kbd>d</kbd>: delete branch
   <kbd>u</kbd>: set as upstream of checked-out branch
-  <kbd>esc</kbd>: Return to remotes list
+  <kbd>&lt;esc&gt;</kbd>: Return to remotes list
   <kbd>g</kbd>: view reset options
-  <kbd>enter</kbd>: view commits
+  <kbd>&lt;enter&gt;</kbd>: view commits
 </pre>
 
 ## Remotes
@@ -260,12 +262,12 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Stash
 
 <pre>
-  <kbd>space</kbd>: apply
+  <kbd>&lt;space&gt;</kbd>: apply
   <kbd>g</kbd>: pop
   <kbd>d</kbd>: drop
   <kbd>n</kbd>: new branch
   <kbd>r</kbd>: rename stash
-  <kbd>enter</kbd>: view selected item's files
+  <kbd>&lt;enter&gt;</kbd>: view selected item's files
 </pre>
 
 ## Status
@@ -274,30 +276,30 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>o</kbd>: open config file
   <kbd>e</kbd>: edit config file
   <kbd>u</kbd>: check for update
-  <kbd>enter</kbd>: switch to a recent repo
+  <kbd>&lt;enter&gt;</kbd>: switch to a recent repo
   <kbd>a</kbd>: show all branch logs
 </pre>
 
 ## Sub-commits
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy commit SHA to clipboard
-  <kbd>space</kbd>: checkout commit
+  <kbd>&lt;c-o&gt;</kbd>: copy commit SHA to clipboard
+  <kbd>&lt;space&gt;</kbd>: checkout commit
   <kbd>y</kbd>: copy commit attribute
   <kbd>o</kbd>: open commit in browser
   <kbd>n</kbd>: create new branch off of commit
   <kbd>g</kbd>: view reset options
   <kbd>c</kbd>: copy commit (cherry-pick)
   <kbd>C</kbd>: copy commit range (cherry-pick)
-  <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
-  <kbd>enter</kbd>: view selected item's files
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (copied) commits selection
+  <kbd>&lt;enter&gt;</kbd>: view selected item's files
 </pre>
 
 ## Submodules
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy submodule name to clipboard
-  <kbd>enter</kbd>: enter submodule
+  <kbd>&lt;c-o&gt;</kbd>: copy submodule name to clipboard
+  <kbd>&lt;enter&gt;</kbd>: enter submodule
   <kbd>d</kbd>: remove submodule
   <kbd>u</kbd>: update submodule
   <kbd>n</kbd>: add new submodule
@@ -309,10 +311,10 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Tags
 
 <pre>
-  <kbd>space</kbd>: checkout
+  <kbd>&lt;space&gt;</kbd>: checkout
   <kbd>d</kbd>: delete tag
   <kbd>P</kbd>: push tag
   <kbd>n</kbd>: create tag
   <kbd>g</kbd>: view reset options
-  <kbd>enter</kbd>: view commits
+  <kbd>&lt;enter&gt;</kbd>: view commits
 </pre>

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -2,28 +2,30 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 # Lazygit キーバインド
 
+_Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
+
 ## グローバルキーバインド
 
 <pre>
-  <kbd>ctrl+r</kbd>: 最近使用したリポジトリに切り替え
-  <kbd>pgup</kbd>: メインパネルを上にスクロール (fn+up/shift+k)
-  <kbd>pgdown</kbd>: メインパネルを下にスクロール (fn+down/shift+j)
+  <kbd>&lt;c-r&gt;</kbd>: 最近使用したリポジトリに切り替え
+  <kbd>&lt;pgup&gt;</kbd>: メインパネルを上にスクロール (fn+up/shift+k)
+  <kbd>&lt;pgdown&gt;</kbd>: メインパネルを下にスクロール (fn+down/shift+j)
   <kbd>@</kbd>: コマンドログメニューを開く
   <kbd>}</kbd>: Increase the size of the context shown around changes in the diff view
   <kbd>{</kbd>: Decrease the size of the context shown around changes in the diff view
   <kbd>:</kbd>: カスタムコマンドを実行
-  <kbd>ctrl+p</kbd>: view custom patch options
+  <kbd>&lt;c-p&gt;</kbd>: view custom patch options
   <kbd>m</kbd>: view merge/rebase options
   <kbd>R</kbd>: リフレッシュ
   <kbd>+</kbd>: 次のスクリーンモード (normal/half/fullscreen)
   <kbd>_</kbd>: 前のスクリーンモード
   <kbd>?</kbd>: メニューを開く
-  <kbd>ctrl+s</kbd>: view filter-by-path options
+  <kbd>&lt;c-s&gt;</kbd>: view filter-by-path options
   <kbd>W</kbd>: 差分メニューを開く
-  <kbd>ctrl+e</kbd>: 差分メニューを開く
-  <kbd>ctrl+w</kbd>: 空白文字の差分の表示有無を切り替え
+  <kbd>&lt;c-e&gt;</kbd>: 差分メニューを開く
+  <kbd>&lt;c-w&gt;</kbd>: 空白文字の差分の表示有無を切り替え
   <kbd>z</kbd>: アンドゥ (via reflog) (experimental)
-  <kbd>ctrl+z</kbd>: リドゥ (via reflog) (experimental)
+  <kbd>&lt;c-z&gt;</kbd>: リドゥ (via reflog) (experimental)
   <kbd>P</kbd>: push
   <kbd>p</kbd>: pull
 </pre>
@@ -33,9 +35,9 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>,</kbd>: 前のページ
   <kbd>.</kbd>: 次のページ
-  <kbd><</kbd>: 最上部までスクロール
+  <kbd>&lt;</kbd>: 最上部までスクロール
   <kbd>/</kbd>: 検索を開始
-  <kbd>></kbd>: 最下部までスクロール
+  <kbd>&gt;</kbd>: 最下部までスクロール
   <kbd>H</kbd>: 左スクロール
   <kbd>L</kbd>: 右スクロール
   <kbd>]</kbd>: 次のタブ
@@ -45,34 +47,34 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Stash
 
 <pre>
-  <kbd>space</kbd>: 適用
+  <kbd>&lt;space&gt;</kbd>: 適用
   <kbd>g</kbd>: pop
   <kbd>d</kbd>: drop
   <kbd>n</kbd>: 新しいブランチを作成
   <kbd>r</kbd>: Stashを変更
-  <kbd>enter</kbd>: view selected item's files
+  <kbd>&lt;enter&gt;</kbd>: view selected item's files
 </pre>
 
 ## Sub-commits
 
 <pre>
-  <kbd>ctrl+o</kbd>: コミットのSHAをクリップボードにコピー
-  <kbd>space</kbd>: コミットをチェックアウト
+  <kbd>&lt;c-o&gt;</kbd>: コミットのSHAをクリップボードにコピー
+  <kbd>&lt;space&gt;</kbd>: コミットをチェックアウト
   <kbd>y</kbd>: コミットの情報をコピー
   <kbd>o</kbd>: ブラウザでコミットを開く
   <kbd>n</kbd>: コミットにブランチを作成
   <kbd>g</kbd>: view reset options
   <kbd>c</kbd>: コミットをコピー (cherry-pick)
   <kbd>C</kbd>: コミットを範囲コピー (cherry-pick)
-  <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
-  <kbd>enter</kbd>: view selected item's files
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (copied) commits selection
+  <kbd>&lt;enter&gt;</kbd>: view selected item's files
 </pre>
 
 ## コミット
 
 <pre>
-  <kbd>ctrl+o</kbd>: コミットのSHAをクリップボードにコピー
-  <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
+  <kbd>&lt;c-o&gt;</kbd>: コミットのSHAをクリップボードにコピー
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (copied) commits selection
   <kbd>b</kbd>: view bisect options
   <kbd>s</kbd>: squash down
   <kbd>f</kbd>: fixup commit
@@ -83,50 +85,50 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>p</kbd>: pick commit (when mid-rebase)
   <kbd>F</kbd>: このコミットに対するfixupコミットを作成
   <kbd>S</kbd>: squash all 'fixup!' commits above selected commit (autosquash)
-  <kbd>ctrl+j</kbd>: コミットを1つ下に移動
-  <kbd>ctrl+k</kbd>: コミットを1つ上に移動
+  <kbd>&lt;c-j&gt;</kbd>: コミットを1つ下に移動
+  <kbd>&lt;c-k&gt;</kbd>: コミットを1つ上に移動
   <kbd>v</kbd>: コミットを貼り付け (cherry-pick)
   <kbd>A</kbd>: ステージされた変更でamendコミット
   <kbd>a</kbd>: reset commit author
   <kbd>t</kbd>: コミットをrevert
   <kbd>T</kbd>: タグを作成
-  <kbd>ctrl+l</kbd>: ログメニューを開く
-  <kbd>space</kbd>: コミットをチェックアウト
+  <kbd>&lt;c-l&gt;</kbd>: ログメニューを開く
+  <kbd>&lt;space&gt;</kbd>: コミットをチェックアウト
   <kbd>y</kbd>: コミットの情報をコピー
   <kbd>o</kbd>: ブラウザでコミットを開く
   <kbd>n</kbd>: コミットにブランチを作成
   <kbd>g</kbd>: view reset options
   <kbd>c</kbd>: コミットをコピー (cherry-pick)
   <kbd>C</kbd>: コミットを範囲コピー (cherry-pick)
-  <kbd>enter</kbd>: view selected item's files
+  <kbd>&lt;enter&gt;</kbd>: view selected item's files
 </pre>
 
 ## コミットファイル
 
 <pre>
-  <kbd>ctrl+o</kbd>: コミットされたファイル名をクリップボードにコピー
+  <kbd>&lt;c-o&gt;</kbd>: コミットされたファイル名をクリップボードにコピー
   <kbd>c</kbd>: checkout file
   <kbd>d</kbd>: discard this commit's changes to this file
   <kbd>o</kbd>: ファイルを開く
   <kbd>e</kbd>: ファイルを編集
-  <kbd>space</kbd>: toggle file included in patch
+  <kbd>&lt;space&gt;</kbd>: toggle file included in patch
   <kbd>a</kbd>: toggle all files included in patch
-  <kbd>enter</kbd>: enter file to add selected lines to the patch (or toggle directory collapsed)
+  <kbd>&lt;enter&gt;</kbd>: enter file to add selected lines to the patch (or toggle directory collapsed)
   <kbd>`</kbd>: ファイルツリーの表示を切り替え
 </pre>
 
 ## コミットメッセージ
 
 <pre>
-  <kbd>enter</kbd>: 確認
-  <kbd>esc</kbd>: 閉じる
+  <kbd>&lt;enter&gt;</kbd>: 確認
+  <kbd>&lt;esc&gt;</kbd>: 閉じる
 </pre>
 
 ## サブモジュール
 
 <pre>
-  <kbd>ctrl+o</kbd>: サブモジュール名をクリップボードにコピー
-  <kbd>enter</kbd>: サブモジュールを開く
+  <kbd>&lt;c-o&gt;</kbd>: サブモジュール名をクリップボードにコピー
+  <kbd>&lt;enter&gt;</kbd>: サブモジュールを開く
   <kbd>d</kbd>: サブモジュールを削除
   <kbd>u</kbd>: サブモジュールを更新
   <kbd>n</kbd>: サブモジュールを新規追加
@@ -141,28 +143,28 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>o</kbd>: 設定ファイルを開く
   <kbd>e</kbd>: 設定ファイルを編集
   <kbd>u</kbd>: 更新を確認
-  <kbd>enter</kbd>: 最近使用したリポジトリに切り替え
+  <kbd>&lt;enter&gt;</kbd>: 最近使用したリポジトリに切り替え
   <kbd>a</kbd>: すべてのブランチログを表示
 </pre>
 
 ## タグ
 
 <pre>
-  <kbd>space</kbd>: チェックアウト
+  <kbd>&lt;space&gt;</kbd>: チェックアウト
   <kbd>d</kbd>: タグを削除
   <kbd>P</kbd>: タグをpush
   <kbd>n</kbd>: タグを作成
   <kbd>g</kbd>: view reset options
-  <kbd>enter</kbd>: コミットを閲覧
+  <kbd>&lt;enter&gt;</kbd>: コミットを閲覧
 </pre>
 
 ## ファイル
 
 <pre>
-  <kbd>ctrl+o</kbd>: ファイル名をクリップボードにコピー
+  <kbd>&lt;c-o&gt;</kbd>: ファイル名をクリップボードにコピー
   <kbd>d</kbd>: view 'discard changes' options
-  <kbd>space</kbd>: ステージ/アンステージ
-  <kbd>ctrl+b</kbd>: ファイルをフィルタ (ステージ/アンステージ)
+  <kbd>&lt;space&gt;</kbd>: ステージ/アンステージ
+  <kbd>&lt;c-b&gt;</kbd>: ファイルをフィルタ (ステージ/アンステージ)
   <kbd>c</kbd>: 変更をコミット
   <kbd>w</kbd>: pre-commitフックを実行せずに変更をコミット
   <kbd>A</kbd>: 最新のコミットにamend
@@ -174,7 +176,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>s</kbd>: 変更をstash
   <kbd>S</kbd>: view stash options
   <kbd>a</kbd>: すべての変更をステージ/アンステージ
-  <kbd>enter</kbd>: stage individual hunks/lines for file, or collapse/expand for directory
+  <kbd>&lt;enter&gt;</kbd>: stage individual hunks/lines for file, or collapse/expand for directory
   <kbd>g</kbd>: view upstream reset options
   <kbd>D</kbd>: view reset options
   <kbd>`</kbd>: ファイルツリーの表示を切り替え
@@ -185,13 +187,13 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## ブランチ
 
 <pre>
-  <kbd>ctrl+o</kbd>: ブランチ名をクリップボードにコピー
+  <kbd>&lt;c-o&gt;</kbd>: ブランチ名をクリップボードにコピー
   <kbd>i</kbd>: show git-flow options
-  <kbd>space</kbd>: チェックアウト
+  <kbd>&lt;space&gt;</kbd>: チェックアウト
   <kbd>n</kbd>: 新しいブランチを作成
   <kbd>o</kbd>: Pull Requestを作成
   <kbd>O</kbd>: create pull request options
-  <kbd>ctrl+y</kbd>: Pull RequestのURLをクリップボードにコピー
+  <kbd>&lt;c-y&gt;</kbd>: Pull RequestのURLをクリップボードにコピー
   <kbd>c</kbd>: checkout by name
   <kbd>F</kbd>: force checkout
   <kbd>d</kbd>: ブランチを削除
@@ -202,7 +204,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>g</kbd>: view reset options
   <kbd>R</kbd>: ブランチ名を変更
   <kbd>u</kbd>: set/unset upstream
-  <kbd>enter</kbd>: コミットを閲覧
+  <kbd>&lt;enter&gt;</kbd>: コミットを閲覧
 </pre>
 
 ## メインパネル (Merging)
@@ -210,53 +212,53 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>e</kbd>: ファイルを編集
   <kbd>o</kbd>: ファイルを開く
-  <kbd>◀</kbd>: 前のコンフリクトを選択
-  <kbd>▶</kbd>: 次のコンフリクトを選択
-  <kbd>▲</kbd>: 前のhunkを選択
-  <kbd>▼</kbd>: 次のhunkを選択
+  <kbd>&lt;left&gt;</kbd>: 前のコンフリクトを選択
+  <kbd>&lt;right&gt;</kbd>: 次のコンフリクトを選択
+  <kbd>&lt;up&gt;</kbd>: 前のhunkを選択
+  <kbd>&lt;down&gt;</kbd>: 次のhunkを選択
   <kbd>z</kbd>: アンドゥ
   <kbd>M</kbd>: git mergetoolを開く
-  <kbd>space</kbd>: pick hunk
+  <kbd>&lt;space&gt;</kbd>: pick hunk
   <kbd>b</kbd>: pick all hunks
-  <kbd>esc</kbd>: ファイル一覧に戻る
+  <kbd>&lt;esc&gt;</kbd>: ファイル一覧に戻る
 </pre>
 
 ## メインパネル (Normal)
 
 <pre>
-  <kbd>mouse wheel ▼</kbd>: 下にスクロール (fn+up)
-  <kbd>mouse wheel ▲</kbd>: 上にスクロール (fn+down)
+  <kbd>mouse wheel down</kbd>: 下にスクロール (fn+up)
+  <kbd>mouse wheel up</kbd>: 上にスクロール (fn+down)
 </pre>
 
 ## メインパネル (Patch Building)
 
 <pre>
-  <kbd>◀</kbd>: 前のhunkを選択
-  <kbd>▶</kbd>: 次のhunkを選択
+  <kbd>&lt;left&gt;</kbd>: 前のhunkを選択
+  <kbd>&lt;right&gt;</kbd>: 次のhunkを選択
   <kbd>v</kbd>: 範囲選択を切り替え
   <kbd>V</kbd>: 範囲選択を切り替え
   <kbd>a</kbd>: hunk選択を切り替え
-  <kbd>ctrl+o</kbd>: 選択されたテキストをクリップボードにコピー
+  <kbd>&lt;c-o&gt;</kbd>: 選択されたテキストをクリップボードにコピー
   <kbd>o</kbd>: ファイルを開く
   <kbd>e</kbd>: ファイルを編集
-  <kbd>space</kbd>: 行をパッチに追加/削除
-  <kbd>esc</kbd>: exit custom patch builder
+  <kbd>&lt;space&gt;</kbd>: 行をパッチに追加/削除
+  <kbd>&lt;esc&gt;</kbd>: exit custom patch builder
 </pre>
 
 ## メインパネル (Staging)
 
 <pre>
-  <kbd>◀</kbd>: 前のhunkを選択
-  <kbd>▶</kbd>: 次のhunkを選択
+  <kbd>&lt;left&gt;</kbd>: 前のhunkを選択
+  <kbd>&lt;right&gt;</kbd>: 次のhunkを選択
   <kbd>v</kbd>: 範囲選択を切り替え
   <kbd>V</kbd>: 範囲選択を切り替え
   <kbd>a</kbd>: hunk選択を切り替え
-  <kbd>ctrl+o</kbd>: 選択されたテキストをクリップボードにコピー
+  <kbd>&lt;c-o&gt;</kbd>: 選択されたテキストをクリップボードにコピー
   <kbd>o</kbd>: ファイルを開く
   <kbd>e</kbd>: ファイルを編集
-  <kbd>esc</kbd>: ファイル一覧に戻る
-  <kbd>tab</kbd>: パネルを切り替え
-  <kbd>space</kbd>: 選択行をステージ/アンステージ
+  <kbd>&lt;esc&gt;</kbd>: ファイル一覧に戻る
+  <kbd>&lt;tab&gt;</kbd>: パネルを切り替え
+  <kbd>&lt;space&gt;</kbd>: 選択行をステージ/アンステージ
   <kbd>d</kbd>: 変更を削除 (git reset)
   <kbd>E</kbd>: edit hunk
   <kbd>c</kbd>: 変更をコミット
@@ -267,8 +269,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## メニュー
 
 <pre>
-  <kbd>enter</kbd>: 実行
-  <kbd>esc</kbd>: 閉じる
+  <kbd>&lt;enter&gt;</kbd>: 実行
+  <kbd>&lt;esc&gt;</kbd>: 閉じる
 </pre>
 
 ## リモート
@@ -283,36 +285,36 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## リモートブランチ
 
 <pre>
-  <kbd>ctrl+o</kbd>: ブランチ名をクリップボードにコピー
-  <kbd>space</kbd>: チェックアウト
+  <kbd>&lt;c-o&gt;</kbd>: ブランチ名をクリップボードにコピー
+  <kbd>&lt;space&gt;</kbd>: チェックアウト
   <kbd>n</kbd>: 新しいブランチを作成
   <kbd>M</kbd>: 現在のブランチにマージ
   <kbd>r</kbd>: rebase checked-out branch onto this branch
   <kbd>d</kbd>: ブランチを削除
   <kbd>u</kbd>: set as upstream of checked-out branch
-  <kbd>esc</kbd>: リモート一覧に戻る
+  <kbd>&lt;esc&gt;</kbd>: リモート一覧に戻る
   <kbd>g</kbd>: view reset options
-  <kbd>enter</kbd>: コミットを閲覧
+  <kbd>&lt;enter&gt;</kbd>: コミットを閲覧
 </pre>
 
 ## 参照ログ
 
 <pre>
-  <kbd>ctrl+o</kbd>: コミットのSHAをクリップボードにコピー
-  <kbd>space</kbd>: コミットをチェックアウト
+  <kbd>&lt;c-o&gt;</kbd>: コミットのSHAをクリップボードにコピー
+  <kbd>&lt;space&gt;</kbd>: コミットをチェックアウト
   <kbd>y</kbd>: コミットの情報をコピー
   <kbd>o</kbd>: ブラウザでコミットを開く
   <kbd>n</kbd>: コミットにブランチを作成
   <kbd>g</kbd>: view reset options
   <kbd>c</kbd>: コミットをコピー (cherry-pick)
   <kbd>C</kbd>: コミットを範囲コピー (cherry-pick)
-  <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
-  <kbd>enter</kbd>: コミットを閲覧
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (copied) commits selection
+  <kbd>&lt;enter&gt;</kbd>: コミットを閲覧
 </pre>
 
 ## 確認パネル
 
 <pre>
-  <kbd>enter</kbd>: 確認
-  <kbd>esc</kbd>: 閉じる/キャンセル
+  <kbd>&lt;enter&gt;</kbd>: 確認
+  <kbd>&lt;esc&gt;</kbd>: 閉じる/キャンセル
 </pre>

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -2,28 +2,30 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 # Lazygit 키 바인딩
 
+_Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
+
 ## 글로벌 키 바인딩
 
 <pre>
-  <kbd>ctrl+r</kbd>: 최근에 사용한 저장소로 전환
-  <kbd>pgup</kbd>: 메인 패널을 위로 스크롤 (fn+up/shift+k)
-  <kbd>pgdown</kbd>: 메인 패널을 아래로로 스크롤 (fn+down/shift+j)
+  <kbd>&lt;c-r&gt;</kbd>: 최근에 사용한 저장소로 전환
+  <kbd>&lt;pgup&gt;</kbd>: 메인 패널을 위로 스크롤 (fn+up/shift+k)
+  <kbd>&lt;pgdown&gt;</kbd>: 메인 패널을 아래로로 스크롤 (fn+down/shift+j)
   <kbd>@</kbd>: 명령어 로그 메뉴 열기
   <kbd>}</kbd>: diff 보기의 변경 사항 주위에 표시되는 컨텍스트의 크기를 늘리기
   <kbd>{</kbd>: diff 보기의 변경 사항 주위에 표시되는 컨텍스트 크기 줄이기
   <kbd>:</kbd>: execute custom command
-  <kbd>ctrl+p</kbd>: 커스텀 Patch 옵션 보기
+  <kbd>&lt;c-p&gt;</kbd>: 커스텀 Patch 옵션 보기
   <kbd>m</kbd>: view merge/rebase options
   <kbd>R</kbd>: 새로고침
   <kbd>+</kbd>: 다음 스크린 모드 (normal/half/fullscreen)
   <kbd>_</kbd>: 이전 스크린 모드
   <kbd>?</kbd>: 매뉴 열기
-  <kbd>ctrl+s</kbd>: view filter-by-path options
+  <kbd>&lt;c-s&gt;</kbd>: view filter-by-path options
   <kbd>W</kbd>: Diff 메뉴 열기
-  <kbd>ctrl+e</kbd>: Diff 메뉴 열기
-  <kbd>ctrl+w</kbd>: 공백문자를 Diff 뷰에서 표시 여부 전환
+  <kbd>&lt;c-e&gt;</kbd>: Diff 메뉴 열기
+  <kbd>&lt;c-w&gt;</kbd>: 공백문자를 Diff 뷰에서 표시 여부 전환
   <kbd>z</kbd>: 되돌리기 (reflog) (실험적)
-  <kbd>ctrl+z</kbd>: 다시 실행 (reflog) (실험적)
+  <kbd>&lt;c-z&gt;</kbd>: 다시 실행 (reflog) (실험적)
   <kbd>P</kbd>: 푸시
   <kbd>p</kbd>: 업데이트
 </pre>
@@ -33,9 +35,9 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>,</kbd>: 이전 페이지
   <kbd>.</kbd>: 다음 페이지
-  <kbd><</kbd>: 맨 위로 스크롤 
+  <kbd>&lt;</kbd>: 맨 위로 스크롤 
   <kbd>/</kbd>: 검색 시작
-  <kbd>></kbd>: 맨 아래로 스크롤 
+  <kbd>&gt;</kbd>: 맨 아래로 스크롤 
   <kbd>H</kbd>: 우 스크롤
   <kbd>L</kbd>: 좌 스크롤
   <kbd>]</kbd>: 이전 탭
@@ -45,49 +47,49 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Reflog
 
 <pre>
-  <kbd>ctrl+o</kbd>: 커밋 SHA를 클립보드에 복사
-  <kbd>space</kbd>: 커밋을 체크아웃
+  <kbd>&lt;c-o&gt;</kbd>: 커밋 SHA를 클립보드에 복사
+  <kbd>&lt;space&gt;</kbd>: 커밋을 체크아웃
   <kbd>y</kbd>: 커밋 attribute 복사
   <kbd>o</kbd>: 브라우저에서 커밋 열기
   <kbd>n</kbd>: 커밋에서 새 브랜치를 만듭니다.
   <kbd>g</kbd>: view reset options
   <kbd>c</kbd>: 커밋을 복사 (cherry-pick)
   <kbd>C</kbd>: 커밋을 범위로 복사 (cherry-pick)
-  <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
-  <kbd>enter</kbd>: 커밋 보기
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (copied) commits selection
+  <kbd>&lt;enter&gt;</kbd>: 커밋 보기
 </pre>
 
 ## Stash
 
 <pre>
-  <kbd>space</kbd>: 적용
+  <kbd>&lt;space&gt;</kbd>: 적용
   <kbd>g</kbd>: pop
   <kbd>d</kbd>: drop
   <kbd>n</kbd>: 새 브랜치 생성
   <kbd>r</kbd>: rename stash
-  <kbd>enter</kbd>: view selected item's files
+  <kbd>&lt;enter&gt;</kbd>: view selected item's files
 </pre>
 
 ## Sub-commits
 
 <pre>
-  <kbd>ctrl+o</kbd>: 커밋 SHA를 클립보드에 복사
-  <kbd>space</kbd>: 커밋을 체크아웃
+  <kbd>&lt;c-o&gt;</kbd>: 커밋 SHA를 클립보드에 복사
+  <kbd>&lt;space&gt;</kbd>: 커밋을 체크아웃
   <kbd>y</kbd>: 커밋 attribute 복사
   <kbd>o</kbd>: 브라우저에서 커밋 열기
   <kbd>n</kbd>: 커밋에서 새 브랜치를 만듭니다.
   <kbd>g</kbd>: view reset options
   <kbd>c</kbd>: 커밋을 복사 (cherry-pick)
   <kbd>C</kbd>: 커밋을 범위로 복사 (cherry-pick)
-  <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
-  <kbd>enter</kbd>: view selected item's files
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (copied) commits selection
+  <kbd>&lt;enter&gt;</kbd>: view selected item's files
 </pre>
 
 ## 메뉴
 
 <pre>
-  <kbd>enter</kbd>: 실행
-  <kbd>esc</kbd>: 닫기
+  <kbd>&lt;enter&gt;</kbd>: 실행
+  <kbd>&lt;esc&gt;</kbd>: 닫기
 </pre>
 
 ## 메인 패널 (Merging)
@@ -95,53 +97,53 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>e</kbd>: 파일 편집
   <kbd>o</kbd>: 파일 닫기
-  <kbd>◀</kbd>: 이전 충돌을 선택
-  <kbd>▶</kbd>: 다음 충돌을 선택
-  <kbd>▲</kbd>: 이전 hunk를 선택
-  <kbd>▼</kbd>: 다음 hunk를 선택
+  <kbd>&lt;left&gt;</kbd>: 이전 충돌을 선택
+  <kbd>&lt;right&gt;</kbd>: 다음 충돌을 선택
+  <kbd>&lt;up&gt;</kbd>: 이전 hunk를 선택
+  <kbd>&lt;down&gt;</kbd>: 다음 hunk를 선택
   <kbd>z</kbd>: 되돌리기
   <kbd>M</kbd>: git mergetool를 열기
-  <kbd>space</kbd>: pick hunk
+  <kbd>&lt;space&gt;</kbd>: pick hunk
   <kbd>b</kbd>: pick all hunks
-  <kbd>esc</kbd>: 파일 목록으로 돌아가기
+  <kbd>&lt;esc&gt;</kbd>: 파일 목록으로 돌아가기
 </pre>
 
 ## 메인 패널 (Normal)
 
 <pre>
-  <kbd>mouse wheel ▼</kbd>: 아래로 스크롤 (fn+up)
-  <kbd>mouse wheel ▲</kbd>: 위로 스크롤 (fn+down)
+  <kbd>mouse wheel down</kbd>: 아래로 스크롤 (fn+up)
+  <kbd>mouse wheel up</kbd>: 위로 스크롤 (fn+down)
 </pre>
 
 ## 메인 패널 (Patch Building)
 
 <pre>
-  <kbd>◀</kbd>: 이전 hunk를 선택
-  <kbd>▶</kbd>: 다음 hunk를 선택
+  <kbd>&lt;left&gt;</kbd>: 이전 hunk를 선택
+  <kbd>&lt;right&gt;</kbd>: 다음 hunk를 선택
   <kbd>v</kbd>: 드래그 선택 전환
   <kbd>V</kbd>: 드래그 선택 전환
   <kbd>a</kbd>: toggle select hunk
-  <kbd>ctrl+o</kbd>: 선택한 텍스트를 클립보드에 복사
+  <kbd>&lt;c-o&gt;</kbd>: 선택한 텍스트를 클립보드에 복사
   <kbd>o</kbd>: 파일 닫기
   <kbd>e</kbd>: 파일 편집
-  <kbd>space</kbd>: line(s)을 패치에 추가/삭제
-  <kbd>esc</kbd>: exit custom patch builder
+  <kbd>&lt;space&gt;</kbd>: line(s)을 패치에 추가/삭제
+  <kbd>&lt;esc&gt;</kbd>: exit custom patch builder
 </pre>
 
 ## 메인 패널 (Staging)
 
 <pre>
-  <kbd>◀</kbd>: 이전 hunk를 선택
-  <kbd>▶</kbd>: 다음 hunk를 선택
+  <kbd>&lt;left&gt;</kbd>: 이전 hunk를 선택
+  <kbd>&lt;right&gt;</kbd>: 다음 hunk를 선택
   <kbd>v</kbd>: 드래그 선택 전환
   <kbd>V</kbd>: 드래그 선택 전환
   <kbd>a</kbd>: toggle select hunk
-  <kbd>ctrl+o</kbd>: 선택한 텍스트를 클립보드에 복사
+  <kbd>&lt;c-o&gt;</kbd>: 선택한 텍스트를 클립보드에 복사
   <kbd>o</kbd>: 파일 닫기
   <kbd>e</kbd>: 파일 편집
-  <kbd>esc</kbd>: 파일 목록으로 돌아가기
-  <kbd>tab</kbd>: 패널 전환
-  <kbd>space</kbd>: 선택한 행을 staged / unstaged
+  <kbd>&lt;esc&gt;</kbd>: 파일 목록으로 돌아가기
+  <kbd>&lt;tab&gt;</kbd>: 패널 전환
+  <kbd>&lt;space&gt;</kbd>: 선택한 행을 staged / unstaged
   <kbd>d</kbd>: 변경을 삭제 (git reset)
   <kbd>E</kbd>: edit hunk
   <kbd>c</kbd>: 커밋 변경내용
@@ -152,13 +154,13 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## 브랜치
 
 <pre>
-  <kbd>ctrl+o</kbd>: 브랜치명을 클립보드에 복사
+  <kbd>&lt;c-o&gt;</kbd>: 브랜치명을 클립보드에 복사
   <kbd>i</kbd>: git-flow 옵션 보기
-  <kbd>space</kbd>: 체크아웃
+  <kbd>&lt;space&gt;</kbd>: 체크아웃
   <kbd>n</kbd>: 새 브랜치 생성
   <kbd>o</kbd>: 풀 리퀘스트 생성
   <kbd>O</kbd>: 풀 리퀘스트 생성 옵션
-  <kbd>ctrl+y</kbd>: 풀 리퀘스트 URL을 클립보드에 복사
+  <kbd>&lt;c-y&gt;</kbd>: 풀 리퀘스트 URL을 클립보드에 복사
   <kbd>c</kbd>: 이름으로 체크아웃
   <kbd>F</kbd>: 강제 체크아웃
   <kbd>d</kbd>: 브랜치 삭제
@@ -169,7 +171,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>g</kbd>: view reset options
   <kbd>R</kbd>: 브랜치 이름 변경
   <kbd>u</kbd>: set/unset upstream
-  <kbd>enter</kbd>: 커밋 보기
+  <kbd>&lt;enter&gt;</kbd>: 커밋 보기
 </pre>
 
 ## 상태
@@ -178,15 +180,15 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>o</kbd>: 설정 파일 열기
   <kbd>e</kbd>: 설정 파일 수정
   <kbd>u</kbd>: 업데이트 확인
-  <kbd>enter</kbd>: 최근에 사용한 저장소로 전환
+  <kbd>&lt;enter&gt;</kbd>: 최근에 사용한 저장소로 전환
   <kbd>a</kbd>: 모든 브랜치 로그 표시
 </pre>
 
 ## 서브모듈
 
 <pre>
-  <kbd>ctrl+o</kbd>: 서브모듈 이름을 클립보드에 복사
-  <kbd>enter</kbd>: 서브모듈 열기
+  <kbd>&lt;c-o&gt;</kbd>: 서브모듈 이름을 클립보드에 복사
+  <kbd>&lt;enter&gt;</kbd>: 서브모듈 열기
   <kbd>d</kbd>: 서브모듈 삭제
   <kbd>u</kbd>: 서브모듈 업데이트
   <kbd>n</kbd>: 새로운 서브모듈 추가
@@ -207,23 +209,23 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## 원격 브랜치
 
 <pre>
-  <kbd>ctrl+o</kbd>: 브랜치명을 클립보드에 복사
-  <kbd>space</kbd>: 체크아웃
+  <kbd>&lt;c-o&gt;</kbd>: 브랜치명을 클립보드에 복사
+  <kbd>&lt;space&gt;</kbd>: 체크아웃
   <kbd>n</kbd>: 새 브랜치 생성
   <kbd>M</kbd>: 현재 브랜치에 병합
   <kbd>r</kbd>: 체크아웃된 브랜치를 이 브랜치에 리베이스
   <kbd>d</kbd>: 브랜치 삭제
   <kbd>u</kbd>: set as upstream of checked-out branch
-  <kbd>esc</kbd>: 원격목록으로 돌아가기
+  <kbd>&lt;esc&gt;</kbd>: 원격목록으로 돌아가기
   <kbd>g</kbd>: view reset options
-  <kbd>enter</kbd>: 커밋 보기
+  <kbd>&lt;enter&gt;</kbd>: 커밋 보기
 </pre>
 
 ## 커밋
 
 <pre>
-  <kbd>ctrl+o</kbd>: 커밋 SHA를 클립보드에 복사
-  <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
+  <kbd>&lt;c-o&gt;</kbd>: 커밋 SHA를 클립보드에 복사
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (copied) commits selection
   <kbd>b</kbd>: bisect 옵션 보기
   <kbd>s</kbd>: squash down
   <kbd>f</kbd>: fixup commit
@@ -234,63 +236,63 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>p</kbd>: pick commit (when mid-rebase)
   <kbd>F</kbd>: create fixup commit for this commit
   <kbd>S</kbd>: squash all 'fixup!' commits above selected commit (autosquash)
-  <kbd>ctrl+j</kbd>: 커밋을 1개 아래로 이동
-  <kbd>ctrl+k</kbd>: 커밋을 1개 위로 이동
+  <kbd>&lt;c-j&gt;</kbd>: 커밋을 1개 아래로 이동
+  <kbd>&lt;c-k&gt;</kbd>: 커밋을 1개 위로 이동
   <kbd>v</kbd>: 커밋을 붙여넣기 (cherry-pick)
   <kbd>A</kbd>: amend commit with staged changes
   <kbd>a</kbd>: reset commit author
   <kbd>t</kbd>: 커밋 되돌리기
   <kbd>T</kbd>: tag commit
-  <kbd>ctrl+l</kbd>: 로그 메뉴 열기
-  <kbd>space</kbd>: 커밋을 체크아웃
+  <kbd>&lt;c-l&gt;</kbd>: 로그 메뉴 열기
+  <kbd>&lt;space&gt;</kbd>: 커밋을 체크아웃
   <kbd>y</kbd>: 커밋 attribute 복사
   <kbd>o</kbd>: 브라우저에서 커밋 열기
   <kbd>n</kbd>: 커밋에서 새 브랜치를 만듭니다.
   <kbd>g</kbd>: view reset options
   <kbd>c</kbd>: 커밋을 복사 (cherry-pick)
   <kbd>C</kbd>: 커밋을 범위로 복사 (cherry-pick)
-  <kbd>enter</kbd>: view selected item's files
+  <kbd>&lt;enter&gt;</kbd>: view selected item's files
 </pre>
 
 ## 커밋 파일
 
 <pre>
-  <kbd>ctrl+o</kbd>: 커밋한 파일명을 클립보드에 복사
+  <kbd>&lt;c-o&gt;</kbd>: 커밋한 파일명을 클립보드에 복사
   <kbd>c</kbd>: checkout file
   <kbd>d</kbd>: discard this commit's changes to this file
   <kbd>o</kbd>: 파일 닫기
   <kbd>e</kbd>: 파일 편집
-  <kbd>space</kbd>: toggle file included in patch
+  <kbd>&lt;space&gt;</kbd>: toggle file included in patch
   <kbd>a</kbd>: toggle all files included in patch
-  <kbd>enter</kbd>: enter file to add selected lines to the patch (or toggle directory collapsed)
+  <kbd>&lt;enter&gt;</kbd>: enter file to add selected lines to the patch (or toggle directory collapsed)
   <kbd>`</kbd>: 파일 트리뷰로 전환
 </pre>
 
 ## 커밋메시지
 
 <pre>
-  <kbd>enter</kbd>: 확인
-  <kbd>esc</kbd>: 닫기
+  <kbd>&lt;enter&gt;</kbd>: 확인
+  <kbd>&lt;esc&gt;</kbd>: 닫기
 </pre>
 
 ## 태그
 
 <pre>
-  <kbd>space</kbd>: 체크아웃
+  <kbd>&lt;space&gt;</kbd>: 체크아웃
   <kbd>d</kbd>: 태그 삭제
   <kbd>P</kbd>: 태그를 push
   <kbd>n</kbd>: 태그를 생성
   <kbd>g</kbd>: view reset options
-  <kbd>enter</kbd>: 커밋 보기
+  <kbd>&lt;enter&gt;</kbd>: 커밋 보기
 </pre>
 
 ## 파일
 
 <pre>
-  <kbd>ctrl+o</kbd>: 파일명을 클립보드에 복사
+  <kbd>&lt;c-o&gt;</kbd>: 파일명을 클립보드에 복사
   <kbd>d</kbd>: view 'discard changes' options
-  <kbd>space</kbd>: Staged 전환
-  <kbd>ctrl+b</kbd>: 파일을 필터하기 (Staged/unstaged)
+  <kbd>&lt;space&gt;</kbd>: Staged 전환
+  <kbd>&lt;c-b&gt;</kbd>: 파일을 필터하기 (Staged/unstaged)
   <kbd>c</kbd>: 커밋 변경내용
   <kbd>w</kbd>: commit changes without pre-commit hook
   <kbd>A</kbd>: 마지맛 커밋 수정
@@ -302,7 +304,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>s</kbd>: 변경사항을 Stash
   <kbd>S</kbd>: Stash 옵션 보기
   <kbd>a</kbd>: 모든 변경을 Staged/unstaged으로 전환
-  <kbd>enter</kbd>: stage individual hunks/lines for file, or collapse/expand for directory
+  <kbd>&lt;enter&gt;</kbd>: stage individual hunks/lines for file, or collapse/expand for directory
   <kbd>g</kbd>: view upstream reset options
   <kbd>D</kbd>: view reset options
   <kbd>`</kbd>: 파일 트리뷰로 전환
@@ -313,6 +315,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## 확인 패널
 
 <pre>
-  <kbd>enter</kbd>: 확인
-  <kbd>esc</kbd>: 닫기/취소
+  <kbd>&lt;enter&gt;</kbd>: 확인
+  <kbd>&lt;esc&gt;</kbd>: 닫기/취소
 </pre>

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -2,28 +2,30 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 # Lazygit Sneltoetsen
 
+_Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
+
 ## Globale Sneltoetsen
 
 <pre>
-  <kbd>ctrl+r</kbd>: wissel naar een recente repo
-  <kbd>pgup</kbd>: scroll naar beneden vanaf hoofdpaneel (fn+up/shift+k)
-  <kbd>pgdown</kbd>: scroll naar beneden vanaf hoofdpaneel (fn+down/shift+j)
+  <kbd>&lt;c-r&gt;</kbd>: wissel naar een recente repo
+  <kbd>&lt;pgup&gt;</kbd>: scroll naar beneden vanaf hoofdpaneel (fn+up/shift+k)
+  <kbd>&lt;pgdown&gt;</kbd>: scroll naar beneden vanaf hoofdpaneel (fn+down/shift+j)
   <kbd>@</kbd>: open command log menu
   <kbd>}</kbd>: Increase the size of the context shown around changes in the diff view
   <kbd>{</kbd>: Decrease the size of the context shown around changes in the diff view
   <kbd>:</kbd>: voer aangepaste commando uit
-  <kbd>ctrl+p</kbd>: bekijk aangepaste patch opties
+  <kbd>&lt;c-p&gt;</kbd>: bekijk aangepaste patch opties
   <kbd>m</kbd>: bekijk merge/rebase opties
   <kbd>R</kbd>: verversen
   <kbd>+</kbd>: volgende scherm modus (normaal/half/groot)
   <kbd>_</kbd>: vorige scherm modus
   <kbd>?</kbd>: open menu
-  <kbd>ctrl+s</kbd>: bekijk scoping opties
+  <kbd>&lt;c-s&gt;</kbd>: bekijk scoping opties
   <kbd>W</kbd>: open diff menu
-  <kbd>ctrl+e</kbd>: open diff menu
-  <kbd>ctrl+w</kbd>: Toggle whether or not whitespace changes are shown in the diff view
+  <kbd>&lt;c-e&gt;</kbd>: open diff menu
+  <kbd>&lt;c-w&gt;</kbd>: Toggle whether or not whitespace changes are shown in the diff view
   <kbd>z</kbd>: ongedaan maken (via reflog) (experimenteel)
-  <kbd>ctrl+z</kbd>: redo (via reflog) (experimenteel)
+  <kbd>&lt;c-z&gt;</kbd>: redo (via reflog) (experimenteel)
   <kbd>P</kbd>: push
   <kbd>p</kbd>: pull
 </pre>
@@ -33,9 +35,9 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>,</kbd>: vorige pagina
   <kbd>.</kbd>: volgende pagina
-  <kbd><</kbd>: scroll naar boven
+  <kbd>&lt;</kbd>: scroll naar boven
   <kbd>/</kbd>: start met zoeken
-  <kbd>></kbd>: scroll naar beneden
+  <kbd>&gt;</kbd>: scroll naar beneden
   <kbd>H</kbd>: scroll left
   <kbd>L</kbd>: scroll right
   <kbd>]</kbd>: volgende tabblad
@@ -45,10 +47,10 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Bestanden
 
 <pre>
-  <kbd>ctrl+o</kbd>: kopieer de bestandsnaam naar het klembord
+  <kbd>&lt;c-o&gt;</kbd>: kopieer de bestandsnaam naar het klembord
   <kbd>d</kbd>: bekijk 'veranderingen ongedaan maken' opties
-  <kbd>space</kbd>: toggle staged
-  <kbd>ctrl+b</kbd>: Filter files (staged/unstaged)
+  <kbd>&lt;space&gt;</kbd>: toggle staged
+  <kbd>&lt;c-b&gt;</kbd>: Filter files (staged/unstaged)
   <kbd>c</kbd>: commit veranderingen
   <kbd>w</kbd>: commit veranderingen zonder pre-commit hook
   <kbd>A</kbd>: wijzig laatste commit
@@ -60,7 +62,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>s</kbd>: stash-bestanden
   <kbd>S</kbd>: bekijk stash opties
   <kbd>a</kbd>: toggle staged alle
-  <kbd>enter</kbd>: stage individuele hunks/lijnen
+  <kbd>&lt;enter&gt;</kbd>: stage individuele hunks/lijnen
   <kbd>g</kbd>: bekijk upstream reset opties
   <kbd>D</kbd>: bekijk reset opties
   <kbd>`</kbd>: toggle bestandsboom weergave
@@ -71,20 +73,20 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Bevestigingspaneel
 
 <pre>
-  <kbd>enter</kbd>: bevestig
-  <kbd>esc</kbd>: sluiten
+  <kbd>&lt;enter&gt;</kbd>: bevestig
+  <kbd>&lt;esc&gt;</kbd>: sluiten
 </pre>
 
 ## Branches
 
 <pre>
-  <kbd>ctrl+o</kbd>: kopieer branch name naar klembord
+  <kbd>&lt;c-o&gt;</kbd>: kopieer branch name naar klembord
   <kbd>i</kbd>: laat git-flow opties zien
-  <kbd>space</kbd>: uitchecken
+  <kbd>&lt;space&gt;</kbd>: uitchecken
   <kbd>n</kbd>: nieuwe branch
   <kbd>o</kbd>: maak een pull-request
   <kbd>O</kbd>: bekijk opties voor pull-aanvraag
-  <kbd>ctrl+y</kbd>: kopieer de URL van het pull-verzoek naar het klembord
+  <kbd>&lt;c-y&gt;</kbd>: kopieer de URL van het pull-verzoek naar het klembord
   <kbd>c</kbd>: uitchecken bij naam
   <kbd>F</kbd>: forceer checkout
   <kbd>d</kbd>: verwijder branch
@@ -95,35 +97,35 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>g</kbd>: bekijk reset opties
   <kbd>R</kbd>: hernoem branch
   <kbd>u</kbd>: set/unset upstream
-  <kbd>enter</kbd>: bekijk commits
+  <kbd>&lt;enter&gt;</kbd>: bekijk commits
 </pre>
 
 ## Commit Bericht
 
 <pre>
-  <kbd>enter</kbd>: bevestig
-  <kbd>esc</kbd>: sluiten
+  <kbd>&lt;enter&gt;</kbd>: bevestig
+  <kbd>&lt;esc&gt;</kbd>: sluiten
 </pre>
 
 ## Commit bestanden
 
 <pre>
-  <kbd>ctrl+o</kbd>: kopieer de vastgelegde bestandsnaam naar het klembord
+  <kbd>&lt;c-o&gt;</kbd>: kopieer de vastgelegde bestandsnaam naar het klembord
   <kbd>c</kbd>: bestand uitchecken
   <kbd>d</kbd>: uitsluit deze commit zijn veranderingen aan dit bestand
   <kbd>o</kbd>: open bestand
   <kbd>e</kbd>: verander bestand
-  <kbd>space</kbd>: toggle bestand inbegrepen in patch
+  <kbd>&lt;space&gt;</kbd>: toggle bestand inbegrepen in patch
   <kbd>a</kbd>: toggle all files included in patch
-  <kbd>enter</kbd>: enter bestand om geselecteerde regels toe te voegen aan de patch
+  <kbd>&lt;enter&gt;</kbd>: enter bestand om geselecteerde regels toe te voegen aan de patch
   <kbd>`</kbd>: toggle bestandsboom weergave
 </pre>
 
 ## Commits
 
 <pre>
-  <kbd>ctrl+o</kbd>: kopieer commit SHA naar klembord
-  <kbd>ctrl+r</kbd>: reset cherry-picked (gekopieerde) commits selectie
+  <kbd>&lt;c-o&gt;</kbd>: kopieer commit SHA naar klembord
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (gekopieerde) commits selectie
   <kbd>b</kbd>: view bisect options
   <kbd>s</kbd>: squash beneden
   <kbd>f</kbd>: Fixup commit
@@ -134,29 +136,29 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>p</kbd>: kies commit (wanneer midden in rebase)
   <kbd>F</kbd>: creëer fixup commit voor deze commit
   <kbd>S</kbd>: squash bovenstaande commits
-  <kbd>ctrl+j</kbd>: verplaats commit 1 naar beneden
-  <kbd>ctrl+k</kbd>: verplaats commit 1 naar boven
+  <kbd>&lt;c-j&gt;</kbd>: verplaats commit 1 naar beneden
+  <kbd>&lt;c-k&gt;</kbd>: verplaats commit 1 naar boven
   <kbd>v</kbd>: plak commits (cherry-pick)
   <kbd>A</kbd>: wijzig commit met staged veranderingen
   <kbd>a</kbd>: reset commit author
   <kbd>t</kbd>: commit ongedaan maken
   <kbd>T</kbd>: tag commit
-  <kbd>ctrl+l</kbd>: open log menu
-  <kbd>space</kbd>: checkout commit
+  <kbd>&lt;c-l&gt;</kbd>: open log menu
+  <kbd>&lt;space&gt;</kbd>: checkout commit
   <kbd>y</kbd>: copy commit attribute
   <kbd>o</kbd>: open commit in browser
   <kbd>n</kbd>: creëer nieuwe branch van commit
   <kbd>g</kbd>: bekijk reset opties
   <kbd>c</kbd>: kopieer commit (cherry-pick)
   <kbd>C</kbd>: kopieer commit reeks (cherry-pick)
-  <kbd>enter</kbd>: bekijk gecommite bestanden
+  <kbd>&lt;enter&gt;</kbd>: bekijk gecommite bestanden
 </pre>
 
 ## Menu
 
 <pre>
-  <kbd>enter</kbd>: uitvoeren
-  <kbd>esc</kbd>: sluiten
+  <kbd>&lt;enter&gt;</kbd>: uitvoeren
+  <kbd>&lt;esc&gt;</kbd>: sluiten
 </pre>
 
 ## Mergen
@@ -164,67 +166,67 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>e</kbd>: verander bestand
   <kbd>o</kbd>: open bestand
-  <kbd>◀</kbd>: selecteer voorgaand conflict
-  <kbd>▶</kbd>: selecteer volgende conflict
-  <kbd>▲</kbd>: selecteer bovenste hunk
-  <kbd>▼</kbd>: selecteer onderste hunk
+  <kbd>&lt;left&gt;</kbd>: selecteer voorgaand conflict
+  <kbd>&lt;right&gt;</kbd>: selecteer volgende conflict
+  <kbd>&lt;up&gt;</kbd>: selecteer bovenste hunk
+  <kbd>&lt;down&gt;</kbd>: selecteer onderste hunk
   <kbd>z</kbd>: ongedaan maken
   <kbd>M</kbd>: open external merge tool (git mergetool)
-  <kbd>space</kbd>: kies hunk
+  <kbd>&lt;space&gt;</kbd>: kies hunk
   <kbd>b</kbd>: kies bijde hunks
-  <kbd>esc</kbd>: ga terug naar het bestanden paneel
+  <kbd>&lt;esc&gt;</kbd>: ga terug naar het bestanden paneel
 </pre>
 
 ## Normaal
 
 <pre>
-  <kbd>mouse wheel ▼</kbd>: scroll omlaag (fn+up)
-  <kbd>mouse wheel ▲</kbd>: scroll omhoog (fn+down)
+  <kbd>mouse wheel down</kbd>: scroll omlaag (fn+up)
+  <kbd>mouse wheel up</kbd>: scroll omhoog (fn+down)
 </pre>
 
 ## Patch Bouwen
 
 <pre>
-  <kbd>◀</kbd>: selecteer de vorige hunk
-  <kbd>▶</kbd>: selecteer de volgende hunk
+  <kbd>&lt;left&gt;</kbd>: selecteer de vorige hunk
+  <kbd>&lt;right&gt;</kbd>: selecteer de volgende hunk
   <kbd>v</kbd>: toggle drag selecteer
   <kbd>V</kbd>: toggle drag selecteer
   <kbd>a</kbd>: toggle selecteer hunk
-  <kbd>ctrl+o</kbd>: copy the selected text to the clipboard
+  <kbd>&lt;c-o&gt;</kbd>: copy the selected text to the clipboard
   <kbd>o</kbd>: open bestand
   <kbd>e</kbd>: verander bestand
-  <kbd>space</kbd>: voeg toe/verwijder lijn(en) in patch
-  <kbd>esc</kbd>: sluit lijn-bij-lijn modus
+  <kbd>&lt;space&gt;</kbd>: voeg toe/verwijder lijn(en) in patch
+  <kbd>&lt;esc&gt;</kbd>: sluit lijn-bij-lijn modus
 </pre>
 
 ## Reflog
 
 <pre>
-  <kbd>ctrl+o</kbd>: kopieer commit SHA naar klembord
-  <kbd>space</kbd>: checkout commit
+  <kbd>&lt;c-o&gt;</kbd>: kopieer commit SHA naar klembord
+  <kbd>&lt;space&gt;</kbd>: checkout commit
   <kbd>y</kbd>: copy commit attribute
   <kbd>o</kbd>: open commit in browser
   <kbd>n</kbd>: creëer nieuwe branch van commit
   <kbd>g</kbd>: bekijk reset opties
   <kbd>c</kbd>: kopieer commit (cherry-pick)
   <kbd>C</kbd>: kopieer commit reeks (cherry-pick)
-  <kbd>ctrl+r</kbd>: reset cherry-picked (gekopieerde) commits selectie
-  <kbd>enter</kbd>: bekijk commits
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (gekopieerde) commits selectie
+  <kbd>&lt;enter&gt;</kbd>: bekijk commits
 </pre>
 
 ## Remote Branches
 
 <pre>
-  <kbd>ctrl+o</kbd>: kopieer branch name naar klembord
-  <kbd>space</kbd>: uitchecken
+  <kbd>&lt;c-o&gt;</kbd>: kopieer branch name naar klembord
+  <kbd>&lt;space&gt;</kbd>: uitchecken
   <kbd>n</kbd>: nieuwe branch
   <kbd>M</kbd>: merge in met huidige checked out branch
   <kbd>r</kbd>: rebase branch
   <kbd>d</kbd>: verwijder branch
   <kbd>u</kbd>: stel in als upstream van uitgecheckte branch
-  <kbd>esc</kbd>: ga terug naar remotes lijst
+  <kbd>&lt;esc&gt;</kbd>: ga terug naar remotes lijst
   <kbd>g</kbd>: bekijk reset opties
-  <kbd>enter</kbd>: bekijk commits
+  <kbd>&lt;enter&gt;</kbd>: bekijk commits
 </pre>
 
 ## Remotes
@@ -239,17 +241,17 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Staging
 
 <pre>
-  <kbd>◀</kbd>: selecteer de vorige hunk
-  <kbd>▶</kbd>: selecteer de volgende hunk
+  <kbd>&lt;left&gt;</kbd>: selecteer de vorige hunk
+  <kbd>&lt;right&gt;</kbd>: selecteer de volgende hunk
   <kbd>v</kbd>: toggle drag selecteer
   <kbd>V</kbd>: toggle drag selecteer
   <kbd>a</kbd>: toggle selecteer hunk
-  <kbd>ctrl+o</kbd>: copy the selected text to the clipboard
+  <kbd>&lt;c-o&gt;</kbd>: copy the selected text to the clipboard
   <kbd>o</kbd>: open bestand
   <kbd>e</kbd>: verander bestand
-  <kbd>esc</kbd>: ga terug naar het bestanden paneel
-  <kbd>tab</kbd>: ga naar een ander paneel
-  <kbd>space</kbd>: toggle lijnen staged / unstaged
+  <kbd>&lt;esc&gt;</kbd>: ga terug naar het bestanden paneel
+  <kbd>&lt;tab&gt;</kbd>: ga naar een ander paneel
+  <kbd>&lt;space&gt;</kbd>: toggle lijnen staged / unstaged
   <kbd>d</kbd>: verwijdert change (git reset)
   <kbd>E</kbd>: edit hunk
   <kbd>c</kbd>: commit veranderingen
@@ -260,12 +262,12 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Stash
 
 <pre>
-  <kbd>space</kbd>: toepassen
+  <kbd>&lt;space&gt;</kbd>: toepassen
   <kbd>g</kbd>: pop
   <kbd>d</kbd>: laten vallen
   <kbd>n</kbd>: nieuwe branch
   <kbd>r</kbd>: rename stash
-  <kbd>enter</kbd>: bekijk gecommite bestanden
+  <kbd>&lt;enter&gt;</kbd>: bekijk gecommite bestanden
 </pre>
 
 ## Status
@@ -274,30 +276,30 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>o</kbd>: open config bestand
   <kbd>e</kbd>: verander config bestand
   <kbd>u</kbd>: check voor updates
-  <kbd>enter</kbd>: wissel naar een recente repo
+  <kbd>&lt;enter&gt;</kbd>: wissel naar een recente repo
   <kbd>a</kbd>: alle logs van de branch laten zien
 </pre>
 
 ## Sub-commits
 
 <pre>
-  <kbd>ctrl+o</kbd>: kopieer commit SHA naar klembord
-  <kbd>space</kbd>: checkout commit
+  <kbd>&lt;c-o&gt;</kbd>: kopieer commit SHA naar klembord
+  <kbd>&lt;space&gt;</kbd>: checkout commit
   <kbd>y</kbd>: copy commit attribute
   <kbd>o</kbd>: open commit in browser
   <kbd>n</kbd>: creëer nieuwe branch van commit
   <kbd>g</kbd>: bekijk reset opties
   <kbd>c</kbd>: kopieer commit (cherry-pick)
   <kbd>C</kbd>: kopieer commit reeks (cherry-pick)
-  <kbd>ctrl+r</kbd>: reset cherry-picked (gekopieerde) commits selectie
-  <kbd>enter</kbd>: bekijk gecommite bestanden
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (gekopieerde) commits selectie
+  <kbd>&lt;enter&gt;</kbd>: bekijk gecommite bestanden
 </pre>
 
 ## Submodules
 
 <pre>
-  <kbd>ctrl+o</kbd>: kopieer submodule naam naar klembord
-  <kbd>enter</kbd>: enter submodule
+  <kbd>&lt;c-o&gt;</kbd>: kopieer submodule naam naar klembord
+  <kbd>&lt;enter&gt;</kbd>: enter submodule
   <kbd>d</kbd>: remove submodule
   <kbd>u</kbd>: update submodule
   <kbd>n</kbd>: voeg nieuwe submodule toe
@@ -309,10 +311,10 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Tags
 
 <pre>
-  <kbd>space</kbd>: uitchecken
+  <kbd>&lt;space&gt;</kbd>: uitchecken
   <kbd>d</kbd>: verwijder tag
   <kbd>P</kbd>: push tag
   <kbd>n</kbd>: creëer tag
   <kbd>g</kbd>: bekijk reset opties
-  <kbd>enter</kbd>: bekijk commits
+  <kbd>&lt;enter&gt;</kbd>: bekijk commits
 </pre>

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -2,28 +2,30 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 # Lazygit Keybindings
 
+_Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
+
 ## Globalne
 
 <pre>
-  <kbd>ctrl+r</kbd>: switch to a recent repo
-  <kbd>pgup</kbd>: scroll up main panel (fn+up/shift+k)
-  <kbd>pgdown</kbd>: scroll down main panel (fn+down/shift+j)
+  <kbd>&lt;c-r&gt;</kbd>: switch to a recent repo
+  <kbd>&lt;pgup&gt;</kbd>: scroll up main panel (fn+up/shift+k)
+  <kbd>&lt;pgdown&gt;</kbd>: scroll down main panel (fn+down/shift+j)
   <kbd>@</kbd>: open command log menu
   <kbd>}</kbd>: Increase the size of the context shown around changes in the diff view
   <kbd>{</kbd>: Decrease the size of the context shown around changes in the diff view
   <kbd>:</kbd>: wykonaj własną komendę
-  <kbd>ctrl+p</kbd>: view custom patch options
+  <kbd>&lt;c-p&gt;</kbd>: view custom patch options
   <kbd>m</kbd>: widok scalenia/opcje zmiany bazy
   <kbd>R</kbd>: odśwież
   <kbd>+</kbd>: next screen mode (normal/half/fullscreen)
   <kbd>_</kbd>: prev screen mode
   <kbd>?</kbd>: open menu
-  <kbd>ctrl+s</kbd>: view filter-by-path options
+  <kbd>&lt;c-s&gt;</kbd>: view filter-by-path options
   <kbd>W</kbd>: open diff menu
-  <kbd>ctrl+e</kbd>: open diff menu
-  <kbd>ctrl+w</kbd>: Toggle whether or not whitespace changes are shown in the diff view
+  <kbd>&lt;c-e&gt;</kbd>: open diff menu
+  <kbd>&lt;c-w&gt;</kbd>: Toggle whether or not whitespace changes are shown in the diff view
   <kbd>z</kbd>: undo (via reflog) (experimental)
-  <kbd>ctrl+z</kbd>: redo (via reflog) (experimental)
+  <kbd>&lt;c-z&gt;</kbd>: redo (via reflog) (experimental)
   <kbd>P</kbd>: push
   <kbd>p</kbd>: pull
 </pre>
@@ -33,9 +35,9 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>,</kbd>: previous page
   <kbd>.</kbd>: next page
-  <kbd><</kbd>: scroll to top
+  <kbd>&lt;</kbd>: scroll to top
   <kbd>/</kbd>: start search
-  <kbd>></kbd>: scroll to bottom
+  <kbd>&gt;</kbd>: scroll to bottom
   <kbd>H</kbd>: scroll left
   <kbd>L</kbd>: scroll right
   <kbd>]</kbd>: next tab
@@ -45,15 +47,15 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Commit Summary
 
 <pre>
-  <kbd>enter</kbd>: potwierdź
-  <kbd>esc</kbd>: zamknij
+  <kbd>&lt;enter&gt;</kbd>: potwierdź
+  <kbd>&lt;esc&gt;</kbd>: zamknij
 </pre>
 
 ## Commity
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy commit SHA to clipboard
-  <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
+  <kbd>&lt;c-o&gt;</kbd>: copy commit SHA to clipboard
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (copied) commits selection
   <kbd>b</kbd>: view bisect options
   <kbd>s</kbd>: ściśnij
   <kbd>f</kbd>: napraw commit
@@ -64,41 +66,41 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>p</kbd>: wybierz commit (podczas zmiany bazy)
   <kbd>F</kbd>: utwórz commit naprawczy dla tego commita
   <kbd>S</kbd>: spłaszcz wszystkie commity naprawcze powyżej zaznaczonych commitów (autosquash)
-  <kbd>ctrl+j</kbd>: przenieś commit 1 w dół
-  <kbd>ctrl+k</kbd>: przenieś commit 1 w górę
+  <kbd>&lt;c-j&gt;</kbd>: przenieś commit 1 w dół
+  <kbd>&lt;c-k&gt;</kbd>: przenieś commit 1 w górę
   <kbd>v</kbd>: wklej commity (przebieranie)
   <kbd>A</kbd>: popraw commit zmianami z poczekalni
   <kbd>a</kbd>: reset commit author
   <kbd>t</kbd>: odwróć commit
   <kbd>T</kbd>: tag commit
-  <kbd>ctrl+l</kbd>: open log menu
-  <kbd>space</kbd>: checkout commit
+  <kbd>&lt;c-l&gt;</kbd>: open log menu
+  <kbd>&lt;space&gt;</kbd>: checkout commit
   <kbd>y</kbd>: copy commit attribute
   <kbd>o</kbd>: open commit in browser
   <kbd>n</kbd>: create new branch off of commit
   <kbd>g</kbd>: wyświetl opcje resetu
   <kbd>c</kbd>: kopiuj commit (przebieranie)
   <kbd>C</kbd>: kopiuj zakres commitów (przebieranie)
-  <kbd>enter</kbd>: przeglądaj pliki commita
+  <kbd>&lt;enter&gt;</kbd>: przeglądaj pliki commita
 </pre>
 
 ## Confirmation Panel
 
 <pre>
-  <kbd>enter</kbd>: potwierdź
-  <kbd>esc</kbd>: zamknij
+  <kbd>&lt;enter&gt;</kbd>: potwierdź
+  <kbd>&lt;esc&gt;</kbd>: zamknij
 </pre>
 
 ## Local Branches
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy branch name to clipboard
+  <kbd>&lt;c-o&gt;</kbd>: copy branch name to clipboard
   <kbd>i</kbd>: show git-flow options
-  <kbd>space</kbd>: przełącz
+  <kbd>&lt;space&gt;</kbd>: przełącz
   <kbd>n</kbd>: nowa gałąź
   <kbd>o</kbd>: utwórz żądanie pobrania
   <kbd>O</kbd>: utwórz opcje żądania ściągnięcia
-  <kbd>ctrl+y</kbd>: skopiuj adres URL żądania pobrania do schowka
+  <kbd>&lt;c-y&gt;</kbd>: skopiuj adres URL żądania pobrania do schowka
   <kbd>c</kbd>: przełącz używając nazwy
   <kbd>F</kbd>: wymuś przełączenie
   <kbd>d</kbd>: usuń gałąź
@@ -109,38 +111,38 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>g</kbd>: wyświetl opcje resetu
   <kbd>R</kbd>: rename branch
   <kbd>u</kbd>: set/unset upstream
-  <kbd>enter</kbd>: view commits
+  <kbd>&lt;enter&gt;</kbd>: view commits
 </pre>
 
 ## Main Panel (Patch Building)
 
 <pre>
-  <kbd>◀</kbd>: poprzedni kawałek
-  <kbd>▶</kbd>: następny kawałek
+  <kbd>&lt;left&gt;</kbd>: poprzedni kawałek
+  <kbd>&lt;right&gt;</kbd>: następny kawałek
   <kbd>v</kbd>: toggle drag select
   <kbd>V</kbd>: toggle drag select
   <kbd>a</kbd>: toggle select hunk
-  <kbd>ctrl+o</kbd>: copy the selected text to the clipboard
+  <kbd>&lt;c-o&gt;</kbd>: copy the selected text to the clipboard
   <kbd>o</kbd>: otwórz plik
   <kbd>e</kbd>: edytuj plik
-  <kbd>space</kbd>: add/remove line(s) to patch
-  <kbd>esc</kbd>: wyście z trybu "linia po linii"
+  <kbd>&lt;space&gt;</kbd>: add/remove line(s) to patch
+  <kbd>&lt;esc&gt;</kbd>: wyście z trybu "linia po linii"
 </pre>
 
 ## Menu
 
 <pre>
-  <kbd>enter</kbd>: wykonaj
-  <kbd>esc</kbd>: zamknij
+  <kbd>&lt;enter&gt;</kbd>: wykonaj
+  <kbd>&lt;esc&gt;</kbd>: zamknij
 </pre>
 
 ## Pliki
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy the file name to the clipboard
+  <kbd>&lt;c-o&gt;</kbd>: copy the file name to the clipboard
   <kbd>d</kbd>: pokaż opcje porzucania zmian
-  <kbd>space</kbd>: przełącz stan poczekalni
-  <kbd>ctrl+b</kbd>: Filter files (staged/unstaged)
+  <kbd>&lt;space&gt;</kbd>: przełącz stan poczekalni
+  <kbd>&lt;c-b&gt;</kbd>: Filter files (staged/unstaged)
   <kbd>c</kbd>: Zatwierdź zmiany
   <kbd>w</kbd>: zatwierdź zmiany bez skryptu pre-commit
   <kbd>A</kbd>: Zmień ostatni commit
@@ -152,7 +154,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>s</kbd>: przechowaj zmiany
   <kbd>S</kbd>: wyświetl opcje schowka
   <kbd>a</kbd>: przełącz stan poczekalni wszystkich
-  <kbd>enter</kbd>: zatwierdź pojedyncze linie
+  <kbd>&lt;enter&gt;</kbd>: zatwierdź pojedyncze linie
   <kbd>g</kbd>: view upstream reset options
   <kbd>D</kbd>: wyświetl opcje resetu
   <kbd>`</kbd>: toggle file tree view
@@ -163,31 +165,31 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Pliki commita
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy the committed file name to the clipboard
+  <kbd>&lt;c-o&gt;</kbd>: copy the committed file name to the clipboard
   <kbd>c</kbd>: plik wybierania
   <kbd>d</kbd>: porzuć zmiany commita dla tego pliku
   <kbd>o</kbd>: otwórz plik
   <kbd>e</kbd>: edytuj plik
-  <kbd>space</kbd>: toggle file included in patch
+  <kbd>&lt;space&gt;</kbd>: toggle file included in patch
   <kbd>a</kbd>: toggle all files included in patch
-  <kbd>enter</kbd>: enter file to add selected lines to the patch (or toggle directory collapsed)
+  <kbd>&lt;enter&gt;</kbd>: enter file to add selected lines to the patch (or toggle directory collapsed)
   <kbd>`</kbd>: toggle file tree view
 </pre>
 
 ## Poczekalnia
 
 <pre>
-  <kbd>◀</kbd>: poprzedni kawałek
-  <kbd>▶</kbd>: następny kawałek
+  <kbd>&lt;left&gt;</kbd>: poprzedni kawałek
+  <kbd>&lt;right&gt;</kbd>: następny kawałek
   <kbd>v</kbd>: toggle drag select
   <kbd>V</kbd>: toggle drag select
   <kbd>a</kbd>: toggle select hunk
-  <kbd>ctrl+o</kbd>: copy the selected text to the clipboard
+  <kbd>&lt;c-o&gt;</kbd>: copy the selected text to the clipboard
   <kbd>o</kbd>: otwórz plik
   <kbd>e</kbd>: edytuj plik
-  <kbd>esc</kbd>: wróć do panelu plików
-  <kbd>tab</kbd>: switch to other panel (staged/unstaged changes)
-  <kbd>space</kbd>: toggle line staged / unstaged
+  <kbd>&lt;esc&gt;</kbd>: wróć do panelu plików
+  <kbd>&lt;tab&gt;</kbd>: switch to other panel (staged/unstaged changes)
+  <kbd>&lt;space&gt;</kbd>: toggle line staged / unstaged
   <kbd>d</kbd>: delete change (git reset)
   <kbd>E</kbd>: edit hunk
   <kbd>c</kbd>: Zatwierdź zmiany
@@ -198,31 +200,31 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Reflog
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy commit SHA to clipboard
-  <kbd>space</kbd>: checkout commit
+  <kbd>&lt;c-o&gt;</kbd>: copy commit SHA to clipboard
+  <kbd>&lt;space&gt;</kbd>: checkout commit
   <kbd>y</kbd>: copy commit attribute
   <kbd>o</kbd>: open commit in browser
   <kbd>n</kbd>: create new branch off of commit
   <kbd>g</kbd>: wyświetl opcje resetu
   <kbd>c</kbd>: kopiuj commit (przebieranie)
   <kbd>C</kbd>: kopiuj zakres commitów (przebieranie)
-  <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
-  <kbd>enter</kbd>: view commits
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (copied) commits selection
+  <kbd>&lt;enter&gt;</kbd>: view commits
 </pre>
 
 ## Remote Branches
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy branch name to clipboard
-  <kbd>space</kbd>: przełącz
+  <kbd>&lt;c-o&gt;</kbd>: copy branch name to clipboard
+  <kbd>&lt;space&gt;</kbd>: przełącz
   <kbd>n</kbd>: nowa gałąź
   <kbd>M</kbd>: scal do obecnej gałęzi
   <kbd>r</kbd>: zmiana bazy gałęzi
   <kbd>d</kbd>: usuń gałąź
   <kbd>u</kbd>: set as upstream of checked-out branch
-  <kbd>esc</kbd>: wróć do listy repozytoriów zdalnych
+  <kbd>&lt;esc&gt;</kbd>: wróć do listy repozytoriów zdalnych
   <kbd>g</kbd>: wyświetl opcje resetu
-  <kbd>enter</kbd>: view commits
+  <kbd>&lt;enter&gt;</kbd>: view commits
 </pre>
 
 ## Remotes
@@ -239,26 +241,26 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>e</kbd>: edytuj plik
   <kbd>o</kbd>: otwórz plik
-  <kbd>◀</kbd>: poprzedni konflikt
-  <kbd>▶</kbd>: następny konflikt
-  <kbd>▲</kbd>: wybierz poprzedni kawałek
-  <kbd>▼</kbd>: wybierz następny kawałek
+  <kbd>&lt;left&gt;</kbd>: poprzedni konflikt
+  <kbd>&lt;right&gt;</kbd>: następny konflikt
+  <kbd>&lt;up&gt;</kbd>: wybierz poprzedni kawałek
+  <kbd>&lt;down&gt;</kbd>: wybierz następny kawałek
   <kbd>z</kbd>: cofnij
   <kbd>M</kbd>: open external merge tool (git mergetool)
-  <kbd>space</kbd>: wybierz kawałek
+  <kbd>&lt;space&gt;</kbd>: wybierz kawałek
   <kbd>b</kbd>: wybierz wszystkie kawałki
-  <kbd>esc</kbd>: wróć do panelu plików
+  <kbd>&lt;esc&gt;</kbd>: wróć do panelu plików
 </pre>
 
 ## Schowek
 
 <pre>
-  <kbd>space</kbd>: zastosuj
+  <kbd>&lt;space&gt;</kbd>: zastosuj
   <kbd>g</kbd>: wyciągnij
   <kbd>d</kbd>: porzuć
   <kbd>n</kbd>: nowa gałąź
   <kbd>r</kbd>: rename stash
-  <kbd>enter</kbd>: przeglądaj pliki commita
+  <kbd>&lt;enter&gt;</kbd>: przeglądaj pliki commita
 </pre>
 
 ## Status
@@ -267,30 +269,30 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>o</kbd>: otwórz konfigurację
   <kbd>e</kbd>: edytuj konfigurację
   <kbd>u</kbd>: sprawdź aktualizacje
-  <kbd>enter</kbd>: switch to a recent repo
+  <kbd>&lt;enter&gt;</kbd>: switch to a recent repo
   <kbd>a</kbd>: pokaż wszystkie logi gałęzi
 </pre>
 
 ## Sub-commits
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy commit SHA to clipboard
-  <kbd>space</kbd>: checkout commit
+  <kbd>&lt;c-o&gt;</kbd>: copy commit SHA to clipboard
+  <kbd>&lt;space&gt;</kbd>: checkout commit
   <kbd>y</kbd>: copy commit attribute
   <kbd>o</kbd>: open commit in browser
   <kbd>n</kbd>: create new branch off of commit
   <kbd>g</kbd>: wyświetl opcje resetu
   <kbd>c</kbd>: kopiuj commit (przebieranie)
   <kbd>C</kbd>: kopiuj zakres commitów (przebieranie)
-  <kbd>ctrl+r</kbd>: reset cherry-picked (copied) commits selection
-  <kbd>enter</kbd>: przeglądaj pliki commita
+  <kbd>&lt;c-r&gt;</kbd>: reset cherry-picked (copied) commits selection
+  <kbd>&lt;enter&gt;</kbd>: przeglądaj pliki commita
 </pre>
 
 ## Submodules
 
 <pre>
-  <kbd>ctrl+o</kbd>: copy submodule name to clipboard
-  <kbd>enter</kbd>: enter submodule
+  <kbd>&lt;c-o&gt;</kbd>: copy submodule name to clipboard
+  <kbd>&lt;enter&gt;</kbd>: enter submodule
   <kbd>d</kbd>: remove submodule
   <kbd>u</kbd>: update submodule
   <kbd>n</kbd>: add new submodule
@@ -302,17 +304,17 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Tags
 
 <pre>
-  <kbd>space</kbd>: przełącz
+  <kbd>&lt;space&gt;</kbd>: przełącz
   <kbd>d</kbd>: delete tag
   <kbd>P</kbd>: push tag
   <kbd>n</kbd>: create tag
   <kbd>g</kbd>: wyświetl opcje resetu
-  <kbd>enter</kbd>: view commits
+  <kbd>&lt;enter&gt;</kbd>: view commits
 </pre>
 
 ## Zwykłe
 
 <pre>
-  <kbd>mouse wheel ▼</kbd>: przewiń w dół (fn+up)
-  <kbd>mouse wheel ▲</kbd>: przewiń w górę (fn+down)
+  <kbd>mouse wheel down</kbd>: przewiń w dół (fn+up)
+  <kbd>mouse wheel up</kbd>: przewiń w górę (fn+down)
 </pre>

--- a/docs/keybindings/Keybindings_zh.md
+++ b/docs/keybindings/Keybindings_zh.md
@@ -2,28 +2,30 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 # Lazygit 按键绑定
 
+_Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
+
 ## 全局键绑定
 
 <pre>
-  <kbd>ctrl+r</kbd>: 切换到最近的仓库
-  <kbd>pgup</kbd>: 向上滚动主面板 (fn+up/shift+k)
-  <kbd>pgdown</kbd>: 向下滚动主面板 (fn+down/shift+j)
+  <kbd>&lt;c-r&gt;</kbd>: 切换到最近的仓库
+  <kbd>&lt;pgup&gt;</kbd>: 向上滚动主面板 (fn+up/shift+k)
+  <kbd>&lt;pgdown&gt;</kbd>: 向下滚动主面板 (fn+down/shift+j)
   <kbd>@</kbd>: 打开命令日志菜单
   <kbd>}</kbd>: 扩大差异视图中显示的上下文范围
   <kbd>{</kbd>: 缩小差异视图中显示的上下文范围
   <kbd>:</kbd>: 执行自定义命令
-  <kbd>ctrl+p</kbd>: 查看自定义补丁选项
+  <kbd>&lt;c-p&gt;</kbd>: 查看自定义补丁选项
   <kbd>m</kbd>: 查看 合并/变基 选项
   <kbd>R</kbd>: 刷新
   <kbd>+</kbd>: 下一屏模式（正常/半屏/全屏）
   <kbd>_</kbd>: 上一屏模式
   <kbd>?</kbd>: 打开菜单
-  <kbd>ctrl+s</kbd>: 查看按路径过滤选项
+  <kbd>&lt;c-s&gt;</kbd>: 查看按路径过滤选项
   <kbd>W</kbd>: 打开 diff 菜单
-  <kbd>ctrl+e</kbd>: 打开 diff 菜单
-  <kbd>ctrl+w</kbd>: 切换是否在差异视图中显示空白字符差异
+  <kbd>&lt;c-e&gt;</kbd>: 打开 diff 菜单
+  <kbd>&lt;c-w&gt;</kbd>: 切换是否在差异视图中显示空白字符差异
   <kbd>z</kbd>: （通过 reflog）撤销「实验功能」
-  <kbd>ctrl+z</kbd>: （通过 reflog）重做「实验功能」
+  <kbd>&lt;c-z&gt;</kbd>: （通过 reflog）重做「实验功能」
   <kbd>P</kbd>: 推送
   <kbd>p</kbd>: 拉取
 </pre>
@@ -33,9 +35,9 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>,</kbd>: 上一页
   <kbd>.</kbd>: 下一页
-  <kbd><</kbd>: 滚动到顶部
+  <kbd>&lt;</kbd>: 滚动到顶部
   <kbd>/</kbd>: 开始搜索
-  <kbd>></kbd>: 滚动到底部
+  <kbd>&gt;</kbd>: 滚动到底部
   <kbd>H</kbd>: 向左滚动
   <kbd>L</kbd>: 向右滚动
   <kbd>]</kbd>: 下一个标签
@@ -45,28 +47,28 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## Reflog 页面
 
 <pre>
-  <kbd>ctrl+o</kbd>: 将提交的 SHA 复制到剪贴板
-  <kbd>space</kbd>: 检出提交
+  <kbd>&lt;c-o&gt;</kbd>: 将提交的 SHA 复制到剪贴板
+  <kbd>&lt;space&gt;</kbd>: 检出提交
   <kbd>y</kbd>: copy commit attribute
   <kbd>o</kbd>: 在浏览器中打开提交
   <kbd>n</kbd>: 从提交创建新分支
   <kbd>g</kbd>: 查看重置选项
   <kbd>c</kbd>: 复制提交（拣选）
   <kbd>C</kbd>: 复制提交范围（拣选）
-  <kbd>ctrl+r</kbd>: 重置已拣选（复制）的提交
-  <kbd>enter</kbd>: 查看提交
+  <kbd>&lt;c-r&gt;</kbd>: 重置已拣选（复制）的提交
+  <kbd>&lt;enter&gt;</kbd>: 查看提交
 </pre>
 
 ## 分支页面
 
 <pre>
-  <kbd>ctrl+o</kbd>: 将分支名称复制到剪贴板
+  <kbd>&lt;c-o&gt;</kbd>: 将分支名称复制到剪贴板
   <kbd>i</kbd>: 显示 git-flow 选项
-  <kbd>space</kbd>: 检出
+  <kbd>&lt;space&gt;</kbd>: 检出
   <kbd>n</kbd>: 新分支
   <kbd>o</kbd>: 创建抓取请求
   <kbd>O</kbd>: 创建抓取请求选项
-  <kbd>ctrl+y</kbd>: 将抓取请求 URL 复制到剪贴板
+  <kbd>&lt;c-y&gt;</kbd>: 将抓取请求 URL 复制到剪贴板
   <kbd>c</kbd>: 按名称检出
   <kbd>F</kbd>: 强制检出
   <kbd>d</kbd>: 删除分支
@@ -77,29 +79,29 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>g</kbd>: 查看重置选项
   <kbd>R</kbd>: 重命名分支
   <kbd>u</kbd>: set/unset upstream
-  <kbd>enter</kbd>: 查看提交
+  <kbd>&lt;enter&gt;</kbd>: 查看提交
 </pre>
 
 ## 子提交
 
 <pre>
-  <kbd>ctrl+o</kbd>: 将提交的 SHA 复制到剪贴板
-  <kbd>space</kbd>: 检出提交
+  <kbd>&lt;c-o&gt;</kbd>: 将提交的 SHA 复制到剪贴板
+  <kbd>&lt;space&gt;</kbd>: 检出提交
   <kbd>y</kbd>: copy commit attribute
   <kbd>o</kbd>: 在浏览器中打开提交
   <kbd>n</kbd>: 从提交创建新分支
   <kbd>g</kbd>: 查看重置选项
   <kbd>c</kbd>: 复制提交（拣选）
   <kbd>C</kbd>: 复制提交范围（拣选）
-  <kbd>ctrl+r</kbd>: 重置已拣选（复制）的提交
-  <kbd>enter</kbd>: 查看提交的文件
+  <kbd>&lt;c-r&gt;</kbd>: 重置已拣选（复制）的提交
+  <kbd>&lt;enter&gt;</kbd>: 查看提交的文件
 </pre>
 
 ## 子模块
 
 <pre>
-  <kbd>ctrl+o</kbd>: 将子模块名称复制到剪贴板
-  <kbd>enter</kbd>: 输入子模块
+  <kbd>&lt;c-o&gt;</kbd>: 将子模块名称复制到剪贴板
+  <kbd>&lt;enter&gt;</kbd>: 输入子模块
   <kbd>d</kbd>: 删除子模块
   <kbd>u</kbd>: 更新子模块
   <kbd>n</kbd>: 添加新的子模块
@@ -111,8 +113,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## 提交
 
 <pre>
-  <kbd>ctrl+o</kbd>: 将提交的 SHA 复制到剪贴板
-  <kbd>ctrl+r</kbd>: 重置已拣选（复制）的提交
+  <kbd>&lt;c-o&gt;</kbd>: 将提交的 SHA 复制到剪贴板
+  <kbd>&lt;c-r&gt;</kbd>: 重置已拣选（复制）的提交
   <kbd>b</kbd>: 查看二分查找选项
   <kbd>s</kbd>: 向下压缩
   <kbd>f</kbd>: 修正提交（fixup）
@@ -123,52 +125,52 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>p</kbd>: 选择提交（变基过程中）
   <kbd>F</kbd>: 为此提交创建修正
   <kbd>S</kbd>: 压缩在所选提交之上的所有“fixup!”提交（自动压缩）
-  <kbd>ctrl+j</kbd>: 下移提交
-  <kbd>ctrl+k</kbd>: 上移提交
+  <kbd>&lt;c-j&gt;</kbd>: 下移提交
+  <kbd>&lt;c-k&gt;</kbd>: 上移提交
   <kbd>v</kbd>: 粘贴提交（拣选）
   <kbd>A</kbd>: 用已暂存的更改来修补提交
   <kbd>a</kbd>: reset commit author
   <kbd>t</kbd>: 还原提交
   <kbd>T</kbd>: 标签提交
-  <kbd>ctrl+l</kbd>: 打开日志菜单
-  <kbd>space</kbd>: 检出提交
+  <kbd>&lt;c-l&gt;</kbd>: 打开日志菜单
+  <kbd>&lt;space&gt;</kbd>: 检出提交
   <kbd>y</kbd>: copy commit attribute
   <kbd>o</kbd>: 在浏览器中打开提交
   <kbd>n</kbd>: 从提交创建新分支
   <kbd>g</kbd>: 查看重置选项
   <kbd>c</kbd>: 复制提交（拣选）
   <kbd>C</kbd>: 复制提交范围（拣选）
-  <kbd>enter</kbd>: 查看提交的文件
+  <kbd>&lt;enter&gt;</kbd>: 查看提交的文件
 </pre>
 
 ## 提交文件
 
 <pre>
-  <kbd>ctrl+o</kbd>: 将提交的文件名复制到剪贴板
+  <kbd>&lt;c-o&gt;</kbd>: 将提交的文件名复制到剪贴板
   <kbd>c</kbd>: 检出文件
   <kbd>d</kbd>: 放弃对此文件的提交更改
   <kbd>o</kbd>: 打开文件
   <kbd>e</kbd>: 编辑文件
-  <kbd>space</kbd>: 补丁中包含的切换文件
+  <kbd>&lt;space&gt;</kbd>: 补丁中包含的切换文件
   <kbd>a</kbd>: toggle all files included in patch
-  <kbd>enter</kbd>: 输入文件以将所选行添加到补丁中（或切换目录折叠）
+  <kbd>&lt;enter&gt;</kbd>: 输入文件以将所选行添加到补丁中（或切换目录折叠）
   <kbd>`</kbd>: 切换文件树视图
 </pre>
 
 ## 提交讯息
 
 <pre>
-  <kbd>enter</kbd>: 确认
-  <kbd>esc</kbd>: 关闭
+  <kbd>&lt;enter&gt;</kbd>: 确认
+  <kbd>&lt;esc&gt;</kbd>: 关闭
 </pre>
 
 ## 文件
 
 <pre>
-  <kbd>ctrl+o</kbd>: 将文件名复制到剪贴板
+  <kbd>&lt;c-o&gt;</kbd>: 将文件名复制到剪贴板
   <kbd>d</kbd>: 查看'放弃更改'选项
-  <kbd>space</kbd>: 切换暂存状态
-  <kbd>ctrl+b</kbd>: Filter files (staged/unstaged)
+  <kbd>&lt;space&gt;</kbd>: 切换暂存状态
+  <kbd>&lt;c-b&gt;</kbd>: Filter files (staged/unstaged)
   <kbd>c</kbd>: 提交更改
   <kbd>w</kbd>: 提交更改而无需预先提交钩子
   <kbd>A</kbd>: 修补最后一次提交
@@ -180,7 +182,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>s</kbd>: 将所有更改加入贮藏
   <kbd>S</kbd>: 查看贮藏选项
   <kbd>a</kbd>: 切换所有文件的暂存状态
-  <kbd>enter</kbd>: 暂存单个 块/行 用于文件, 或 折叠/展开 目录
+  <kbd>&lt;enter&gt;</kbd>: 暂存单个 块/行 用于文件, 或 折叠/展开 目录
   <kbd>g</kbd>: 查看上游重置选项
   <kbd>D</kbd>: 查看重置选项
   <kbd>`</kbd>: 切换文件树视图
@@ -191,27 +193,27 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## 构建补丁中
 
 <pre>
-  <kbd>◀</kbd>: 选择上一个区块
-  <kbd>▶</kbd>: 选择下一个区块
+  <kbd>&lt;left&gt;</kbd>: 选择上一个区块
+  <kbd>&lt;right&gt;</kbd>: 选择下一个区块
   <kbd>v</kbd>: 切换拖动选择
   <kbd>V</kbd>: 切换拖动选择
   <kbd>a</kbd>: 切换选择区块
-  <kbd>ctrl+o</kbd>: 将选中文本复制到剪贴板
+  <kbd>&lt;c-o&gt;</kbd>: 将选中文本复制到剪贴板
   <kbd>o</kbd>: 打开文件
   <kbd>e</kbd>: 编辑文件
-  <kbd>space</kbd>: 添加/移除 行到补丁
-  <kbd>esc</kbd>: 退出逐行模式
+  <kbd>&lt;space&gt;</kbd>: 添加/移除 行到补丁
+  <kbd>&lt;esc&gt;</kbd>: 退出逐行模式
 </pre>
 
 ## 标签页面
 
 <pre>
-  <kbd>space</kbd>: 检出
+  <kbd>&lt;space&gt;</kbd>: 检出
   <kbd>d</kbd>: 删除标签
   <kbd>P</kbd>: 推送标签
   <kbd>n</kbd>: 创建标签
   <kbd>g</kbd>: 查看重置选项
-  <kbd>enter</kbd>: 查看提交
+  <kbd>&lt;enter&gt;</kbd>: 查看提交
 </pre>
 
 ## 正在合并
@@ -219,31 +221,31 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 <pre>
   <kbd>e</kbd>: 编辑文件
   <kbd>o</kbd>: 打开文件
-  <kbd>◀</kbd>: 选择上一个冲突
-  <kbd>▶</kbd>: 选择下一个冲突
-  <kbd>▲</kbd>: 选择顶部块
-  <kbd>▼</kbd>: 选择底部块
+  <kbd>&lt;left&gt;</kbd>: 选择上一个冲突
+  <kbd>&lt;right&gt;</kbd>: 选择下一个冲突
+  <kbd>&lt;up&gt;</kbd>: 选择顶部块
+  <kbd>&lt;down&gt;</kbd>: 选择底部块
   <kbd>z</kbd>: 撤销
   <kbd>M</kbd>: 打开外部合并工具 (git mergetool)
-  <kbd>space</kbd>: 选中区块
+  <kbd>&lt;space&gt;</kbd>: 选中区块
   <kbd>b</kbd>: 选中所有区块
-  <kbd>esc</kbd>: 返回文件面板
+  <kbd>&lt;esc&gt;</kbd>: 返回文件面板
 </pre>
 
 ## 正在暂存
 
 <pre>
-  <kbd>◀</kbd>: 选择上一个区块
-  <kbd>▶</kbd>: 选择下一个区块
+  <kbd>&lt;left&gt;</kbd>: 选择上一个区块
+  <kbd>&lt;right&gt;</kbd>: 选择下一个区块
   <kbd>v</kbd>: 切换拖动选择
   <kbd>V</kbd>: 切换拖动选择
   <kbd>a</kbd>: 切换选择区块
-  <kbd>ctrl+o</kbd>: 将选中文本复制到剪贴板
+  <kbd>&lt;c-o&gt;</kbd>: 将选中文本复制到剪贴板
   <kbd>o</kbd>: 打开文件
   <kbd>e</kbd>: 编辑文件
-  <kbd>esc</kbd>: 返回文件面板
-  <kbd>tab</kbd>: 切换到其他面板
-  <kbd>space</kbd>: 切换行暂存状态
+  <kbd>&lt;esc&gt;</kbd>: 返回文件面板
+  <kbd>&lt;tab&gt;</kbd>: 切换到其他面板
+  <kbd>&lt;space&gt;</kbd>: 切换行暂存状态
   <kbd>d</kbd>: 取消变更 (git reset)
   <kbd>E</kbd>: edit hunk
   <kbd>c</kbd>: 提交更改
@@ -254,8 +256,8 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 ## 正常
 
 <pre>
-  <kbd>mouse wheel ▼</kbd>: 向下滚动 (fn+up)
-  <kbd>mouse wheel ▲</kbd>: 向上滚动 (fn+down)
+  <kbd>mouse wheel down</kbd>: 向下滚动 (fn+up)
+  <kbd>mouse wheel up</kbd>: 向上滚动 (fn+down)
 </pre>
 
 ## 状态
@@ -264,48 +266,48 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
   <kbd>o</kbd>: 打开配置文件
   <kbd>e</kbd>: 编辑配置文件
   <kbd>u</kbd>: 检查更新
-  <kbd>enter</kbd>: 切换到最近的仓库
+  <kbd>&lt;enter&gt;</kbd>: 切换到最近的仓库
   <kbd>a</kbd>: 显示所有分支的日志
 </pre>
 
 ## 确认面板
 
 <pre>
-  <kbd>enter</kbd>: 确认
-  <kbd>esc</kbd>: 关闭
+  <kbd>&lt;enter&gt;</kbd>: 确认
+  <kbd>&lt;esc&gt;</kbd>: 关闭
 </pre>
 
 ## 菜单
 
 <pre>
-  <kbd>enter</kbd>: 执行
-  <kbd>esc</kbd>: 关闭
+  <kbd>&lt;enter&gt;</kbd>: 执行
+  <kbd>&lt;esc&gt;</kbd>: 关闭
 </pre>
 
 ## 贮藏
 
 <pre>
-  <kbd>space</kbd>: 应用
+  <kbd>&lt;space&gt;</kbd>: 应用
   <kbd>g</kbd>: 应用并删除
   <kbd>d</kbd>: 删除
   <kbd>n</kbd>: 新分支
   <kbd>r</kbd>: rename stash
-  <kbd>enter</kbd>: 查看提交的文件
+  <kbd>&lt;enter&gt;</kbd>: 查看提交的文件
 </pre>
 
 ## 远程分支
 
 <pre>
-  <kbd>ctrl+o</kbd>: 将分支名称复制到剪贴板
-  <kbd>space</kbd>: 检出
+  <kbd>&lt;c-o&gt;</kbd>: 将分支名称复制到剪贴板
+  <kbd>&lt;space&gt;</kbd>: 检出
   <kbd>n</kbd>: 新分支
   <kbd>M</kbd>: 合并到当前检出的分支
   <kbd>r</kbd>: 将已检出的分支变基到该分支
   <kbd>d</kbd>: 删除分支
   <kbd>u</kbd>: 设置为检出分支的上游
-  <kbd>esc</kbd>: 返回远程仓库列表
+  <kbd>&lt;esc&gt;</kbd>: 返回远程仓库列表
   <kbd>g</kbd>: 查看重置选项
-  <kbd>enter</kbd>: 查看提交
+  <kbd>&lt;enter&gt;</kbd>: 查看提交
 </pre>
 
 ## 远程页面

--- a/pkg/cheatsheet/generate.go
+++ b/pkg/cheatsheet/generate.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/jesseduffield/generics/maps"
 	"github.com/jesseduffield/generics/slices"
@@ -183,6 +184,8 @@ func getHeader(binding *types.Binding, tr *i18n.TranslationSet) header {
 func formatSections(tr *i18n.TranslationSet, bindingSections []*bindingSection) string {
 	content := fmt.Sprintf("# Lazygit %s\n", tr.Keybindings)
 
+	content += fmt.Sprintf("\n%s\n", italicize(tr.KeybindingsLegend))
+
 	for _, section := range bindingSections {
 		content += formatTitle(section.title)
 		content += "<pre>\n"
@@ -200,13 +203,21 @@ func formatTitle(title string) string {
 }
 
 func formatBinding(binding *types.Binding) string {
+	result := fmt.Sprintf("  <kbd>%s</kbd>: %s", escapeAngleBrackets(keybindings.LabelFromKey(binding.Key)), binding.Description)
 	if binding.Alternative != "" {
-		return fmt.Sprintf(
-			"  <kbd>%s</kbd>: %s (%s)\n",
-			keybindings.LabelFromKey(binding.Key),
-			binding.Description,
-			binding.Alternative,
-		)
+		result += fmt.Sprintf(" (%s)", binding.Alternative)
 	}
-	return fmt.Sprintf("  <kbd>%s</kbd>: %s\n", keybindings.LabelFromKey(binding.Key), binding.Description)
+	result += "\n"
+
+	return result
+}
+
+func escapeAngleBrackets(str string) string {
+	result := strings.ReplaceAll(str, ">", "&gt;")
+	result = strings.ReplaceAll(result, "<", "&lt;")
+	return result
+}
+
+func italicize(str string) string {
+	return fmt.Sprintf("_%s_", str)
 }

--- a/pkg/gui/controllers/menu_controller.go
+++ b/pkg/gui/controllers/menu_controller.go
@@ -21,6 +21,8 @@ func NewMenuController(
 	}
 }
 
+// NOTE: if you add a new keybinding here, you'll also need to add it to
+// `reservedKeys` in `pkg/gui/context/menu_context.go`
 func (self *MenuController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
 	bindings := []*types.Binding{
 		{

--- a/pkg/gui/keybindings/keybindings.go
+++ b/pkg/gui/keybindings/keybindings.go
@@ -9,142 +9,73 @@ import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/constants"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/samber/lo"
 )
 
-var keyMapReversed = map[gocui.Key]string{
-	gocui.KeyF1:          "f1",
-	gocui.KeyF2:          "f2",
-	gocui.KeyF3:          "f3",
-	gocui.KeyF4:          "f4",
-	gocui.KeyF5:          "f5",
-	gocui.KeyF6:          "f6",
-	gocui.KeyF7:          "f7",
-	gocui.KeyF8:          "f8",
-	gocui.KeyF9:          "f9",
-	gocui.KeyF10:         "f10",
-	gocui.KeyF11:         "f11",
-	gocui.KeyF12:         "f12",
-	gocui.KeyInsert:      "insert",
-	gocui.KeyDelete:      "delete",
-	gocui.KeyHome:        "home",
-	gocui.KeyEnd:         "end",
-	gocui.KeyPgup:        "pgup",
-	gocui.KeyPgdn:        "pgdown",
-	gocui.KeyArrowUp:     "▲",
-	gocui.KeyArrowDown:   "▼",
-	gocui.KeyArrowLeft:   "◀",
-	gocui.KeyArrowRight:  "▶",
-	gocui.KeyTab:         "tab", // ctrl+i
-	gocui.KeyBacktab:     "shift+tab",
-	gocui.KeyEnter:       "enter", // ctrl+m
-	gocui.KeyAltEnter:    "alt+enter",
-	gocui.KeyEsc:         "esc",        // ctrl+[, ctrl+3
-	gocui.KeyBackspace:   "backspace",  // ctrl+h
-	gocui.KeyCtrlSpace:   "ctrl+space", // ctrl+~, ctrl+2
-	gocui.KeyCtrlSlash:   "ctrl+/",     // ctrl+_
-	gocui.KeySpace:       "space",
-	gocui.KeyCtrlA:       "ctrl+a",
-	gocui.KeyCtrlB:       "ctrl+b",
-	gocui.KeyCtrlC:       "ctrl+c",
-	gocui.KeyCtrlD:       "ctrl+d",
-	gocui.KeyCtrlE:       "ctrl+e",
-	gocui.KeyCtrlF:       "ctrl+f",
-	gocui.KeyCtrlG:       "ctrl+g",
-	gocui.KeyCtrlJ:       "ctrl+j",
-	gocui.KeyCtrlK:       "ctrl+k",
-	gocui.KeyCtrlL:       "ctrl+l",
-	gocui.KeyCtrlN:       "ctrl+n",
-	gocui.KeyCtrlO:       "ctrl+o",
-	gocui.KeyCtrlP:       "ctrl+p",
-	gocui.KeyCtrlQ:       "ctrl+q",
-	gocui.KeyCtrlR:       "ctrl+r",
-	gocui.KeyCtrlS:       "ctrl+s",
-	gocui.KeyCtrlT:       "ctrl+t",
-	gocui.KeyCtrlU:       "ctrl+u",
-	gocui.KeyCtrlV:       "ctrl+v",
-	gocui.KeyCtrlW:       "ctrl+w",
-	gocui.KeyCtrlX:       "ctrl+x",
-	gocui.KeyCtrlY:       "ctrl+y",
-	gocui.KeyCtrlZ:       "ctrl+z",
-	gocui.KeyCtrl4:       "ctrl+4", // ctrl+\
-	gocui.KeyCtrl5:       "ctrl+5", // ctrl+]
-	gocui.KeyCtrl6:       "ctrl+6",
-	gocui.KeyCtrl8:       "ctrl+8",
-	gocui.MouseWheelUp:   "mouse wheel ▲",
-	gocui.MouseWheelDown: "mouse wheel ▼",
+var labelByKey = map[gocui.Key]string{
+	gocui.KeyF1:          "<f1>",
+	gocui.KeyF2:          "<f2>",
+	gocui.KeyF3:          "<f3>",
+	gocui.KeyF4:          "<f4>",
+	gocui.KeyF5:          "<f5>",
+	gocui.KeyF6:          "<f6>",
+	gocui.KeyF7:          "<f7>",
+	gocui.KeyF8:          "<f8>",
+	gocui.KeyF9:          "<f9>",
+	gocui.KeyF10:         "<f10>",
+	gocui.KeyF11:         "<f11>",
+	gocui.KeyF12:         "<f12>",
+	gocui.KeyInsert:      "<insert>",
+	gocui.KeyDelete:      "<delete>",
+	gocui.KeyHome:        "<home>",
+	gocui.KeyEnd:         "<end>",
+	gocui.KeyPgup:        "<pgup>",
+	gocui.KeyPgdn:        "<pgdown>",
+	gocui.KeyArrowUp:     "<up>",
+	gocui.KeyArrowDown:   "<down>",
+	gocui.KeyArrowLeft:   "<left>",
+	gocui.KeyArrowRight:  "<right>",
+	gocui.KeyTab:         "<tab>", // <c-i>
+	gocui.KeyBacktab:     "<backtab>",
+	gocui.KeyEnter:       "<enter>", // <c-m>
+	gocui.KeyAltEnter:    "<a-enter>",
+	gocui.KeyEsc:         "<esc>",       // <c-[>, <c-3>
+	gocui.KeyBackspace:   "<backspace>", // <c-h>
+	gocui.KeyCtrlSpace:   "<c-space>",   // <c-~>, <c-2>
+	gocui.KeyCtrlSlash:   "<c-/>",       // <c-_>
+	gocui.KeySpace:       "<space>",
+	gocui.KeyCtrlA:       "<c-a>",
+	gocui.KeyCtrlB:       "<c-b>",
+	gocui.KeyCtrlC:       "<c-c>",
+	gocui.KeyCtrlD:       "<c-d>",
+	gocui.KeyCtrlE:       "<c-e>",
+	gocui.KeyCtrlF:       "<c-f>",
+	gocui.KeyCtrlG:       "<c-g>",
+	gocui.KeyCtrlJ:       "<c-j>",
+	gocui.KeyCtrlK:       "<c-k>",
+	gocui.KeyCtrlL:       "<c-l>",
+	gocui.KeyCtrlN:       "<c-n>",
+	gocui.KeyCtrlO:       "<c-o>",
+	gocui.KeyCtrlP:       "<c-p>",
+	gocui.KeyCtrlQ:       "<c-q>",
+	gocui.KeyCtrlR:       "<c-r>",
+	gocui.KeyCtrlS:       "<c-s>",
+	gocui.KeyCtrlT:       "<c-t>",
+	gocui.KeyCtrlU:       "<c-u>",
+	gocui.KeyCtrlV:       "<c-v>",
+	gocui.KeyCtrlW:       "<c-w>",
+	gocui.KeyCtrlX:       "<c-x>",
+	gocui.KeyCtrlY:       "<c-y>",
+	gocui.KeyCtrlZ:       "<c-z>",
+	gocui.KeyCtrl4:       "<c-4>", // <c-\>
+	gocui.KeyCtrl5:       "<c-5>", // <c-]>
+	gocui.KeyCtrl6:       "<c-6>",
+	gocui.KeyCtrl8:       "<c-8>",
+	gocui.MouseWheelUp:   "mouse wheel up",
+	gocui.MouseWheelDown: "mouse wheel down",
 }
 
-var keyMap = map[string]types.Key{
-	"<c-a>":       gocui.KeyCtrlA,
-	"<c-b>":       gocui.KeyCtrlB,
-	"<c-c>":       gocui.KeyCtrlC,
-	"<c-d>":       gocui.KeyCtrlD,
-	"<c-e>":       gocui.KeyCtrlE,
-	"<c-f>":       gocui.KeyCtrlF,
-	"<c-g>":       gocui.KeyCtrlG,
-	"<c-h>":       gocui.KeyCtrlH,
-	"<c-i>":       gocui.KeyCtrlI,
-	"<c-j>":       gocui.KeyCtrlJ,
-	"<c-k>":       gocui.KeyCtrlK,
-	"<c-l>":       gocui.KeyCtrlL,
-	"<c-m>":       gocui.KeyCtrlM,
-	"<c-n>":       gocui.KeyCtrlN,
-	"<c-o>":       gocui.KeyCtrlO,
-	"<c-p>":       gocui.KeyCtrlP,
-	"<c-q>":       gocui.KeyCtrlQ,
-	"<c-r>":       gocui.KeyCtrlR,
-	"<c-s>":       gocui.KeyCtrlS,
-	"<c-t>":       gocui.KeyCtrlT,
-	"<c-u>":       gocui.KeyCtrlU,
-	"<c-v>":       gocui.KeyCtrlV,
-	"<c-w>":       gocui.KeyCtrlW,
-	"<c-x>":       gocui.KeyCtrlX,
-	"<c-y>":       gocui.KeyCtrlY,
-	"<c-z>":       gocui.KeyCtrlZ,
-	"<c-~>":       gocui.KeyCtrlTilde,
-	"<c-2>":       gocui.KeyCtrl2,
-	"<c-3>":       gocui.KeyCtrl3,
-	"<c-4>":       gocui.KeyCtrl4,
-	"<c-5>":       gocui.KeyCtrl5,
-	"<c-6>":       gocui.KeyCtrl6,
-	"<c-7>":       gocui.KeyCtrl7,
-	"<c-8>":       gocui.KeyCtrl8,
-	"<c-space>":   gocui.KeyCtrlSpace,
-	"<c-\\>":      gocui.KeyCtrlBackslash,
-	"<c-[>":       gocui.KeyCtrlLsqBracket,
-	"<c-]>":       gocui.KeyCtrlRsqBracket,
-	"<c-/>":       gocui.KeyCtrlSlash,
-	"<c-_>":       gocui.KeyCtrlUnderscore,
-	"<backspace>": gocui.KeyBackspace,
-	"<tab>":       gocui.KeyTab,
-	"<backtab>":   gocui.KeyBacktab,
-	"<enter>":     gocui.KeyEnter,
-	"<a-enter>":   gocui.KeyAltEnter,
-	"<esc>":       gocui.KeyEsc,
-	"<space>":     gocui.KeySpace,
-	"<f1>":        gocui.KeyF1,
-	"<f2>":        gocui.KeyF2,
-	"<f3>":        gocui.KeyF3,
-	"<f4>":        gocui.KeyF4,
-	"<f5>":        gocui.KeyF5,
-	"<f6>":        gocui.KeyF6,
-	"<f7>":        gocui.KeyF7,
-	"<f8>":        gocui.KeyF8,
-	"<f9>":        gocui.KeyF9,
-	"<f10>":       gocui.KeyF10,
-	"<f11>":       gocui.KeyF11,
-	"<f12>":       gocui.KeyF12,
-	"<insert>":    gocui.KeyInsert,
-	"<delete>":    gocui.KeyDelete,
-	"<home>":      gocui.KeyHome,
-	"<end>":       gocui.KeyEnd,
-	"<pgup>":      gocui.KeyPgup,
-	"<pgdown>":    gocui.KeyPgdn,
-	"<up>":        gocui.KeyArrowUp,
-	"<down>":      gocui.KeyArrowDown,
-	"<left>":      gocui.KeyArrowLeft,
-	"<right>":     gocui.KeyArrowRight,
-}
+var keyByLabel = lo.Invert(labelByKey)
 
 func Label(name string) string {
 	return LabelFromKey(GetKey(name))
@@ -157,7 +88,7 @@ func LabelFromKey(key types.Key) string {
 	case rune:
 		keyInt = int(key)
 	case gocui.Key:
-		value, ok := keyMapReversed[key]
+		value, ok := labelByKey[key]
 		if ok {
 			return value
 		}
@@ -170,8 +101,8 @@ func LabelFromKey(key types.Key) string {
 func GetKey(key string) types.Key {
 	runeCount := utf8.RuneCountInString(key)
 	if runeCount > 1 {
-		binding := keyMap[strings.ToLower(key)]
-		if binding == nil {
+		binding, ok := keyByLabel[strings.ToLower(key)]
+		if !ok {
 			log.Fatalf("Unrecognized key %s for keybinding. For permitted values see %s", strings.ToLower(key), constants.Links.Docs.CustomKeybindings)
 		} else {
 			return binding

--- a/pkg/gui/options_map.go
+++ b/pkg/gui/options_map.go
@@ -61,10 +61,6 @@ func (self *OptionsMapMgr) globalOptions() []bindingInfo {
 			description: self.c.Tr.LcScroll,
 		},
 		{
-			key:         fmt.Sprintf("%s %s %s %s", keybindings.Label(keybindingConfig.Universal.PrevBlock), keybindings.Label(keybindingConfig.Universal.NextBlock), keybindings.Label(keybindingConfig.Universal.PrevItem), keybindings.Label(keybindingConfig.Universal.NextItem)),
-			description: self.c.Tr.LcNavigate,
-		},
-		{
 			key:         keybindings.Label(keybindingConfig.Universal.Return),
 			description: self.c.Tr.LcCancel,
 		},

--- a/pkg/gui/style/decoration.go
+++ b/pkg/gui/style/decoration.go
@@ -3,9 +3,10 @@ package style
 import "github.com/gookit/color"
 
 type Decoration struct {
-	bold      bool
-	underline bool
-	reverse   bool
+	bold          bool
+	underline     bool
+	reverse       bool
+	strikethrough bool
 }
 
 func (d *Decoration) SetBold() {
@@ -18,6 +19,10 @@ func (d *Decoration) SetUnderline() {
 
 func (d *Decoration) SetReverse() {
 	d.reverse = true
+}
+
+func (d *Decoration) SetStrikethrough() {
+	d.strikethrough = true
 }
 
 func (d Decoration) ToOpts() color.Opts {
@@ -35,6 +40,10 @@ func (d Decoration) ToOpts() color.Opts {
 		opts = append(opts, color.OpReverse)
 	}
 
+	if d.strikethrough {
+		opts = append(opts, color.OpStrikethrough)
+	}
+
 	return opts
 }
 
@@ -49,6 +58,10 @@ func (d Decoration) Merge(other Decoration) Decoration {
 
 	if other.reverse {
 		d.reverse = true
+	}
+
+	if other.strikethrough {
+		d.strikethrough = true
 	}
 
 	return d

--- a/pkg/gui/style/text_style.go
+++ b/pkg/gui/style/text_style.go
@@ -98,6 +98,12 @@ func (b TextStyle) SetReverse() TextStyle {
 	return b
 }
 
+func (b TextStyle) SetStrikethrough() TextStyle {
+	b.decoration.SetStrikethrough()
+	b.Style = b.deriveStyle()
+	return b
+}
+
 func (b TextStyle) SetBg(color Color) TextStyle {
 	b.bg = &color
 	b.Style = b.deriveStyle()

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -368,6 +368,7 @@ type TranslationSet struct {
 	LcStartSearch                       string
 	Panel                               string
 	Keybindings                         string
+	KeybindingsLegend                   string
 	LcRenameBranch                      string
 	LcSetUnsetUpstream                  string
 	NewGitFlowBranchPrompt              string
@@ -1039,6 +1040,7 @@ func EnglishTranslationSet() TranslationSet {
 		LcStartSearch:                       "start search",
 		Panel:                               "Panel",
 		Keybindings:                         "Keybindings",
+		KeybindingsLegend:                   "Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b",
 		LcRenameBranch:                      "rename branch",
 		LcSetUnsetUpstream:                  "set/unset upstream",
 		NewBranchNamePrompt:                 "Enter new branch name for branch",

--- a/pkg/theme/style.go
+++ b/pkg/theme/style.go
@@ -17,6 +17,8 @@ func GetTextStyle(keys []string, background bool) style.TextStyle {
 			s = s.SetReverse()
 		case "underline":
 			s = s.SetUnderline()
+		case "strikethrough":
+			s = s.SetStrikethrough()
 		default:
 			value, present := style.ColorMap[key]
 			if present {


### PR DESCRIPTION
- **PR Description**

Fixes https://github.com/jesseduffield/lazygit/issues/2650 by adding a strikethrough style to menu items whose keybindings are reserved for the menu controller.

This PR also makes our key labels consistent across the app, so we're using the same notation (e.g. `<c-a>`) in our cheatsheets, config, and in-app labels. This will hopefully reduce confusion. For those who don't get the notation, I've added a legend at the top of the cheatsheets.

Before:
![image](https://github.com/jesseduffield/lazygit/assets/8456633/31d5c07d-4ad5-406f-b53e-93ab894de150)

After:
![image](https://github.com/jesseduffield/lazygit/assets/8456633/12a26489-128b-4b00-86b9-d1c08728d136)


- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc
