### PR TITLE
Support suggestions generated from command in custom commands

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -5,20 +5,22 @@ You can add custom command keybindings in your config.yml (accessible by pressin
 ```yml
 customCommands:
   - key: '<c-r>'
-    command: 'hub browse -- "commit/{{.SelectedLocalCommit.Sha}}"'
     context: 'commits'
+    command: 'hub browse -- "commit/{{.SelectedLocalCommit.Sha}}"'
   - key: 'a'
-    command: "git {{if .SelectedFile.HasUnstagedChanges}} add {{else}} reset {{end}} {{.SelectedFile.Name | quote}}"
     context: 'files'
-    description: 'toggle file staged'
+    command: "git {{if .SelectedFile.HasUnstagedChanges}} add {{else}} reset {{end}} {{.SelectedFile.Name | quote}}"
+    description: 'Toggle file staged'
   - key: 'C'
-    command: "git commit"
     context: 'global'
+    command: "git commit"
     subprocess: true
   - key: 'n'
+    context: 'localBranches'
     prompts:
       - type: 'menu'
         title: 'What kind of branch is it?'
+        key: 'BranchType'
         options:
           - name: 'feature'
             description: 'a feature branch'
@@ -31,111 +33,238 @@ customCommands:
             value: 'release'
       - type: 'input'
         title: 'What is the new branch name?'
+        key: 'BranchName'
         initialValue: ''
-    command: "git flow {{index .PromptResponses 0}} start {{index .PromptResponses 1}}"
-    context: 'localBranches'
-    loadingText: 'creating branch'
-  - key : 'r'
-    description: 'Checkout a remote branch as FETCH_HEAD'
-    command: "git fetch {{index .PromptResponses 0}} {{index .PromptResponses 1}} && git checkout FETCH_HEAD"
-    context: 'remotes'
-    prompts:
-      - type: 'input'
-        title: 'Remote:'
-        initialValue: "{{index .SelectedRemote.Name }}"
-      - type: 'menuFromCommand'
-        title: 'Remote branch:'
-        command: 'git branch  -r --list {{index .PromptResponses 0}}/*'
-        filter: '.*{{index .PromptResponses 0}}/(?P<branch>.*)'
-        valueFormat: '{{ .branch }}'
-        labelFormat: '{{ .branch | green }}'
-  - key: '<f1>'
-    command: 'git reset --soft {{.CheckedOutBranch.UpstreamRemote}}'
-    context: 'files'
-    prompts:
-      - type: 'confirm'
-        title: "Confirm:"
-        body: "Are you sure you want to reset HEAD to {{.CheckedOutBranch.UpstreamRemote}}?"
+    command: "git flow {{.Form.BranchType}} start {{.Form.BranchName}}"
+    loadingText: 'Creating branch'
 ```
 
 Looking at the command assigned to the 'n' key, here's what the result looks like:
 
 ![](../../assets/custom-command-keybindings.gif)
 
-Custom command keybindings will appear alongside inbuilt keybindings when you view the options menu by pressing 'x':
+Custom command keybindings will appear alongside inbuilt keybindings when you view the keybindings menu by pressing '?':
 
 ![](https://i.imgur.com/QB21FPx.png)
 
 For a given custom command, here are the allowed fields:
 | _field_ | _description_ | required |
 |-----------------|----------------------|-|
-| key | the key to trigger the command. Use a single letter or one of the values from [here](https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Custom_Keybindings.md) | yes |
-| command | the command to run | yes |
-| context | the context in which to listen for the key (see below) | yes |
-| subprocess | whether you want the command to run in a subprocess (necessary if you want to view the output of the command or provide user input) | no |
-| prompts | a list of prompts that will request user input before running the final command | no |
-| loadingText | text to display while waiting for command to finish | no |
-| description | text to display in the keybindings menu that appears when you press 'x' | no |
-| stream | whether you want to stream the command's output to the Command Log panel | no |
-| showOutput | whether you want to show the command's output in a gui prompt | no |
+| key | The key to trigger the command. Use a single letter or one of the values from [here](https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Custom_Keybindings.md) | yes |
+| command | The command to run (using Go template syntax for placeholder values) | yes |
+| context | The context in which to listen for the key (see [below](#contexts)) | yes |
+| subprocess | Whether you want the command to run in a subprocess (e.g. if the command requires user input) | no |
+| prompts | A list of prompts that will request user input before running the final command | no |
+| loadingText | Text to display while waiting for command to finish | no |
+| description | Label for the custom command when displayed in the keybindings menu | no |
+| stream | Whether you want to stream the command's output to the Command Log panel | no |
+| showOutput | Whether you want to show the command's output in a popup within Lazygit | no |
 
-### Contexts
+## Contexts
 
 The permitted contexts are:
 
 | _context_      | _description_                                                                                            |
 | -------------- | -------------------------------------------------------------------------------------------------------- |
-| status         | the 'Status' tab                                                                                         |
-| files          | the 'Files' tab                                                                                          |
-| localBranches  | the 'Local Branches' tab                                                                                 |
-| remotes        | the 'Remotes' tab                                                                                        |
-| remoteBranches | the context you get when pressing enter on a remote in the remotes tab                                   |
-| tags           | the 'Tags' tab                                                                                           |
-| commits        | the 'Commits' tab                                                                                        |
-| reflogCommits  | the 'Reflog' tab                                                                                         |
-| subCommits     | the context you see when pressing enter on a branch                                                      |
-| commitFiles    | the context you see when pressing enter on a commit or stash entry (warning, might be renamed in future) |
-| stash          | the 'Stash' tab                                                                                          |
-| global         | this keybinding will take affect everywhere                                                              |
+| status         | The 'Status' tab                                                                                         |
+| files          | The 'Files' tab                                                                                          |
+| localBranches  | The 'Local Branches' tab                                                                                 |
+| remotes        | The 'Remotes' tab                                                                                        |
+| remoteBranches | The context you get when pressing enter on a remote in the remotes tab                                   |
+| tags           | The 'Tags' tab                                                                                           |
+| commits        | The 'Commits' tab                                                                                        |
+| reflogCommits  | The 'Reflog' tab                                                                                         |
+| subCommits     | The context you see when pressing enter on a branch                                                      |
+| commitFiles    | The context you see when pressing enter on a commit or stash entry (warning, might be renamed in future) |
+| stash          | The 'Stash' tab                                                                                          |
+| global         | This keybinding will take affect everywhere                                                              |
 
-### Prompts
+## Prompts
 
-The permitted prompt fields are:
+### Common fields
+
+These fields are applicable to all prompts.
 
 | _field_           | _description_                                                                                  | _required_ |
 | ------------      | -----------------------------------------------------------------------------------------------| ---------- |
-| type              | one of 'input', 'menu', or 'confirm'                                                           | yes        |
-| title             | the title to display in the popup panel                                                        | no         |
-| initialValue      | (only applicable to 'input' prompts) the initial value to appear in the text box               | no         |
-| suggestionsPreset | (only applicable to 'input prompts'. Shows suggestions as the value is typed. One of 'files', 'branches', 'remotes', 'remoteBranches', refs'.                                 | no         |
-| body              | (only applicable to 'confirm' prompts) the immutable body text to appear in the text box       | no         |
-| options           | (only applicable to 'menu' prompts) the options to display in the menu                         | no         |
-| command           | (only applicable to 'menuFromCommand' prompts) the command to run to generate                  | yes        |
-|                   | menu options                                                                                   |            |
-| filter            | (only applicable to 'menuFromCommand' prompts) the regexp to run specifying groups which are going to be kept from the command's output      | yes        |
-| valueFormat       | (only applicable to 'menuFromCommand' prompts) how to format matched groups from the filter to construct a menu item's value (What gets appended to prompt responses when the item is selected). You can use named groups, or `{{ .group_GROUPID }}`. PS: named groups keep first match only | yes        |
-| labelFormat       | (only applicable to 'menuFromCommand' prompts) how to format matched groups from the filter to construct the item's label (What's shown on screen). You can use named groups, or `{{ .group_GROUPID }}`. You can also color each match with `{{ .group_GROUPID \| colorname }}` (Color names from [here](https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md)). If `labelFormat` is not specified, `valueFormat` is shown instead. PS: named groups keep first match only | no         |
+| type              | One of 'input', 'confirm', 'menu', 'menuFromCommand'                                                           | yes        |
+| title             | The title to display in the popup panel                                                        | no         |
+| key | Used to reference the entered value from within the custom command. E.g. a prompt with `key: 'Branch'` can be referred to as `{{.Form.Branch}}` in the command | yes |
+
+### Input
+
+| _field_           | _description_                                                                                  | _required_ |
+| ------------      | -----------------------------------------------------------------------------------------------| ---------- |
+| initialValue      | The initial value to appear in the text box               | no         |
+| suggestions       | Shows suggestions as the input is entered. See below for details                                                          | no         |
+
+The permitted suggestions fields are:
+| _field_ | _description_ | _required_ |
+|-----------------|----------------------|-|
+| preset | Uses built-in logic to obtain the suggestions. One of 'files', 'branches', 'remotes', 'remoteBranches', 'refs' | no |
+| command | Command to run such that each line in the output becomes a suggestion. Mutually exclusive with 'preset' field. | no |
+
+Here's an example of passing a preset:
+
+```yml
+customCommands:
+  - key: 'a'
+    command: 'echo {{.Form.Branch | quote}}'
+    context: 'commits'
+    prompts:
+      - type: 'input'
+        title: 'Which branch?'
+        key: 'Branch'
+        suggestions:
+          preset: 'branches' # use built-in logic for obtaining branches
+```
+
+Here's an example of passing a command directly:
+
+```yml
+customCommands:
+  - key: 'a'
+    command: 'echo {{.Form.Branch | quote}}'
+    context: 'commits'
+    prompts:
+      - type: 'input'
+        title: 'Which branch?'
+        key: 'Branch'
+        suggestions:
+          command: "git branch --format='%(refname:short)'"
+```
+
+
+Here's an example of passing an initial value for the input:
+
+```yml
+customCommands:
+  - key: 'a'
+    command: 'echo {{.Form.Remote | quote}}'
+    context: 'commits'
+    prompts:
+    - type: 'input'
+      title: 'Remote:'
+      key: 'Remote'
+      initialValue: "{{.SelectedRemote.Name}}"
+```
+
+### Confirm
+
+| _field_           | _description_                                                                                  | _required_ |
+| ------------      | -----------------------------------------------------------------------------------------------| ---------- |
+| body              | The immutable body text to appear in the text box       | no         |
+
+Example:
+
+```yml
+customCommands:
+  - key: 'a'
+    command: 'echo "pushing to remote"'
+    context: 'commits'
+    prompts:
+    - type: 'confirm'
+      title: 'Push to remote'
+      body: 'Are you sure you want to push to the remote?'
+```
+
+### Menu
+
+| _field_           | _description_                                                                                  | _required_ |
+| ------------      | -----------------------------------------------------------------------------------------------| ---------- |
+| options           | The options to display in the menu                         | yes         |
 
 The permitted option fields are:
 | _field_ | _description_ | _required_ |
 |-----------------|----------------------|-|
-| name | the string which will appear first on the line | no |
-| description | the string which will appear second on the line | no |
-| value | the value that will be stored in `.PromptResponses` if the option is selected | yes |
+| name | The first part of the label | no |
+| description | The second part of the label | no |
+| value | the value that will be used in the command | yes |
 
 If an option has no name the value will be displayed to the user in place of the name, so you're allowed to only include the value like so:
 
 ```yml
+customCommands:
+  - key: 'a'
+    command: 'echo {{.Form.BranchType | quote}}'
+    context: 'commits'
     prompts:
       - type: 'menu'
         title: 'What kind of branch is it?'
+        key: 'BranchType'
         options:
           - value: 'feature'
           - value: 'hotfix'
           - value: 'release'
 ```
 
-### Placeholder values
+Here's an example of supplying more detail for each option:
+
+```yml
+customCommands:
+  - key: 'a'
+    command: 'echo {{.Form.BranchType | quote}}'
+    context: 'commits'
+    prompts:
+      - type: 'menu'
+        title: 'What kind of branch is it?'
+        key: 'BranchType'
+        options:
+          - value: 'feature'
+            name: 'feature branch'
+            description: 'branch based off develop'
+          - value: 'hotfix'
+            name: 'hotfix branch'
+            description: 'branch based off main for fast bug fixes'
+          - value: 'release'
+            name: 'release branch'
+            description: 'branch for a release'
+```
+
+### Menu-from-command
+
+| _field_           | _description_                                                                                  | _required_ |
+| ------------      | -----------------------------------------------------------------------------------------------| ---------- |
+| command           | The command to run to generate menu options                  | yes        |
+| filter            | The regexp to run specifying groups which are going to be kept from the command's output      | no        |
+| valueFormat       | How to format matched groups from the filter to construct a menu item's value | no        |
+| labelFormat       | Like valueFormat but for the labels. If `labelFormat` is not specified, `valueFormat` is shown instead. | no         |
+
+Here's an example using named groups in the regex. Notice how we can pipe the label to a colour function for coloured output (available colours [here](https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md))
+
+```yml
+  - key : 'a'
+    description: 'Checkout a remote branch as FETCH_HEAD'
+    command: "git fetch {{.Form.Remote}} {{.Form.Branch}} && git checkout FETCH_HEAD"
+    context: 'remotes'
+    prompts:
+      - type: 'menuFromCommand'
+        title: 'Remote branch:'
+        key: 'Branch'
+        command: 'git branch  -r --list {{.SelectedRemote.Name }}/*'
+        filter: '.*{{.SelectedRemote.Name }}/(?P<branch>.*)'
+        valueFormat: '{{ .branch }}'
+        labelFormat: '{{ .branch | green }}'
+```
+
+Here's an example using unnamed groups:
+
+```yml
+  - key : 'a'
+    description: 'Checkout a remote branch as FETCH_HEAD'
+    command: "git fetch {{.Form.Remote}} {{.Form.Branch}} && git checkout FETCH_HEAD"
+    context: 'remotes'
+    prompts:
+      - type: 'menuFromCommand'
+        title: 'Remote branch:'
+        key: 'Branch'
+        command: 'git branch  -r --list {{.SelectedRemote.Name }}/*'
+        filter: '.*{{.SelectedRemote.Name }}/(.*)'
+        valueFormat: '{{ .group_1 }}'
+        labelFormat: '{{ .group_1 | green }}'
+```
+
+## Placeholder values
 
 Your commands can contain placeholder strings using Go's [template syntax](https://jan.newmarch.name/golang/template/chapter-template.html). The template syntax is pretty powerful, letting you do things like conditionals if you want, but for the most part you'll simply want to be accessing the fields on the following objects:
 
@@ -154,16 +283,16 @@ SelectedCommitFile
 CheckedOutBranch
 ```
 
-To see what fields are available on e.g. the `SelectedFile`, see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/commands/models/file.go) (all the modelling lives in the same directory). Note that the custom commands feature does not guarantee backwards compatibility (until we hit lazygit version 1.0 of course) which means a field you're accessing on an object may no longer be available from one release to the next. Typically however, all you'll need is `{{.SelectedFile.Name}}`, `{{.SelectedLocalCommit.Sha}}` and `{{.SelectedLocalBranch.Name}}`. In the future we will likely introduce a tighter interface that exposes a limited set of fields for each model.
+To see what fields are available on e.g. the `SelectedFile`, see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/commands/models/file.go) (all the modelling lives in the same directory). Note that the custom commands feature does not guarantee backwards compatibility (until we hit Lazygit version 1.0 of course) which means a field you're accessing on an object may no longer be available from one release to the next. Typically however, all you'll need is `{{.SelectedFile.Name}}`, `{{.SelectedLocalCommit.Sha}}` and `{{.SelectedLocalBranch.Name}}`. In the future we will likely introduce a tighter interface that exposes a limited set of fields for each model.
 
-### Keybinding collisions
+## Keybinding collisions
 
 If your custom keybinding collides with an inbuilt keybinding that is defined for the same context, only the custom keybinding will be executed. This also applies to the global context. However, one caveat is that if you have a custom keybinding defined on the global context for some key, and there is an in-built keybinding defined for the same key and for a specific context (say the 'files' context), then the in-built keybinding will take precedence. See how to change in-built keybindings [here](https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#keybindings)
 
-### Debugging
+## Debugging
 
-If you want to verify that your command actually does what you expect, you can wrap it in an 'echo' call and set `showOutput: true` so that it doesn't actually execute the command but you can see how the placeholders were resolved. Alternatively you can run lazygit in debug mode with `lazygit --debug` and in another terminal window run `lazygit --logs` to see which commands are actually run
+If you want to verify that your command actually does what you expect, you can wrap it in an 'echo' call and set `showOutput: true` so that it doesn't actually execute the command but you can see how the placeholders were resolved.
 
-### More Examples
+## More Examples
 
 See the [wiki](https://github.com/jesseduffield/lazygit/wiki/Custom-Commands-Compendium) page for more examples, and feel free to add your own custom commands to this page so others can benefit!

--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -264,6 +264,20 @@ Here's an example using unnamed groups:
         labelFormat: '{{ .group_1 | green }}'
 ```
 
+Here's an example using a command but not specifying anything else: so each line from the command becomes the value and label of the menu items
+
+```yml
+  - key : 'a'
+    description: 'Checkout a remote branch as FETCH_HEAD'
+    command: "open {{.Form.File | quote}}"
+    context: 'global'
+    prompts:
+      - type: 'menuFromCommand'
+        title: 'File:'
+        key: 'File'
+        command: 'ls'
+```
+
 ## Placeholder values
 
 Your commands can contain placeholder strings using Go's [template syntax](https://jan.newmarch.name/golang/template/chapter-template.html). The template syntax is pretty powerful, letting you do things like conditionals if you want, but for the most part you'll simply want to be accessing the fields on the following objects:

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -358,16 +358,14 @@ type CustomCommand struct {
 }
 
 type CustomCommandPrompt struct {
-	Key string `yaml:"key"`
-
 	// one of 'input', 'menu', 'confirm', or 'menuFromCommand'
-	Type string `yaml:"type"`
-
+	Type  string `yaml:"type"`
+	Key   string `yaml:"key"`
 	Title string `yaml:"title"`
 
-	// this only apply to input prompts
-	InitialValue      string `yaml:"initialValue"`
-	SuggestionsPreset string `yaml:"suggestionsPreset"`
+	// these only apply to input prompts
+	InitialValue string                   `yaml:"initialValue"`
+	Suggestions  CustomCommandSuggestions `yaml:"suggestions"`
 
 	// this only applies to confirm prompts
 	Body string `yaml:"body"`
@@ -380,6 +378,11 @@ type CustomCommandPrompt struct {
 	Filter      string `yaml:"filter"`
 	ValueFormat string `yaml:"valueFormat"`
 	LabelFormat string `yaml:"labelFormat"`
+}
+
+type CustomCommandSuggestions struct {
+	Preset  string `yaml:"preset"`
+	Command string `yaml:"command"`
 }
 
 type CustomCommandMenuOption struct {

--- a/pkg/gui/services/custom_commands/handler_creator.go
+++ b/pkg/gui/services/custom_commands/handler_creator.go
@@ -210,7 +210,7 @@ func (self *HandlerCreator) menuPromptFromCommand(prompt *config.CustomCommandPr
 		return self.c.Error(err)
 	}
 
-	menuItems := slices.Map(candidates, func(candidate *commandMenuEntry) *types.MenuItem {
+	menuItems := slices.Map(candidates, func(candidate *commandMenuItem) *types.MenuItem {
 		return &types.MenuItem{
 			LabelColumns: []string{candidate.label},
 			OnPress: func() error {

--- a/pkg/gui/services/custom_commands/menu_generator_test.go
+++ b/pkg/gui/services/custom_commands/menu_generator_test.go
@@ -14,7 +14,7 @@ func TestMenuGenerator(t *testing.T) {
 		filter      string
 		valueFormat string
 		labelFormat string
-		test        func([]*commandMenuEntry, error)
+		test        func([]*commandMenuItem, error)
 	}
 
 	scenarios := []scenario{
@@ -24,7 +24,7 @@ func TestMenuGenerator(t *testing.T) {
 			"(?P<remote>[a-z_]+)/(?P<branch>.*)",
 			"{{ .branch }}",
 			"Remote: {{ .remote }}",
-			func(actualEntry []*commandMenuEntry, err error) {
+			func(actualEntry []*commandMenuItem, err error) {
 				assert.NoError(t, err)
 				assert.EqualValues(t, "pr-1", actualEntry[0].value)
 				assert.EqualValues(t, "Remote: upstream", actualEntry[0].label)
@@ -36,7 +36,7 @@ func TestMenuGenerator(t *testing.T) {
 			"(?P<remote>[a-z]*)/(?P<branch>.*)",
 			"{{ .branch }}|{{ .remote }}",
 			"",
-			func(actualEntry []*commandMenuEntry, err error) {
+			func(actualEntry []*commandMenuItem, err error) {
 				assert.NoError(t, err)
 				assert.EqualValues(t, "pr-1|upstream", actualEntry[0].value)
 				assert.EqualValues(t, "pr-1|upstream", actualEntry[0].label)
@@ -48,10 +48,34 @@ func TestMenuGenerator(t *testing.T) {
 			"(?P<remote>[a-z]*)/(?P<branch>.*)",
 			"{{ .group_2 }}|{{ .group_1 }}",
 			"Remote: {{ .group_1 }}",
-			func(actualEntry []*commandMenuEntry, err error) {
+			func(actualEntry []*commandMenuItem, err error) {
 				assert.NoError(t, err)
 				assert.EqualValues(t, "pr-1|upstream", actualEntry[0].value)
 				assert.EqualValues(t, "Remote: upstream", actualEntry[0].label)
+			},
+		},
+		{
+			"No named groups",
+			"upstream/pr-1",
+			"([a-z]*)/(.*)",
+			"{{ .group_2 }}|{{ .group_1 }}",
+			"Remote: {{ .group_1 }}",
+			func(actualEntry []*commandMenuItem, err error) {
+				assert.NoError(t, err)
+				assert.EqualValues(t, "pr-1|upstream", actualEntry[0].value)
+				assert.EqualValues(t, "Remote: upstream", actualEntry[0].label)
+			},
+		},
+		{
+			"No filter",
+			"upstream/pr-1",
+			"",
+			"",
+			"",
+			func(actualEntry []*commandMenuItem, err error) {
+				assert.NoError(t, err)
+				assert.EqualValues(t, "upstream/pr-1", actualEntry[0].value)
+				assert.EqualValues(t, "upstream/pr-1", actualEntry[0].label)
 			},
 		},
 	}

--- a/pkg/gui/services/custom_commands/resolver.go
+++ b/pkg/gui/services/custom_commands/resolver.go
@@ -34,7 +34,12 @@ func (self *Resolver) resolvePrompt(
 		return nil, err
 	}
 
-	result.SuggestionsPreset, err = resolveTemplate(prompt.SuggestionsPreset)
+	result.Suggestions.Preset, err = resolveTemplate(prompt.Suggestions.Preset)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Suggestions.Command, err = resolveTemplate(prompt.Suggestions.Command)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/integration/tests/custom_commands/suggestions_command.go
+++ b/pkg/integration/tests/custom_commands/suggestions_command.go
@@ -5,8 +5,8 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
-var SuggestionsPreset = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Using a custom command that uses a suggestions preset in a prompt step",
+var SuggestionsCommand = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Using a custom command that uses a suggestions command in a prompt step",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
@@ -31,7 +31,7 @@ var SuggestionsPreset = NewIntegrationTest(NewIntegrationTestArgs{
 						Type:  "input",
 						Title: "Enter a branch name",
 						Suggestions: config.CustomCommandSuggestions{
-							Preset: "branches",
+							Command: "git branch --format='%(refname:short)'",
 						},
 					},
 				},

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -77,6 +77,7 @@ var tests = []*components.IntegrationTest{
 	custom_commands.MenuFromCommandsOutput,
 	custom_commands.MultiplePrompts,
 	custom_commands.OmitFromHistory,
+	custom_commands.SuggestionsCommand,
 	custom_commands.SuggestionsPreset,
 	diff.Diff,
 	diff.DiffAndApplyPatch,


### PR DESCRIPTION
This changes the interface a bit but it was only added earlier today so I doubt anybody is dependent on it yet.

This PR adds support for commands to generate suggestions. After making that change I realised it would be convenient if menuFromCommand also allowed you to just provide a command and nothing else, so I've implemented that too. For this to be truly symmetrical I'd add a way to parse and format the lines with suggestions in the same way we do in menuFromCommand but that can come later.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
