### PR TITLE
Do not quote initial branch arg when creating repo

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -194,7 +194,7 @@ func (app *App) setupRepo() (bool, error) {
 				fmt.Print(app.Tr.InitialBranch)
 				response, _ := bufio.NewReader(os.Stdin).ReadString('\n')
 				if trimmedResponse := strings.Trim(response, " \r\n"); len(trimmedResponse) > 0 {
-					initialBranchArg += "--initial-branch=" + app.OSCommand.Quote(trimmedResponse)
+					initialBranchArg += "--initial-branch=" + trimmedResponse
 				}
 			}
 		case "create":
@@ -210,7 +210,11 @@ func (app *App) setupRepo() (bool, error) {
 		}
 
 		if shouldInitRepo {
-			if err := app.OSCommand.Cmd.New([]string{"git", "init", initialBranchArg}).Run(); err != nil {
+			args := []string{"git", "init"}
+			if initialBranchArg != "" {
+				args = append(args, initialBranchArg)
+			}
+			if err := app.OSCommand.Cmd.New(args).Run(); err != nil {
 				return false, err
 			}
 			return false, nil


### PR DESCRIPTION
Fixes https://github.com/jesseduffield/lazygit/issues/2739

Also, we shouldn't pass the initial branch arg if it's empty.

I haven't added a test because this code doesn't change much and I would rather get this flow running through gocui so that we can write a proper integration test for it. The best we can do otherwise is confirm the expected command is run but that doesn't tell us much about what will happen when we run it.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc
