### PR TITLE
Cache binary paths

### DIFF
--- a/pkg/secureexec/secureexec_windows.go
+++ b/pkg/secureexec/secureexec_windows.go
@@ -21,11 +21,25 @@ import (
 // you call `git status` from the command line directly but no harm in playing it
 // safe.
 
+var pathCache = map[string]string{}
+
 func Command(name string, args ...string) *exec.Cmd {
-	bin, err := safeexec.LookPath(name)
-	if err != nil {
-		bin = name
+	path := getPath(name)
+
+	return exec.Command(path, args...)
+}
+
+func getPath(name string) string {
+	if path, ok := pathCache[name]; ok {
+		return path
 	}
 
-	return exec.Command(bin, args...)
+	path, err := safeexec.LookPath(name)
+	if err != nil {
+		pathCache[name] = name
+		return name
+	}
+
+	pathCache[name] = path
+	return path
 }


### PR DESCRIPTION
- **PR Description**

Turns out that with our secureexec package (which we only use on windows due to a windows security thing), we have been obtaining the path to the binary every time we try to run the binary and this takes TEN MILLISECONDS EVERY TIME! So now we're caching it.

This means that if a user changes the location of their git binary while lazygit is running they'll need to restart lazygit. I'll see if that becomes a problem before adding more complex code to deal with that.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
