### PR TITLE
Fetch --all

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -94,6 +94,7 @@ git:
   mainBranches: [master, main]
   autoFetch: true
   autoRefresh: true
+  fetchAll: true # Pass --all flag when running git fetch. Set to false to fetch only origin (or the current branch's upstream remote if there is one)
   branchLogCmd: 'git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --'
   allBranchesLogCmd: 'git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium'
   overrideGpg: false # prevents lazygit from spawning a separate process when using GPG

--- a/pkg/commands/git_commands/sync.go
+++ b/pkg/commands/git_commands/sync.go
@@ -53,7 +53,7 @@ type FetchOptions struct {
 }
 
 // Fetch fetch git repo
-func (self *SyncCommands) Fetch(opts FetchOptions) error {
+func (self *SyncCommands) FetchCmdObj(opts FetchOptions) oscommands.ICmdObj {
 	cmdArgs := NewGitCmd("fetch").ToArgv()
 
 	cmdObj := self.cmd.New(cmdArgs)
@@ -62,7 +62,12 @@ func (self *SyncCommands) Fetch(opts FetchOptions) error {
 	} else {
 		cmdObj.PromptOnCredentialRequest()
 	}
-	return cmdObj.WithMutex(self.syncMutex).Run()
+	return cmdObj.WithMutex(self.syncMutex)
+}
+
+func (self *SyncCommands) Fetch(opts FetchOptions) error {
+	cmdObj := self.FetchCmdObj(opts)
+	return cmdObj.Run()
 }
 
 type PullOptions struct {

--- a/pkg/commands/git_commands/sync.go
+++ b/pkg/commands/git_commands/sync.go
@@ -50,16 +50,11 @@ func (self *SyncCommands) Push(opts PushOpts) error {
 
 type FetchOptions struct {
 	Background bool
-	RemoteName string
-	BranchName string
 }
 
 // Fetch fetch git repo
 func (self *SyncCommands) Fetch(opts FetchOptions) error {
-	cmdArgs := NewGitCmd("fetch").
-		ArgIf(opts.RemoteName != "", opts.RemoteName).
-		ArgIf(opts.BranchName != "", opts.BranchName).
-		ToArgv()
+	cmdArgs := NewGitCmd("fetch").ToArgv()
 
 	cmdObj := self.cmd.New(cmdArgs)
 	if opts.Background {

--- a/pkg/commands/git_commands/sync.go
+++ b/pkg/commands/git_commands/sync.go
@@ -54,7 +54,9 @@ type FetchOptions struct {
 
 // Fetch fetch git repo
 func (self *SyncCommands) FetchCmdObj(opts FetchOptions) oscommands.ICmdObj {
-	cmdArgs := NewGitCmd("fetch").ToArgv()
+	cmdArgs := NewGitCmd("fetch").
+		ArgIf(self.UserConfig.Git.FetchAll, "--all").
+		ToArgv()
 
 	cmdObj := self.cmd.New(cmdArgs)
 	if opts.Background {

--- a/pkg/commands/git_commands/sync_test.go
+++ b/pkg/commands/git_commands/sync_test.go
@@ -92,3 +92,40 @@ func TestSyncPush(t *testing.T) {
 		})
 	}
 }
+
+func TestSyncFetch(t *testing.T) {
+	type scenario struct {
+		testName string
+		opts     FetchOptions
+		test     func(oscommands.ICmdObj)
+	}
+
+	scenarios := []scenario{
+		{
+			testName: "Fetch in foreground",
+			opts:     FetchOptions{Background: false},
+			test: func(cmdObj oscommands.ICmdObj) {
+				assert.True(t, cmdObj.ShouldLog())
+				assert.Equal(t, cmdObj.GetCredentialStrategy(), oscommands.PROMPT)
+				assert.Equal(t, cmdObj.Args(), []string{"git", "fetch"})
+			},
+		},
+		{
+			testName: "Fetch in background",
+			opts:     FetchOptions{Background: true},
+			test: func(cmdObj oscommands.ICmdObj) {
+				assert.False(t, cmdObj.ShouldLog())
+				assert.Equal(t, cmdObj.GetCredentialStrategy(), oscommands.FAIL)
+				assert.Equal(t, cmdObj.Args(), []string{"git", "fetch"})
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		s := s
+		t.Run(s.testName, func(t *testing.T) {
+			instance := buildSyncCommands(commonDeps{})
+			s.test(instance.FetchCmdObj(s.opts))
+		})
+	}
+}

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -81,6 +81,7 @@ type GitConfig struct {
 	SkipHookPrefix      string                        `yaml:"skipHookPrefix"`
 	AutoFetch           bool                          `yaml:"autoFetch"`
 	AutoRefresh         bool                          `yaml:"autoRefresh"`
+	FetchAll            bool                          `yaml:"fetchAll"`
 	BranchLogCmd        string                        `yaml:"branchLogCmd"`
 	AllBranchesLogCmd   string                        `yaml:"allBranchesLogCmd"`
 	OverrideGpg         bool                          `yaml:"overrideGpg"`
@@ -453,6 +454,7 @@ func GetDefaultConfig() *UserConfig {
 			MainBranches:        []string{"master", "main"},
 			AutoFetch:           true,
 			AutoRefresh:         true,
+			FetchAll:            true,
 			BranchLogCmd:        "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",
 			AllBranchesLogCmd:   "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium",
 			DisableForcePushing: false,


### PR DESCRIPTION
- **PR Description**

When doing a background fetch, or when pressing `f` in the files panel, fetch all remotes. This is useful when multiple remotes are configured.

I couldn't come up with any reason why this could be undesirable, so I didn't make this configurable. Let me know if you'd rather have a config for this.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
