### PR TITLE
Improve yaml_utils

### DIFF
--- a/pkg/utils/formatting_test.go
+++ b/pkg/utils/formatting_test.go
@@ -79,9 +79,7 @@ func TestGetPadWidths(t *testing.T) {
 
 	for _, test := range tests {
 		output := getPadWidths(test.input)
-		if !assert.EqualValues(t, output, test.expected) {
-			t.Errorf("getPadWidths(%v) = %v, want %v", test.input, output, test.expected)
-		}
+		assert.EqualValues(t, output, test.expected)
 	}
 }
 
@@ -219,8 +217,6 @@ func TestRenderDisplayStrings(t *testing.T) {
 
 	for _, test := range tests {
 		output := RenderDisplayStrings(test.input, test.columnAlignments)
-		if !assert.EqualValues(t, output, test.expected) {
-			t.Errorf("RenderDisplayStrings(%v) = %v, want %v", test.input, output, test.expected)
-		}
+		assert.EqualValues(t, output, test.expected)
 	}
 }

--- a/pkg/utils/rebase_todo_test.go
+++ b/pkg/utils/rebase_todo_test.go
@@ -321,18 +321,12 @@ func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
 			actualTodos, actualErr := moveFixupCommitDown(scenario.todos, scenario.originalSha, scenario.fixupSha)
 
 			if scenario.expectedErr == nil {
-				if !assert.NoError(t, actualErr) {
-					t.Errorf("Expected no error, got: %v", actualErr)
-				}
+				assert.NoError(t, actualErr)
 			} else {
-				if !assert.EqualError(t, actualErr, scenario.expectedErr.Error()) {
-					t.Errorf("Expected err: %v, got: %v", scenario.expectedErr, actualErr)
-				}
+				assert.EqualError(t, actualErr, scenario.expectedErr.Error())
 			}
 
-			if !assert.EqualValues(t, actualTodos, scenario.expectedTodos) {
-				t.Errorf("Expected todos: %v, got: %v", scenario.expectedTodos, actualTodos)
-			}
+			assert.EqualValues(t, actualTodos, scenario.expectedTodos)
 		})
 	}
 }

--- a/pkg/utils/yaml_utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils/yaml_utils.go
@@ -1,6 +1,7 @@
 package yaml_utils
 
 import (
+	"errors"
 	"fmt"
 
 	"gopkg.in/yaml.v3"
@@ -23,6 +24,10 @@ func UpdateYamlValue(yamlBytes []byte, path []string, value string) ([]byte, err
 	}
 
 	body := node.Content[0]
+
+	if body.Kind != yaml.MappingNode {
+		return yamlBytes, errors.New("yaml document is not a dictionary")
+	}
 
 	updateYamlNode(body, path, value)
 

--- a/pkg/utils/yaml_utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils/yaml_utils.go
@@ -57,10 +57,8 @@ func updateYamlNode(node *yaml.Node, path []string, value string) error {
 	}
 
 	key := path[0]
-	for i := 0; i < len(node.Content)-1; i += 2 {
-		if node.Content[i].Value == key {
-			return updateYamlNode(node.Content[i+1], path[1:], value)
-		}
+	if _, valueNode := lookupKey(node, key); valueNode != nil {
+		return updateYamlNode(valueNode, path[1:], value)
 	}
 
 	// if the key doesn't exist, we'll add it
@@ -86,4 +84,14 @@ func updateYamlNode(node *yaml.Node, path []string, value string) error {
 		Value: key,
 	}, newNode)
 	return updateYamlNode(newNode, path[1:], value)
+}
+
+func lookupKey(node *yaml.Node, key string) (*yaml.Node, *yaml.Node) {
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i], node.Content[i+1]
+		}
+	}
+
+	return nil, nil
 }

--- a/pkg/utils/yaml_utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils/yaml_utils.go
@@ -52,6 +52,10 @@ func updateYamlNode(node *yaml.Node, path []string, value string) error {
 		return nil
 	}
 
+	if node.Kind != yaml.MappingNode {
+		return errors.New("yaml node in path is not a dictionary")
+	}
+
 	key := path[0]
 	for i := 0; i < len(node.Content)-1; i += 2 {
 		if node.Content[i].Value == key {

--- a/pkg/utils/yaml_utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils/yaml_utils.go
@@ -15,6 +15,13 @@ func UpdateYamlValue(yamlBytes []byte, path []string, value string) ([]byte, err
 		return nil, fmt.Errorf("failed to parse YAML: %w", err)
 	}
 
+	// Empty document: need to create the top-level map ourselves
+	if len(node.Content) == 0 {
+		node.Content = append(node.Content, &yaml.Node{
+			Kind: yaml.MappingNode,
+		})
+	}
+
 	body := node.Content[0]
 
 	updateYamlNode(body, path, value)

--- a/pkg/utils/yaml_utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils/yaml_utils.go
@@ -7,7 +7,7 @@ import (
 )
 
 // takes a yaml document in bytes, a path to a key, and a value to set. The value must be a scalar.
-func UpdateYaml(yamlBytes []byte, path []string, value string) ([]byte, error) {
+func UpdateYamlValue(yamlBytes []byte, path []string, value string) ([]byte, error) {
 	// Parse the YAML file.
 	var node yaml.Node
 	err := yaml.Unmarshal(yamlBytes, &node)

--- a/pkg/utils/yaml_utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils/yaml_utils.go
@@ -64,12 +64,26 @@ func updateYamlNode(node *yaml.Node, path []string, value string) error {
 	}
 
 	// if the key doesn't exist, we'll add it
+
+	// at end of path: add the new key, done
+	if len(path) == 1 {
+		node.Content = append(node.Content, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: key,
+		}, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: value,
+		})
+		return nil
+	}
+
+	// otherwise, create the missing intermediate node and continue
+	newNode := &yaml.Node{
+		Kind: yaml.MappingNode,
+	}
 	node.Content = append(node.Content, &yaml.Node{
 		Kind:  yaml.ScalarNode,
 		Value: key,
-	}, &yaml.Node{
-		Kind:  yaml.ScalarNode,
-		Value: value,
-	})
-	return nil
+	}, newNode)
+	return updateYamlNode(newNode, path[1:], value)
 }

--- a/pkg/utils/yaml_utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils/yaml_utils_test.go
@@ -1,6 +1,10 @@
 package yaml_utils
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestUpdateYaml(t *testing.T) {
 	tests := []struct {
@@ -49,16 +53,14 @@ func TestUpdateYaml(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			out, err := UpdateYaml([]byte(test.in), test.path, test.value)
-			if test.expectedErr != "" {
-				if err == nil {
-					t.Errorf("expected error %q but got none", test.expectedErr)
-				}
-			} else if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			} else if string(out) != test.expectedOut {
-				t.Errorf("expected %q but got %q", test.expectedOut, string(out))
+			out, actualErr := UpdateYaml([]byte(test.in), test.path, test.value)
+			if test.expectedErr == "" {
+				assert.NoError(t, actualErr)
+			} else {
+				assert.EqualError(t, actualErr, test.expectedErr)
 			}
+
+			assert.Equal(t, test.expectedOut, string(out))
 		})
 	}
 }

--- a/pkg/utils/yaml_utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils/yaml_utils_test.go
@@ -56,6 +56,16 @@ func TestUpdateYamlValue(t *testing.T) {
 			expectedOut: "foo:\n    bar: qux\n",
 			expectedErr: "",
 		},
+
+		// Error cases
+		{
+			name:        "existing document is not a dictionary",
+			in:          "42\n",
+			path:        []string{"foo"},
+			value:       "bar",
+			expectedOut: "42\n",
+			expectedErr: "yaml document is not a dictionary",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/utils/yaml_utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils/yaml_utils_test.go
@@ -66,6 +66,14 @@ func TestUpdateYamlValue(t *testing.T) {
 			expectedOut: "42\n",
 			expectedErr: "yaml document is not a dictionary",
 		},
+		{
+			name:        "trying to update a note that is not a scalar",
+			in:          "foo: [1, 2, 3]\n",
+			path:        []string{"foo"},
+			value:       "bar",
+			expectedOut: "foo: [1, 2, 3]\n",
+			expectedErr: "yaml node is not a scalar",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/utils/yaml_utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils/yaml_utils_test.go
@@ -74,6 +74,14 @@ func TestUpdateYamlValue(t *testing.T) {
 			expectedOut: "foo: [1, 2, 3]\n",
 			expectedErr: "yaml node is not a scalar",
 		},
+		{
+			name:        "not all path elements are dictionaries",
+			in:          "foo:\n  bar: [1, 2, 3]\n",
+			path:        []string{"foo", "bar", "baz"},
+			value:       "qux",
+			expectedOut: "foo:\n  bar: [1, 2, 3]\n",
+			expectedErr: "yaml node in path is not a dictionary",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/utils/yaml_utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils/yaml_utils_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUpdateYaml(t *testing.T) {
+func TestUpdateYamlValue(t *testing.T) {
 	tests := []struct {
 		name        string
 		in          string
@@ -53,7 +53,7 @@ func TestUpdateYaml(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			out, actualErr := UpdateYaml([]byte(test.in), test.path, test.value)
+			out, actualErr := UpdateYamlValue([]byte(test.in), test.path, test.value)
 			if test.expectedErr == "" {
 				assert.NoError(t, actualErr)
 			} else {

--- a/pkg/utils/yaml_utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils/yaml_utils_test.go
@@ -64,6 +64,14 @@ func TestUpdateYamlValue(t *testing.T) {
 			expectedOut: "foo:\n    bar:\n        baz: qux\n",
 			expectedErr: "",
 		},
+		{
+			name:        "don't rewrite file if value didn't change",
+			in:          "foo:\n  bar: baz\n",
+			path:        []string{"foo", "bar"},
+			value:       "baz",
+			expectedOut: "foo:\n  bar: baz\n",
+			expectedErr: "",
+		},
 
 		// Error cases
 		{
@@ -140,6 +148,14 @@ func TestRenameYamlKey(t *testing.T) {
 			newKey: "qux",
 			// indentation is not preserved. See https://github.com/go-yaml/yaml/issues/899
 			expectedOut: "qux:\n    bar: 5\n",
+			expectedErr: "",
+		},
+		{
+			name:        "don't rewrite file if value didn't change",
+			in:          "foo:\n  bar: 5\n",
+			path:        []string{"nonExistingKey"},
+			newKey:      "qux",
+			expectedOut: "foo:\n  bar: 5\n",
 			expectedErr: "",
 		},
 

--- a/pkg/utils/yaml_utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils/yaml_utils_test.go
@@ -32,6 +32,14 @@ func TestUpdateYamlValue(t *testing.T) {
 			expectedErr: "",
 		},
 		{
+			name:        "add new key and value when document was empty",
+			in:          "",
+			path:        []string{"foo"},
+			value:       "bar",
+			expectedOut: "foo: bar\n",
+			expectedErr: "",
+		},
+		{
 			name:        "preserve inline comment",
 			in:          "foo: bar # my comment\n",
 			path:        []string{"foo2"},

--- a/pkg/utils/yaml_utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils/yaml_utils_test.go
@@ -56,6 +56,14 @@ func TestUpdateYamlValue(t *testing.T) {
 			expectedOut: "foo:\n    bar: qux\n",
 			expectedErr: "",
 		},
+		{
+			name:        "nested where parents doesn't exist yet",
+			in:          "",
+			path:        []string{"foo", "bar", "baz"},
+			value:       "qux",
+			expectedOut: "foo:\n    bar:\n        baz: qux\n",
+			expectedErr: "",
+		},
 
 		// Error cases
 		{


### PR DESCRIPTION
- Rename `UpdateYaml` to `UpdateYamlValue`, since we will add other ways of updating yaml documents in the future
- Fix an error in `UpdateYamlValue` where trying to update the value of `gui.someOption` would add a `someOption` key at root level if `gui` doesn't exist
- Add error checking for several things that could go wrong in `UpdateYamlValue`
- Add a new function `RenameYamlKey`