### PR TITLE
Stop hiding underscores for VSCode

### DIFF
--- a/pkg/gui/style/text_style.go
+++ b/pkg/gui/style/text_style.go
@@ -1,8 +1,6 @@
 package style
 
 import (
-	"os"
-
 	"github.com/gookit/color"
 )
 
@@ -26,23 +24,6 @@ import (
 // So that we aren't rederiving the underlying style each time we want to print
 // a string, we derive it when a new TextStyle is created and store it in the
 // `style` field.
-
-// See https://github.com/xtermjs/xterm.js/issues/4238
-// VSCode is soon to fix this in an upcoming update.
-// Once that's done, we can scrap the HIDE_UNDERSCORES variable
-var (
-	underscoreEnvChecked bool
-	hideUnderscores      bool
-)
-
-func hideUnderScores() bool {
-	if !underscoreEnvChecked {
-		hideUnderscores = os.Getenv("TERM_PROGRAM") == "vscode"
-		underscoreEnvChecked = true
-	}
-
-	return hideUnderscores
-}
 
 type TextStyle struct {
 	fg         *Color
@@ -83,10 +64,6 @@ func (b TextStyle) SetBold() TextStyle {
 }
 
 func (b TextStyle) SetUnderline() TextStyle {
-	if hideUnderScores() {
-		return b
-	}
-
 	b.decoration.SetUnderline()
 	b.Style = b.deriveStyle()
 	return b


### PR DESCRIPTION
VSCode had an issue in their terminal where underscores were printed all over the place. That has now been fixed.
See https://github.com/jesseduffield/lazygit/issues/2294 and https://github.com/xtermjs/xterm.js/issues/4238

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
