### PR TITLE
Show rebase todo entry for conflicted commit

### DIFF
--- a/pkg/commands/models/commit.go
+++ b/pkg/commands/models/commit.go
@@ -26,6 +26,8 @@ const (
 	// Conveniently for us, the todo package starts the enum at 1, and given
 	// that it doesn't have a "none" value, we're setting ours to 0
 	ActionNone todo.TodoCommand = 0
+	// "Comment" is the last one of the todo package's enum entries
+	ActionConflict = todo.Comment + 1
 )
 
 // Commit : A git commit

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -385,6 +385,10 @@ func (self *LocalCommitsController) interactiveRebase(action todo.TodoCommand) e
 // commit meaning you are trying to edit the todo file rather than actually
 // begin a rebase. It then updates the todo file with that action
 func (self *LocalCommitsController) handleMidRebaseCommand(action todo.TodoCommand, commit *models.Commit) (bool, error) {
+	if commit.Action == models.ActionConflict {
+		return true, self.c.ErrorMsg(self.c.Tr.ChangingThisActionIsNotAllowed)
+	}
+
 	if !commit.IsTODO() {
 		if self.c.Git().Status.WorkingTreeState() != enums.REBASE_MODE_NONE {
 			// If we are in a rebase, the only action that is allowed for
@@ -434,7 +438,7 @@ func (self *LocalCommitsController) moveDown(commit *models.Commit) error {
 	}
 
 	if commit.IsTODO() {
-		if !commits[index+1].IsTODO() {
+		if !commits[index+1].IsTODO() || commits[index+1].Action == models.ActionConflict {
 			return nil
 		}
 

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/theme"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/kyokomi/emoji/v2"
+	"github.com/samber/lo"
 	"github.com/sasha-s/go-deadlock"
 )
 
@@ -103,7 +104,11 @@ func GetCommitListDisplayStrings(
 	for i, commit := range filteredCommits {
 		unfilteredIdx := i + startIdx
 		bisectStatus = getBisectStatus(unfilteredIdx, commit.Sha, bisectInfo, bisectBounds)
-		isYouAreHereCommit := showYouAreHereLabel && unfilteredIdx == rebaseOffset
+		isYouAreHereCommit := false
+		if showYouAreHereLabel && (commit.Action == models.ActionConflict || unfilteredIdx == rebaseOffset) {
+			isYouAreHereCommit = true
+			showYouAreHereLabel = false
+		}
 		lines = append(lines, displayCommit(
 			common,
 			commit,
@@ -272,7 +277,7 @@ func displayCommit(
 
 	actionString := ""
 	if commit.Action != models.ActionNone {
-		todoString := commit.Action.String()
+		todoString := lo.Ternary(commit.Action == models.ActionConflict, "conflict", commit.Action.String())
 		actionString = actionColorMap(commit.Action).Sprint(todoString) + " "
 	}
 
@@ -295,7 +300,8 @@ func displayCommit(
 	}
 
 	if isYouAreHereCommit {
-		youAreHere := style.FgYellow.Sprintf("<-- %s ---", common.Tr.YouAreHere)
+		color := lo.Ternary(commit.Action == models.ActionConflict, style.FgRed, style.FgYellow)
+		youAreHere := color.Sprintf("<-- %s ---", common.Tr.YouAreHere)
 		name = fmt.Sprintf("%s %s", youAreHere, name)
 	}
 
@@ -391,6 +397,8 @@ func actionColorMap(action todo.TodoCommand) style.TextStyle {
 		return style.FgGreen
 	case todo.Fixup:
 		return style.FgMagenta
+	case models.ActionConflict:
+		return style.FgRed
 	default:
 		return style.FgYellow
 	}

--- a/pkg/integration/tests/branch/rebase_and_drop.go
+++ b/pkg/integration/tests/branch/rebase_and_drop.go
@@ -53,7 +53,8 @@ var RebaseAndDrop = NewIntegrationTest(NewIntegrationTestArgs{
 			TopLines(
 				MatchesRegexp(`pick.*to keep`).IsSelected(),
 				MatchesRegexp(`pick.*to remove`),
-				MatchesRegexp("YOU ARE HERE.*second-change-branch unrelated change"),
+				MatchesRegexp(`conflict.*YOU ARE HERE.*first change`),
+				MatchesRegexp("second-change-branch unrelated change"),
 				MatchesRegexp("second change"),
 				MatchesRegexp("original"),
 			).
@@ -62,7 +63,8 @@ var RebaseAndDrop = NewIntegrationTest(NewIntegrationTestArgs{
 			TopLines(
 				MatchesRegexp(`pick.*to keep`),
 				MatchesRegexp(`drop.*to remove`).IsSelected(),
-				MatchesRegexp("YOU ARE HERE.*second-change-branch unrelated change"),
+				MatchesRegexp(`conflict.*YOU ARE HERE.*first change`),
+				MatchesRegexp("second-change-branch unrelated change"),
 				MatchesRegexp("second change"),
 				MatchesRegexp("original"),
 			)

--- a/pkg/integration/tests/interactive_rebase/amend_commit_with_conflict.go
+++ b/pkg/integration/tests/interactive_rebase/amend_commit_with_conflict.go
@@ -1,0 +1,74 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var AmendCommitWithConflict = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Amends a staged file to a commit, causing a conflict there.",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file", "1\n").Commit("one")
+		shell.UpdateFileAndAdd("file", "1\n2\n").Commit("two")
+		shell.UpdateFileAndAdd("file", "1\n2\n3\n").Commit("three")
+		shell.UpdateFileAndAdd("file", "1\n2\n4\n")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("three"),
+				Contains("two"),
+				Contains("one"),
+			).
+			NavigateToLine(Contains("two")).
+			Press(keys.Commits.AmendToCommit).
+			Tap(func() {
+				t.ExpectPopup().Confirmation().
+					Title(Equals("Amend commit")).
+					Content(Contains("Are you sure you want to amend this commit with your staged files?")).
+					Confirm()
+				t.Common().AcknowledgeConflicts()
+			}).
+			Lines(
+				Contains("pick").Contains("three"),
+				// Would be nice to see "fixup! two" here, because that's what git is trying to apply right now
+				Contains("<-- YOU ARE HERE --- two"),
+				Contains("one"),
+			)
+
+		t.Views().Files().
+			IsFocused().
+			Lines(
+				Contains("UU file"),
+			).
+			PressEnter()
+
+		t.Views().MergeConflicts().
+			IsFocused().
+			TopLines(
+				Contains("1"),
+				Contains("2"),
+				Contains("<<<<<<< HEAD"),
+				Contains("======="),
+				Contains("4"),
+				Contains(">>>>>>>"),
+			).
+			SelectNextItem().
+			PressPrimaryAction() // pick "4"
+
+		t.Common().ContinueOnConflictsResolved()
+
+		t.Common().AcknowledgeConflicts()
+
+		t.Views().Commits().
+			Lines(
+				// Would be nice to see "three" here, because that's what git is trying to apply right now
+				Contains("<-- YOU ARE HERE --- two"),
+				Contains("one"),
+			)
+	},
+})

--- a/pkg/integration/tests/interactive_rebase/amend_commit_with_conflict.go
+++ b/pkg/integration/tests/interactive_rebase/amend_commit_with_conflict.go
@@ -35,8 +35,8 @@ var AmendCommitWithConflict = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Lines(
 				Contains("pick").Contains("three"),
-				// Would be nice to see "fixup! two" here, because that's what git is trying to apply right now
-				Contains("<-- YOU ARE HERE --- two"),
+				Contains("conflict").Contains("<-- YOU ARE HERE --- fixup! two"),
+				Contains("two"),
 				Contains("one"),
 			)
 
@@ -66,8 +66,8 @@ var AmendCommitWithConflict = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Commits().
 			Lines(
-				// Would be nice to see "three" here, because that's what git is trying to apply right now
-				Contains("<-- YOU ARE HERE --- two"),
+				Contains("<-- YOU ARE HERE --- three"),
+				Contains("two"),
 				Contains("one"),
 			)
 	},

--- a/pkg/integration/tests/interactive_rebase/edit_the_confl_commit.go
+++ b/pkg/integration/tests/interactive_rebase/edit_the_confl_commit.go
@@ -1,0 +1,47 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var EditTheConflCommit = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Swap two commits, causing a conflict; then try to interact with the 'confl' commit, which results in an error.",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("myfile", "one")
+		shell.Commit("commit one")
+		shell.UpdateFileAndAdd("myfile", "two")
+		shell.Commit("commit two")
+		shell.UpdateFileAndAdd("myfile", "three")
+		shell.Commit("commit three")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("commit three").IsSelected(),
+				Contains("commit two"),
+				Contains("commit one"),
+			).
+			Press(keys.Commits.MoveDownCommit).
+			Tap(func() {
+				t.Common().AcknowledgeConflicts()
+			}).
+			Focus().
+			Lines(
+				Contains("pick").Contains("commit two"),
+				Contains("conflict").Contains("<-- YOU ARE HERE --- commit three"),
+				Contains("commit one"),
+			).
+			NavigateToLine(Contains("<-- YOU ARE HERE --- commit three")).
+			Press(keys.Commits.RenameCommit)
+
+		t.ExpectPopup().Alert().
+			Title(Equals("Error")).
+			Content(Contains("Changing this kind of rebase todo entry is not allowed")).
+			Confirm()
+	},
+})

--- a/pkg/integration/tests/interactive_rebase/pick_rescheduled.go
+++ b/pkg/integration/tests/interactive_rebase/pick_rescheduled.go
@@ -1,0 +1,47 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var PickRescheduled = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Makes a pick during a rebase fail because it would overwrite an untracked file",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file1", "1\n").Commit("one")
+		shell.UpdateFileAndAdd("file2", "2\n").Commit("two")
+		shell.UpdateFileAndAdd("file3", "3\n").Commit("three")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("three").IsSelected(),
+				Contains("two"),
+				Contains("one"),
+			).
+			NavigateToLine(Contains("one")).
+			Press(keys.Universal.Edit).
+			Lines(
+				Contains("pick").Contains("three"),
+				Contains("pick").Contains("two"),
+				Contains("<-- YOU ARE HERE --- one").IsSelected(),
+			).
+			Tap(func() {
+				t.Shell().CreateFile("file3", "other content\n")
+				t.Common().ContinueRebase()
+				t.ExpectPopup().Alert().Title(Equals("Error")).
+					Content(Contains("The following untracked working tree files would be overwritten by merge").
+						Contains("Please move or remove them before you merge.")).
+					Confirm()
+			}).
+			Lines(
+				Contains("pick").Contains("three"),
+				Contains("<-- YOU ARE HERE --- two"),
+				Contains("one"),
+			)
+	},
+})

--- a/pkg/integration/tests/interactive_rebase/reword_commit_with_editor_and_fail.go
+++ b/pkg/integration/tests/interactive_rebase/reword_commit_with_editor_and_fail.go
@@ -1,0 +1,45 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var RewordCommitWithEditorAndFail = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Rewords a commit with editor, and fails because an empty commit message is given",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			CreateNCommits(3).
+			SetConfig("core.editor", "sh -c 'echo </dev/null >.git/COMMIT_EDITMSG'")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("commit 03").IsSelected(),
+				Contains("commit 02"),
+				Contains("commit 01"),
+			).
+			NavigateToLine(Contains("commit 02")).
+			Press(keys.Commits.RenameCommitWithEditor).
+			Tap(func() {
+				t.ExpectPopup().Confirmation().
+					Title(Equals("Reword in editor")).
+					Content(Contains("Are you sure you want to reword this commit in your editor?")).
+					Confirm()
+			}).
+			Lines(
+				Contains("commit 03"),
+				Contains("<-- YOU ARE HERE --- commit 02").IsSelected(),
+				Contains("commit 01"),
+			)
+
+		t.ExpectPopup().Alert().
+			Title(Equals("Error")).
+			Content(Contains("exit status 1"))
+	},
+})

--- a/pkg/integration/tests/interactive_rebase/shared.go
+++ b/pkg/integration/tests/interactive_rebase/shared.go
@@ -10,8 +10,8 @@ func handleConflictsFromSwap(t *TestDriver) {
 	t.Views().Commits().
 		Lines(
 			Contains("pick").Contains("commit two"),
-			// Would be nice to see "three" here, it's the one that conflicted
-			Contains("<-- YOU ARE HERE --- commit one"),
+			Contains("conflict").Contains("<-- YOU ARE HERE --- commit three"),
+			Contains("commit one"),
 		)
 
 	t.Views().Files().

--- a/pkg/integration/tests/interactive_rebase/shared.go
+++ b/pkg/integration/tests/interactive_rebase/shared.go
@@ -7,6 +7,13 @@ import (
 func handleConflictsFromSwap(t *TestDriver) {
 	t.Common().AcknowledgeConflicts()
 
+	t.Views().Commits().
+		Lines(
+			Contains("pick").Contains("commit two"),
+			// Would be nice to see "three" here, it's the one that conflicted
+			Contains("<-- YOU ARE HERE --- commit one"),
+		)
+
 	t.Views().Files().
 		IsFocused().
 		Lines(

--- a/pkg/integration/tests/interactive_rebase/swap_in_rebase_with_conflict_and_edit.go
+++ b/pkg/integration/tests/interactive_rebase/swap_in_rebase_with_conflict_and_edit.go
@@ -1,0 +1,52 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var SwapInRebaseWithConflictAndEdit = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Via an edit-triggered rebase, swap two commits, causing a conflict, then edit the commit that will conflict.",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("myfile", "one")
+		shell.Commit("commit one")
+		shell.UpdateFileAndAdd("myfile", "two")
+		shell.Commit("commit two")
+		shell.UpdateFileAndAdd("myfile", "three")
+		shell.Commit("commit three")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("commit three").IsSelected(),
+				Contains("commit two"),
+				Contains("commit one"),
+			).
+			NavigateToLine(Contains("commit one")).
+			Press(keys.Universal.Edit).
+			Lines(
+				Contains("commit three"),
+				Contains("commit two"),
+				Contains("<-- YOU ARE HERE --- commit one").IsSelected(),
+			).
+			NavigateToLine(Contains("commit two")).
+			Press(keys.Commits.MoveUpCommit).
+			Lines(
+				Contains("commit two").IsSelected(),
+				Contains("commit three"),
+				Contains("<-- YOU ARE HERE --- commit one"),
+			).
+			NavigateToLine(Contains("commit three")).
+			Press(keys.Universal.Edit).
+			SelectPreviousItem().
+			Tap(func() {
+				t.Common().ContinueRebase()
+			})
+
+		handleConflictsFromSwap(t)
+	},
+})

--- a/pkg/integration/tests/sync/pull_rebase_interactive_conflict.go
+++ b/pkg/integration/tests/sync/pull_rebase_interactive_conflict.go
@@ -47,7 +47,8 @@ var PullRebaseInteractiveConflict = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Lines(
 				Contains("pick").Contains("five"),
-				Contains("YOU ARE HERE").Contains("three"),
+				Contains("conflict").Contains("YOU ARE HERE").Contains("four"),
+				Contains("three"),
 				Contains("two"),
 				Contains("one"),
 			)

--- a/pkg/integration/tests/sync/pull_rebase_interactive_conflict_drop.go
+++ b/pkg/integration/tests/sync/pull_rebase_interactive_conflict_drop.go
@@ -48,14 +48,16 @@ var PullRebaseInteractiveConflictDrop = NewIntegrationTest(NewIntegrationTestArg
 			Focus().
 			Lines(
 				Contains("pick").Contains("five").IsSelected(),
-				Contains("YOU ARE HERE").Contains("three"),
+				Contains("conflict").Contains("YOU ARE HERE").Contains("four"),
+				Contains("three"),
 				Contains("two"),
 				Contains("one"),
 			).
 			Press(keys.Universal.Remove).
 			Lines(
 				Contains("drop").Contains("five").IsSelected(),
-				Contains("YOU ARE HERE").Contains("three"),
+				Contains("conflict").Contains("YOU ARE HERE").Contains("four"),
+				Contains("three"),
 				Contains("two"),
 				Contains("one"),
 			)

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -95,6 +95,7 @@ var tests = []*components.IntegrationTest{
 	filter_by_path.SelectFile,
 	filter_by_path.TypeFile,
 	interactive_rebase.AdvancedInteractiveRebase,
+	interactive_rebase.AmendCommitWithConflict,
 	interactive_rebase.AmendFirstCommit,
 	interactive_rebase.AmendFixupCommit,
 	interactive_rebase.AmendHeadCommitDuringRebase,

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -109,6 +109,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.FixupSecondCommit,
 	interactive_rebase.Move,
 	interactive_rebase.MoveInRebase,
+	interactive_rebase.PickRescheduled,
 	interactive_rebase.Rebase,
 	interactive_rebase.RewordFirstCommit,
 	interactive_rebase.RewordLastCommit,

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -105,6 +105,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.DropTodoCommitWithUpdateRefShowBranchHeads,
 	interactive_rebase.EditFirstCommit,
 	interactive_rebase.EditNonTodoCommitDuringRebase,
+	interactive_rebase.EditTheConflCommit,
 	interactive_rebase.FixupFirstCommit,
 	interactive_rebase.FixupSecondCommit,
 	interactive_rebase.Move,

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -121,6 +121,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.SquashDownSecondCommit,
 	interactive_rebase.SquashFixupsAboveFirstCommit,
 	interactive_rebase.SwapInRebaseWithConflict,
+	interactive_rebase.SwapInRebaseWithConflictAndEdit,
 	interactive_rebase.SwapWithConflict,
 	misc.ConfirmOnQuit,
 	misc.InitialOpen,

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -111,6 +111,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.MoveInRebase,
 	interactive_rebase.PickRescheduled,
 	interactive_rebase.Rebase,
+	interactive_rebase.RewordCommitWithEditorAndFail,
 	interactive_rebase.RewordFirstCommit,
 	interactive_rebase.RewordLastCommit,
 	interactive_rebase.RewordYouAreHereCommit,


### PR DESCRIPTION
- **PR Description**

Suppose you have a branch with four commits, you rebase it onto master, and the third commit conflicts. Right now, what you see in the commits panel is this:

<img width="547" alt="image" src="https://github.com/jesseduffield/lazygit/assets/1225667/d410e742-855d-4e6f-9836-b5dc4ecf1a4d">

I find this very confusing, I would expect to see the 3rd commit in the list too, with the "<-- You are here" pointing to it. And that's what this PR does:

<img width="547" alt="image" src="https://github.com/jesseduffield/lazygit/assets/1225667/ba38ff71-f68a-45c9-9767-2d6d02b795a1">

The nice thing about this is that you can unfold the conflicting commit and look at its (original) diff; this is useful in cases where the conflict is complicated to resolve, but the original diff was very simple, in which case it can be easier to "checkout ours" and redo the change manually.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
