### PR TITLE
Set defaults colours to 'default', not 'white'

### DIFF
--- a/pkg/theme/theme.go
+++ b/pkg/theme/theme.go
@@ -7,8 +7,11 @@ import (
 )
 
 var (
+	// DefaultTextColor is the default text color
+	DefaultTextColor = style.FgDefault
+
 	// GocuiDefaultTextColor does the same as DefaultTextColor but this one only colors gocui default text colors
-	GocuiDefaultTextColor gocui.Attribute
+	GocuiDefaultTextColor = gocui.ColorDefault
 
 	// ActiveBorderColor is the border color of the active frame
 	ActiveBorderColor gocui.Attribute
@@ -20,9 +23,6 @@ var (
 	GocuiSelectedLineBgColor gocui.Attribute
 
 	OptionsColor gocui.Attribute
-
-	// DefaultTextColor is the default text color
-	DefaultTextColor = style.FgWhite
 
 	// SelectedLineBgColor is the background color for the selected line
 	SelectedLineBgColor = style.New()


### PR DESCRIPTION
'white' is great on dark themes, and terrible on light themes.

This shouldn't make any difference because we manually override these variables before showing the gui but no harm in having sensible defaults regardless

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc
