### PR TITLE
Fix discard logic

### DIFF
--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -149,7 +149,7 @@ func (self *WorkingTreeCommands) DiscardAllFileChanges(file *models.File) error 
 
 	if file.ShortStatus == "DU" {
 		return self.cmd.New(
-			NewGitCmd("rm").Arg("rm", "--", file.Name).ToArgv(),
+			NewGitCmd("rm").Arg("--", file.Name).ToArgv(),
 		).Run()
 	}
 

--- a/pkg/integration/tests/file/discard_changes.go
+++ b/pkg/integration/tests/file/discard_changes.go
@@ -99,9 +99,13 @@ var DiscardChanges = NewIntegrationTest(NewIntegrationTestArgs{
 			{status: "DU", label: "deleted-us.txt", menuTitle: "deleted-us.txt"},
 		})
 
-		t.Common().ContinueOnConflictsResolved()
+		t.ExpectPopup().Confirmation().
+			Title(Equals("continue")).
+			Content(Contains("all merge conflicts resolved. Continue?")).
+			Cancel()
 
 		discardOneByOne([]statusFile{
+			{status: "AM", label: "added-changed.txt", menuTitle: "added-changed.txt"},
 			{status: "MD", label: "change-delete.txt", menuTitle: "change-delete.txt"},
 			{status: "D ", label: "delete-change.txt", menuTitle: "delete-change.txt"},
 			{status: "D ", label: "deleted-staged.txt", menuTitle: "deleted-staged.txt"},
@@ -109,11 +113,10 @@ var DiscardChanges = NewIntegrationTest(NewIntegrationTestArgs{
 			{status: "MM", label: "double-modded.txt", menuTitle: "double-modded.txt"},
 			{status: "M ", label: "modded-staged.txt", menuTitle: "modded-staged.txt"},
 			{status: " M", label: "modded.txt", menuTitle: "modded.txt"},
-			// the menu title only includes the new file
-			{status: "R ", label: "renamed.txt → renamed2.txt", menuTitle: "renamed2.txt"},
-			{status: "AM", label: "added-changed.txt", menuTitle: "added-changed.txt"},
 			{status: "A ", label: "new-staged.txt", menuTitle: "new-staged.txt"},
 			{status: "??", label: "new.txt", menuTitle: "new.txt"},
+			// the menu title only includes the new file
+			{status: "R ", label: "renamed.txt → renamed2.txt", menuTitle: "renamed2.txt"},
 		})
 
 		t.Views().Files().IsEmpty()


### PR DESCRIPTION
Missed a spot a couple PR's ago. We had an integration test which caught this but which was skipped due to index.lock file issues. The test was also broken for other reasons due to it not having been running for a while, so I've fixed that up too.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
