### PR TITLE
More compact and flexible date format

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -28,7 +28,8 @@ gui:
   expandFocusedSidePanel: false
   mainPanelSplitMode: 'flexible' # one of 'horizontal' | 'flexible' | 'vertical'
   language: 'auto' # one of 'auto' | 'en' | 'zh' | 'pl' | 'nl' | 'ja' | 'ko'
-  timeFormat: '02 Jan 06 15:04 MST' # https://pkg.go.dev/time#Time.Format
+  timeFormat: '02 Jan 06' # https://pkg.go.dev/time#Time.Format
+  shortTimeFormat: '3:04PM'
   theme:
     activeBorderColor:
       - green

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -39,6 +39,7 @@ type GuiConfig struct {
 	MainPanelSplitMode          string             `yaml:"mainPanelSplitMode"`
 	Language                    string             `yaml:"language"`
 	TimeFormat                  string             `yaml:"timeFormat"`
+	ShortTimeFormat             string             `yaml:"shortTimeFormat"`
 	Theme                       ThemeConfig        `yaml:"theme"`
 	CommitLength                CommitLengthConfig `yaml:"commitLength"`
 	SkipNoStagedFilesWarning    bool               `yaml:"skipNoStagedFilesWarning"`
@@ -398,7 +399,8 @@ func GetDefaultConfig() *UserConfig {
 			ExpandFocusedSidePanel: false,
 			MainPanelSplitMode:     "flexible",
 			Language:               "auto",
-			TimeFormat:             time.RFC822,
+			TimeFormat:             "02 Jan 06",
+			ShortTimeFormat:        time.Kitchen,
 			Theme: ThemeConfig{
 				ActiveBorderColor:         []string{"green", "bold"},
 				InactiveBorderColor:       []string{"default"},

--- a/pkg/gui/context/local_commits_context.go
+++ b/pkg/gui/context/local_commits_context.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"log"
+	"time"
 
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/commands/types/enums"
@@ -44,6 +45,8 @@ func NewLocalCommitsContext(c *ContextCommon) *LocalCommitsContext {
 			c.Modes().CherryPicking.SelectedShaSet(),
 			c.Modes().Diffing.Ref,
 			c.UserConfig.Gui.TimeFormat,
+			c.UserConfig.Gui.ShortTimeFormat,
+			time.Now(),
 			c.UserConfig.Git.ParseEmoji,
 			selectedCommitSha,
 			startIdx,

--- a/pkg/gui/context/reflog_commits_context.go
+++ b/pkg/gui/context/reflog_commits_context.go
@@ -1,6 +1,8 @@
 package context
 
 import (
+	"time"
+
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
@@ -25,7 +27,9 @@ func NewReflogCommitsContext(c *ContextCommon) *ReflogCommitsContext {
 			c.State().GetRepoState().GetScreenMode() != types.SCREEN_NORMAL,
 			c.Modes().CherryPicking.SelectedShaSet(),
 			c.Modes().Diffing.Ref,
+			time.Now(),
 			c.UserConfig.Gui.TimeFormat,
+			c.UserConfig.Gui.ShortTimeFormat,
 			c.UserConfig.Git.ParseEmoji,
 		)
 	}

--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
@@ -47,6 +48,8 @@ func NewSubCommitsContext(
 			c.Modes().CherryPicking.SelectedShaSet(),
 			c.Modes().Diffing.Ref,
 			c.UserConfig.Gui.TimeFormat,
+			c.UserConfig.Gui.ShortTimeFormat,
+			time.Now(),
 			c.UserConfig.Git.ParseEmoji,
 			selectedCommitSha,
 			startIdx,

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -3,6 +3,7 @@ package presentation
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/fsmiamoto/git-todo-parser/todo"
 	"github.com/jesseduffield/generics/set"
@@ -41,6 +42,8 @@ func GetCommitListDisplayStrings(
 	cherryPickedCommitShaSet *set.Set[string],
 	diffName string,
 	timeFormat string,
+	shortTimeFormat string,
+	now time.Time,
 	parseEmoji bool,
 	selectedCommitSha string,
 	startIdx int,
@@ -107,6 +110,8 @@ func GetCommitListDisplayStrings(
 			cherryPickedCommitShaSet,
 			diffName,
 			timeFormat,
+			shortTimeFormat,
+			now,
 			parseEmoji,
 			getGraphLine(unfilteredIdx),
 			fullDescription,
@@ -253,6 +258,8 @@ func displayCommit(
 	cherryPickedCommitShaSet *set.Set[string],
 	diffName string,
 	timeFormat string,
+	shortTimeFormat string,
+	now time.Time,
 	parseEmoji bool,
 	graphLine string,
 	fullDescription bool,
@@ -304,7 +311,9 @@ func displayCommit(
 	cols = append(cols, shaColor.Sprint(commit.ShortSha()))
 	cols = append(cols, bisectString)
 	if fullDescription {
-		cols = append(cols, style.FgBlue.Sprint(utils.UnixToDate(commit.UnixTimestamp, timeFormat)))
+		cols = append(cols, style.FgBlue.Sprint(
+			utils.UnixToDateSmart(now, commit.UnixTimestamp, timeFormat, shortTimeFormat),
+		))
 	}
 	cols = append(
 		cols,

--- a/pkg/gui/presentation/commits_test.go
+++ b/pkg/gui/presentation/commits_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fsmiamoto/git-todo-parser/todo"
 	"github.com/gookit/color"
@@ -31,6 +32,8 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 		cherryPickedCommitShaSet *set.Set[string]
 		diffName                 string
 		timeFormat               string
+		shortTimeFormat          string
+		now                      time.Time
 		parseEmoji               bool
 		selectedCommitSha        string
 		startIdx                 int
@@ -49,6 +52,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			showGraph:                false,
 			bisectInfo:               git_commands.NewNullBisectInfo(),
 			cherryPickedCommitShaSet: set.New[string](),
+			now:                      time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected:                 "",
 		},
 		{
@@ -62,6 +66,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			showGraph:                false,
 			bisectInfo:               git_commands.NewNullBisectInfo(),
 			cherryPickedCommitShaSet: set.New[string](),
+			now:                      time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
 		sha1 commit1
 		sha2 commit2
@@ -81,6 +86,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			showGraph:                true,
 			bisectInfo:               git_commands.NewNullBisectInfo(),
 			cherryPickedCommitShaSet: set.New[string](),
+			now:                      time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
 		sha1 ⏣─╮ commit1
 		sha2 ◯ │ commit2
@@ -104,6 +110,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			bisectInfo:               git_commands.NewNullBisectInfo(),
 			cherryPickedCommitShaSet: set.New[string](),
 			showYouAreHereLabel:      true,
+			now:                      time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
 		sha1 pick  commit1
 		sha2 pick  commit2
@@ -127,6 +134,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			bisectInfo:               git_commands.NewNullBisectInfo(),
 			cherryPickedCommitShaSet: set.New[string](),
 			showYouAreHereLabel:      true,
+			now:                      time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
 		sha2 pick  commit2
 		sha3       ◯ <-- YOU ARE HERE --- commit3
@@ -149,6 +157,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			bisectInfo:               git_commands.NewNullBisectInfo(),
 			cherryPickedCommitShaSet: set.New[string](),
 			showYouAreHereLabel:      true,
+			now:                      time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
 		sha4 ◯ commit4
 		sha5 ◯ commit5
@@ -169,6 +178,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			bisectInfo:               git_commands.NewNullBisectInfo(),
 			cherryPickedCommitShaSet: set.New[string](),
 			showYouAreHereLabel:      true,
+			now:                      time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
 		sha1 pick  commit1
 		sha2 pick  commit2
@@ -189,6 +199,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			bisectInfo:               git_commands.NewNullBisectInfo(),
 			cherryPickedCommitShaSet: set.New[string](),
 			showYouAreHereLabel:      true,
+			now:                      time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
 			sha5 ◯ commit5
 				`),
@@ -208,6 +219,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			bisectInfo:               git_commands.NewNullBisectInfo(),
 			cherryPickedCommitShaSet: set.New[string](),
 			showYouAreHereLabel:      true,
+			now:                      time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
 			sha1 pick  commit1
 			sha2 pick  commit2
@@ -226,6 +238,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			bisectInfo:               git_commands.NewNullBisectInfo(),
 			cherryPickedCommitShaSet: set.New[string](),
 			showYouAreHereLabel:      false,
+			now:                      time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
 		sha1 pick  commit1
 		sha2       ◯ commit2
@@ -235,19 +248,21 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 		{
 			testName: "custom time format",
 			commits: []*models.Commit{
-				{Name: "commit1", Sha: "sha1", UnixTimestamp: 1652443200, AuthorName: "Jesse Duffield"},
-				{Name: "commit2", Sha: "sha2", UnixTimestamp: 1652529600, AuthorName: "Jesse Duffield"},
+				{Name: "commit1", Sha: "sha1", UnixTimestamp: 1577844184, AuthorName: "Jesse Duffield"},
+				{Name: "commit2", Sha: "sha2", UnixTimestamp: 1576844184, AuthorName: "Jesse Duffield"},
 			},
 			fullDescription:          true,
-			timeFormat:               "2006-01-02 15:04:05",
+			timeFormat:               "2006-01-02",
+			shortTimeFormat:          "3:04PM",
 			startIdx:                 0,
 			length:                   2,
 			showGraph:                false,
 			bisectInfo:               git_commands.NewNullBisectInfo(),
 			cherryPickedCommitShaSet: set.New[string](),
+			now:                      time.Date(2020, 1, 1, 5, 3, 4, 0, time.UTC),
 			expected: formatExpected(`
-		sha1 2022-05-13 12:00:00 Jesse Duffield    commit1
-		sha2 2022-05-14 12:00:00 Jesse Duffield    commit2
+		sha1 2:03AM     Jesse Duffield    commit1
+		sha2 2019-12-20 Jesse Duffield    commit2
 						`),
 		},
 	}
@@ -274,6 +289,8 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 					s.cherryPickedCommitShaSet,
 					s.diffName,
 					s.timeFormat,
+					s.shortTimeFormat,
+					s.now,
 					s.parseEmoji,
 					s.selectedCommitSha,
 					s.startIdx,

--- a/pkg/utils/date.go
+++ b/pkg/utils/date.go
@@ -20,6 +20,13 @@ func UnixToTimeAgo(timestamp int64) string {
 	return fmt.Sprintf("%dy", int(delta))
 }
 
-func UnixToDate(timestamp int64, timeFormat string) string {
-	return time.Unix(timestamp, 0).Format(timeFormat)
+// formats the date in a smart way, if the date is today, it will show the time, otherwise it will show the date
+func UnixToDateSmart(now time.Time, timestamp int64, longTimeFormat string, shortTimeFormat string) string {
+	date := time.Unix(timestamp, 0)
+
+	if date.Day() == now.Day() && date.Month() == now.Month() && date.Year() == now.Year() {
+		return date.Format(shortTimeFormat)
+	}
+
+	return date.Format(longTimeFormat)
 }


### PR DESCRIPTION
You can now configure both a time format and a short time format, where the short format kicks in when the time is within the last day

The impetus for doing this was saving more horizontal space in the commits view because there's a lot to fit into limited space.

Before

![image](https://github.com/jesseduffield/lazygit/assets/8456633/f99f4041-74e0-4832-99b3-90810672b920)

After

![image](https://github.com/jesseduffield/lazygit/assets/8456633/3ddd0f25-11bb-4d0a-ac6f-2df49e4d94b8)

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc
