### PR TITLE
Add suggestionsPreset to custom commands system

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -107,6 +107,7 @@ The permitted prompt fields are:
 | type              | one of 'input', 'menu', or 'confirm'                                                           | yes        |
 | title             | the title to display in the popup panel                                                        | no         |
 | initialValue      | (only applicable to 'input' prompts) the initial value to appear in the text box               | no         |
+| suggestionsPreset | (only applicable to 'input prompts'. Shows suggestions as the value is typed. One of 'files', 'branches', 'remotes', 'remoteBranches', refs'.                                 | no         |
 | body              | (only applicable to 'confirm' prompts) the immutable body text to appear in the text box       | no         |
 | options           | (only applicable to 'menu' prompts) the options to display in the menu                         | no         |
 | command           | (only applicable to 'menuFromCommand' prompts) the command to run to generate                  | yes        |

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -366,7 +366,8 @@ type CustomCommandPrompt struct {
 	Title string `yaml:"title"`
 
 	// this only apply to input prompts
-	InitialValue string `yaml:"initialValue"`
+	InitialValue      string `yaml:"initialValue"`
+	SuggestionsPreset string `yaml:"suggestionsPreset"`
 
 	// this only applies to confirm prompts
 	Body string `yaml:"body"`

--- a/pkg/gui/services/custom_commands/client.go
+++ b/pkg/gui/services/custom_commands/client.go
@@ -19,7 +19,7 @@ func NewClient(
 	helpers *helpers.Helpers,
 ) *Client {
 	sessionStateLoader := NewSessionStateLoader(c, helpers.Refs)
-	handlerCreator := NewHandlerCreator(c, sessionStateLoader)
+	handlerCreator := NewHandlerCreator(c, sessionStateLoader, helpers.Suggestions)
 	keybindingCreator := NewKeybindingCreator(c)
 	customCommands := c.UserConfig.CustomCommands
 

--- a/pkg/gui/services/custom_commands/resolver.go
+++ b/pkg/gui/services/custom_commands/resolver.go
@@ -34,6 +34,11 @@ func (self *Resolver) resolvePrompt(
 		return nil, err
 	}
 
+	result.SuggestionsPreset, err = resolveTemplate(prompt.SuggestionsPreset)
+	if err != nil {
+		return nil, err
+	}
+
 	result.Body, err = resolveTemplate(prompt.Body)
 	if err != nil {
 		return nil, err

--- a/pkg/integration/tests/custom_commands/suggestions_preset.go
+++ b/pkg/integration/tests/custom_commands/suggestions_preset.go
@@ -1,0 +1,64 @@
+package custom_commands
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var SuggestionsPreset = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Using a custom command that uses a suggestions preset in a prompt step",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo: func(shell *Shell) {
+		shell.NewBranch("branch-one")
+		shell.EmptyCommit("blah")
+		shell.NewBranch("branch-two")
+		shell.EmptyCommit("blah")
+		shell.NewBranch("branch-three")
+		shell.EmptyCommit("blah")
+		shell.NewBranch("branch-four")
+		shell.EmptyCommit("blah")
+	},
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.UserConfig.CustomCommands = []config.CustomCommand{
+			{
+				Key:     "a",
+				Context: "localBranches",
+				Command: `git checkout {{.Form.Branch}}`,
+				Prompts: []config.CustomCommandPrompt{
+					{
+						Key:               "Branch",
+						Type:              "input",
+						Title:             "Enter a branch name",
+						SuggestionsPreset: "branches",
+					},
+				},
+			},
+		}
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("branch-four").IsSelected(),
+				Contains("branch-three"),
+				Contains("branch-two"),
+				Contains("branch-one"),
+			).
+			Press("a")
+
+		t.ExpectPopup().Prompt().
+			Title(Equals("Enter a branch name")).
+			Type("three").
+			SuggestionLines(Contains("branch-three")).
+			ConfirmFirstSuggestion()
+
+		t.Views().Branches().
+			Lines(
+				Contains("branch-three").IsSelected(),
+				Contains("branch-four"),
+				Contains("branch-two"),
+				Contains("branch-one"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -77,6 +77,7 @@ var tests = []*components.IntegrationTest{
 	custom_commands.MenuFromCommandsOutput,
 	custom_commands.MultiplePrompts,
 	custom_commands.OmitFromHistory,
+	custom_commands.SuggestionsPreset,
 	diff.Diff,
 	diff.DiffAndApplyPatch,
 	diff.DiffCommits,


### PR DESCRIPTION
- **PR Description**

You can test with this custom command:
```yml
  - key : 'C'
    description: 'Checkout a file from the selected branch'
    command: "git checkout {{.SelectedLocalBranch.Name}} -- {{index .PromptResponses 0}}"
    context: 'localBranches'
    prompts:
      - type: 'input'
        key: 'file'
        title: 'Enter file to checkout from {{.SelectedLocalBranch.Name}}:'
        suggestionsPreset: 'files'
```

In future we can allow the user to specify a `suggestionsCommand` that returns one suggestion per line.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
