### PR TITLE
Fix crash on empty menu

### DIFF
--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -135,6 +135,10 @@ func (self *MenuContext) OnMenuPress(selectedItem *types.MenuItem) error {
 		return err
 	}
 
+	if selectedItem == nil {
+		return nil
+	}
+
 	if err := selectedItem.OnPress(); err != nil {
 		return err
 	}

--- a/pkg/gui/controllers/helpers/confirmation_helper.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper.go
@@ -302,7 +302,12 @@ func (self *ConfirmationHelper) resizeMenu() {
 	_, _ = self.c.GocuiGui().SetView(self.c.Views().Menu.Name(), x0, y0, x1, menuBottom, 0)
 
 	tooltipTop := menuBottom + 1
-	tooltipHeight := getMessageHeight(true, self.c.Contexts().Menu.GetSelected().Tooltip, panelWidth) + 2 // plus 2 for the frame
+	tooltip := ""
+	selectedItem := self.c.Contexts().Menu.GetSelected()
+	if selectedItem != nil {
+		tooltip = selectedItem.Tooltip
+	}
+	tooltipHeight := getMessageHeight(true, tooltip, panelWidth) + 2 // plus 2 for the frame
 	_, _ = self.c.GocuiGui().SetView(self.c.Views().Tooltip.Name(), x0, tooltipTop, x1, tooltipTop+tooltipHeight-1, 0)
 }
 

--- a/pkg/gui/controllers/menu_controller.go
+++ b/pkg/gui/controllers/menu_controller.go
@@ -53,7 +53,9 @@ func (self *MenuController) GetOnClick() func() error {
 func (self *MenuController) GetOnFocus() func(types.OnFocusOpts) error {
 	return func(types.OnFocusOpts) error {
 		selectedMenuItem := self.context().GetSelected()
-		self.c.Views().Tooltip.SetContent(selectedMenuItem.Tooltip)
+		if selectedMenuItem != nil {
+			self.c.Views().Tooltip.SetContent(selectedMenuItem.Tooltip)
+		}
 		return nil
 	}
 }

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -211,6 +211,7 @@ var tests = []*components.IntegrationTest{
 	tag.Reset,
 	ui.Accordion,
 	ui.DoublePopup,
+	ui.EmptyMenu,
 	ui.SwitchTabFromMenu,
 	undo.UndoCheckoutAndDrop,
 	undo.UndoDrop,

--- a/pkg/integration/tests/ui/empty_menu.go
+++ b/pkg/integration/tests/ui/empty_menu.go
@@ -1,0 +1,31 @@
+package ui
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var EmptyMenu = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Verify that we don't crash on an empty menu",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			IsFocused().
+			Press(keys.Universal.OptionMenu)
+
+		t.Views().Menu().
+			IsFocused().
+			// a string that filters everything out
+			FilterOrSearch("ljasldkjaslkdjalskdjalsdjaslkd").
+			IsEmpty().
+			Press(keys.Universal.Select)
+
+		// back in the files view, selecting the non-existing menu item was a no-op
+		t.Views().Files().
+			IsFocused()
+	},
+})


### PR DESCRIPTION
- **PR Description**

Fixes https://github.com/jesseduffield/lazygit/issues/2756

When a menu is empty (e.g. due to filtering) we shouldn't crash on focus or selection

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
