### PR TITLE
Prompt for commit message when moving a custom patch to a new commit

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -107,14 +107,6 @@ func (self *CommitCommands) signoffFlag() string {
 	}
 }
 
-// Get the subject of the HEAD commit
-func (self *CommitCommands) GetHeadCommitMessage() (string, error) {
-	cmdArgs := NewGitCmd("log").Arg("-1", "--pretty=%s").ToArgv()
-
-	message, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
-	return strings.TrimSpace(message), err
-}
-
 func (self *CommitCommands) GetCommitMessage(commitSha string) (string, error) {
 	cmdArgs := NewGitCmd("rev-list").
 		Arg("--format=%B", "--max-count=1", commitSha).

--- a/pkg/commands/git_commands/patch.go
+++ b/pkg/commands/git_commands/patch.go
@@ -1,7 +1,6 @@
 package git_commands
 
 import (
-	"fmt"
 	"path/filepath"
 	"time"
 
@@ -274,7 +273,12 @@ func (self *PatchCommands) MovePatchIntoIndex(commits []*models.Commit, commitId
 	return self.rebase.ContinueRebase()
 }
 
-func (self *PatchCommands) PullPatchIntoNewCommit(commits []*models.Commit, commitIdx int) error {
+func (self *PatchCommands) PullPatchIntoNewCommit(
+	commits []*models.Commit,
+	commitIdx int,
+	commitSummary string,
+	commitDescription string,
+) error {
 	if err := self.rebase.BeginInteractiveRebaseForCommit(commits, commitIdx, false); err != nil {
 		return err
 	}
@@ -300,9 +304,7 @@ func (self *PatchCommands) PullPatchIntoNewCommit(commits []*models.Commit, comm
 		return err
 	}
 
-	head_message, _ := self.commit.GetHeadCommitMessage()
-	new_message := fmt.Sprintf("Split from \"%s\"", head_message)
-	if err := self.commit.CommitCmdObj(new_message, "").Run(); err != nil {
+	if err := self.commit.CommitCmdObj(commitSummary, commitDescription).Run(); err != nil {
 		return err
 	}
 

--- a/pkg/integration/tests/patch_building/move_to_new_commit.go
+++ b/pkg/integration/tests/patch_building/move_to_new_commit.go
@@ -50,11 +50,15 @@ var MoveToNewCommit = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Common().SelectPatchOption(Contains("Move patch into new commit"))
 
+		t.ExpectPopup().CommitMessagePanel().
+			InitialText(Equals("")).
+			Type("new commit").Confirm()
+
 		t.Views().Commits().
 			IsFocused().
 			Lines(
 				Contains("third commit"),
-				Contains(`Split from "commit to move from"`).IsSelected(),
+				Contains("new commit").IsSelected(),
 				Contains("commit to move from"),
 				Contains("first commit"),
 			).
@@ -74,7 +78,7 @@ var MoveToNewCommit = NewIntegrationTest(NewIntegrationTestArgs{
 			IsFocused().
 			Lines(
 				Contains("third commit"),
-				Contains(`Split from "commit to move from"`).IsSelected(),
+				Contains("new commit").IsSelected(),
 				Contains("commit to move from"),
 				Contains("first commit"),
 			).

--- a/pkg/integration/tests/patch_building/move_to_new_commit_partial_hunk.go
+++ b/pkg/integration/tests/patch_building/move_to_new_commit_partial_hunk.go
@@ -47,6 +47,10 @@ var MoveToNewCommitPartialHunk = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Common().SelectPatchOption(Contains("Move patch into new commit"))
 
+		t.ExpectPopup().CommitMessagePanel().
+			InitialText(Equals("")).
+			Type("new commit").Confirm()
+
 		t.Views().CommitFiles().
 			IsFocused().
 			Lines(
@@ -62,7 +66,7 @@ var MoveToNewCommitPartialHunk = NewIntegrationTest(NewIntegrationTestArgs{
 			IsFocused().
 			Lines(
 				Contains("third commit"),
-				Contains(`Split from "commit to move from"`).IsSelected(),
+				Contains("new commit").IsSelected(),
 				Contains("commit to move from"),
 				Contains("first commit"),
 			).


### PR DESCRIPTION
Instead of using the hard-coded "Split from 'bla bla bla'" message that you afterwards have to reword in 100% of the cases, prompt for a commit message right away.
