### PR TITLE
Fix crash when a background fetch prompts for credentials

### DIFF
--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -331,9 +331,13 @@ func (self *cmdObjRunner) processOutput(
 		askFor, ok := checkForCredentialRequest(newBytes)
 		if ok {
 			responseChan := promptUserForCredential(askFor)
-			task.Pause()
+			if task != nil {
+				task.Pause()
+			}
 			toInput := <-responseChan
-			task.Continue()
+			if task != nil {
+				task.Continue()
+			}
 			// If the return data is empty we don't write anything to stdin
 			if toInput != "" {
 				_, _ = writer.Write([]byte(toInput))


### PR DESCRIPTION
This happens consistently for my when I close my MacBook's lid. It seems that MacOS locks the user's keychain in this case, and since I have my keychain provide the pass phrases for my ssh keys, fetching fails because it tries to prompt me for a pass phrase.

This all worked correctly already, we have the FailOnCredentialRequest() mechanism specifically for this situation, so all is great. The only problem was that it was trying to pause the ongoing task while prompting the user for input; but the task is nil for a background fetch (and should be).

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
