### PR TITLE
Construct arg vector manually rather than parse string

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -191,7 +191,7 @@ func (app *App) setupRepo() (bool, error) {
 		}
 
 		if shouldInitRepo {
-			if err := app.OSCommand.Cmd.New("git init " + initialBranchArg).Run(); err != nil {
+			if err := app.OSCommand.Cmd.New([]string{"git", "init", initialBranchArg}).Run(); err != nil {
 				return false, err
 			}
 			return false, nil

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -24,6 +24,7 @@ type GitCommand struct {
 	Commit      *git_commands.CommitCommands
 	Config      *git_commands.ConfigCommands
 	Custom      *git_commands.CustomCommands
+	Diff        *git_commands.DiffCommands
 	File        *git_commands.FileCommands
 	Flow        *git_commands.FlowCommands
 	Patch       *git_commands.PatchCommands
@@ -112,6 +113,7 @@ func NewGitCommandAux(
 	tagCommands := git_commands.NewTagCommands(gitCommon)
 	commitCommands := git_commands.NewCommitCommands(gitCommon)
 	customCommands := git_commands.NewCustomCommands(gitCommon)
+	diffCommands := git_commands.NewDiffCommands(gitCommon)
 	fileCommands := git_commands.NewFileCommands(gitCommon)
 	submoduleCommands := git_commands.NewSubmoduleCommands(gitCommon)
 	workingTreeCommands := git_commands.NewWorkingTreeCommands(gitCommon, submoduleCommands, fileLoader)
@@ -139,6 +141,7 @@ func NewGitCommandAux(
 		Commit:      commitCommands,
 		Config:      configCommands,
 		Custom:      customCommands,
+		Diff:        diffCommands,
 		File:        fileCommands,
 		Flow:        flowCommands,
 		Patch:       patchCommands,
@@ -274,5 +277,5 @@ func findDotGitDir(stat func(string) (os.FileInfo, error), readFile func(filenam
 }
 
 func VerifyInGitRepo(osCommand *oscommands.OSCommand) error {
-	return osCommand.Cmd.New("git rev-parse --git-dir").DontLog().Run()
+	return osCommand.Cmd.New(git_commands.NewGitCmd("rev-parse").Arg("--git-dir").ToArgv()).DontLog().Run()
 }

--- a/pkg/commands/git_cmd_obj_builder.go
+++ b/pkg/commands/git_cmd_obj_builder.go
@@ -30,12 +30,8 @@ func NewGitCmdObjBuilder(log *logrus.Entry, innerBuilder *oscommands.CmdObjBuild
 
 var defaultEnvVar = "GIT_OPTIONAL_LOCKS=0"
 
-func (self *gitCmdObjBuilder) New(cmdStr string) oscommands.ICmdObj {
-	return self.innerBuilder.New(cmdStr).AddEnvVars(defaultEnvVar)
-}
-
-func (self *gitCmdObjBuilder) NewFromArgs(args []string) oscommands.ICmdObj {
-	return self.innerBuilder.NewFromArgs(args).AddEnvVars(defaultEnvVar)
+func (self *gitCmdObjBuilder) New(args []string) oscommands.ICmdObj {
+	return self.innerBuilder.New(args).AddEnvVars(defaultEnvVar)
 }
 
 func (self *gitCmdObjBuilder) NewShell(cmdStr string) oscommands.ICmdObj {

--- a/pkg/commands/git_commands/bisect.go
+++ b/pkg/commands/git_commands/bisect.go
@@ -97,15 +97,15 @@ func (self *BisectCommands) GetInfo() *BisectInfo {
 }
 
 func (self *BisectCommands) Reset() error {
-	cmdStr := NewGitCmd("bisect").Arg("reset").ToString()
+	cmdArgs := NewGitCmd("bisect").Arg("reset").ToArgv()
 
-	return self.cmd.New(cmdStr).StreamOutput().Run()
+	return self.cmd.New(cmdArgs).StreamOutput().Run()
 }
 
 func (self *BisectCommands) Mark(ref string, term string) error {
-	cmdStr := NewGitCmd("bisect").Arg(term, ref).ToString()
+	cmdArgs := NewGitCmd("bisect").Arg(term, ref).ToArgv()
 
-	return self.cmd.New(cmdStr).
+	return self.cmd.New(cmdArgs).
 		IgnoreEmptyError().
 		StreamOutput().
 		Run()
@@ -116,9 +116,9 @@ func (self *BisectCommands) Skip(ref string) error {
 }
 
 func (self *BisectCommands) Start() error {
-	cmdStr := NewGitCmd("bisect").Arg("start").ToString()
+	cmdArgs := NewGitCmd("bisect").Arg("start").ToArgv()
 
-	return self.cmd.New(cmdStr).StreamOutput().Run()
+	return self.cmd.New(cmdArgs).StreamOutput().Run()
 }
 
 // tells us whether we've found our problem commit(s). We return a string slice of
@@ -140,8 +140,8 @@ func (self *BisectCommands) IsDone() (bool, []string, error) {
 	done := false
 	candidates := []string{}
 
-	cmdStr := NewGitCmd("rev-list").Arg(newSha).ToString()
-	err := self.cmd.New(cmdStr).RunAndProcessLines(func(line string) (bool, error) {
+	cmdArgs := NewGitCmd("rev-list").Arg(newSha).ToArgv()
+	err := self.cmd.New(cmdArgs).RunAndProcessLines(func(line string) (bool, error) {
 		sha := strings.TrimSpace(line)
 
 		if status, ok := info.statusMap[sha]; ok {
@@ -171,11 +171,11 @@ func (self *BisectCommands) IsDone() (bool, []string, error) {
 // bisecting is actually a descendant of our current bisect commit. If it's not, we need to
 // render the commits from the bad commit.
 func (self *BisectCommands) ReachableFromStart(bisectInfo *BisectInfo) bool {
-	cmdStr := NewGitCmd("merge-base").
+	cmdArgs := NewGitCmd("merge-base").
 		Arg("--is-ancestor", bisectInfo.GetNewSha(), bisectInfo.GetStartSha()).
-		ToString()
+		ToArgv()
 
-	err := self.cmd.New(cmdStr).DontLog().Run()
+	err := self.cmd.New(cmdArgs).DontLog().Run()
 
 	return err == nil
 }

--- a/pkg/commands/git_commands/commit_file_loader.go
+++ b/pkg/commands/git_commands/commit_file_loader.go
@@ -24,7 +24,7 @@ func NewCommitFileLoader(common *common.Common, cmd oscommands.ICmdObjBuilder) *
 
 // GetFilesInDiff get the specified commit files
 func (self *CommitFileLoader) GetFilesInDiff(from string, to string, reverse bool) ([]*models.CommitFile, error) {
-	cmdStr := NewGitCmd("diff").
+	cmdArgs := NewGitCmd("diff").
 		Arg("--submodule").
 		Arg("--no-ext-diff").
 		Arg("--name-status").
@@ -33,9 +33,9 @@ func (self *CommitFileLoader) GetFilesInDiff(from string, to string, reverse boo
 		ArgIf(reverse, "-R").
 		Arg(from).
 		Arg(to).
-		ToString()
+		ToArgv()
 
-	filenames, err := self.cmd.New(cmdStr).DontLog().RunWithOutput()
+	filenames, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/git_commands/commit_loader_test.go
+++ b/pkg/commands/git_commands/commit_loader_test.go
@@ -43,8 +43,8 @@ func TestGetCommits(t *testing.T) {
 			rebaseMode: enums.REBASE_MODE_NONE,
 			opts:       GetCommitsOptions{RefName: "HEAD", IncludeRebaseCommits: false},
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git merge-base "HEAD" "HEAD"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
-				Expect(`git log "HEAD" --topo-order --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40 --no-show-signature --`, "", nil),
+				ExpectGitArgs([]string{"merge-base", "HEAD", "HEAD@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
 
 			expectedCommits: []*models.Commit{},
 			expectedError:   nil,
@@ -55,8 +55,8 @@ func TestGetCommits(t *testing.T) {
 			rebaseMode: enums.REBASE_MODE_NONE,
 			opts:       GetCommitsOptions{RefName: "refs/heads/mybranch", IncludeRebaseCommits: false},
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git merge-base "refs/heads/mybranch" "mybranch"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
-				Expect(`git log "refs/heads/mybranch" --topo-order --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40 --no-show-signature --`, "", nil),
+				ExpectGitArgs([]string{"merge-base", "refs/heads/mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"log", "refs/heads/mybranch", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
 
 			expectedCommits: []*models.Commit{},
 			expectedError:   nil,
@@ -69,14 +69,14 @@ func TestGetCommits(t *testing.T) {
 			mainBranches: []string{"master", "main"},
 			runner: oscommands.NewFakeRunner(t).
 				// here it's seeing which commits are yet to be pushed
-				Expect(`git merge-base "HEAD" "HEAD"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"merge-base", "HEAD", "HEAD@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
-				Expect(`git log "HEAD" --topo-order --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40 --no-show-signature --`, commitsOutput, nil).
+				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s", "--abbrev=40", "--no-show-signature", "--"}, commitsOutput, nil).
 				// here it's testing which of the configured main branches exist
-				Expect(`git rev-parse --verify --quiet "refs/heads/master"`, "", nil).               // this one does
-				Expect(`git rev-parse --verify --quiet "refs/heads/main"`, "", errors.New("error")). // this one doesn't
+				ExpectGitArgs([]string{"rev-parse", "--verify", "--quiet", "refs/heads/master"}, "", nil).               // this one does
+				ExpectGitArgs([]string{"rev-parse", "--verify", "--quiet", "refs/heads/main"}, "", errors.New("error")). // this one doesn't
 				// here it's seeing where our branch diverged from the master branch so that we can mark that commit and parent commits as 'merged'
-				Expect(`git merge-base "HEAD" "refs/heads/master"`, "26c07b1ab33860a1a7591a0638f9925ccf497ffa", nil),
+				ExpectGitArgs([]string{"merge-base", "HEAD", "refs/heads/master"}, "26c07b1ab33860a1a7591a0638f9925ccf497ffa", nil),
 
 			expectedCommits: []*models.Commit{
 				{
@@ -202,12 +202,12 @@ func TestGetCommits(t *testing.T) {
 			mainBranches: []string{"master", "main"},
 			runner: oscommands.NewFakeRunner(t).
 				// here it's seeing which commits are yet to be pushed
-				Expect(`git merge-base "HEAD" "HEAD"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"merge-base", "HEAD", "HEAD@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
-				Expect(`git log "HEAD" --topo-order --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40 --no-show-signature --`, singleCommitOutput, nil).
+				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s", "--abbrev=40", "--no-show-signature", "--"}, singleCommitOutput, nil).
 				// here it's testing which of the configured main branches exist; neither does
-				Expect(`git rev-parse --verify --quiet "refs/heads/master"`, "", errors.New("error")).
-				Expect(`git rev-parse --verify --quiet "refs/heads/main"`, "", errors.New("error")),
+				ExpectGitArgs([]string{"rev-parse", "--verify", "--quiet", "refs/heads/master"}, "", errors.New("error")).
+				ExpectGitArgs([]string{"rev-parse", "--verify", "--quiet", "refs/heads/main"}, "", errors.New("error")),
 
 			expectedCommits: []*models.Commit{
 				{
@@ -235,16 +235,16 @@ func TestGetCommits(t *testing.T) {
 			mainBranches: []string{"master", "main", "develop", "1.0-hotfixes"},
 			runner: oscommands.NewFakeRunner(t).
 				// here it's seeing which commits are yet to be pushed
-				Expect(`git merge-base "HEAD" "HEAD"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"merge-base", "HEAD", "HEAD@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
-				Expect(`git log "HEAD" --topo-order --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40 --no-show-signature --`, singleCommitOutput, nil).
+				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s", "--abbrev=40", "--no-show-signature", "--"}, singleCommitOutput, nil).
 				// here it's testing which of the configured main branches exist
-				Expect(`git rev-parse --verify --quiet "refs/heads/master"`, "", nil).
-				Expect(`git rev-parse --verify --quiet "refs/heads/main"`, "", errors.New("error")).
-				Expect(`git rev-parse --verify --quiet "refs/heads/develop"`, "", nil).
-				Expect(`git rev-parse --verify --quiet "refs/heads/1.0-hotfixes"`, "", nil).
+				ExpectGitArgs([]string{"rev-parse", "--verify", "--quiet", "refs/heads/master"}, "", nil).
+				ExpectGitArgs([]string{"rev-parse", "--verify", "--quiet", "refs/heads/main"}, "", errors.New("error")).
+				ExpectGitArgs([]string{"rev-parse", "--verify", "--quiet", "refs/heads/develop"}, "", nil).
+				ExpectGitArgs([]string{"rev-parse", "--verify", "--quiet", "refs/heads/1.0-hotfixes"}, "", nil).
 				// here it's seeing where our branch diverged from the master branch so that we can mark that commit and parent commits as 'merged'
-				Expect(`git merge-base "HEAD" "refs/heads/master" "refs/heads/develop" "refs/heads/1.0-hotfixes"`, "26c07b1ab33860a1a7591a0638f9925ccf497ffa", nil),
+				ExpectGitArgs([]string{"merge-base", "HEAD", "refs/heads/master", "refs/heads/develop", "refs/heads/1.0-hotfixes"}, "26c07b1ab33860a1a7591a0638f9925ccf497ffa", nil),
 
 			expectedCommits: []*models.Commit{
 				{
@@ -270,8 +270,8 @@ func TestGetCommits(t *testing.T) {
 			rebaseMode: enums.REBASE_MODE_NONE,
 			opts:       GetCommitsOptions{RefName: "HEAD", IncludeRebaseCommits: false},
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git merge-base "HEAD" "HEAD"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
-				Expect(`git log "HEAD" --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40 --no-show-signature --`, "", nil),
+				ExpectGitArgs([]string{"merge-base", "HEAD", "HEAD@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"log", "HEAD", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
 
 			expectedCommits: []*models.Commit{},
 			expectedError:   nil,
@@ -282,8 +282,8 @@ func TestGetCommits(t *testing.T) {
 			rebaseMode: enums.REBASE_MODE_NONE,
 			opts:       GetCommitsOptions{RefName: "HEAD", FilterPath: "src"},
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git merge-base "HEAD" "HEAD"@{u}`, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
-				Expect(`git log "HEAD" --oneline --pretty=format:"%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s" --abbrev=40 --follow --no-show-signature -- "src"`, "", nil),
+				ExpectGitArgs([]string{"merge-base", "HEAD", "HEAD@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"log", "HEAD", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%d%x00%p%x00%s", "--abbrev=40", "--follow", "--no-show-signature", "--", "src"}, "", nil),
 
 			expectedCommits: []*models.Commit{},
 			expectedError:   nil,

--- a/pkg/commands/git_commands/custom.go
+++ b/pkg/commands/git_commands/custom.go
@@ -1,5 +1,7 @@
 package git_commands
 
+import "github.com/mgutz/str"
+
 type CustomCommands struct {
 	*GitCommon
 }
@@ -14,5 +16,5 @@ func NewCustomCommands(gitCommon *GitCommon) *CustomCommands {
 // If you want to run a new command, try finding a place for it in one of the neighbouring
 // files, or creating a new BlahCommands struct to hold it.
 func (self *CustomCommands) RunWithOutput(cmdStr string) (string, error) {
-	return self.cmd.New(cmdStr).RunWithOutput()
+	return self.cmd.New(str.ToArgv(cmdStr)).RunWithOutput()
 }

--- a/pkg/commands/git_commands/diff.go
+++ b/pkg/commands/git_commands/diff.go
@@ -1,0 +1,19 @@
+package git_commands
+
+import "github.com/jesseduffield/lazygit/pkg/commands/oscommands"
+
+type DiffCommands struct {
+	*GitCommon
+}
+
+func NewDiffCommands(gitCommon *GitCommon) *DiffCommands {
+	return &DiffCommands{
+		GitCommon: gitCommon,
+	}
+}
+
+func (self *DiffCommands) DiffCmdObj(diffArgs []string) oscommands.ICmdObj {
+	return self.cmd.New(
+		NewGitCmd("diff").Arg("--submodule", "--no-ext-diff", "--color").Arg(diffArgs...).ToArgv(),
+	)
+}

--- a/pkg/commands/git_commands/file.go
+++ b/pkg/commands/git_commands/file.go
@@ -45,7 +45,7 @@ func (self *FileCommands) GetEditCmdStrLegacy(filename string, lineNumber int) (
 		editor = self.os.Getenv("EDITOR")
 	}
 	if editor == "" {
-		if err := self.cmd.New("which vi").DontLog().Run(); err == nil {
+		if err := self.cmd.New([]string{"which", "vi"}).DontLog().Run(); err == nil {
 			editor = "vi"
 		}
 	}

--- a/pkg/commands/git_commands/file_loader.go
+++ b/pkg/commands/git_commands/file_loader.go
@@ -82,14 +82,14 @@ type FileStatus struct {
 }
 
 func (c *FileLoader) gitStatus(opts GitStatusOptions) ([]FileStatus, error) {
-	cmdStr := NewGitCmd("status").
+	cmdArgs := NewGitCmd("status").
 		Arg(opts.UntrackedFilesArg).
 		Arg("--porcelain").
 		Arg("-z").
 		ArgIf(opts.NoRenames, "--no-renames").
-		ToString()
+		ToArgv()
 
-	statusLines, _, err := c.cmd.New(cmdStr).DontLog().RunWithOutputs()
+	statusLines, _, err := c.cmd.New(cmdArgs).DontLog().RunWithOutputs()
 	if err != nil {
 		return []FileStatus{}, err
 	}

--- a/pkg/commands/git_commands/file_loader_test.go
+++ b/pkg/commands/git_commands/file_loader_test.go
@@ -20,14 +20,13 @@ func TestFileGetStatusFiles(t *testing.T) {
 		{
 			"No files found",
 			oscommands.NewFakeRunner(t).
-				Expect(`git status --untracked-files=yes --porcelain -z`, "", nil),
+				ExpectGitArgs([]string{"status", "--untracked-files=yes", "--porcelain", "-z"}, "", nil),
 			[]*models.File{},
 		},
 		{
 			"Several files found",
 			oscommands.NewFakeRunner(t).
-				Expect(
-					`git status --untracked-files=yes --porcelain -z`,
+				ExpectGitArgs([]string{"status", "--untracked-files=yes", "--porcelain", "-z"},
 					"MM file1.txt\x00A  file3.txt\x00AM file2.txt\x00?? file4.txt\x00UU file5.txt",
 					nil,
 				),
@@ -102,7 +101,7 @@ func TestFileGetStatusFiles(t *testing.T) {
 		{
 			"File with new line char",
 			oscommands.NewFakeRunner(t).
-				Expect(`git status --untracked-files=yes --porcelain -z`, "MM a\nb.txt", nil),
+				ExpectGitArgs([]string{"status", "--untracked-files=yes", "--porcelain", "-z"}, "MM a\nb.txt", nil),
 			[]*models.File{
 				{
 					Name:                    "a\nb.txt",
@@ -122,8 +121,7 @@ func TestFileGetStatusFiles(t *testing.T) {
 		{
 			"Renamed files",
 			oscommands.NewFakeRunner(t).
-				Expect(
-					`git status --untracked-files=yes --porcelain -z`,
+				ExpectGitArgs([]string{"status", "--untracked-files=yes", "--porcelain", "-z"},
 					"R  after1.txt\x00before1.txt\x00RM after2.txt\x00before2.txt",
 					nil,
 				),
@@ -161,8 +159,7 @@ func TestFileGetStatusFiles(t *testing.T) {
 		{
 			"File with arrow in name",
 			oscommands.NewFakeRunner(t).
-				Expect(
-					`git status --untracked-files=yes --porcelain -z`,
+				ExpectGitArgs([]string{"status", "--untracked-files=yes", "--porcelain", "-z"},
 					`?? a -> b.txt`,
 					nil,
 				),

--- a/pkg/commands/git_commands/file_test.go
+++ b/pkg/commands/git_commands/file_test.go
@@ -27,7 +27,7 @@ func TestEditFileCmdStrLegacy(t *testing.T) {
 			configEditCommand:         "",
 			configEditCommandTemplate: "{{editor}} {{filename}}",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`which vi`, "", errors.New("error")),
+				ExpectArgs([]string{"which", "vi"}, "", errors.New("error")),
 			getenv: func(env string) string {
 				return ""
 			},
@@ -105,7 +105,7 @@ func TestEditFileCmdStrLegacy(t *testing.T) {
 			configEditCommand:         "",
 			configEditCommandTemplate: "{{editor}} {{filename}}",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`which vi`, "/usr/bin/vi", nil),
+				ExpectArgs([]string{"which", "vi"}, "/usr/bin/vi", nil),
 			getenv: func(env string) string {
 				return ""
 			},
@@ -120,7 +120,7 @@ func TestEditFileCmdStrLegacy(t *testing.T) {
 			configEditCommand:         "",
 			configEditCommandTemplate: "{{editor}} {{filename}}",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`which vi`, "/usr/bin/vi", nil),
+				ExpectArgs([]string{"which", "vi"}, "/usr/bin/vi", nil),
 			getenv: func(env string) string {
 				return ""
 			},

--- a/pkg/commands/git_commands/flow.go
+++ b/pkg/commands/git_commands/flow.go
@@ -49,13 +49,13 @@ func (self *FlowCommands) FinishCmdObj(branchName string) (oscommands.ICmdObj, e
 		return nil, errors.New(self.Tr.NotAGitFlowBranch)
 	}
 
-	cmdStr := NewGitCmd("flow").Arg(branchType, "finish", suffix).ToString()
+	cmdArgs := NewGitCmd("flow").Arg(branchType, "finish", suffix).ToArgv()
 
-	return self.cmd.New(cmdStr), nil
+	return self.cmd.New(cmdArgs), nil
 }
 
 func (self *FlowCommands) StartCmdObj(branchType string, name string) oscommands.ICmdObj {
-	cmdStr := NewGitCmd("flow").Arg(branchType, "start", name).ToString()
+	cmdArgs := NewGitCmd("flow").Arg(branchType, "start", name).ToArgv()
 
-	return self.cmd.New(cmdStr)
+	return self.cmd.New(cmdArgs)
 }

--- a/pkg/commands/git_commands/flow_test.go
+++ b/pkg/commands/git_commands/flow_test.go
@@ -12,13 +12,13 @@ func TestStartCmdObj(t *testing.T) {
 		testName   string
 		branchType string
 		name       string
-		expected   string
+		expected   []string
 	}{
 		{
 			testName:   "basic",
 			branchType: "feature",
 			name:       "test",
-			expected:   "git flow feature start test",
+			expected:   []string{"git", "flow", "feature", "start", "test"},
 		},
 	}
 
@@ -28,7 +28,7 @@ func TestStartCmdObj(t *testing.T) {
 			instance := buildFlowCommands(commonDeps{})
 
 			assert.Equal(t,
-				instance.StartCmdObj(s.branchType, s.name).ToString(),
+				instance.StartCmdObj(s.branchType, s.name).Args(),
 				s.expected,
 			)
 		})
@@ -39,28 +39,28 @@ func TestFinishCmdObj(t *testing.T) {
 	scenarios := []struct {
 		testName               string
 		branchName             string
-		expected               string
+		expected               []string
 		expectedError          string
 		gitConfigMockResponses map[string]string
 	}{
 		{
 			testName:               "not a git flow branch",
 			branchName:             "mybranch",
-			expected:               "",
+			expected:               nil,
 			expectedError:          "This does not seem to be a git flow branch",
 			gitConfigMockResponses: nil,
 		},
 		{
 			testName:               "feature branch without config",
 			branchName:             "feature/mybranch",
-			expected:               "",
+			expected:               nil,
 			expectedError:          "This does not seem to be a git flow branch",
 			gitConfigMockResponses: nil,
 		},
 		{
 			testName:      "feature branch with config",
 			branchName:    "feature/mybranch",
-			expected:      "git flow feature finish mybranch",
+			expected:      []string{"git", "flow", "feature", "finish", "mybranch"},
 			expectedError: "",
 			gitConfigMockResponses: map[string]string{
 				"--local --get-regexp gitflow.prefix": "gitflow.prefix.feature feature/",
@@ -85,7 +85,7 @@ func TestFinishCmdObj(t *testing.T) {
 				}
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, cmd.ToString(), s.expected)
+				assert.Equal(t, cmd.Args(), s.expected)
 			}
 		})
 	}

--- a/pkg/commands/git_commands/git_command_builder.go
+++ b/pkg/commands/git_commands/git_command_builder.go
@@ -49,6 +49,10 @@ func (self *GitCommandBuilder) RepoPath(value string) *GitCommandBuilder {
 	return self
 }
 
+func (self *GitCommandBuilder) ToArgv() []string {
+	return append([]string{"git"}, self.args...)
+}
+
 func (self *GitCommandBuilder) ToString() string {
-	return "git " + strings.Join(self.args, " ")
+	return strings.Join(self.ToArgv(), " ")
 }

--- a/pkg/commands/git_commands/git_command_builder_test.go
+++ b/pkg/commands/git_commands/git_command_builder_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestGitCommandBuilder(t *testing.T) {
 	scenarios := []struct {
-		input    string
-		expected string
+		input    []string
+		expected []string
 	}{
 		{
 			input: NewGitCmd("push").
@@ -17,36 +17,36 @@ func TestGitCommandBuilder(t *testing.T) {
 				Arg("--set-upstream").
 				Arg("origin").
 				Arg("master").
-				ToString(),
-			expected: "git push --force-with-lease --set-upstream origin master",
+				ToArgv(),
+			expected: []string{"git", "push", "--force-with-lease", "--set-upstream", "origin", "master"},
 		},
 		{
-			input:    NewGitCmd("push").ArgIf(true, "--test").ToString(),
-			expected: "git push --test",
+			input:    NewGitCmd("push").ArgIf(true, "--test").ToArgv(),
+			expected: []string{"git", "push", "--test"},
 		},
 		{
-			input:    NewGitCmd("push").ArgIf(false, "--test").ToString(),
-			expected: "git push",
+			input:    NewGitCmd("push").ArgIf(false, "--test").ToArgv(),
+			expected: []string{"git", "push"},
 		},
 		{
-			input:    NewGitCmd("push").ArgIfElse(true, "-b", "-a").ToString(),
-			expected: "git push -b",
+			input:    NewGitCmd("push").ArgIfElse(true, "-b", "-a").ToArgv(),
+			expected: []string{"git", "push", "-b"},
 		},
 		{
-			input:    NewGitCmd("push").ArgIfElse(false, "-a", "-b").ToString(),
-			expected: "git push -b",
+			input:    NewGitCmd("push").ArgIfElse(false, "-a", "-b").ToArgv(),
+			expected: []string{"git", "push", "-b"},
 		},
 		{
-			input:    NewGitCmd("push").Arg("-a", "-b").ToString(),
-			expected: "git push -a -b",
+			input:    NewGitCmd("push").Arg("-a", "-b").ToArgv(),
+			expected: []string{"git", "push", "-a", "-b"},
 		},
 		{
-			input:    NewGitCmd("push").Config("user.name=foo").Config("user.email=bar").ToString(),
-			expected: "git -c user.email=bar -c user.name=foo push",
+			input:    NewGitCmd("push").Config("user.name=foo").Config("user.email=bar").ToArgv(),
+			expected: []string{"git", "-c", "user.email=bar", "-c", "user.name=foo", "push"},
 		},
 		{
-			input:    NewGitCmd("push").RepoPath("a/b/c").ToString(),
-			expected: "git -C a/b/c push",
+			input:    NewGitCmd("push").RepoPath("a/b/c").ToArgv(),
+			expected: []string{"git", "-C", "a/b/c", "push"},
 		},
 	}
 

--- a/pkg/commands/git_commands/patch.go
+++ b/pkg/commands/git_commands/patch.go
@@ -69,15 +69,15 @@ func (self *PatchCommands) ApplyPatch(patch string, opts ApplyPatchOpts) error {
 }
 
 func (self *PatchCommands) applyPatchFile(filepath string, opts ApplyPatchOpts) error {
-	cmdStr := NewGitCmd("apply").
+	cmdArgs := NewGitCmd("apply").
 		ArgIf(opts.ThreeWay, "--3way").
 		ArgIf(opts.Cached, "--cached").
 		ArgIf(opts.Index, "--index").
 		ArgIf(opts.Reverse, "--reverse").
-		Arg(self.cmd.Quote(filepath)).
-		ToString()
+		Arg(filepath).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *PatchCommands) SaveTemporaryPatch(patch string) (string, error) {
@@ -320,7 +320,7 @@ func (self *PatchCommands) PullPatchIntoNewCommit(commits []*models.Commit, comm
 // only some lines of a range of adjacent added lines. To solve this, we
 // get the diff of HEAD and the original commit and then apply that.
 func (self *PatchCommands) diffHeadAgainstCommit(commit *models.Commit) (string, error) {
-	cmdStr := NewGitCmd("diff").Arg("HEAD.." + commit.Sha).ToString()
+	cmdArgs := NewGitCmd("diff").Arg("HEAD.." + commit.Sha).ToArgv()
 
-	return self.cmd.New(cmdStr).RunWithOutput()
+	return self.cmd.New(cmdArgs).RunWithOutput()
 }

--- a/pkg/commands/git_commands/rebase_test.go
+++ b/pkg/commands/git_commands/rebase_test.go
@@ -29,7 +29,7 @@ func TestRebaseRebaseBranch(t *testing.T) {
 			arg:        "master",
 			gitVersion: &GitVersion{2, 26, 0, ""},
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git rebase --interactive --autostash --keep-empty --no-autosquash --rebase-merges master`, "", nil),
+				ExpectGitArgs([]string{"rebase", "--interactive", "--autostash", "--keep-empty", "--no-autosquash", "--rebase-merges", "master"}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -39,7 +39,7 @@ func TestRebaseRebaseBranch(t *testing.T) {
 			arg:        "master",
 			gitVersion: &GitVersion{2, 26, 0, ""},
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git rebase --interactive --autostash --keep-empty --no-autosquash --rebase-merges master`, "", errors.New("error")),
+				ExpectGitArgs([]string{"rebase", "--interactive", "--autostash", "--keep-empty", "--no-autosquash", "--rebase-merges", "master"}, "", errors.New("error")),
 			test: func(err error) {
 				assert.Error(t, err)
 			},
@@ -49,7 +49,7 @@ func TestRebaseRebaseBranch(t *testing.T) {
 			arg:        "master",
 			gitVersion: &GitVersion{2, 25, 5, ""},
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git rebase --interactive --autostash --keep-empty --no-autosquash --rebase-merges master`, "", nil),
+				ExpectGitArgs([]string{"rebase", "--interactive", "--autostash", "--keep-empty", "--no-autosquash", "--rebase-merges", "master"}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -59,7 +59,7 @@ func TestRebaseRebaseBranch(t *testing.T) {
 			arg:        "master",
 			gitVersion: &GitVersion{2, 21, 9, ""},
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git rebase --interactive --autostash --keep-empty --no-autosquash master`, "", nil),
+				ExpectGitArgs([]string{"rebase", "--interactive", "--autostash", "--keep-empty", "--no-autosquash", "master"}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -78,9 +78,9 @@ func TestRebaseRebaseBranch(t *testing.T) {
 // TestRebaseSkipEditorCommand confirms that SkipEditorCommand injects
 // environment variables that suppress an interactive editor
 func TestRebaseSkipEditorCommand(t *testing.T) {
-	commandStr := "git blah"
+	cmdArgs := []string{"git", "blah"}
 	runner := oscommands.NewFakeRunner(t).ExpectFunc(func(cmdObj oscommands.ICmdObj) (string, error) {
-		assert.Equal(t, commandStr, cmdObj.ToString())
+		assert.EqualValues(t, cmdArgs, cmdObj.Args())
 		envVars := cmdObj.GetEnvVars()
 		for _, regexStr := range []string{
 			`^VISUAL=.*$`,
@@ -100,7 +100,7 @@ func TestRebaseSkipEditorCommand(t *testing.T) {
 		return "", nil
 	})
 	instance := buildRebaseCommands(commonDeps{runner: runner})
-	err := instance.runSkipEditorCommand(instance.cmd.New(commandStr))
+	err := instance.runSkipEditorCommand(instance.cmd.New(cmdArgs))
 	assert.NoError(t, err)
 	runner.CheckForMissingCalls()
 }
@@ -149,11 +149,11 @@ func TestRebaseDiscardOldFileChanges(t *testing.T) {
 			commitIndex: 0,
 			fileName:    "test999.txt",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git rebase --interactive --autostash --keep-empty --no-autosquash --rebase-merges abcdef`, "", nil).
-				Expect(`git cat-file -e HEAD^:"test999.txt"`, "", nil).
-				Expect(`git checkout HEAD^ -- "test999.txt"`, "", nil).
-				Expect(`git commit --amend --no-edit --allow-empty`, "", nil).
-				Expect(`git rebase --continue`, "", nil),
+				ExpectGitArgs([]string{"rebase", "--interactive", "--autostash", "--keep-empty", "--no-autosquash", "--rebase-merges", "abcdef"}, "", nil).
+				ExpectGitArgs([]string{"cat-file", "-e", "HEAD^:test999.txt"}, "", nil).
+				ExpectGitArgs([]string{"checkout", "HEAD^", "--", "test999.txt"}, "", nil).
+				ExpectGitArgs([]string{"commit", "--amend", "--no-edit", "--allow-empty"}, "", nil).
+				ExpectGitArgs([]string{"rebase", "--continue"}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},

--- a/pkg/commands/git_commands/reflog_commit_loader_test.go
+++ b/pkg/commands/git_commands/reflog_commit_loader_test.go
@@ -34,7 +34,7 @@ func TestGetReflogCommits(t *testing.T) {
 		{
 			testName: "no reflog entries",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git -c log.showSignature=false log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p"`, "", nil),
+				ExpectGitArgs([]string{"-c", "log.showSignature=false", "log", "-g", "--abbrev=40", "--format=%h%x00%ct%x00%gs%x00%p"}, "", nil),
 
 			lastReflogCommit:        nil,
 			expectedCommits:         []*models.Commit{},
@@ -44,7 +44,7 @@ func TestGetReflogCommits(t *testing.T) {
 		{
 			testName: "some reflog entries",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git -c log.showSignature=false log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p"`, reflogOutput, nil),
+				ExpectGitArgs([]string{"-c", "log.showSignature=false", "log", "-g", "--abbrev=40", "--format=%h%x00%ct%x00%gs%x00%p"}, reflogOutput, nil),
 
 			lastReflogCommit: nil,
 			expectedCommits: []*models.Commit{
@@ -90,7 +90,7 @@ func TestGetReflogCommits(t *testing.T) {
 		{
 			testName: "some reflog entries where last commit is given",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git -c log.showSignature=false log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p"`, reflogOutput, nil),
+				ExpectGitArgs([]string{"-c", "log.showSignature=false", "log", "-g", "--abbrev=40", "--format=%h%x00%ct%x00%gs%x00%p"}, reflogOutput, nil),
 
 			lastReflogCommit: &models.Commit{
 				Sha:           "c3c4b66b64c97ffeecde",
@@ -114,7 +114,7 @@ func TestGetReflogCommits(t *testing.T) {
 		{
 			testName: "when passing filterPath",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git -c log.showSignature=false log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p" --follow -- "path"`, reflogOutput, nil),
+				ExpectGitArgs([]string{"-c", "log.showSignature=false", "log", "-g", "--abbrev=40", "--format=%h%x00%ct%x00%gs%x00%p", "--follow", "--", "path"}, reflogOutput, nil),
 
 			lastReflogCommit: &models.Commit{
 				Sha:           "c3c4b66b64c97ffeecde",
@@ -139,7 +139,7 @@ func TestGetReflogCommits(t *testing.T) {
 		{
 			testName: "when command returns error",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git -c log.showSignature=false log -g --abbrev=40 --format="%h%x00%ct%x00%gs%x00%p"`, "", errors.New("haha")),
+				ExpectGitArgs([]string{"-c", "log.showSignature=false", "log", "-g", "--abbrev=40", "--format=%h%x00%ct%x00%gs%x00%p"}, "", errors.New("haha")),
 
 			lastReflogCommit:        nil,
 			filterPath:              "",

--- a/pkg/commands/git_commands/remote.go
+++ b/pkg/commands/git_commands/remote.go
@@ -15,52 +15,52 @@ func NewRemoteCommands(gitCommon *GitCommon) *RemoteCommands {
 }
 
 func (self *RemoteCommands) AddRemote(name string, url string) error {
-	cmdStr := NewGitCmd("remote").
-		Arg("add", self.cmd.Quote(name), self.cmd.Quote(url)).
-		ToString()
+	cmdArgs := NewGitCmd("remote").
+		Arg("add", name, url).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *RemoteCommands) RemoveRemote(name string) error {
-	cmdStr := NewGitCmd("remote").
-		Arg("remove", self.cmd.Quote(name)).
-		ToString()
+	cmdArgs := NewGitCmd("remote").
+		Arg("remove", name).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *RemoteCommands) RenameRemote(oldRemoteName string, newRemoteName string) error {
-	cmdStr := NewGitCmd("remote").
-		Arg("rename", self.cmd.Quote(oldRemoteName), self.cmd.Quote(newRemoteName)).
-		ToString()
+	cmdArgs := NewGitCmd("remote").
+		Arg("rename", oldRemoteName, newRemoteName).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *RemoteCommands) UpdateRemoteUrl(remoteName string, updatedUrl string) error {
-	cmdStr := NewGitCmd("remote").
-		Arg("set-url", self.cmd.Quote(remoteName), self.cmd.Quote(updatedUrl)).
-		ToString()
+	cmdArgs := NewGitCmd("remote").
+		Arg("set-url", remoteName, updatedUrl).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *RemoteCommands) DeleteRemoteBranch(remoteName string, branchName string) error {
-	cmdStr := NewGitCmd("push").
-		Arg(self.cmd.Quote(remoteName), "--delete", self.cmd.Quote(branchName)).
-		ToString()
+	cmdArgs := NewGitCmd("push").
+		Arg(remoteName, "--delete", branchName).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
+	return self.cmd.New(cmdArgs).PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
 }
 
 // CheckRemoteBranchExists Returns remote branch
 func (self *RemoteCommands) CheckRemoteBranchExists(branchName string) bool {
-	cmdStr := NewGitCmd("show-ref").
-		Arg("--verify", "--", fmt.Sprintf("refs/remotes/origin/%s", self.cmd.Quote(branchName))).
-		ToString()
+	cmdArgs := NewGitCmd("show-ref").
+		Arg("--verify", "--", fmt.Sprintf("refs/remotes/origin/%s", branchName)).
+		ToArgv()
 
-	_, err := self.cmd.New(cmdStr).DontLog().RunWithOutput()
+	_, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
 
 	return err == nil
 }

--- a/pkg/commands/git_commands/remote_loader.go
+++ b/pkg/commands/git_commands/remote_loader.go
@@ -31,8 +31,8 @@ func NewRemoteLoader(
 }
 
 func (self *RemoteLoader) GetRemotes() ([]*models.Remote, error) {
-	cmdStr := NewGitCmd("branch").Arg("-r").ToString()
-	remoteBranchesStr, err := self.cmd.New(cmdStr).DontLog().RunWithOutput()
+	cmdArgs := NewGitCmd("branch").Arg("-r").ToArgv()
+	remoteBranchesStr, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/git_commands/stash_loader.go
+++ b/pkg/commands/git_commands/stash_loader.go
@@ -32,8 +32,8 @@ func (self *StashLoader) GetStashEntries(filterPath string) []*models.StashEntry
 		return self.getUnfilteredStashEntries()
 	}
 
-	cmdStr := NewGitCmd("stash").Arg("list", "--name-only").ToString()
-	rawString, err := self.cmd.New(cmdStr).DontLog().RunWithOutput()
+	cmdArgs := NewGitCmd("stash").Arg("list", "--name-only").ToArgv()
+	rawString, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
 	if err != nil {
 		return self.getUnfilteredStashEntries()
 	}
@@ -66,9 +66,9 @@ outer:
 }
 
 func (self *StashLoader) getUnfilteredStashEntries() []*models.StashEntry {
-	cmdStr := NewGitCmd("stash").Arg("list", "-z", "--pretty='%gs'").ToString()
+	cmdArgs := NewGitCmd("stash").Arg("list", "-z", "--pretty=%gs").ToArgv()
 
-	rawString, _ := self.cmd.New(cmdStr).DontLog().RunWithOutput()
+	rawString, _ := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
 	return slices.MapWithIndex(utils.SplitNul(rawString), func(line string, index int) *models.StashEntry {
 		return self.stashEntryFromLine(line, index)
 	})

--- a/pkg/commands/git_commands/stash_loader_test.go
+++ b/pkg/commands/git_commands/stash_loader_test.go
@@ -22,15 +22,14 @@ func TestGetStashEntries(t *testing.T) {
 			"No stash entries found",
 			"",
 			oscommands.NewFakeRunner(t).
-				Expect(`git stash list -z --pretty='%gs'`, "", nil),
+				ExpectGitArgs([]string{"stash", "list", "-z", "--pretty=%gs"}, "", nil),
 			[]*models.StashEntry{},
 		},
 		{
 			"Several stash entries found",
 			"",
 			oscommands.NewFakeRunner(t).
-				Expect(
-					`git stash list -z --pretty='%gs'`,
+				ExpectGitArgs([]string{"stash", "list", "-z", "--pretty=%gs"},
 					"WIP on add-pkg-commands-test: 55c6af2 increase parallel build\x00WIP on master: bb86a3f update github template\x00",
 					nil,
 				),

--- a/pkg/commands/git_commands/stash_test.go
+++ b/pkg/commands/git_commands/stash_test.go
@@ -103,7 +103,7 @@ func TestStashStashEntryCmdObj(t *testing.T) {
 		index            int
 		contextSize      int
 		ignoreWhitespace bool
-		expected         string
+		expected         []string
 	}
 
 	scenarios := []scenario{
@@ -112,21 +112,21 @@ func TestStashStashEntryCmdObj(t *testing.T) {
 			index:            5,
 			contextSize:      3,
 			ignoreWhitespace: false,
-			expected:         "git stash show -p --stat --color=always --unified=3 stash@{5}",
+			expected:         []string{"git", "stash", "show", "-p", "--stat", "--color=always", "--unified=3", "stash@{5}"},
 		},
 		{
 			testName:         "Show diff with custom context size",
 			index:            5,
 			contextSize:      77,
 			ignoreWhitespace: false,
-			expected:         "git stash show -p --stat --color=always --unified=77 stash@{5}",
+			expected:         []string{"git", "stash", "show", "-p", "--stat", "--color=always", "--unified=77", "stash@{5}"},
 		},
 		{
 			testName:         "Default case",
 			index:            5,
 			contextSize:      3,
 			ignoreWhitespace: true,
-			expected:         "git stash show -p --stat --color=always --unified=3 --ignore-all-space stash@{5}",
+			expected:         []string{"git", "stash", "show", "-p", "--stat", "--color=always", "--unified=3", "--ignore-all-space", "stash@{5}"},
 		},
 	}
 
@@ -137,7 +137,7 @@ func TestStashStashEntryCmdObj(t *testing.T) {
 			userConfig.Git.DiffContextSize = s.contextSize
 			instance := buildStashCommands(commonDeps{userConfig: userConfig})
 
-			cmdStr := instance.ShowStashEntryCmdObj(s.index, s.ignoreWhitespace).ToString()
+			cmdStr := instance.ShowStashEntryCmdObj(s.index, s.ignoreWhitespace).Args()
 			assert.Equal(t, s.expected, cmdStr)
 		})
 	}

--- a/pkg/commands/git_commands/status.go
+++ b/pkg/commands/git_commands/status.go
@@ -57,7 +57,7 @@ func (self *StatusCommands) IsBareRepo() (bool, error) {
 
 func IsBareRepo(osCommand *oscommands.OSCommand) (bool, error) {
 	res, err := osCommand.Cmd.New(
-		NewGitCmd("rev-parse").Arg("--is-bare-repository").ToString(),
+		NewGitCmd("rev-parse").Arg("--is-bare-repository").ToArgv(),
 	).DontLog().RunWithOutput()
 	if err != nil {
 		return false, err

--- a/pkg/commands/git_commands/submodule.go
+++ b/pkg/commands/git_commands/submodule.go
@@ -81,27 +81,27 @@ func (self *SubmoduleCommands) Stash(submodule *models.SubmoduleConfig) error {
 		return nil
 	}
 
-	cmdStr := NewGitCmd("stash").
-		RepoPath(self.cmd.Quote(submodule.Path)).
+	cmdArgs := NewGitCmd("stash").
+		RepoPath(submodule.Path).
 		Arg("--include-untracked").
-		ToString()
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *SubmoduleCommands) Reset(submodule *models.SubmoduleConfig) error {
-	cmdStr := NewGitCmd("submodule").
-		Arg("update", "--init", "--force", "--", self.cmd.Quote(submodule.Path)).
-		ToString()
+	cmdArgs := NewGitCmd("submodule").
+		Arg("update", "--init", "--force", "--", submodule.Path).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *SubmoduleCommands) UpdateAll() error {
 	// not doing an --init here because the user probably doesn't want that
-	cmdStr := NewGitCmd("submodule").Arg("update", "--force").ToString()
+	cmdArgs := NewGitCmd("submodule").Arg("update", "--force").ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *SubmoduleCommands) Delete(submodule *models.SubmoduleConfig) error {
@@ -109,7 +109,7 @@ func (self *SubmoduleCommands) Delete(submodule *models.SubmoduleConfig) error {
 
 	if err := self.cmd.New(
 		NewGitCmd("submodule").
-			Arg("deinit", "--force", "--", self.cmd.Quote(submodule.Path)).ToString(),
+			Arg("deinit", "--force", "--", submodule.Path).ToArgv(),
 	).Run(); err != nil {
 		if !strings.Contains(err.Error(), "did not match any file(s) known to git") {
 			return err
@@ -117,23 +117,23 @@ func (self *SubmoduleCommands) Delete(submodule *models.SubmoduleConfig) error {
 
 		if err := self.cmd.New(
 			NewGitCmd("config").
-				Arg("--file", ".gitmodules", "--remove-section", "submodule."+self.cmd.Quote(submodule.Path)).
-				ToString(),
+				Arg("--file", ".gitmodules", "--remove-section", "submodule."+submodule.Path).
+				ToArgv(),
 		).Run(); err != nil {
 			return err
 		}
 
 		if err := self.cmd.New(
 			NewGitCmd("config").
-				Arg("--remove-section", "submodule."+self.cmd.Quote(submodule.Path)).
-				ToString(),
+				Arg("--remove-section", "submodule."+submodule.Path).
+				ToArgv(),
 		).Run(); err != nil {
 			return err
 		}
 	}
 
 	if err := self.cmd.New(
-		NewGitCmd("rm").Arg("--force", "-r", submodule.Path).ToString(),
+		NewGitCmd("rm").Arg("--force", "-r", submodule.Path).ToArgv(),
 	).Run(); err != nil {
 		// if the directory isn't there then that's fine
 		self.Log.Error(err)
@@ -143,33 +143,33 @@ func (self *SubmoduleCommands) Delete(submodule *models.SubmoduleConfig) error {
 }
 
 func (self *SubmoduleCommands) Add(name string, path string, url string) error {
-	cmdStr := NewGitCmd("submodule").
+	cmdArgs := NewGitCmd("submodule").
 		Arg("add").
 		Arg("--force").
 		Arg("--name").
-		Arg(self.cmd.Quote(name)).
+		Arg(name).
 		Arg("--").
-		Arg(self.cmd.Quote(url)).
-		Arg(self.cmd.Quote(path)).
-		ToString()
+		Arg(url).
+		Arg(path).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *SubmoduleCommands) UpdateUrl(name string, path string, newUrl string) error {
 	setUrlCmdStr := NewGitCmd("config").
 		Arg(
-			"--file", ".gitmodules", "submodule."+self.cmd.Quote(name)+".url", self.cmd.Quote(newUrl),
+			"--file", ".gitmodules", "submodule."+name+".url", newUrl,
 		).
-		ToString()
+		ToArgv()
 
 	// the set-url command is only for later git versions so we're doing it manually here
 	if err := self.cmd.New(setUrlCmdStr).Run(); err != nil {
 		return err
 	}
 
-	syncCmdStr := NewGitCmd("submodule").Arg("sync", "--", self.cmd.Quote(path)).
-		ToString()
+	syncCmdStr := NewGitCmd("submodule").Arg("sync", "--", path).
+		ToArgv()
 
 	if err := self.cmd.New(syncCmdStr).Run(); err != nil {
 		return err
@@ -179,45 +179,45 @@ func (self *SubmoduleCommands) UpdateUrl(name string, path string, newUrl string
 }
 
 func (self *SubmoduleCommands) Init(path string) error {
-	cmdStr := NewGitCmd("submodule").Arg("init", "--", self.cmd.Quote(path)).
-		ToString()
+	cmdArgs := NewGitCmd("submodule").Arg("init", "--", path).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *SubmoduleCommands) Update(path string) error {
-	cmdStr := NewGitCmd("submodule").Arg("update", "--init", "--", self.cmd.Quote(path)).
-		ToString()
+	cmdArgs := NewGitCmd("submodule").Arg("update", "--init", "--", path).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *SubmoduleCommands) BulkInitCmdObj() oscommands.ICmdObj {
-	cmdStr := NewGitCmd("submodule").Arg("init").
-		ToString()
+	cmdArgs := NewGitCmd("submodule").Arg("init").
+		ToArgv()
 
-	return self.cmd.New(cmdStr)
+	return self.cmd.New(cmdArgs)
 }
 
 func (self *SubmoduleCommands) BulkUpdateCmdObj() oscommands.ICmdObj {
-	cmdStr := NewGitCmd("submodule").Arg("update").
-		ToString()
+	cmdArgs := NewGitCmd("submodule").Arg("update").
+		ToArgv()
 
-	return self.cmd.New(cmdStr)
+	return self.cmd.New(cmdArgs)
 }
 
 func (self *SubmoduleCommands) ForceBulkUpdateCmdObj() oscommands.ICmdObj {
-	cmdStr := NewGitCmd("submodule").Arg("update", "--force").
-		ToString()
+	cmdArgs := NewGitCmd("submodule").Arg("update", "--force").
+		ToArgv()
 
-	return self.cmd.New(cmdStr)
+	return self.cmd.New(cmdArgs)
 }
 
 func (self *SubmoduleCommands) BulkDeinitCmdObj() oscommands.ICmdObj {
-	cmdStr := NewGitCmd("submodule").Arg("deinit", "--all", "--force").
-		ToString()
+	cmdArgs := NewGitCmd("submodule").Arg("deinit", "--all", "--force").
+		ToArgv()
 
-	return self.cmd.New(cmdStr)
+	return self.cmd.New(cmdArgs)
 }
 
 func (self *SubmoduleCommands) ResetSubmodules(submodules []*models.SubmoduleConfig) error {

--- a/pkg/commands/git_commands/sync.go
+++ b/pkg/commands/git_commands/sync.go
@@ -28,14 +28,14 @@ func (self *SyncCommands) PushCmdObj(opts PushOpts) (oscommands.ICmdObj, error) 
 		return nil, errors.New(self.Tr.MustSpecifyOriginError)
 	}
 
-	cmdStr := NewGitCmd("push").
+	cmdArgs := NewGitCmd("push").
 		ArgIf(opts.Force, "--force-with-lease").
 		ArgIf(opts.SetUpstream, "--set-upstream").
-		ArgIf(opts.UpstreamRemote != "", self.cmd.Quote(opts.UpstreamRemote)).
-		ArgIf(opts.UpstreamBranch != "", self.cmd.Quote(opts.UpstreamBranch)).
-		ToString()
+		ArgIf(opts.UpstreamRemote != "", opts.UpstreamRemote).
+		ArgIf(opts.UpstreamBranch != "", opts.UpstreamBranch).
+		ToArgv()
 
-	cmdObj := self.cmd.New(cmdStr).PromptOnCredentialRequest().WithMutex(self.syncMutex)
+	cmdObj := self.cmd.New(cmdArgs).PromptOnCredentialRequest().WithMutex(self.syncMutex)
 	return cmdObj, nil
 }
 
@@ -56,12 +56,12 @@ type FetchOptions struct {
 
 // Fetch fetch git repo
 func (self *SyncCommands) Fetch(opts FetchOptions) error {
-	cmdStr := NewGitCmd("fetch").
-		ArgIf(opts.RemoteName != "", self.cmd.Quote(opts.RemoteName)).
-		ArgIf(opts.BranchName != "", self.cmd.Quote(opts.BranchName)).
-		ToString()
+	cmdArgs := NewGitCmd("fetch").
+		ArgIf(opts.RemoteName != "", opts.RemoteName).
+		ArgIf(opts.BranchName != "", opts.BranchName).
+		ToArgv()
 
-	cmdObj := self.cmd.New(cmdStr)
+	cmdObj := self.cmd.New(cmdArgs)
 	if opts.Background {
 		cmdObj.DontLog().FailOnCredentialRequest()
 	} else {
@@ -77,31 +77,31 @@ type PullOptions struct {
 }
 
 func (self *SyncCommands) Pull(opts PullOptions) error {
-	cmdStr := NewGitCmd("pull").
+	cmdArgs := NewGitCmd("pull").
 		Arg("--no-edit").
 		ArgIf(opts.FastForwardOnly, "--ff-only").
-		ArgIf(opts.RemoteName != "", self.cmd.Quote(opts.RemoteName)).
-		ArgIf(opts.BranchName != "", self.cmd.Quote(opts.BranchName)).
-		ToString()
+		ArgIf(opts.RemoteName != "", opts.RemoteName).
+		ArgIf(opts.BranchName != "", opts.BranchName).
+		ToArgv()
 
 	// setting GIT_SEQUENCE_EDITOR to ':' as a way of skipping it, in case the user
 	// has 'pull.rebase = interactive' configured.
-	return self.cmd.New(cmdStr).AddEnvVars("GIT_SEQUENCE_EDITOR=:").PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
+	return self.cmd.New(cmdArgs).AddEnvVars("GIT_SEQUENCE_EDITOR=:").PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
 }
 
 func (self *SyncCommands) FastForward(branchName string, remoteName string, remoteBranchName string) error {
-	cmdStr := NewGitCmd("fetch").
-		Arg(self.cmd.Quote(remoteName)).
-		Arg(self.cmd.Quote(remoteBranchName) + ":" + self.cmd.Quote(branchName)).
-		ToString()
+	cmdArgs := NewGitCmd("fetch").
+		Arg(remoteName).
+		Arg(remoteBranchName + ":" + branchName).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
+	return self.cmd.New(cmdArgs).PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
 }
 
 func (self *SyncCommands) FetchRemote(remoteName string) error {
-	cmdStr := NewGitCmd("fetch").
-		Arg(self.cmd.Quote(remoteName)).
-		ToString()
+	cmdArgs := NewGitCmd("fetch").
+		Arg(remoteName).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
+	return self.cmd.New(cmdArgs).PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
 }

--- a/pkg/commands/git_commands/sync_test.go
+++ b/pkg/commands/git_commands/sync_test.go
@@ -19,7 +19,7 @@ func TestSyncPush(t *testing.T) {
 			testName: "Push with force disabled",
 			opts:     PushOpts{Force: false},
 			test: func(cmdObj oscommands.ICmdObj, err error) {
-				assert.Equal(t, cmdObj.ToString(), "git push")
+				assert.Equal(t, cmdObj.Args(), []string{"git", "push"})
 				assert.NoError(t, err)
 			},
 		},
@@ -27,7 +27,7 @@ func TestSyncPush(t *testing.T) {
 			testName: "Push with force enabled",
 			opts:     PushOpts{Force: true},
 			test: func(cmdObj oscommands.ICmdObj, err error) {
-				assert.Equal(t, cmdObj.ToString(), "git push --force-with-lease")
+				assert.Equal(t, cmdObj.Args(), []string{"git", "push", "--force-with-lease"})
 				assert.NoError(t, err)
 			},
 		},
@@ -39,7 +39,7 @@ func TestSyncPush(t *testing.T) {
 				UpstreamBranch: "master",
 			},
 			test: func(cmdObj oscommands.ICmdObj, err error) {
-				assert.Equal(t, cmdObj.ToString(), `git push "origin" "master"`)
+				assert.Equal(t, cmdObj.Args(), []string{"git", "push", "origin", "master"})
 				assert.NoError(t, err)
 			},
 		},
@@ -52,7 +52,7 @@ func TestSyncPush(t *testing.T) {
 				SetUpstream:    true,
 			},
 			test: func(cmdObj oscommands.ICmdObj, err error) {
-				assert.Equal(t, cmdObj.ToString(), `git push --set-upstream "origin" "master"`)
+				assert.Equal(t, cmdObj.Args(), []string{"git", "push", "--set-upstream", "origin", "master"})
 				assert.NoError(t, err)
 			},
 		},
@@ -65,7 +65,7 @@ func TestSyncPush(t *testing.T) {
 				SetUpstream:    true,
 			},
 			test: func(cmdObj oscommands.ICmdObj, err error) {
-				assert.Equal(t, cmdObj.ToString(), `git push --force-with-lease --set-upstream "origin" "master"`)
+				assert.Equal(t, cmdObj.Args(), []string{"git", "push", "--force-with-lease", "--set-upstream", "origin", "master"})
 				assert.NoError(t, err)
 			},
 		},

--- a/pkg/commands/git_commands/tag.go
+++ b/pkg/commands/git_commands/tag.go
@@ -11,32 +11,32 @@ func NewTagCommands(gitCommon *GitCommon) *TagCommands {
 }
 
 func (self *TagCommands) CreateLightweight(tagName string, ref string) error {
-	cmdStr := NewGitCmd("tag").Arg("--", self.cmd.Quote(tagName)).
-		ArgIf(len(ref) > 0, self.cmd.Quote(ref)).
-		ToString()
+	cmdArgs := NewGitCmd("tag").Arg("--", tagName).
+		ArgIf(len(ref) > 0, ref).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *TagCommands) CreateAnnotated(tagName, ref, msg string) error {
-	cmdStr := NewGitCmd("tag").Arg(self.cmd.Quote(tagName)).
-		ArgIf(len(ref) > 0, self.cmd.Quote(ref)).
-		Arg("-m", self.cmd.Quote(msg)).
-		ToString()
+	cmdArgs := NewGitCmd("tag").Arg(tagName).
+		ArgIf(len(ref) > 0, ref).
+		Arg("-m", msg).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *TagCommands) Delete(tagName string) error {
-	cmdStr := NewGitCmd("tag").Arg("-d", self.cmd.Quote(tagName)).
-		ToString()
+	cmdArgs := NewGitCmd("tag").Arg("-d", tagName).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).Run()
+	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *TagCommands) Push(remoteName string, tagName string) error {
-	cmdStr := NewGitCmd("push").Arg(self.cmd.Quote(remoteName), "tag", self.cmd.Quote(tagName)).
-		ToString()
+	cmdArgs := NewGitCmd("push").Arg(remoteName, "tag", tagName).
+		ToArgv()
 
-	return self.cmd.New(cmdStr).PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
+	return self.cmd.New(cmdArgs).PromptOnCredentialRequest().WithMutex(self.syncMutex).Run()
 }

--- a/pkg/commands/git_commands/tag_loader.go
+++ b/pkg/commands/git_commands/tag_loader.go
@@ -28,8 +28,8 @@ func NewTagLoader(
 func (self *TagLoader) GetTags() ([]*models.Tag, error) {
 	// get remote branches, sorted  by creation date (descending)
 	// see: https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---sortltkeygt
-	cmdStr := NewGitCmd("tag").Arg("--list", "-n", "--sort=-creatordate").ToString()
-	tagsOutput, err := self.cmd.New(cmdStr).DontLog().RunWithOutput()
+	cmdArgs := NewGitCmd("tag").Arg("--list", "-n", "--sort=-creatordate").ToArgv()
+	tagsOutput, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/git_commands/tag_loader_test.go
+++ b/pkg/commands/git_commands/tag_loader_test.go
@@ -26,14 +26,14 @@ func TestGetTags(t *testing.T) {
 		{
 			testName: "should return no tags if there are none",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git tag --list -n --sort=-creatordate`, "", nil),
+				ExpectGitArgs([]string{"tag", "--list", "-n", "--sort=-creatordate"}, "", nil),
 			expectedTags:  []*models.Tag{},
 			expectedError: nil,
 		},
 		{
 			testName: "should return tags if present",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git tag --list -n --sort=-creatordate`, tagsOutput, nil),
+				ExpectGitArgs([]string{"tag", "--list", "-n", "--sort=-creatordate"}, tagsOutput, nil),
 			expectedTags: []*models.Tag{
 				{Name: "tag1", Message: "this is my message"},
 				{Name: "tag2", Message: ""},

--- a/pkg/commands/git_commands/version.go
+++ b/pkg/commands/git_commands/version.go
@@ -15,7 +15,7 @@ type GitVersion struct {
 }
 
 func GetGitVersion(osCommand *oscommands.OSCommand) (*GitVersion, error) {
-	versionStr, _, err := osCommand.Cmd.New(NewGitCmd("--version").ToString()).RunWithOutputs()
+	versionStr, _, err := osCommand.Cmd.New(NewGitCmd("--version").ToArgv()).RunWithOutputs()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/git_commands/working_tree_test.go
+++ b/pkg/commands/git_commands/working_tree_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestWorkingTreeStageFile(t *testing.T) {
 	runner := oscommands.NewFakeRunner(t).
-		Expect(`git add -- "test.txt"`, "", nil)
+		ExpectGitArgs([]string{"add", "--", "test.txt"}, "", nil)
 
 	instance := buildWorkingTreeCommands(commonDeps{runner: runner})
 
@@ -23,7 +23,7 @@ func TestWorkingTreeStageFile(t *testing.T) {
 
 func TestWorkingTreeStageFiles(t *testing.T) {
 	runner := oscommands.NewFakeRunner(t).
-		Expect(`git add -- "test.txt" "test2.txt"`, "", nil)
+		ExpectGitArgs([]string{"add", "--", "test.txt", "test2.txt"}, "", nil)
 
 	instance := buildWorkingTreeCommands(commonDeps{runner: runner})
 
@@ -44,7 +44,7 @@ func TestWorkingTreeUnstageFile(t *testing.T) {
 			testName: "Remove an untracked file from staging",
 			reset:    false,
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git rm --cached --force -- "test.txt"`, "", nil),
+				ExpectGitArgs([]string{"rm", "--cached", "--force", "--", "test.txt"}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -53,7 +53,7 @@ func TestWorkingTreeUnstageFile(t *testing.T) {
 			testName: "Remove a tracked file from staging",
 			reset:    true,
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git reset HEAD -- "test.txt"`, "", nil),
+				ExpectGitArgs([]string{"reset", "HEAD", "--", "test.txt"}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -90,7 +90,7 @@ func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
 			},
 			removeFile: func(string) error { return nil },
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git reset -- "test"`, "", errors.New("error")),
+				ExpectGitArgs([]string{"reset", "--", "test"}, "", errors.New("error")),
 			expectedError: "error",
 		},
 		{
@@ -115,7 +115,7 @@ func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
 			},
 			removeFile: func(string) error { return nil },
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git checkout -- "test"`, "", errors.New("error")),
+				ExpectGitArgs([]string{"checkout", "--", "test"}, "", errors.New("error")),
 			expectedError: "error",
 		},
 		{
@@ -127,7 +127,7 @@ func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
 			},
 			removeFile: func(string) error { return nil },
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git checkout -- "test"`, "", nil),
+				ExpectGitArgs([]string{"checkout", "--", "test"}, "", nil),
 			expectedError: "",
 		},
 		{
@@ -139,8 +139,8 @@ func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
 			},
 			removeFile: func(string) error { return nil },
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git reset -- "test"`, "", nil).
-				Expect(`git checkout -- "test"`, "", nil),
+				ExpectGitArgs([]string{"reset", "--", "test"}, "", nil).
+				ExpectGitArgs([]string{"checkout", "--", "test"}, "", nil),
 			expectedError: "",
 		},
 		{
@@ -152,8 +152,8 @@ func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
 			},
 			removeFile: func(string) error { return nil },
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git reset -- "test"`, "", nil).
-				Expect(`git checkout -- "test"`, "", nil),
+				ExpectGitArgs([]string{"reset", "--", "test"}, "", nil).
+				ExpectGitArgs([]string{"checkout", "--", "test"}, "", nil),
 			expectedError: "",
 		},
 		{
@@ -169,7 +169,7 @@ func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
 				return nil
 			},
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git reset -- "test"`, "", nil),
+				ExpectGitArgs([]string{"reset", "--", "test"}, "", nil),
 			expectedError: "",
 		},
 		{
@@ -231,7 +231,7 @@ func TestWorkingTreeDiff(t *testing.T) {
 			ignoreWhitespace: false,
 			contextSize:      3,
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git diff --submodule --no-ext-diff --unified=3 --color=always -- "test.txt"`, expectedResult, nil),
+				ExpectGitArgs([]string{"diff", "--submodule", "--no-ext-diff", "--unified=3", "--color=always", "--", "test.txt"}, expectedResult, nil),
 		},
 		{
 			testName: "cached",
@@ -245,7 +245,7 @@ func TestWorkingTreeDiff(t *testing.T) {
 			ignoreWhitespace: false,
 			contextSize:      3,
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git diff --submodule --no-ext-diff --unified=3 --color=always --cached -- "test.txt"`, expectedResult, nil),
+				ExpectGitArgs([]string{"diff", "--submodule", "--no-ext-diff", "--unified=3", "--color=always", "--cached", "--", "test.txt"}, expectedResult, nil),
 		},
 		{
 			testName: "plain",
@@ -259,7 +259,7 @@ func TestWorkingTreeDiff(t *testing.T) {
 			ignoreWhitespace: false,
 			contextSize:      3,
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git diff --submodule --no-ext-diff --unified=3 --color=never -- "test.txt"`, expectedResult, nil),
+				ExpectGitArgs([]string{"diff", "--submodule", "--no-ext-diff", "--unified=3", "--color=never", "--", "test.txt"}, expectedResult, nil),
 		},
 		{
 			testName: "File not tracked and file has no staged changes",
@@ -273,7 +273,7 @@ func TestWorkingTreeDiff(t *testing.T) {
 			ignoreWhitespace: false,
 			contextSize:      3,
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git diff --submodule --no-ext-diff --unified=3 --color=always --no-index -- /dev/null "test.txt"`, expectedResult, nil),
+				ExpectGitArgs([]string{"diff", "--submodule", "--no-ext-diff", "--unified=3", "--color=always", "--no-index", "--", "/dev/null", "test.txt"}, expectedResult, nil),
 		},
 		{
 			testName: "Default case (ignore whitespace)",
@@ -287,7 +287,7 @@ func TestWorkingTreeDiff(t *testing.T) {
 			ignoreWhitespace: true,
 			contextSize:      3,
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git diff --submodule --no-ext-diff --unified=3 --color=always --ignore-all-space -- "test.txt"`, expectedResult, nil),
+				ExpectGitArgs([]string{"diff", "--submodule", "--no-ext-diff", "--unified=3", "--color=always", "--ignore-all-space", "--", "test.txt"}, expectedResult, nil),
 		},
 		{
 			testName: "Show diff with custom context size",
@@ -301,7 +301,7 @@ func TestWorkingTreeDiff(t *testing.T) {
 			ignoreWhitespace: false,
 			contextSize:      17,
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git diff --submodule --no-ext-diff --unified=17 --color=always -- "test.txt"`, expectedResult, nil),
+				ExpectGitArgs([]string{"diff", "--submodule", "--no-ext-diff", "--unified=17", "--color=always", "--", "test.txt"}, expectedResult, nil),
 		},
 	}
 
@@ -343,7 +343,7 @@ func TestWorkingTreeShowFileDiff(t *testing.T) {
 			ignoreWhitespace: false,
 			contextSize:      3,
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git diff --submodule --no-ext-diff --unified=3 --no-renames --color=always 1234567890 0987654321 -- "test.txt"`, expectedResult, nil),
+				ExpectGitArgs([]string{"diff", "--submodule", "--no-ext-diff", "--unified=3", "--no-renames", "--color=always", "1234567890", "0987654321", "--", "test.txt"}, expectedResult, nil),
 		},
 		{
 			testName:         "Show diff with custom context size",
@@ -354,7 +354,7 @@ func TestWorkingTreeShowFileDiff(t *testing.T) {
 			ignoreWhitespace: false,
 			contextSize:      123,
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git diff --submodule --no-ext-diff --unified=123 --no-renames --color=always 1234567890 0987654321 -- "test.txt"`, expectedResult, nil),
+				ExpectGitArgs([]string{"diff", "--submodule", "--no-ext-diff", "--unified=123", "--no-renames", "--color=always", "1234567890", "0987654321", "--", "test.txt"}, expectedResult, nil),
 		},
 		{
 			testName:         "Default case (ignore whitespace)",
@@ -365,7 +365,7 @@ func TestWorkingTreeShowFileDiff(t *testing.T) {
 			ignoreWhitespace: true,
 			contextSize:      3,
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git diff --submodule --no-ext-diff --unified=3 --no-renames --color=always 1234567890 0987654321 --ignore-all-space -- "test.txt"`, expectedResult, nil),
+				ExpectGitArgs([]string{"diff", "--submodule", "--no-ext-diff", "--unified=3", "--no-renames", "--color=always", "1234567890", "0987654321", "--ignore-all-space", "--", "test.txt"}, expectedResult, nil),
 		},
 	}
 
@@ -400,7 +400,7 @@ func TestWorkingTreeCheckoutFile(t *testing.T) {
 			commitSha: "11af912",
 			fileName:  "test999.txt",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git checkout 11af912 -- "test999.txt"`, "", nil),
+				ExpectGitArgs([]string{"checkout", "11af912", "--", "test999.txt"}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -410,7 +410,7 @@ func TestWorkingTreeCheckoutFile(t *testing.T) {
 			commitSha: "11af912",
 			fileName:  "test999.txt",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git checkout 11af912 -- "test999.txt"`, "", errors.New("error")),
+				ExpectGitArgs([]string{"checkout", "11af912", "--", "test999.txt"}, "", errors.New("error")),
 			test: func(err error) {
 				assert.Error(t, err)
 			},
@@ -441,7 +441,7 @@ func TestWorkingTreeDiscardUnstagedFileChanges(t *testing.T) {
 			testName: "valid case",
 			file:     &models.File{Name: "test.txt"},
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git checkout -- "test.txt"`, "", nil),
+				ExpectGitArgs([]string{"checkout", "--", "test.txt"}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -469,7 +469,7 @@ func TestWorkingTreeDiscardAnyUnstagedFileChanges(t *testing.T) {
 		{
 			testName: "valid case",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git checkout -- .`, "", nil),
+				ExpectGitArgs([]string{"checkout", "--", "."}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -497,7 +497,7 @@ func TestWorkingTreeRemoveUntrackedFiles(t *testing.T) {
 		{
 			testName: "valid case",
 			runner: oscommands.NewFakeRunner(t).
-				Expect(`git clean -fd`, "", nil),
+				ExpectGitArgs([]string{"clean", "-fd"}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -527,7 +527,7 @@ func TestWorkingTreeResetHard(t *testing.T) {
 			"valid case",
 			"HEAD",
 			oscommands.NewFakeRunner(t).
-				Expect(`git reset --hard "HEAD"`, "", nil),
+				ExpectGitArgs([]string{"reset", "--hard", "HEAD"}, "", nil),
 			func(err error) {
 				assert.NoError(t, err)
 			},

--- a/pkg/commands/oscommands/cmd_obj_test.go
+++ b/pkg/commands/oscommands/cmd_obj_test.go
@@ -1,0 +1,33 @@
+package oscommands
+
+import (
+	"testing"
+)
+
+func TestCmdObjToString(t *testing.T) {
+	quote := func(s string) string {
+		return "\"" + s + "\""
+	}
+
+	scenarios := []struct {
+		cmdArgs  []string
+		expected string
+	}{
+		{
+			cmdArgs:  []string{"git", "push", "myfile.txt"},
+			expected: "git push myfile.txt",
+		},
+		{
+			cmdArgs:  []string{"git", "push", "my file.txt"},
+			expected: "git push \"my file.txt\"",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		cmdObj := &CmdObj{args: scenario.cmdArgs}
+		actual := cmdObj.ToString()
+		if actual != scenario.expected {
+			t.Errorf("Expected %s, got %s", quote(scenario.expected), quote(actual))
+		}
+	}
+}

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/go-errors/errors"
+	"github.com/samber/lo"
 
 	"github.com/atotto/clipboard"
 	"github.com/jesseduffield/generics/slices"
@@ -187,12 +188,18 @@ func (c *OSCommand) FileExists(path string) (bool, error) {
 }
 
 // PipeCommands runs a heap of commands and pipes their inputs/outputs together like A | B | C
-func (c *OSCommand) PipeCommands(commandStrings ...string) error {
-	cmds := slices.Map(commandStrings, func(cmdString string) *exec.Cmd {
-		return c.Cmd.New(cmdString).GetCmd()
+func (c *OSCommand) PipeCommands(cmdObjs ...ICmdObj) error {
+	cmds := slices.Map(cmdObjs, func(cmdObj ICmdObj) *exec.Cmd {
+		return cmdObj.GetCmd()
 	})
 
-	logCmdStr := strings.Join(commandStrings, " | ")
+	logCmdStr := strings.Join(
+		lo.Map(cmdObjs, func(cmdObj ICmdObj, _ int) string {
+			return cmdObj.ToString()
+		}),
+		" | ",
+	)
+
 	c.LogCommand(logCmdStr, true)
 
 	for i := 0; i < len(cmds)-1; i++ {

--- a/pkg/commands/oscommands/os_default_test.go
+++ b/pkg/commands/oscommands/os_default_test.go
@@ -12,20 +12,20 @@ import (
 
 func TestOSCommandRunWithOutput(t *testing.T) {
 	type scenario struct {
-		command string
-		test    func(string, error)
+		args []string
+		test func(string, error)
 	}
 
 	scenarios := []scenario{
 		{
-			"echo -n '123'",
+			[]string{"echo", "-n", "123"},
 			func(output string, err error) {
 				assert.NoError(t, err)
 				assert.EqualValues(t, "123", output)
 			},
 		},
 		{
-			"rmdir unexisting-folder",
+			[]string{"rmdir", "unexisting-folder"},
 			func(output string, err error) {
 				assert.Regexp(t, "rmdir.*unexisting-folder.*", err.Error())
 			},
@@ -34,7 +34,7 @@ func TestOSCommandRunWithOutput(t *testing.T) {
 
 	for _, s := range scenarios {
 		c := NewDummyOSCommand()
-		s.test(c.Cmd.New(s.command).RunWithOutput())
+		s.test(c.Cmd.New(s.args).RunWithOutput())
 	}
 }
 

--- a/pkg/commands/oscommands/os_test.go
+++ b/pkg/commands/oscommands/os_test.go
@@ -10,13 +10,13 @@ import (
 
 func TestOSCommandRun(t *testing.T) {
 	type scenario struct {
-		command string
-		test    func(error)
+		args []string
+		test func(error)
 	}
 
 	scenarios := []scenario{
 		{
-			"rmdir unexisting-folder",
+			[]string{"rmdir", "unexisting-folder"},
 			func(err error) {
 				assert.Regexp(t, "rmdir.*unexisting-folder.*", err.Error())
 			},
@@ -25,7 +25,7 @@ func TestOSCommandRun(t *testing.T) {
 
 	for _, s := range scenarios {
 		c := NewDummyOSCommand()
-		s.test(c.Cmd.New(s.command).Run())
+		s.test(c.Cmd.New(s.args).Run())
 	}
 }
 

--- a/pkg/gui/controllers/helpers/diff_helper.go
+++ b/pkg/gui/controllers/helpers/diff_helper.go
@@ -1,8 +1,6 @@
 package helpers
 
 import (
-	"fmt"
-
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/modes/diffing"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
@@ -19,27 +17,29 @@ func NewDiffHelper(c *HelperCommon) *DiffHelper {
 	}
 }
 
-func (self *DiffHelper) DiffStr() string {
-	output := self.c.Modes().Diffing.Ref
+func (self *DiffHelper) DiffArgs() []string {
+	output := []string{self.c.Modes().Diffing.Ref}
 
 	right := self.currentDiffTerminal()
 	if right != "" {
-		output += " " + right
+		output = append(output, right)
 	}
 
 	if self.c.Modes().Diffing.Reverse {
-		output += " -R"
+		output = append(output, "-R")
 	}
 
 	if self.c.State().GetIgnoreWhitespaceInDiffView() {
-		output += " --ignore-all-space"
+		output = append(output, "--ignore-all-space")
 	}
+
+	output = append(output, "--")
 
 	file := self.currentlySelectedFilename()
 	if file != "" {
-		output += " -- " + file
+		output = append(output, file)
 	} else if self.c.Modes().Filtering.Active() {
-		output += " -- " + self.c.Modes().Filtering.GetPath()
+		output = append(output, self.c.Modes().Filtering.GetPath())
 	}
 
 	return output
@@ -51,9 +51,7 @@ func (self *DiffHelper) ExitDiffMode() error {
 }
 
 func (self *DiffHelper) RenderDiff() error {
-	cmdObj := self.c.OS().Cmd.New(
-		fmt.Sprintf("git diff --submodule --no-ext-diff --color %s", self.DiffStr()),
-	)
+	cmdObj := self.c.Git().Diff.DiffCmdObj(self.DiffArgs())
 	task := types.NewRunPtyTask(cmdObj.GetCmd())
 
 	return self.c.RenderToMainViews(types.RefreshMainOpts{

--- a/pkg/gui/controllers/helpers/gpg_helper.go
+++ b/pkg/gui/controllers/helpers/gpg_helper.go
@@ -21,11 +21,10 @@ func NewGpgHelper(c *HelperCommon) *GpgHelper {
 // WithWaitingStatus we get stuck there and can't return to lazygit. We could
 // fix this bug, or just stop running subprocesses from within there, given that
 // we don't need to see a loading status if we're in a subprocess.
-// TODO: we shouldn't need to use a shell here, but looks like that NewShell function contains some windows specific quoting stuff. We should centralise that.
 func (self *GpgHelper) WithGpgHandling(cmdObj oscommands.ICmdObj, waitingStatus string, onSuccess func() error) error {
 	useSubprocess := self.c.Git().Config.UsingGpg()
 	if useSubprocess {
-		success, err := self.c.RunSubprocess(self.c.OS().Cmd.NewShell(cmdObj.ToString()))
+		success, err := self.c.RunSubprocess(cmdObj)
 		if success && onSuccess != nil {
 			if err := onSuccess(); err != nil {
 				return err
@@ -42,8 +41,6 @@ func (self *GpgHelper) WithGpgHandling(cmdObj oscommands.ICmdObj, waitingStatus 
 }
 
 func (self *GpgHelper) runAndStream(cmdObj oscommands.ICmdObj, waitingStatus string, onSuccess func() error) error {
-	cmdObj = self.c.OS().Cmd.NewShell(cmdObj.ToString())
-
 	return self.c.WithWaitingStatus(waitingStatus, func() error {
 		if err := cmdObj.StreamOutput().Run(); err != nil {
 			_ = self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})

--- a/pkg/gui/controllers/helpers/mode_helper.go
+++ b/pkg/gui/controllers/helpers/mode_helper.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jesseduffield/generics/slices"
 	"github.com/jesseduffield/lazygit/pkg/commands/types/enums"
@@ -53,7 +54,7 @@ func (self *ModeHelper) Statuses() []ModeStatus {
 					fmt.Sprintf(
 						"%s %s",
 						self.c.Tr.LcShowingGitDiff,
-						"git diff "+self.diffHelper.DiffStr(),
+						"git diff "+strings.Join(self.diffHelper.DiffArgs(), " "),
 					),
 					style.FgMagenta,
 				)

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -288,7 +288,7 @@ func (self *LocalCommitsController) doRewordEditor() error {
 	self.c.LogAction(self.c.Tr.Actions.RewordCommit)
 
 	if self.isHeadCommit() {
-		return self.c.RunSubprocessAndRefresh(self.c.OS().Cmd.New("git commit --allow-empty --amend --only"))
+		return self.c.RunSubprocessAndRefresh(self.c.Git().Commit.RewordLastCommitInEditorCmdObj())
 	}
 
 	subProcess, err := self.c.Git().Rebase.RewordCommitInEditor(

--- a/pkg/integration/components/git.go
+++ b/pkg/integration/components/git.go
@@ -11,18 +11,18 @@ type Git struct {
 }
 
 func (self *Git) CurrentBranchName(expectedName string) *Git {
-	return self.assert("git rev-parse --abbrev-ref HEAD", expectedName)
+	return self.assert([]string{"git", "rev-parse", "--abbrev-ref", "HEAD"}, expectedName)
 }
 
 func (self *Git) TagNamesAt(ref string, expectedNames []string) *Git {
-	return self.assert(fmt.Sprintf(`git tag --sort=v:refname --points-at "%s"`, ref), strings.Join(expectedNames, "\n"))
+	return self.assert([]string{"git", "tag", "--sort=v:refname", "--points-at", ref}, strings.Join(expectedNames, "\n"))
 }
 
-func (self *Git) assert(cmdStr string, expected string) *Git {
+func (self *Git) assert(cmdArgs []string, expected string) *Git {
 	self.assertWithRetries(func() (bool, string) {
-		output, err := self.shell.runCommandWithOutput(cmdStr)
+		output, err := self.shell.runCommandWithOutput(cmdArgs)
 		if err != nil {
-			return false, fmt.Sprintf("Unexpected error running command: `%s`. Error: %s", cmdStr, err.Error())
+			return false, fmt.Sprintf("Unexpected error running command: `%v`. Error: %s", cmdArgs, err.Error())
 		}
 		actual := strings.TrimSpace(output)
 		return actual == expected, fmt.Sprintf("Expected current branch name to be '%s', but got '%s'", expected, actual)

--- a/pkg/integration/components/runner.go
+++ b/pkg/integration/components/runner.go
@@ -134,14 +134,14 @@ func buildLazygit() error {
 	// return nil
 
 	osCommand := oscommands.NewDummyOSCommand()
-	return osCommand.Cmd.New(fmt.Sprintf(
-		"go build -o %s pkg/integration/clients/injector/main.go", tempLazygitPath(),
-	)).Run()
+	return osCommand.Cmd.New([]string{
+		"go", "build", "-o", tempLazygitPath(), filepath.FromSlash("pkg/integration/clients/injector/main.go"),
+	}).Run()
 }
 
 func createFixture(test *IntegrationTest, paths Paths, rootDir string) error {
 	shell := NewShell(paths.ActualRepo(), func(errorMsg string) { panic(errorMsg) })
-	shell.RunCommand("git init -b master")
+	shell.Init("master")
 
 	os.Setenv(GIT_CONFIG_GLOBAL_ENV_VAR, globalGitConfigPath(rootDir))
 
@@ -156,7 +156,7 @@ func globalGitConfigPath(rootDir string) string {
 
 func getGitVersion() (*git_commands.GitVersion, error) {
 	osCommand := oscommands.NewDummyOSCommand()
-	cmdObj := osCommand.Cmd.New("git --version")
+	cmdObj := osCommand.Cmd.New([]string{"git", "--version"})
 	versionStr, err := cmdObj.RunWithOutput()
 	if err != nil {
 		return nil, err
@@ -178,9 +178,10 @@ func getLazygitCommand(test *IntegrationTest, paths Paths, rootDir string, sandb
 		return nil, err
 	}
 
-	cmdStr := fmt.Sprintf("%s -debug --use-config-dir=%s --path=%s %s", tempLazygitPath(), paths.Config(), paths.ActualRepo(), test.ExtraCmdArgs())
+	cmdArgs := []string{tempLazygitPath(), "-debug", "--use-config-dir=" + paths.Config(), "--path=" + paths.ActualRepo()}
+	cmdArgs = append(cmdArgs, test.ExtraCmdArgs()...)
 
-	cmdObj := osCommand.Cmd.New(cmdStr)
+	cmdObj := osCommand.Cmd.New(cmdArgs)
 
 	cmdObj.AddEnvVars(fmt.Sprintf("%s=%s", TEST_NAME_ENV_VAR, test.Name()))
 	if sandbox {

--- a/pkg/integration/components/test.go
+++ b/pkg/integration/components/test.go
@@ -22,7 +22,7 @@ const unitTestDescription = "test test"
 type IntegrationTest struct {
 	name         string
 	description  string
-	extraCmdArgs string
+	extraCmdArgs []string
 	skip         bool
 	setupRepo    func(shell *Shell)
 	setupConfig  func(config *config.AppConfig)
@@ -45,7 +45,7 @@ type NewIntegrationTestArgs struct {
 	// runs the test
 	Run func(t *TestDriver, keys config.KeybindingConfig)
 	// additional args passed to lazygit
-	ExtraCmdArgs string
+	ExtraCmdArgs []string
 	// for when a test is flakey
 	Skip bool
 	// to run a test only on certain git versions
@@ -128,7 +128,7 @@ func (self *IntegrationTest) Description() string {
 	return self.description
 }
 
-func (self *IntegrationTest) ExtraCmdArgs() string {
+func (self *IntegrationTest) ExtraCmdArgs() []string {
 	return self.extraCmdArgs
 }
 

--- a/pkg/integration/tests/bisect/basic.go
+++ b/pkg/integration/tests/bisect/basic.go
@@ -7,7 +7,7 @@ import (
 
 var Basic = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Start a git bisect to find a bad commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/bisect/from_other_branch.go
+++ b/pkg/integration/tests/bisect/from_other_branch.go
@@ -7,7 +7,7 @@ import (
 
 var FromOtherBranch = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Opening lazygit when bisect has been started from another branch. There's an issue where we don't reselect the current branch if we mark the current branch as bad so this test side-steps that problem",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
 		shell.
@@ -15,7 +15,7 @@ var FromOtherBranch = NewIntegrationTest(NewIntegrationTestArgs{
 			NewBranch("other").
 			CreateNCommits(10).
 			Checkout("master").
-			RunCommand("git bisect start other~2 other~5")
+			StartBisect("other~2", "other~5")
 	},
 	SetupConfig: func(cfg *config.AppConfig) {},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {

--- a/pkg/integration/tests/branch/checkout_by_name.go
+++ b/pkg/integration/tests/branch/checkout_by_name.go
@@ -7,7 +7,7 @@ import (
 
 var CheckoutByName = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Try to checkout branch by name. Verify that it also works on the branch with the special name @.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/branch/create_tag.go
+++ b/pkg/integration/tests/branch/create_tag.go
@@ -7,7 +7,7 @@ import (
 
 var CreateTag = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Create a new tag on branch",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/branch/delete.go
+++ b/pkg/integration/tests/branch/delete.go
@@ -7,7 +7,7 @@ import (
 
 var Delete = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Try to delete the checked out branch first (to no avail), and then delete another branch.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/branch/detached_head.go
+++ b/pkg/integration/tests/branch/detached_head.go
@@ -7,7 +7,7 @@ import (
 
 var DetachedHead = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Create a new branch on detached head",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/branch/open_with_cli_arg.go
+++ b/pkg/integration/tests/branch/open_with_cli_arg.go
@@ -7,7 +7,7 @@ import (
 
 var OpenWithCliArg = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Open straight to branches panel using a CLI arg",
-	ExtraCmdArgs: "branch",
+	ExtraCmdArgs: []string{"branch"},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/branch/rebase.go
+++ b/pkg/integration/tests/branch/rebase.go
@@ -8,7 +8,7 @@ import (
 
 var Rebase = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Rebase onto another branch, deal with the conflicts.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/branch/rebase_and_drop.go
+++ b/pkg/integration/tests/branch/rebase_and_drop.go
@@ -8,7 +8,7 @@ import (
 
 var RebaseAndDrop = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Rebase onto another branch, deal with the conflicts. Also mark a commit to be dropped before continuing.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/branch/rebase_does_not_autosquash.go
+++ b/pkg/integration/tests/branch/rebase_does_not_autosquash.go
@@ -7,7 +7,7 @@ import (
 
 var RebaseDoesNotAutosquash = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Rebase a branch that has fixups onto another branch, and verify that the fixups are not squashed even if rebase.autoSquash is enabled globally.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/branch/reset.go
+++ b/pkg/integration/tests/branch/reset.go
@@ -7,7 +7,7 @@ import (
 
 var Reset = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Hard reset to another branch",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/branch/reset_upstream.go
+++ b/pkg/integration/tests/branch/reset_upstream.go
@@ -7,7 +7,7 @@ import (
 
 var ResetUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Reset the upstream of a branch",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/branch/set_upstream.go
+++ b/pkg/integration/tests/branch/set_upstream.go
@@ -7,7 +7,7 @@ import (
 
 var SetUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Set the upstream of a branch",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/branch/suggestions.go
+++ b/pkg/integration/tests/branch/suggestions.go
@@ -7,7 +7,7 @@ import (
 
 var Suggestions = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Checking out a branch with name suggestions",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/cherry_pick/cherry_pick.go
+++ b/pkg/integration/tests/cherry_pick/cherry_pick.go
@@ -7,7 +7,7 @@ import (
 
 var CherryPick = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Cherry pick commits from the subcommits view, without conflicts",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/cherry_pick/cherry_pick_conflicts.go
+++ b/pkg/integration/tests/cherry_pick/cherry_pick_conflicts.go
@@ -8,7 +8,7 @@ import (
 
 var CherryPickConflicts = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Cherry pick commits from the subcommits view, with conflicts",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/amend.go
+++ b/pkg/integration/tests/commit/amend.go
@@ -7,7 +7,7 @@ import (
 
 var Amend = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Amends the last commit from the files panel",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/commit.go
+++ b/pkg/integration/tests/commit/commit.go
@@ -7,7 +7,7 @@ import (
 
 var Commit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Staging a couple files and committing",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/commit_multiline.go
+++ b/pkg/integration/tests/commit/commit_multiline.go
@@ -7,7 +7,7 @@ import (
 
 var CommitMultiline = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Commit with a multi-line commit message",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/commit_wip_with_prefix.go
+++ b/pkg/integration/tests/commit/commit_wip_with_prefix.go
@@ -7,7 +7,7 @@ import (
 
 var CommitWipWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Commit with skip hook and config commitPrefix is defined. Prefix is ignored when creating WIP commits.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(testConfig *config.AppConfig) {
 		testConfig.UserConfig.Git.CommitPrefixes = map[string]config.CommitPrefixConfig{"repo": {Pattern: "^\\w+\\/(\\w+-\\w+).*", Replace: "[$1]: "}}

--- a/pkg/integration/tests/commit/commit_with_prefix.go
+++ b/pkg/integration/tests/commit/commit_with_prefix.go
@@ -7,7 +7,7 @@ import (
 
 var CommitWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Commit with defined config commitPrefix",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(testConfig *config.AppConfig) {
 		testConfig.UserConfig.Git.CommitPrefixes = map[string]config.CommitPrefixConfig{"repo": {Pattern: "^\\w+\\/(\\w+-\\w+).*", Replace: "[$1]: "}}

--- a/pkg/integration/tests/commit/create_tag.go
+++ b/pkg/integration/tests/commit/create_tag.go
@@ -7,7 +7,7 @@ import (
 
 var CreateTag = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Create a new tag on a commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/discard_old_file_change.go
+++ b/pkg/integration/tests/commit/discard_old_file_change.go
@@ -7,7 +7,7 @@ import (
 
 var DiscardOldFileChange = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Discarding a single file from an old commit (does rebase in background to remove the file but retain the other one)",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/history.go
+++ b/pkg/integration/tests/commit/history.go
@@ -7,7 +7,7 @@ import (
 
 var History = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Cycling through commit message history in the commit message panel",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/history_complex.go
+++ b/pkg/integration/tests/commit/history_complex.go
@@ -7,7 +7,7 @@ import (
 
 var HistoryComplex = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "More complex flow for cycling commit message history",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/new_branch.go
+++ b/pkg/integration/tests/commit/new_branch.go
@@ -7,7 +7,7 @@ import (
 
 var NewBranch = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Creating a new branch from a commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/reset_author.go
+++ b/pkg/integration/tests/commit/reset_author.go
@@ -7,7 +7,7 @@ import (
 
 var ResetAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Reset author on a commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/revert.go
+++ b/pkg/integration/tests/commit/revert.go
@@ -7,7 +7,7 @@ import (
 
 var Revert = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Reverts a commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/revert_merge.go
+++ b/pkg/integration/tests/commit/revert_merge.go
@@ -8,7 +8,7 @@ import (
 
 var RevertMerge = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Reverts a merge commit and chooses to revert to the parent commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/reword.go
+++ b/pkg/integration/tests/commit/reword.go
@@ -7,7 +7,7 @@ import (
 
 var Reword = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Staging a couple files and committing",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/search.go
+++ b/pkg/integration/tests/commit/search.go
@@ -7,7 +7,7 @@ import (
 
 var Search = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Search for a commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/set_author.go
+++ b/pkg/integration/tests/commit/set_author.go
@@ -7,7 +7,7 @@ import (
 
 var SetAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Set author on a commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/stage_range_of_lines.go
+++ b/pkg/integration/tests/commit/stage_range_of_lines.go
@@ -7,7 +7,7 @@ import (
 
 var StageRangeOfLines = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Staging a range of lines",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/staged.go
+++ b/pkg/integration/tests/commit/staged.go
@@ -7,7 +7,7 @@ import (
 
 var Staged = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Staging a couple files, going in the staged files menu, unstaging a line then committing",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/staged_without_hooks.go
+++ b/pkg/integration/tests/commit/staged_without_hooks.go
@@ -7,7 +7,7 @@ import (
 
 var StagedWithoutHooks = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Staging a couple files, going in the staged files menu, unstaging a line then committing without pre-commit hooks",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/commit/unstaged.go
+++ b/pkg/integration/tests/commit/unstaged.go
@@ -7,7 +7,7 @@ import (
 
 var Unstaged = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Staging a couple files, going in the unstaged files menu, staging a line and committing",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/config/remote_named_star.go
+++ b/pkg/integration/tests/config/remote_named_star.go
@@ -7,7 +7,7 @@ import (
 
 var RemoteNamedStar = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Having a config remote.*",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/conflicts/filter.go
+++ b/pkg/integration/tests/conflicts/filter.go
@@ -8,7 +8,7 @@ import (
 
 var Filter = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Ensures that when there are merge conflicts, the files panel only shows conflicted files",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/conflicts/resolve_externally.go
+++ b/pkg/integration/tests/conflicts/resolve_externally.go
@@ -8,7 +8,7 @@ import (
 
 var ResolveExternally = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Ensures that when merge conflicts are resolved outside of lazygit, lazygit prompts you to continue",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/conflicts/resolve_multiple_files.go
+++ b/pkg/integration/tests/conflicts/resolve_multiple_files.go
@@ -8,7 +8,7 @@ import (
 
 var ResolveMultipleFiles = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Ensures that upon resolving conflicts for one file, the next file is selected",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/conflicts/undo_choose_hunk.go
+++ b/pkg/integration/tests/conflicts/undo_choose_hunk.go
@@ -8,7 +8,7 @@ import (
 
 var UndoChooseHunk = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Chooses a hunk when resolving a merge conflict and then undoes the choice",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/custom_commands/basic_cmd_from_config.go
+++ b/pkg/integration/tests/custom_commands/basic_cmd_from_config.go
@@ -7,7 +7,7 @@ import (
 
 var BasicCmdFromConfig = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Using a custom command to create a new file",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("blah")

--- a/pkg/integration/tests/custom_commands/complex_cmd_at_runtime.go
+++ b/pkg/integration/tests/custom_commands/complex_cmd_at_runtime.go
@@ -5,8 +5,8 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
-var BasicCmdAtRuntime = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Using a custom command provided at runtime to create a new file",
+var ComplexCmdAtRuntime = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Using a custom command provided at runtime to create a new file, via a shell command. We invoke custom commands through a shell already. This test proves that we can run a shell within a shell, which requires complex escaping.",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
@@ -21,7 +21,7 @@ var BasicCmdAtRuntime = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().Prompt().
 			Title(Equals("Custom Command:")).
-			Type("touch file.txt").
+			Type("sh -c \"touch file.txt\"").
 			Confirm()
 
 		t.GlobalPress(keys.Files.RefreshFiles)

--- a/pkg/integration/tests/custom_commands/form_prompts.go
+++ b/pkg/integration/tests/custom_commands/form_prompts.go
@@ -7,7 +7,7 @@ import (
 
 var FormPrompts = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Using a custom command reffering prompt responses by name",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("blah")

--- a/pkg/integration/tests/custom_commands/menu_from_command.go
+++ b/pkg/integration/tests/custom_commands/menu_from_command.go
@@ -9,7 +9,7 @@ import (
 
 var MenuFromCommand = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Using menuFromCommand prompt type",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/custom_commands/menu_from_commands_output.go
+++ b/pkg/integration/tests/custom_commands/menu_from_commands_output.go
@@ -7,7 +7,7 @@ import (
 
 var MenuFromCommandsOutput = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Using prompt response in menuFromCommand entries",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/custom_commands/multiple_prompts.go
+++ b/pkg/integration/tests/custom_commands/multiple_prompts.go
@@ -7,7 +7,7 @@ import (
 
 var MultiplePrompts = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Using a custom command with multiple prompts",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("blah")

--- a/pkg/integration/tests/custom_commands/omit_from_history.go
+++ b/pkg/integration/tests/custom_commands/omit_from_history.go
@@ -7,7 +7,7 @@ import (
 
 var OmitFromHistory = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Omitting a runtime custom command from history if it begins with space",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("blah")

--- a/pkg/integration/tests/diff/diff.go
+++ b/pkg/integration/tests/diff/diff.go
@@ -7,7 +7,7 @@ import (
 
 var Diff = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "View the diff of two branches, then view the reverse diff",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/diff/diff_and_apply_patch.go
+++ b/pkg/integration/tests/diff/diff_and_apply_patch.go
@@ -7,7 +7,7 @@ import (
 
 var DiffAndApplyPatch = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Create a patch from the diff between two branches and apply the patch.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/diff/diff_commits.go
+++ b/pkg/integration/tests/diff/diff_commits.go
@@ -7,7 +7,7 @@ import (
 
 var DiffCommits = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "View the diff between two commits",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/diff/ignore_whitespace.go
+++ b/pkg/integration/tests/diff/ignore_whitespace.go
@@ -13,7 +13,7 @@ var (
 
 var IgnoreWhitespace = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Toggle whitespace in the diff",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/file/dir_with_untracked_file.go
+++ b/pkg/integration/tests/file/dir_with_untracked_file.go
@@ -8,7 +8,7 @@ import (
 var DirWithUntrackedFile = NewIntegrationTest(NewIntegrationTestArgs{
 	// notably, we currently _don't_ actually see the untracked file in the diff. Not sure how to get around that.
 	Description:  "When selecting a directory that contains an untracked file, we should not get an error",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/file/discard_changes.go
+++ b/pkg/integration/tests/file/discard_changes.go
@@ -7,7 +7,7 @@ import (
 
 var DiscardChanges = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Discarding all possible permutations of changed files",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         true, // failing due to index.lock file being created
 	SetupConfig: func(config *config.AppConfig) {
 	},
@@ -51,7 +51,7 @@ var DiscardChanges = NewIntegrationTest(NewIntegrationTestArgs{
 		shell.RunShellCommand(`rm deleted-us.txt && git add deleted-us.txt`)
 		shell.RunShellCommand(`git commit -m "three"`)
 		shell.RunShellCommand(`git reset --hard conflict_second`)
-		shell.RunShellCommandExpectError(`git merge conflict`)
+		shell.RunCommandExpectError([]string{"git", "merge", "conflict"})
 
 		shell.RunShellCommand(`echo "new" > new.txt`)
 		shell.RunShellCommand(`echo "new staged" > new-staged.txt && git add new-staged.txt`)

--- a/pkg/integration/tests/file/discard_staged_changes.go
+++ b/pkg/integration/tests/file/discard_staged_changes.go
@@ -7,7 +7,7 @@ import (
 
 var DiscardStagedChanges = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Discarding staged changes",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/file/gitignore.go
+++ b/pkg/integration/tests/file/gitignore.go
@@ -7,7 +7,7 @@ import (
 
 var Gitignore = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Verify that we can't ignore the .gitignore file, then ignore/exclude other files",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/file/remember_commit_message_after_fail.go
+++ b/pkg/integration/tests/file/remember_commit_message_after_fail.go
@@ -14,13 +14,13 @@ fi
 
 var RememberCommitMessageAfterFail = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Verify that the commit message is remembered after a failed attempt at committing",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateFile(".git/hooks/pre-commit", preCommitHook)
-		shell.RunCommand("chmod +x .git/hooks/pre-commit")
+		shell.MakeExecutable(".git/hooks/pre-commit")
 
 		shell.CreateFileAndAdd("one", "one")
 

--- a/pkg/integration/tests/filter_by_path/cli_arg.go
+++ b/pkg/integration/tests/filter_by_path/cli_arg.go
@@ -7,7 +7,7 @@ import (
 
 var CliArg = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Filter commits by file path, using CLI arg",
-	ExtraCmdArgs: "-f filterFile",
+	ExtraCmdArgs: []string{"-f", "filterFile"},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/filter_by_path/select_file.go
+++ b/pkg/integration/tests/filter_by_path/select_file.go
@@ -7,7 +7,7 @@ import (
 
 var SelectFile = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Filter commits by file path, by finding file in UI and filtering on it",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/filter_by_path/type_file.go
+++ b/pkg/integration/tests/filter_by_path/type_file.go
@@ -7,7 +7,7 @@ import (
 
 var TypeFile = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Filter commits by file path, by finding file in UI and filtering on it",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/interactive_rebase/advanced_interactive_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/advanced_interactive_rebase.go
@@ -16,7 +16,7 @@ const (
 
 var AdvancedInteractiveRebase = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "It begins an interactive rebase and verifies to have the possibility of editing the commits of the branch before proceeding with the actual rebase",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/interactive_rebase/amend_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/amend_first_commit.go
@@ -7,7 +7,7 @@ import (
 
 var AmendFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Amends a staged file to the first (initial) commit.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/amend_fixup_commit.go
+++ b/pkg/integration/tests/interactive_rebase/amend_fixup_commit.go
@@ -7,7 +7,7 @@ import (
 
 var AmendFixupCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Amends a staged file to a fixup commit, and checks that other unrelated fixup commits are not auto-squashed.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/amend_head_commit_during_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/amend_head_commit_during_rebase.go
@@ -7,7 +7,7 @@ import (
 
 var AmendHeadCommitDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Amends the current head commit from the commits panel during a rebase.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/amend_merge.go
+++ b/pkg/integration/tests/interactive_rebase/amend_merge.go
@@ -12,7 +12,7 @@ var (
 
 var AmendMerge = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Amends a staged file to a merge commit.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/amend_non_head_commit_during_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/amend_non_head_commit_during_rebase.go
@@ -7,7 +7,7 @@ import (
 
 var AmendNonHeadCommitDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Tries to amend a commit that is not the head while already rebasing, resulting in an error message",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
@@ -7,7 +7,7 @@ import (
 
 var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Drops a commit during interactive rebase when there is an update-ref in the git-rebase-todo file",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig:  func(config *config.AppConfig) {},

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref_show_branch_heads.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref_show_branch_heads.go
@@ -7,7 +7,7 @@ import (
 
 var DropTodoCommitWithUpdateRefShowBranchHeads = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Drops a commit during interactive rebase when there is an update-ref in the git-rebase-todo file (with experimentalShowBranchHeads on)",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {

--- a/pkg/integration/tests/interactive_rebase/edit_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/edit_first_commit.go
@@ -7,7 +7,7 @@ import (
 
 var EditFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Edits the first commit, just to show that it's possible",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/edit_non_todo_commit_during_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/edit_non_todo_commit_during_rebase.go
@@ -7,7 +7,7 @@ import (
 
 var EditNonTodoCommitDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Tries to edit a non-todo commit while already rebasing, resulting in an error message",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/fixup_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/fixup_first_commit.go
@@ -7,7 +7,7 @@ import (
 
 var FixupFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Tries to fixup the first commit, which results in an error message",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/fixup_second_commit.go
+++ b/pkg/integration/tests/interactive_rebase/fixup_second_commit.go
@@ -7,7 +7,7 @@ import (
 
 var FixupSecondCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Fixup the second commit into the first (initial)",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/move.go
+++ b/pkg/integration/tests/interactive_rebase/move.go
@@ -7,7 +7,7 @@ import (
 
 var Move = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Directly move a commit all the way down and all the way back up",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/move_in_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/move_in_rebase.go
@@ -7,7 +7,7 @@ import (
 
 var MoveInRebase = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Via a single interactive rebase move a commit all the way up then back down then slightly back up again and apply the change",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/rebase.go
+++ b/pkg/integration/tests/interactive_rebase/rebase.go
@@ -7,7 +7,7 @@ import (
 
 var Rebase = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Begins an interactive rebase, then fixups, drops, and squashes some commits",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/reword_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/reword_first_commit.go
@@ -10,7 +10,7 @@ import (
 
 var RewordFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Rewords the first commit, just to show that it's possible",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/reword_last_commit.go
+++ b/pkg/integration/tests/interactive_rebase/reword_last_commit.go
@@ -7,7 +7,7 @@ import (
 
 var RewordLastCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Rewords the last (HEAD) commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/reword_you_are_here_commit.go
+++ b/pkg/integration/tests/interactive_rebase/reword_you_are_here_commit.go
@@ -7,7 +7,7 @@ import (
 
 var RewordYouAreHereCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Rewords the current HEAD commit in an interactive rebase",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/reword_you_are_here_commit_with_editor.go
+++ b/pkg/integration/tests/interactive_rebase/reword_you_are_here_commit_with_editor.go
@@ -7,7 +7,7 @@ import (
 
 var RewordYouAreHereCommitWithEditor = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Rewords the current HEAD commit in an interactive rebase with editor",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/interactive_rebase/squash_down_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/squash_down_first_commit.go
@@ -7,7 +7,7 @@ import (
 
 var SquashDownFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Tries to squash down the first commit, which results in an error message",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/squash_down_second_commit.go
+++ b/pkg/integration/tests/interactive_rebase/squash_down_second_commit.go
@@ -7,7 +7,7 @@ import (
 
 var SquashDownSecondCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Squash down the second commit into the first (initial)",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/squash_fixups_above_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/squash_fixups_above_first_commit.go
@@ -7,7 +7,7 @@ import (
 
 var SquashFixupsAboveFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Squashes all fixups above the first (initial) commit.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/swap_in_rebase_with_conflict.go
+++ b/pkg/integration/tests/interactive_rebase/swap_in_rebase_with_conflict.go
@@ -7,7 +7,7 @@ import (
 
 var SwapInRebaseWithConflict = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Via an edit-triggered rebase, swap two commits, causing a conflict. Then resolve the conflict and continue",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/interactive_rebase/swap_with_conflict.go
+++ b/pkg/integration/tests/interactive_rebase/swap_with_conflict.go
@@ -7,7 +7,7 @@ import (
 
 var SwapWithConflict = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Directly swap two commits, causing a conflict. Then resolve the conflict and continue",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/misc/confirm_on_quit.go
+++ b/pkg/integration/tests/misc/confirm_on_quit.go
@@ -7,7 +7,7 @@ import (
 
 var ConfirmOnQuit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Quitting with a confirm prompt",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 		config.UserConfig.ConfirmOnQuit = true

--- a/pkg/integration/tests/misc/initial_open.go
+++ b/pkg/integration/tests/misc/initial_open.go
@@ -7,7 +7,7 @@ import (
 
 var InitialOpen = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Confirms a popup appears on first opening Lazygit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 		config.UserConfig.DisableStartupPopups = false

--- a/pkg/integration/tests/patch_building/apply.go
+++ b/pkg/integration/tests/patch_building/apply.go
@@ -7,7 +7,7 @@ import (
 
 var Apply = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Apply a custom patch",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/apply_in_reverse.go
+++ b/pkg/integration/tests/patch_building/apply_in_reverse.go
@@ -7,7 +7,7 @@ import (
 
 var ApplyInReverse = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Apply a custom patch in reverse",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/apply_in_reverse_with_conflict.go
+++ b/pkg/integration/tests/patch_building/apply_in_reverse_with_conflict.go
@@ -7,7 +7,7 @@ import (
 
 var ApplyInReverseWithConflict = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Apply a custom patch in reverse, resulting in a conflict",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/copy_patch_to_clipboard.go
+++ b/pkg/integration/tests/patch_building/copy_patch_to_clipboard.go
@@ -7,7 +7,7 @@ import (
 
 var CopyPatchToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Create a patch from the commits and copy the patch to clipbaord.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         true, // skipping because CI doesn't have clipboard functionality
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/move_to_earlier_commit.go
+++ b/pkg/integration/tests/patch_building/move_to_earlier_commit.go
@@ -7,7 +7,7 @@ import (
 
 var MoveToEarlierCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Move a patch from a commit to an earlier commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	GitVersion:   AtLeast("2.26.0"),
 	SetupConfig:  func(config *config.AppConfig) {},

--- a/pkg/integration/tests/patch_building/move_to_earlier_commit_no_keep_empty.go
+++ b/pkg/integration/tests/patch_building/move_to_earlier_commit_no_keep_empty.go
@@ -7,7 +7,7 @@ import (
 
 var MoveToEarlierCommitNoKeepEmpty = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Move a patch from a commit to an earlier commit, for older git versions that don't keep the empty commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	GitVersion:   Before("2.26.0"),
 	SetupConfig:  func(config *config.AppConfig) {},

--- a/pkg/integration/tests/patch_building/move_to_index.go
+++ b/pkg/integration/tests/patch_building/move_to_index.go
@@ -7,7 +7,7 @@ import (
 
 var MoveToIndex = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Move a patch from a commit to the index",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/move_to_index_part_of_adjacent_added_lines.go
+++ b/pkg/integration/tests/patch_building/move_to_index_part_of_adjacent_added_lines.go
@@ -7,7 +7,7 @@ import (
 
 var MoveToIndexPartOfAdjacentAddedLines = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Move a patch from a commit to the index, with only some lines of a range of adjacent added lines in the patch",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/move_to_index_partial.go
+++ b/pkg/integration/tests/patch_building/move_to_index_partial.go
@@ -7,7 +7,7 @@ import (
 
 var MoveToIndexPartial = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Move a patch from a commit to the index. This is different from the MoveToIndex test in that we're only selecting a partial patch from a file",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/move_to_index_with_conflict.go
+++ b/pkg/integration/tests/patch_building/move_to_index_with_conflict.go
@@ -7,7 +7,7 @@ import (
 
 var MoveToIndexWithConflict = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Move a patch from a commit to the index, causing a conflict",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/move_to_later_commit.go
+++ b/pkg/integration/tests/patch_building/move_to_later_commit.go
@@ -7,7 +7,7 @@ import (
 
 var MoveToLaterCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Move a patch from a commit to a later commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/move_to_later_commit_partial_hunk.go
+++ b/pkg/integration/tests/patch_building/move_to_later_commit_partial_hunk.go
@@ -7,7 +7,7 @@ import (
 
 var MoveToLaterCommitPartialHunk = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Move a patch from a commit to a later commit, with only parts of a hunk in the patch",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/move_to_new_commit.go
+++ b/pkg/integration/tests/patch_building/move_to_new_commit.go
@@ -7,7 +7,7 @@ import (
 
 var MoveToNewCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Move a patch from a commit to a new commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/move_to_new_commit_partial_hunk.go
+++ b/pkg/integration/tests/patch_building/move_to_new_commit_partial_hunk.go
@@ -7,7 +7,7 @@ import (
 
 var MoveToNewCommitPartialHunk = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Move a patch from a commit to a new commit, with only parts of a hunk in the patch",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/remove_from_commit.go
+++ b/pkg/integration/tests/patch_building/remove_from_commit.go
@@ -7,7 +7,7 @@ import (
 
 var RemoveFromCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Remove a custom patch from a commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/reset_with_escape.go
+++ b/pkg/integration/tests/patch_building/reset_with_escape.go
@@ -7,7 +7,7 @@ import (
 
 var ResetWithEscape = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Reset a custom patch with the escape keybinding",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/select_all_files.go
+++ b/pkg/integration/tests/patch_building/select_all_files.go
@@ -7,7 +7,7 @@ import (
 
 var SelectAllFiles = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "All all files of a commit to a custom patch with the 'a' keybinding",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/specific_selection.go
+++ b/pkg/integration/tests/patch_building/specific_selection.go
@@ -7,7 +7,7 @@ import (
 
 var SpecificSelection = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Build a custom patch with a specific selection of lines, adding individual lines, as well as a range and hunk, and adding a file directly",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/patch_building/start_new_patch.go
+++ b/pkg/integration/tests/patch_building/start_new_patch.go
@@ -7,7 +7,7 @@ import (
 
 var StartNewPatch = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Attempt to add a file from another commit to a patch, then agree to start a new patch",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/reflog/checkout.go
+++ b/pkg/integration/tests/reflog/checkout.go
@@ -7,7 +7,7 @@ import (
 
 var Checkout = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Checkout a reflog commit as a detached head",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/reflog/cherry_pick.go
+++ b/pkg/integration/tests/reflog/cherry_pick.go
@@ -7,7 +7,7 @@ import (
 
 var CherryPick = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Cherry pick a reflog commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/reflog/patch.go
+++ b/pkg/integration/tests/reflog/patch.go
@@ -7,7 +7,7 @@ import (
 
 var Patch = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Build a patch from a reflog commit and apply it",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/reflog/reset.go
+++ b/pkg/integration/tests/reflog/reset.go
@@ -7,7 +7,7 @@ import (
 
 var Reset = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Hard reset to a reflog commit",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/shared/conflicts.go
+++ b/pkg/integration/tests/shared/conflicts.go
@@ -51,7 +51,7 @@ var MergeConflictsSetup = func(shell *Shell) {
 var CreateMergeConflictFile = func(shell *Shell) {
 	MergeConflictsSetup(shell)
 
-	shell.RunShellCommandExpectError("git merge --no-edit second-change-branch")
+	shell.RunCommandExpectError([]string{"git", "merge", "--no-edit", "second-change-branch"})
 }
 
 var CreateMergeCommit = func(shell *Shell) {
@@ -84,7 +84,7 @@ var CreateMergeConflictFiles = func(shell *Shell) {
 		EmptyCommit("second-change-branch unrelated change").
 		Checkout("first-change-branch")
 
-	shell.RunShellCommandExpectError("git merge --no-edit second-change-branch")
+	shell.RunCommandExpectError([]string{"git", "merge", "--no-edit", "second-change-branch"})
 }
 
 // These 'multiple' variants are just like the short ones but with longer file contents and with multiple conflicts within the file.
@@ -155,5 +155,5 @@ var CreateMergeConflictFileMultiple = func(shell *Shell) {
 		EmptyCommit("second-change-branch unrelated change").
 		Checkout("first-change-branch")
 
-	shell.RunShellCommandExpectError("git merge --no-edit second-change-branch")
+	shell.RunCommandExpectError([]string{"git", "merge", "--no-edit", "second-change-branch"})
 }

--- a/pkg/integration/tests/staging/diff_context_change.go
+++ b/pkg/integration/tests/staging/diff_context_change.go
@@ -7,7 +7,7 @@ import (
 
 var DiffContextChange = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Change the number of diff context lines while in the staging panel",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/staging/discard_all_changes.go
+++ b/pkg/integration/tests/staging/discard_all_changes.go
@@ -7,7 +7,7 @@ import (
 
 var DiscardAllChanges = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Discard all changes of a file in the staging panel, then assert we land in the staging panel of the next file",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/staging/search.go
+++ b/pkg/integration/tests/staging/search.go
@@ -7,7 +7,7 @@ import (
 
 var Search = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Use the search feature in the staging panel",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/staging/stage_hunks.go
+++ b/pkg/integration/tests/staging/stage_hunks.go
@@ -7,7 +7,7 @@ import (
 
 var StageHunks = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Stage and unstage various hunks of a file in the staging panel",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/staging/stage_lines.go
+++ b/pkg/integration/tests/staging/stage_lines.go
@@ -7,7 +7,7 @@ import (
 
 var StageLines = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Stage and unstage various lines of a file in the staging panel",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/staging/stage_ranges.go
+++ b/pkg/integration/tests/staging/stage_ranges.go
@@ -7,7 +7,7 @@ import (
 
 var StageRanges = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Stage and unstage various ranges of a file in the staging panel",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/stash/apply.go
+++ b/pkg/integration/tests/stash/apply.go
@@ -7,7 +7,7 @@ import (
 
 var Apply = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Apply a stash entry",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/stash/apply_patch.go
+++ b/pkg/integration/tests/stash/apply_patch.go
@@ -7,7 +7,7 @@ import (
 
 var ApplyPatch = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Restore part of a stash entry via applying a custom patch",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/stash/create_branch.go
+++ b/pkg/integration/tests/stash/create_branch.go
@@ -7,7 +7,7 @@ import (
 
 var CreateBranch = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Create a branch from a stash entry",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/stash/drop.go
+++ b/pkg/integration/tests/stash/drop.go
@@ -7,7 +7,7 @@ import (
 
 var Drop = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Drop a stash entry",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/stash/pop.go
+++ b/pkg/integration/tests/stash/pop.go
@@ -7,7 +7,7 @@ import (
 
 var Pop = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Pop a stash entry",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/stash/rename.go
+++ b/pkg/integration/tests/stash/rename.go
@@ -7,7 +7,7 @@ import (
 
 var Rename = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Try to rename the stash.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/stash/stash.go
+++ b/pkg/integration/tests/stash/stash.go
@@ -7,7 +7,7 @@ import (
 
 var Stash = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Stashing files directly (not going through the stash menu)",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/stash/stash_all.go
+++ b/pkg/integration/tests/stash/stash_all.go
@@ -7,7 +7,7 @@ import (
 
 var StashAll = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Stashing all changes (via the menu)",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/stash/stash_and_keep_index.go
+++ b/pkg/integration/tests/stash/stash_and_keep_index.go
@@ -7,7 +7,7 @@ import (
 
 var StashAndKeepIndex = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Stash staged changes",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/stash/stash_including_untracked_files.go
+++ b/pkg/integration/tests/stash/stash_including_untracked_files.go
@@ -7,7 +7,7 @@ import (
 
 var StashIncludingUntrackedFiles = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Stashing all files including untracked ones",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/stash/stash_staged.go
+++ b/pkg/integration/tests/stash/stash_staged.go
@@ -7,7 +7,7 @@ import (
 
 var StashStaged = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Stash staged changes",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/stash/stash_unstaged.go
+++ b/pkg/integration/tests/stash/stash_unstaged.go
@@ -7,7 +7,7 @@ import (
 
 var StashUnstaged = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Stash unstaged changes",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/submodule/add.go
+++ b/pkg/integration/tests/submodule/add.go
@@ -7,7 +7,7 @@ import (
 
 var Add = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Add a submodule",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/submodule/enter.go
+++ b/pkg/integration/tests/submodule/enter.go
@@ -7,7 +7,7 @@ import (
 
 var Enter = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Enter a submodule, add a commit, and then stage the change in the parent repo",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(cfg *config.AppConfig) {
 		cfg.UserConfig.CustomCommands = []config.CustomCommand{

--- a/pkg/integration/tests/submodule/remove.go
+++ b/pkg/integration/tests/submodule/remove.go
@@ -7,7 +7,7 @@ import (
 
 var Remove = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Remove a submodule",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/submodule/reset.go
+++ b/pkg/integration/tests/submodule/reset.go
@@ -7,7 +7,7 @@ import (
 
 var Reset = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Enter a submodule, create a commit and stage some changes, then reset the submodule from back in the parent repo. This test captures functionality around getting a dirty submodule out of your files panel.",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(cfg *config.AppConfig) {
 		cfg.UserConfig.CustomCommands = []config.CustomCommand{

--- a/pkg/integration/tests/sync/fetch_prune.go
+++ b/pkg/integration/tests/sync/fetch_prune.go
@@ -7,7 +7,7 @@ import (
 
 var FetchPrune = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Fetch from the remote with the 'prune' option set in the git config",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/sync/force_push.go
+++ b/pkg/integration/tests/sync/force_push.go
@@ -7,7 +7,7 @@ import (
 
 var ForcePush = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Push to a remote with new commits, requiring a force push",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/sync/force_push_multiple_matching.go
+++ b/pkg/integration/tests/sync/force_push_multiple_matching.go
@@ -7,7 +7,7 @@ import (
 
 var ForcePushMultipleMatching = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Force push to multiple branches because the user has push.default matching",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/sync/force_push_multiple_upstream.go
+++ b/pkg/integration/tests/sync/force_push_multiple_upstream.go
@@ -7,7 +7,7 @@ import (
 
 var ForcePushMultipleUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Force push to only the upstream branch of the current branch because the user has push.default upstream",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/sync/pull.go
+++ b/pkg/integration/tests/sync/pull.go
@@ -7,7 +7,7 @@ import (
 
 var Pull = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Pull a commit from the remote",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/sync/pull_and_set_upstream.go
+++ b/pkg/integration/tests/sync/pull_and_set_upstream.go
@@ -7,7 +7,7 @@ import (
 
 var PullAndSetUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Pull a commit from the remote, setting the upstream branch in the process",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/sync/pull_merge.go
+++ b/pkg/integration/tests/sync/pull_merge.go
@@ -7,7 +7,7 @@ import (
 
 var PullMerge = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Pull with a merge strategy",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/sync/pull_merge_conflict.go
+++ b/pkg/integration/tests/sync/pull_merge_conflict.go
@@ -7,7 +7,7 @@ import (
 
 var PullMergeConflict = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Pull with a merge strategy, where a conflict occurs",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/sync/pull_rebase.go
+++ b/pkg/integration/tests/sync/pull_rebase.go
@@ -7,7 +7,7 @@ import (
 
 var PullRebase = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Pull with a rebase strategy",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/sync/pull_rebase_conflict.go
+++ b/pkg/integration/tests/sync/pull_rebase_conflict.go
@@ -7,7 +7,7 @@ import (
 
 var PullRebaseConflict = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Pull with a rebase strategy, where a conflict occurs",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/sync/pull_rebase_interactive_conflict.go
+++ b/pkg/integration/tests/sync/pull_rebase_interactive_conflict.go
@@ -7,7 +7,7 @@ import (
 
 var PullRebaseInteractiveConflict = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Pull with an interactive rebase strategy, where a conflict occurs",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/sync/pull_rebase_interactive_conflict_drop.go
+++ b/pkg/integration/tests/sync/pull_rebase_interactive_conflict_drop.go
@@ -7,7 +7,7 @@ import (
 
 var PullRebaseInteractiveConflictDrop = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Pull with an interactive rebase strategy, where a conflict occurs. Also drop a commit while rebasing",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/sync/push.go
+++ b/pkg/integration/tests/sync/push.go
@@ -7,7 +7,7 @@ import (
 
 var Push = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Push a commit to a pre-configured upstream",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/sync/push_and_auto_set_upstream.go
+++ b/pkg/integration/tests/sync/push_and_auto_set_upstream.go
@@ -7,7 +7,7 @@ import (
 
 var PushAndAutoSetUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Push a commit and set the upstream automatically as configured by git",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/sync/push_and_set_upstream.go
+++ b/pkg/integration/tests/sync/push_and_set_upstream.go
@@ -7,7 +7,7 @@ import (
 
 var PushAndSetUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Push a commit and set the upstream via a prompt",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/sync/push_follow_tags.go
+++ b/pkg/integration/tests/sync/push_follow_tags.go
@@ -7,7 +7,7 @@ import (
 
 var PushFollowTags = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Push with --follow-tags configured in git config",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/sync/push_no_follow_tags.go
+++ b/pkg/integration/tests/sync/push_no_follow_tags.go
@@ -7,7 +7,7 @@ import (
 
 var PushNoFollowTags = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Push with --follow-tags NOT configured in git config",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         true, // turns out this actually DOES push the tag. I have no idea why
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/sync/push_tag.go
+++ b/pkg/integration/tests/sync/push_tag.go
@@ -7,7 +7,7 @@ import (
 
 var PushTag = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Push a specific tag",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/sync/push_with_credential_prompt.go
+++ b/pkg/integration/tests/sync/push_with_credential_prompt.go
@@ -7,7 +7,7 @@ import (
 
 var PushWithCredentialPrompt = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Push a commit to a pre-configured upstream, where credentials are required",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/sync/rename_branch_and_pull.go
+++ b/pkg/integration/tests/sync/rename_branch_and_pull.go
@@ -7,7 +7,7 @@ import (
 
 var RenameBranchAndPull = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Rename a branch to no longer match its upstream, then pull from the upstream",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/tag/checkout.go
+++ b/pkg/integration/tests/tag/checkout.go
@@ -7,7 +7,7 @@ import (
 
 var Checkout = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Checkout a tag",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/tag/crud_annotated.go
+++ b/pkg/integration/tests/tag/crud_annotated.go
@@ -7,7 +7,7 @@ import (
 
 var CrudAnnotated = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Create and delete an annotated tag in the tags panel",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/tag/crud_lightweight.go
+++ b/pkg/integration/tests/tag/crud_lightweight.go
@@ -7,7 +7,7 @@ import (
 
 var CrudLightweight = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Create and delete a lightweight tag in the tags panel",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/tag/reset.go
+++ b/pkg/integration/tests/tag/reset.go
@@ -7,7 +7,7 @@ import (
 
 var Reset = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Hard reset to a tag",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -71,6 +71,7 @@ var tests = []*components.IntegrationTest{
 	conflicts.UndoChooseHunk,
 	custom_commands.BasicCmdAtRuntime,
 	custom_commands.BasicCmdFromConfig,
+	custom_commands.ComplexCmdAtRuntime,
 	custom_commands.FormPrompts,
 	custom_commands.MenuFromCommand,
 	custom_commands.MenuFromCommandsOutput,

--- a/pkg/integration/tests/ui/double_popup.go
+++ b/pkg/integration/tests/ui/double_popup.go
@@ -7,7 +7,7 @@ import (
 
 var DoublePopup = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Open a popup from within another popup and assert you can escape back to the side panels",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/ui/switch_tab_from_menu.go
+++ b/pkg/integration/tests/ui/switch_tab_from_menu.go
@@ -7,7 +7,7 @@ import (
 
 var SwitchTabFromMenu = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Switch tab via the options menu",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/undo/undo_checkout_and_drop.go
+++ b/pkg/integration/tests/undo/undo_checkout_and_drop.go
@@ -7,7 +7,7 @@ import (
 
 var UndoCheckoutAndDrop = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Drop some commits and then undo/redo the actions",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/undo/undo_drop.go
+++ b/pkg/integration/tests/undo/undo_drop.go
@@ -7,7 +7,7 @@ import (
 
 var UndoDrop = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Drop some commits and then undo/redo the actions",
-	ExtraCmdArgs: "",
+	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/updates/updates.go
+++ b/pkg/updates/updates.go
@@ -283,7 +283,7 @@ func (u *Updater) downloadAndInstall(rawUrl string) error {
 	}
 
 	u.Log.Info("untarring tarball/unzipping zip file")
-	err = u.OSCommand.Cmd.New(fmt.Sprintf("tar -zxf %s %s", u.OSCommand.Quote(zipPath), "lazygit")).Run()
+	err = u.OSCommand.Cmd.New([]string{"tar", "-zxf", zipPath, "lazygit"}).Run()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As @stefanhaller pointed out, the only reason we've been quoting strings in our commands is to circumvent our own laziness of constructing command strings in the first place. Now that we're constructing commands arg-by-arg, we can pass the arg vector directly when invoking a program.

In a follow-up PR I'll combine the new Args api into our command object builder so that we don't need to construct the command in two separate steps.

One implication of this change is that now the commands we log in the Command Log panel won't necessarily be copy+pastable into one's shell, but most of the value of logging those is so that people know what's going on as opposed to actually obtaining something to copy+paste.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc
