### PR TITLE
Fix focus issue when opening recent-repos menu at launch

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -120,6 +120,11 @@ func NewApp(config config.AppConfigurer, common *common.Common) (*App, error) {
 		return app, err
 	}
 
+	// used for testing purposes
+	if os.Getenv("SHOW_RECENT_REPOS") == "true" {
+		showRecentRepos = true
+	}
+
 	app.Gui, err = gui.NewGui(common, config, gitVersion, updater, showRecentRepos, dirName)
 	if err != nil {
 		return app, err

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -179,7 +179,7 @@ func (gui *Gui) onInitialViewsCreationForRepo() error {
 		}
 	}
 
-	initialContext := gui.c.CurrentSideContext()
+	initialContext := gui.c.CurrentContext()
 	if err := gui.c.ActivateContext(initialContext); err != nil {
 		return err
 	}

--- a/pkg/integration/components/runner.go
+++ b/pkg/integration/components/runner.go
@@ -187,6 +187,11 @@ func getLazygitCommand(test *IntegrationTest, paths Paths, rootDir string, sandb
 	if sandbox {
 		cmdObj.AddEnvVars(fmt.Sprintf("%s=%s", SANDBOX_ENV_VAR, "true"))
 	}
+	if test.ExtraEnvVars() != nil {
+		for key, value := range test.ExtraEnvVars() {
+			cmdObj.AddEnvVars(fmt.Sprintf("%s=%s", key, value))
+		}
+	}
 
 	if keyPressDelay > 0 {
 		cmdObj.AddEnvVars(fmt.Sprintf("KEY_PRESS_DELAY=%d", keyPressDelay))

--- a/pkg/integration/components/test.go
+++ b/pkg/integration/components/test.go
@@ -23,6 +23,7 @@ type IntegrationTest struct {
 	name         string
 	description  string
 	extraCmdArgs []string
+	extraEnvVars map[string]string
 	skip         bool
 	setupRepo    func(shell *Shell)
 	setupConfig  func(config *config.AppConfig)
@@ -47,7 +48,8 @@ type NewIntegrationTestArgs struct {
 	// additional args passed to lazygit
 	ExtraCmdArgs []string
 	// for when a test is flakey
-	Skip bool
+	ExtraEnvVars map[string]string
+	Skip         bool
 	// to run a test only on certain git versions
 	GitVersion GitVersionRestriction
 }
@@ -112,6 +114,7 @@ func NewIntegrationTest(args NewIntegrationTestArgs) *IntegrationTest {
 		name:         name,
 		description:  args.Description,
 		extraCmdArgs: args.ExtraCmdArgs,
+		extraEnvVars: args.ExtraEnvVars,
 		skip:         args.Skip,
 		setupRepo:    args.SetupRepo,
 		setupConfig:  args.SetupConfig,
@@ -130,6 +133,10 @@ func (self *IntegrationTest) Description() string {
 
 func (self *IntegrationTest) ExtraCmdArgs() []string {
 	return self.extraCmdArgs
+}
+
+func (self *IntegrationTest) ExtraEnvVars() map[string]string {
+	return self.extraEnvVars
 }
 
 func (self *IntegrationTest) Skip() bool {

--- a/pkg/integration/tests/misc/recent_repos_on_launch.go
+++ b/pkg/integration/tests/misc/recent_repos_on_launch.go
@@ -1,0 +1,28 @@
+package misc
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+// Couldn't find an easy way to actually reproduce the situation of opening outside a repo,
+// so I'm introducing a hacky env var to force lazygit to show the recent repos meu upon opening.
+
+var RecentReposOnLaunch = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "When opening opening to a menu, focus is correctly given to the menu",
+	ExtraCmdArgs: []string{},
+	ExtraEnvVars: map[string]string{
+		"SHOW_RECENT_REPOS": "true",
+	},
+	Skip:        false,
+	SetupConfig: func(config *config.AppConfig) {},
+	SetupRepo:   func(shell *Shell) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.ExpectPopup().Menu().
+			Title(Equals("Recent repositories")).
+			Select(Contains("Cancel")).
+			Confirm()
+
+		t.Views().Files().IsFocused()
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -120,6 +120,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.SwapWithConflict,
 	misc.ConfirmOnQuit,
 	misc.InitialOpen,
+	misc.RecentReposOnLaunch,
 	patch_building.Apply,
 	patch_building.ApplyInReverse,
 	patch_building.ApplyInReverseWithConflict,


### PR DESCRIPTION
I don't know why we were setting the initial context to CurrentSideContext and not just CurrentContext in the first place. If there is no current context in either case it'll default to the files context. So the only issue is if we anticipated that some random context would be focused and we didn't want to activate that. But I can't think of any situation where that would happen.

Looking back through the git log, I'm confident this change won't break anything. We've got good integration test coverage anyway.

Now if only we had a way to add a test for this fix...

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
