### PR TITLE
Allow checking for merge conflicts after running a custom command

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -59,6 +59,12 @@ For a given custom command, here are the allowed fields:
 | description | Label for the custom command when displayed in the keybindings menu | no |
 | stream | Whether you want to stream the command's output to the Command Log panel | no |
 | showOutput | Whether you want to show the command's output in a popup within Lazygit | no |
+| after | Actions to take after the command has completed | no |
+
+Here are the options for the `after` key:
+| _field_ | _description_ | required |
+|-----------------|----------------------|-|
+| checkForConflicts | true/false. If true, check for merge conflicts | no |
 
 ## Contexts
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -349,16 +349,21 @@ type OSConfig struct {
 	OpenLinkCommand string `yaml:"openLinkCommand,omitempty"`
 }
 
+type CustomCommandAfterHook struct {
+	CheckForConflicts bool `yaml:"checkForConflicts"`
+}
+
 type CustomCommand struct {
-	Key         string                `yaml:"key"`
-	Context     string                `yaml:"context"`
-	Command     string                `yaml:"command"`
-	Subprocess  bool                  `yaml:"subprocess"`
-	Prompts     []CustomCommandPrompt `yaml:"prompts"`
-	LoadingText string                `yaml:"loadingText"`
-	Description string                `yaml:"description"`
-	Stream      bool                  `yaml:"stream"`
-	ShowOutput  bool                  `yaml:"showOutput"`
+	Key         string                 `yaml:"key"`
+	Context     string                 `yaml:"context"`
+	Command     string                 `yaml:"command"`
+	Subprocess  bool                   `yaml:"subprocess"`
+	Prompts     []CustomCommandPrompt  `yaml:"prompts"`
+	LoadingText string                 `yaml:"loadingText"`
+	Description string                 `yaml:"description"`
+	Stream      bool                   `yaml:"stream"`
+	ShowOutput  bool                   `yaml:"showOutput"`
+	After       CustomCommandAfterHook `yaml:"after"`
 }
 
 type CustomCommandPrompt struct {

--- a/pkg/gui/services/custom_commands/client.go
+++ b/pkg/gui/services/custom_commands/client.go
@@ -19,7 +19,12 @@ func NewClient(
 	helpers *helpers.Helpers,
 ) *Client {
 	sessionStateLoader := NewSessionStateLoader(c, helpers.Refs)
-	handlerCreator := NewHandlerCreator(c, sessionStateLoader, helpers.Suggestions)
+	handlerCreator := NewHandlerCreator(
+		c,
+		sessionStateLoader,
+		helpers.Suggestions,
+		helpers.MergeAndRebase,
+	)
 	keybindingCreator := NewKeybindingCreator(c)
 	customCommands := c.UserConfig.CustomCommands
 

--- a/pkg/integration/tests/custom_commands/check_for_conflicts.go
+++ b/pkg/integration/tests/custom_commands/check_for_conflicts.go
@@ -1,0 +1,40 @@
+package custom_commands
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+	"github.com/jesseduffield/lazygit/pkg/integration/tests/shared"
+)
+
+var CheckForConflicts = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Run a command and check for conflicts after",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo: func(shell *Shell) {
+		shared.MergeConflictsSetup(shell)
+	},
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.UserConfig.CustomCommands = []config.CustomCommand{
+			{
+				Key:     "m",
+				Context: "localBranches",
+				Command: "git merge {{ .SelectedLocalBranch.Name | quote }}",
+				After: config.CustomCommandAfterHook{
+					CheckForConflicts: true,
+				},
+			},
+		}
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			TopLines(
+				Contains("first-change-branch"),
+				Contains("second-change-branch"),
+			).
+			NavigateToLine(Contains("second-change-branch")).
+			Press("m")
+
+		t.Common().AcknowledgeConflicts()
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -75,6 +75,7 @@ var tests = []*components.IntegrationTest{
 	conflicts.UndoChooseHunk,
 	custom_commands.BasicCmdAtRuntime,
 	custom_commands.BasicCmdFromConfig,
+	custom_commands.CheckForConflicts,
 	custom_commands.ComplexCmdAtRuntime,
 	custom_commands.FormPrompts,
 	custom_commands.MenuFromCommand,


### PR DESCRIPTION
We have a use-case to rebind 'm' to the merge action in the branches panel. There's three ways to handle this: 1) For all global keybindings, define a per-panel key that invokes it 2) Give a name to all controller actions and allow them to be invoked in custom commands 3) Allow checking for merge conflicts after running a custom command so that users can add their own 'git merge' custom command that matches the in-built action

Option 1 is hairy, Option 2 though good for users introduces new backwards compatibility issues that I don't want to do right now, and option 3 is trivially easy to implement so that's what I'm doing.

I've put this under an 'after' key so that we can add more things later. I'm imagining other things like being able to move the cursor to a newly added item etc.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
