### PR TITLE
Better prompt for discarding old file changes

### DIFF
--- a/pkg/commands/models/commit_file.go
+++ b/pkg/commands/models/commit_file.go
@@ -15,3 +15,11 @@ func (f *CommitFile) ID() string {
 func (f *CommitFile) Description() string {
 	return f.Name
 }
+
+func (f *CommitFile) Added() bool {
+	return f.ChangeStatus == "A"
+}
+
+func (f *CommitFile) Deleted() bool {
+	return f.ChangeStatus == "D"
+}

--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -161,9 +161,16 @@ func (self *CommitFilesController) discard(node *filetree.CommitFileNode) error 
 		return err
 	}
 
+	prompt := self.c.Tr.DiscardFileChangesPrompt
+	if node.File.Added() {
+		prompt = self.c.Tr.DiscardAddedFileChangesPrompt
+	} else if node.File.Deleted() {
+		prompt = self.c.Tr.DiscardDeletedFileChangesPrompt
+	}
+
 	return self.c.Confirm(types.ConfirmOpts{
 		Title:  self.c.Tr.DiscardFileChangesTitle,
-		Prompt: self.c.Tr.DiscardFileChangesPrompt,
+		Prompt: prompt,
 		HandleConfirm: func() error {
 			return self.c.WithWaitingStatus(self.c.Tr.RebasingStatus, func() error {
 				self.c.LogAction(self.c.Tr.Actions.DiscardOldFileChange)

--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -153,6 +153,10 @@ func (self *CommitFilesController) checkout(node *filetree.CommitFileNode) error
 }
 
 func (self *CommitFilesController) discard(node *filetree.CommitFileNode) error {
+	if node.File == nil {
+		return self.c.ErrorMsg(self.c.Tr.DiscardNotSupportedForDirectory)
+	}
+
 	if ok, err := self.c.Helpers().PatchBuilding.ValidateNormalWorkingTreeState(); !ok {
 		return err
 	}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -268,6 +268,7 @@ type TranslationSet struct {
 	DiscardOldFileChange                string
 	DiscardFileChangesTitle             string
 	DiscardFileChangesPrompt            string
+	DiscardNotSupportedForDirectory     string
 	DisabledForGPG                      string
 	CreateRepo                          string
 	BareRepo                            string
@@ -955,6 +956,7 @@ func EnglishTranslationSet() TranslationSet {
 		DiscardOldFileChange:                "Discard this commit's changes to this file",
 		DiscardFileChangesTitle:             "Discard file changes",
 		DiscardFileChangesPrompt:            "Are you sure you want to discard this commit's changes to this file? If this file was created in this commit, it will be deleted",
+		DiscardNotSupportedForDirectory:     "Discarding changes is not supported for entire directories. Please use a custom patch for this.",
 		DisabledForGPG:                      "Feature not available for users using GPG",
 		CreateRepo:                          "Not in a git repository. Create a new git repository? (y/n): ",
 		BareRepo:                            "You've attempted to open Lazygit in a bare repo but Lazygit does not yet support bare repos. Open most recent repo? (y/n) ",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -268,6 +268,8 @@ type TranslationSet struct {
 	DiscardOldFileChange                string
 	DiscardFileChangesTitle             string
 	DiscardFileChangesPrompt            string
+	DiscardAddedFileChangesPrompt       string
+	DiscardDeletedFileChangesPrompt     string
 	DiscardNotSupportedForDirectory     string
 	DisabledForGPG                      string
 	CreateRepo                          string
@@ -955,7 +957,9 @@ func EnglishTranslationSet() TranslationSet {
 		CheckoutCommitFile:                  "Checkout file",
 		DiscardOldFileChange:                "Discard this commit's changes to this file",
 		DiscardFileChangesTitle:             "Discard file changes",
-		DiscardFileChangesPrompt:            "Are you sure you want to discard this commit's changes to this file? If this file was created in this commit, it will be deleted",
+		DiscardFileChangesPrompt:            "Are you sure you want to discard this commit's changes to this file?",
+		DiscardAddedFileChangesPrompt:       "Are you sure you want to discard this commit's changes to this file? The file was added in this commit, so it will be deleted again.",
+		DiscardDeletedFileChangesPrompt:     "Are you sure you want to discard this commit's changes to this file? The file was deleted in this commit, so it will reappear.",
 		DiscardNotSupportedForDirectory:     "Discarding changes is not supported for entire directories. Please use a custom patch for this.",
 		DisabledForGPG:                      "Feature not available for users using GPG",
 		CreateRepo:                          "Not in a git repository. Create a new git repository? (y/n): ",

--- a/pkg/integration/tests/commit/discard_old_file_change.go
+++ b/pkg/integration/tests/commit/discard_old_file_change.go
@@ -43,7 +43,7 @@ var DiscardOldFileChange = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().Confirmation().
 			Title(Equals("Discard file changes")).
-			Content(Contains("Are you sure you want to discard this commit's changes to this file?")).
+			Content(Equals("Are you sure you want to discard this commit's changes to this file? The file was added in this commit, so it will be deleted again.")).
 			Confirm()
 
 		t.Views().CommitFiles().


### PR DESCRIPTION
- **PR Description**

Lazygit knows what kind of file change we are discarding, so there doesn't have to be any "if" in the prompt text.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
