### PR TITLE
Always show branch heads in diff pane

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -212,6 +212,7 @@ func (self *CommitCommands) ShowCmdObj(sha string, filterPath string, ignoreWhit
 		Arg("--color="+self.UserConfig.Git.Paging.ColorArg).
 		Arg(fmt.Sprintf("--unified=%d", contextSize)).
 		Arg("--stat").
+		Arg("--decorate").
 		Arg("-p").
 		Arg(sha).
 		ArgIf(ignoreWhitespace, "--ignore-all-space").

--- a/pkg/commands/git_commands/commit_test.go
+++ b/pkg/commands/git_commands/commit_test.go
@@ -212,28 +212,28 @@ func TestCommitShowCmdObj(t *testing.T) {
 			filterPath:       "",
 			contextSize:      3,
 			ignoreWhitespace: false,
-			expected:         []string{"show", "--submodule", "--color=always", "--unified=3", "--stat", "-p", "1234567890"},
+			expected:         []string{"show", "--submodule", "--color=always", "--unified=3", "--stat", "--decorate", "-p", "1234567890"},
 		},
 		{
 			testName:         "Default case with filter path",
 			filterPath:       "file.txt",
 			contextSize:      3,
 			ignoreWhitespace: false,
-			expected:         []string{"show", "--submodule", "--color=always", "--unified=3", "--stat", "-p", "1234567890", "--", "file.txt"},
+			expected:         []string{"show", "--submodule", "--color=always", "--unified=3", "--stat", "--decorate", "-p", "1234567890", "--", "file.txt"},
 		},
 		{
 			testName:         "Show diff with custom context size",
 			filterPath:       "",
 			contextSize:      77,
 			ignoreWhitespace: false,
-			expected:         []string{"show", "--submodule", "--color=always", "--unified=77", "--stat", "-p", "1234567890"},
+			expected:         []string{"show", "--submodule", "--color=always", "--unified=77", "--stat", "--decorate", "-p", "1234567890"},
 		},
 		{
 			testName:         "Show diff, ignoring whitespace",
 			filterPath:       "",
 			contextSize:      77,
 			ignoreWhitespace: true,
-			expected:         []string{"show", "--submodule", "--color=always", "--unified=77", "--stat", "-p", "1234567890", "--ignore-all-space"},
+			expected:         []string{"show", "--submodule", "--color=always", "--unified=77", "--stat", "--decorate", "-p", "1234567890", "--ignore-all-space"},
 		},
 	}
 


### PR DESCRIPTION
The first line of the diff pane would show branch heads (e.g.

```
commit dd9100ccc8b69a8b14b21a84e34854b5acfb871a (mybranch, origin/mybranch)
```

only when a pager is used. The reason is that the default of the --decorate option to git show is "auto", which means to show the decoration only when output goes to a tty. Lazygit uses a pty only when a pager is used, so the decoration wouldn't show when no pager is used.

Since the branch head annotation is useful and we always want to see it, force it by explicitly passing --decorate.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
