### PR TITLE
Update gitlab merge request URL to match new routing

### DIFF
--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -33,8 +33,8 @@ var bitbucketServiceDef = ServiceDefinition{
 
 var gitLabServiceDef = ServiceDefinition{
 	provider:                        "gitlab",
-	pullRequestURLIntoDefaultBranch: "/merge_requests/new?merge_request[source_branch]={{.From}}",
-	pullRequestURLIntoTargetBranch:  "/merge_requests/new?merge_request[source_branch]={{.From}}&merge_request[target_branch]={{.To}}",
+	pullRequestURLIntoDefaultBranch: "/-/merge_requests/new?merge_request[source_branch]={{.From}}",
+	pullRequestURLIntoTargetBranch:  "/-/merge_requests/new?merge_request[source_branch]={{.From}}&merge_request[target_branch]={{.To}}",
 	commitURL:                       "/commit/{{.CommitSha}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,

--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -35,7 +35,7 @@ var gitLabServiceDef = ServiceDefinition{
 	provider:                        "gitlab",
 	pullRequestURLIntoDefaultBranch: "/-/merge_requests/new?merge_request[source_branch]={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/-/merge_requests/new?merge_request[source_branch]={{.From}}&merge_request[target_branch]={{.To}}",
-	commitURL:                       "/commit/{{.CommitSha}}",
+	commitURL:                       "/-/commit/{{.CommitSha}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }

--- a/pkg/commands/hosting_service/hosting_service_test.go
+++ b/pkg/commands/hosting_service/hosting_service_test.go
@@ -112,7 +112,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "git@gitlab.com:peter/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/peter/calculator/merge_requests/new?merge_request[source_branch]=feature%2Fui", url)
+				assert.Equal(t, "https://gitlab.com/peter/calculator/-/merge_requests/new?merge_request[source_branch]=feature%2Fui", url)
 			},
 		},
 		{
@@ -121,7 +121,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "git@gitlab.com:peter/public/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/peter/public/calculator/merge_requests/new?merge_request[source_branch]=feature%2Fui", url)
+				assert.Equal(t, "https://gitlab.com/peter/public/calculator/-/merge_requests/new?merge_request[source_branch]=feature%2Fui", url)
 			},
 		},
 		{
@@ -130,7 +130,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "https://gitlab.com/peter/public/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/peter/public/calculator/merge_requests/new?merge_request[source_branch]=feature%2Fui", url)
+				assert.Equal(t, "https://gitlab.com/peter/public/calculator/-/merge_requests/new?merge_request[source_branch]=feature%2Fui", url)
 			},
 		},
 		{
@@ -140,7 +140,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "git@gitlab.com:peter/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/peter/calculator/merge_requests/new?merge_request[source_branch]=feature%2Fcommit-ui&merge_request[target_branch]=epic%2Fui", url)
+				assert.Equal(t, "https://gitlab.com/peter/calculator/-/merge_requests/new?merge_request[source_branch]=feature%2Fcommit-ui&merge_request[target_branch]=epic%2Fui", url)
 			},
 		},
 		{
@@ -150,7 +150,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "git@gitlab.com:peter/public/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/peter/public/calculator/merge_requests/new?merge_request[source_branch]=feature%2Fcommit-ui&merge_request[target_branch]=epic%2Fui", url)
+				assert.Equal(t, "https://gitlab.com/peter/public/calculator/-/merge_requests/new?merge_request[source_branch]=feature%2Fcommit-ui&merge_request[target_branch]=epic%2Fui", url)
 			},
 		},
 		{
@@ -160,7 +160,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "https://gitlab.com/peter/public/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/peter/public/calculator/merge_requests/new?merge_request[source_branch]=feature%2Fcommit-ui&merge_request[target_branch]=epic%2Fui", url)
+				assert.Equal(t, "https://gitlab.com/peter/public/calculator/-/merge_requests/new?merge_request[source_branch]=feature%2Fcommit-ui&merge_request[target_branch]=epic%2Fui", url)
 			},
 		},
 		{
@@ -373,7 +373,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "git@gitlab.com:me/public/repo-with-issues.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/me/public/repo-with-issues/merge_requests/new?merge_request[source_branch]=feature%2FsomeIssue%23123&merge_request[target_branch]=master", url)
+				assert.Equal(t, "https://gitlab.com/me/public/repo-with-issues/-/merge_requests/new?merge_request[source_branch]=feature%2FsomeIssue%23123&merge_request[target_branch]=master", url)
 			},
 		},
 		{
@@ -383,7 +383,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "git@gitlab.com:me/public/repo-with-issues.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/me/public/repo-with-issues/merge_requests/new?merge_request[source_branch]=yolo&merge_request[target_branch]=archive%2Fnever-ending-feature%23666", url)
+				assert.Equal(t, "https://gitlab.com/me/public/repo-with-issues/-/merge_requests/new?merge_request[source_branch]=yolo&merge_request[target_branch]=archive%2Fnever-ending-feature%23666", url)
 			},
 		},
 	}


### PR DESCRIPTION
- **Update URLs to match the newer Gitlab routing system**

Fixes #2637

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
