### PR TITLE
config: rely on .gitconfig for verbose commit messages

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -77,7 +77,6 @@ git:
     useConfig: false
   commit:
     signOff: false
-    verbose: default # one of 'default' | 'always' | 'never'
   merging:
     # only applicable to unix users
     manualCommit: false

--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -95,7 +95,6 @@ func (self *CommitCommands) commitMessageArgs(message string) []string {
 func (self *CommitCommands) CommitEditorCmdObj() oscommands.ICmdObj {
 	cmdArgs := NewGitCmd("commit").
 		ArgIf(self.signoffFlag() != "", self.signoffFlag()).
-		ArgIf(self.verboseFlag() != "", self.verboseFlag()).
 		ToArgv()
 
 	return self.cmd.New(cmdArgs)
@@ -105,17 +104,6 @@ func (self *CommitCommands) signoffFlag() string {
 	if self.UserConfig.Git.Commit.SignOff {
 		return "--signoff"
 	} else {
-		return ""
-	}
-}
-
-func (self *CommitCommands) verboseFlag() string {
-	switch self.config.UserConfig.Git.Commit.Verbose {
-	case "always":
-		return "--verbose"
-	case "never":
-		return "--no-verbose"
-	default:
 		return ""
 	}
 }

--- a/pkg/commands/git_commands/commit_test.go
+++ b/pkg/commands/git_commands/commit_test.go
@@ -114,7 +114,6 @@ func TestCommitCommitEditorCmdObj(t *testing.T) {
 	type scenario struct {
 		testName      string
 		configSignoff bool
-		configVerbose string
 		expected      []string
 	}
 
@@ -122,32 +121,12 @@ func TestCommitCommitEditorCmdObj(t *testing.T) {
 		{
 			testName:      "Commit using editor",
 			configSignoff: false,
-			configVerbose: "default",
 			expected:      []string{"commit"},
-		},
-		{
-			testName:      "Commit with --no-verbose flag",
-			configSignoff: false,
-			configVerbose: "never",
-			expected:      []string{"commit", "--no-verbose"},
-		},
-		{
-			testName:      "Commit with --verbose flag",
-			configSignoff: false,
-			configVerbose: "always",
-			expected:      []string{"commit", "--verbose"},
 		},
 		{
 			testName:      "Commit with --signoff",
 			configSignoff: true,
-			configVerbose: "default",
 			expected:      []string{"commit", "--signoff"},
-		},
-		{
-			testName:      "Commit with --signoff and --no-verbose",
-			configSignoff: true,
-			configVerbose: "never",
-			expected:      []string{"commit", "--signoff", "--no-verbose"},
 		},
 	}
 
@@ -156,7 +135,6 @@ func TestCommitCommitEditorCmdObj(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			userConfig := config.GetDefaultConfig()
 			userConfig.Git.Commit.SignOff = s.configSignoff
-			userConfig.Git.Commit.Verbose = s.configVerbose
 
 			runner := oscommands.NewFakeRunner(t).ExpectGitArgs(s.expected, "", nil)
 			instance := buildCommitCommands(commonDeps{userConfig: userConfig, runner: runner})

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -103,8 +103,7 @@ type PagingConfig struct {
 }
 
 type CommitConfig struct {
-	SignOff bool   `yaml:"signOff"`
-	Verbose string `yaml:"verbose"`
+	SignOff bool `yaml:"signOff"`
 }
 
 type MergingConfig struct {
@@ -450,7 +449,6 @@ func GetDefaultConfig() *UserConfig {
 			},
 			Commit: CommitConfig{
 				SignOff: false,
-				Verbose: "default",
 			},
 			Merging: MergingConfig{
 				ManualCommit: false,


### PR DESCRIPTION
As discussed in https://github.com/jesseduffield/lazygit/pull/2599, it makes more sense to have the user specify whether they want verbose commits from their own git config, rather than lazygit config.

This means that we can remove all the code (including test coverage) associated with the custom verbose flag, and lazygit will just inherit the .gitconfig settings automatically.

---

Tested visually locally, as well as running the tests that all pass.