### PR TITLE
Allow discarding changes only from local commits

### DIFF
--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -153,6 +153,11 @@ func (self *CommitFilesController) checkout(node *filetree.CommitFileNode) error
 }
 
 func (self *CommitFilesController) discard(node *filetree.CommitFileNode) error {
+	parentContext, ok := self.c.CurrentContext().GetParentContext()
+	if !ok || parentContext.GetKey() != context.LOCAL_COMMITS_CONTEXT_KEY {
+		return self.c.ErrorMsg(self.c.Tr.CanOnlyDiscardFromLocalCommits)
+	}
+
 	if node.File == nil {
 		return self.c.ErrorMsg(self.c.Tr.DiscardNotSupportedForDirectory)
 	}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -265,6 +265,7 @@ type TranslationSet struct {
 	ViewItemFiles                       string
 	CommitFilesTitle                    string
 	CheckoutCommitFile                  string
+	CanOnlyDiscardFromLocalCommits      string
 	DiscardOldFileChange                string
 	DiscardFileChangesTitle             string
 	DiscardFileChangesPrompt            string
@@ -955,6 +956,7 @@ func EnglishTranslationSet() TranslationSet {
 		ViewItemFiles:                       "View selected item's files",
 		CommitFilesTitle:                    "Commit files",
 		CheckoutCommitFile:                  "Checkout file",
+		CanOnlyDiscardFromLocalCommits:      "Changes can only be discarded from local commits",
 		DiscardOldFileChange:                "Discard this commit's changes to this file",
 		DiscardFileChangesTitle:             "Discard file changes",
 		DiscardFileChangesPrompt:            "Are you sure you want to discard this commit's changes to this file?",

--- a/pkg/integration/tests/stash/prevent_discarding_file_changes.go
+++ b/pkg/integration/tests/stash/prevent_discarding_file_changes.go
@@ -1,0 +1,41 @@
+package stash
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var PreventDiscardingFileChanges = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Check that it is not allowed to discard changes to a file of a stash",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("initial commit")
+		shell.CreateFile("file", "content")
+		shell.GitAddAll()
+		shell.Stash("stash one")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().IsEmpty()
+
+		t.Views().Stash().
+			Focus().
+			Lines(
+				Contains("stash one").IsSelected(),
+			).
+			PressEnter()
+
+		t.Views().CommitFiles().
+			IsFocused().
+			Lines(
+				Contains("file").IsSelected(),
+			).
+			Press(keys.Universal.Remove)
+
+		t.ExpectPopup().Confirmation().
+			Title(Equals("Error")).
+			Content(Contains("Changes can only be discarded from local commits")).
+			Confirm()
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -155,6 +155,7 @@ var tests = []*components.IntegrationTest{
 	stash.CreateBranch,
 	stash.Drop,
 	stash.Pop,
+	stash.PreventDiscardingFileChanges,
 	stash.Rename,
 	stash.Stash,
 	stash.StashAll,


### PR DESCRIPTION
- **PR Description**

The "discard file changes" command was also active when looking at the files of a stash, or at the files of a branch commit or tag commit. Disable the command for those.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
