### PR TITLE
Add emacsclient both GUI and TTY editor presets

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -291,7 +291,7 @@ os:
   editPreset: 'vscode'
 ```
 
-Supported presets are `vim`, `nvim`, `emacs`, `nano`, `vscode`, `sublime`, `bbedit`,
+Supported presets are `vim`, `nvim`, `emacs`, `emacsclient`, `emacsclient_tty`, `nano`, `vscode`, `sublime`, `bbedit`,
 `kakoune`, `helix`, and `xcode`. In many cases lazygit will be able to guess the right preset
 from your $(git config core.editor), or an environment variable such as $VISUAL or $EDITOR.
 

--- a/pkg/config/editor_presets.go
+++ b/pkg/config/editor_presets.go
@@ -50,6 +50,18 @@ func getPreset(osConfig *OSConfig, guessDefaultEditor func() string) *editPreset
 			editAtLineAndWaitTemplate: "hx -- {{filename}}:{{line}}",
 			editInTerminal:            true,
 		},
+		"emacsclient": {
+			editTemplate:              "emacsclient --create-frame --alternate-editor="" {{filename}}",
+			editAtLineTemplate:        "emacsclient --create-frame --alternate-editor="" +{{line}} {{filename}}",
+			editAtLineAndWaitTemplate: "emacsclient --create-frame --alternate-editor="" +{{line}} {{filename}}",
+			editInTerminal:            true,
+		},
+		"emacsclient_tty": {
+			editTemplate:              "emacsclient --create-frame --tty --alternate-editor="" {{filename}}",
+			editAtLineTemplate:        "emacsclient --create-frame --tty --alternate-editor="" +{{line}} {{filename}}",
+			editAtLineAndWaitTemplate: "emacsclient --create-frame --tty --alternate-editor="" +{{line}} {{filename}}",
+			editInTerminal:            true,
+		},
 		"vscode": {
 			editTemplate:              "code --reuse-window -- {{filename}}",
 			editAtLineTemplate:        "code --reuse-window --goto -- {{filename}}:{{line}}",


### PR DESCRIPTION
- **PR Description**

In this PR I'm adding emacsclient (both TTY and GUI forms) into presets.

I have marked this as draft because:
1. I'm not a Go developer, so I might have done something stupid without knowing, although the changes are very minor and the chance of doing something stupid is relatively low 😅 
2. I don't have Go development environment o my machine, so
  2.1. I cannot test it directly, but I have tested it via manual modifications on my own lazygit config
  2.2. I cannot run the Cheatsheets
3. I wanted to add tests, but I realized vscode has extensive tests, but Emacs has three lines, and helix has none. So I don't know to what extent I have to make the tests. Let me know what are the requirements and I will do my best.
4. This is the first preset that has a name with two parts, so I chose the `_tty` to differentiate the GUI from TTY. I didn't find any instructions on naming convention 

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
