### PR TITLE
fix: typo EnteRefName

### DIFF
--- a/pkg/gui/controllers/diffing_menu_action.go
+++ b/pkg/gui/controllers/diffing_menu_action.go
@@ -35,7 +35,7 @@ func (self *DiffingMenuAction) Call() error {
 			Label: self.c.Tr.EnterRefToDiff,
 			OnPress: func() error {
 				return self.c.Prompt(types.PromptOpts{
-					Title:               self.c.Tr.EnteRefName,
+					Title:               self.c.Tr.EnterRefName,
 					FindSuggestionsFunc: self.c.Helpers().Suggestions.GetRefsSuggestionsFunc(),
 					HandleConfirm: func(response string) error {
 						self.c.Modes().Diffing.Ref = strings.TrimSpace(response)

--- a/pkg/i18n/chinese.go
+++ b/pkg/i18n/chinese.go
@@ -359,7 +359,7 @@ func chineseTranslationSet() TranslationSet {
 		MustExitFilterModePrompt:            "命令在过滤模式下不可用。退出过滤模式？",
 		Diff:                                "差异",
 		EnterRefToDiff:                      "输入 ref 以 diff",
-		EnteRefName:                         "输入 ref：",
+		EnterRefName:                        "输入 ref：",
 		ExitDiffMode:                        "退出差异模式",
 		DiffingMenuTitle:                    "正在 diff",
 		SwapDiff:                            "反向 diff",

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -314,7 +314,7 @@ func dutchTranslationSet() TranslationSet {
 		MustExitFilterModePrompt:            "Command niet beschikbaar in filter modus. Sluit filter modus?",
 		Diff:                                "Diff",
 		EnterRefToDiff:                      "Vul in ref naar diff",
-		EnteRefName:                         "Vul in ref:",
+		EnterRefName:                        "Vul in ref:",
 		ExitDiffMode:                        "Sluit diff mode",
 		DiffingMenuTitle:                    "Diffen",
 		SwapDiff:                            "Keer diff richting om",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -403,7 +403,7 @@ type TranslationSet struct {
 	MustExitFilterModePrompt            string
 	Diff                                string
 	EnterRefToDiff                      string
-	EnteRefName                         string
+	EnterRefName                        string
 	ExitDiffMode                        string
 	DiffingMenuTitle                    string
 	SwapDiff                            string
@@ -1093,7 +1093,7 @@ func EnglishTranslationSet() TranslationSet {
 		MustExitFilterModePrompt:            "Command not available in filtered mode. Exit filtered mode?",
 		Diff:                                "Diff",
 		EnterRefToDiff:                      "Enter ref to diff",
-		EnteRefName:                         "Enter ref:",
+		EnterRefName:                        "Enter ref:",
 		ExitDiffMode:                        "Exit diff mode",
 		DiffingMenuTitle:                    "Diffing",
 		SwapDiff:                            "Reverse diff direction",

--- a/pkg/i18n/japanese.go
+++ b/pkg/i18n/japanese.go
@@ -369,7 +369,7 @@ func japaneseTranslationSet() TranslationSet {
 		// MustExitFilterModePrompt:            "Command not available in filtered mode. Exit filtered mode?",
 		Diff: "差分",
 		// LcEnterRefToDiff:                    "Enter ref to diff",
-		EnteRefName:      "参照を入力:",
+		EnterRefName:     "参照を入力:",
 		ExitDiffMode:     "差分モードを終了",
 		DiffingMenuTitle: "差分",
 		// LcSwapDiff:                          "Reverse diff direction",

--- a/pkg/i18n/korean.go
+++ b/pkg/i18n/korean.go
@@ -364,7 +364,7 @@ func koreanTranslationSet() TranslationSet {
 		MustExitFilterModePrompt:   "Command not available in filtered mode. Exit filtered mode?",
 		Diff:                       "Diff",
 		EnterRefToDiff:             "Enter ref to diff",
-		EnteRefName:                "Ref 입력:",
+		EnterRefName:               "Ref 입력:",
 		ExitDiffMode:               "Diff 모드 종료",
 		DiffingMenuTitle:           "Diff",
 		SwapDiff:                   "Reverse diff direction",

--- a/pkg/i18n/russian.go
+++ b/pkg/i18n/russian.go
@@ -428,7 +428,7 @@ func RussianTranslationSet() TranslationSet {
 		MustExitFilterModePrompt:            "Команда недоступна в режиме фильтрации. Выйти из режима фильтрации?",
 		Diff:                                "Разница",
 		EnterRefToDiff:                      "Введите ссылку для сравнения",
-		EnteRefName:                         "Введите ссылку:",
+		EnterRefName:                        "Введите ссылку:",
 		ExitDiffMode:                        "Выйти из режима сравнения",
 		DiffingMenuTitle:                    "Сравнение",
 		SwapDiff:                            "Обратное направление сравнении",

--- a/pkg/i18n/traditional_chinese.go
+++ b/pkg/i18n/traditional_chinese.go
@@ -455,7 +455,7 @@ func traditionalChineseTranslationSet() TranslationSet {
 		MustExitFilterModePrompt:            "在按路徑篩選的模式下，該命令不可用。是否退出按路徑篩選的模式？",
 		Diff:                                "差異",
 		EnterRefToDiff:                      "輸入要比較的 Ref",
-		EnteRefName:                         "輸入 Ref：",
+		EnterRefName:                        "輸入 Ref：",
 		ExitDiffMode:                        "退出差異模式",
 		DiffingMenuTitle:                    "差異比較",
 		SwapDiff:                            "反轉差異方向",


### PR DESCRIPTION
Fixed typo `EnteRefName` --> `EnterRefName`
```diff
- EnteRefName
+ EnterRefName
```

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
