### PR TITLE
Retry tests on CI

### DIFF
--- a/pkg/integration/clients/go_test.go
+++ b/pkg/integration/clients/go_test.go
@@ -48,8 +48,8 @@ func TestIntegration(t *testing.T) {
 		},
 		false,
 		0,
-		// Only allowing one attempt per test. We'll see if we get any flakiness
-		1,
+		// Allow two attempts at each test to get around flakiness
+		2,
 	)
 
 	assert.NoError(t, err)


### PR DESCRIPTION
Now that we are running each test 6 times on CI, the risk of flakiness is higher. I want to fix these tests for good but it'l take time, so we're just retrying for now

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
