### PR TITLE
Only apply right-alignment on first column of keybindings menu

### DIFF
--- a/pkg/gui/context/list_context_trait.go
+++ b/pkg/gui/context/list_context_trait.go
@@ -14,7 +14,7 @@ type ListContextTrait struct {
 	list              types.IList
 	getDisplayStrings func(startIdx int, length int) [][]string
 	// Alignment for each column. If nil, the default is left alignment
-	columnAlignments []utils.Alignment
+	getColumnAlignments func() []utils.Alignment
 	// Some contexts, like the commit context, will highlight the path from the selected commit
 	// to its parents, because it's ambiguous otherwise. For these, we need to refresh the viewport
 	// so that we show the highlighted path.
@@ -82,9 +82,13 @@ func (self *ListContextTrait) HandleFocusLost(opts types.OnFocusLostOpts) error 
 // OnFocus assumes that the content of the context has already been rendered to the view. OnRender is the function which actually renders the content to the view
 func (self *ListContextTrait) HandleRender() error {
 	self.list.RefreshSelectedIdx()
+	var columnAlignments []utils.Alignment
+	if self.getColumnAlignments != nil {
+		columnAlignments = self.getColumnAlignments()
+	}
 	content := utils.RenderDisplayStrings(
 		self.getDisplayStrings(0, self.list.Len()),
-		self.columnAlignments,
+		columnAlignments,
 	)
 	self.GetViewTrait().SetContent(content)
 	self.c.Render()

--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -35,10 +35,10 @@ func NewMenuContext(
 				Focusable:             true,
 				HasUncontrolledBounds: true,
 			})),
-			getDisplayStrings: viewModel.GetDisplayStrings,
-			list:              viewModel,
-			c:                 c,
-			columnAlignments:  []utils.Alignment{utils.AlignRight, utils.AlignLeft},
+			getDisplayStrings:   viewModel.GetDisplayStrings,
+			list:                viewModel,
+			c:                   c,
+			getColumnAlignments: func() []utils.Alignment { return viewModel.columnAlignment },
 		},
 	}
 }
@@ -54,8 +54,9 @@ func (self *MenuContext) GetSelectedItemId() string {
 }
 
 type MenuViewModel struct {
-	c         *ContextCommon
-	menuItems []*types.MenuItem
+	c               *ContextCommon
+	menuItems       []*types.MenuItem
+	columnAlignment []utils.Alignment
 	*FilteredListViewModel[*types.MenuItem]
 }
 
@@ -73,8 +74,9 @@ func NewMenuViewModel(c *ContextCommon) *MenuViewModel {
 	return self
 }
 
-func (self *MenuViewModel) SetMenuItems(items []*types.MenuItem) {
+func (self *MenuViewModel) SetMenuItems(items []*types.MenuItem, columnAlignment []utils.Alignment) {
 	self.menuItems = items
+	self.columnAlignment = columnAlignment
 }
 
 // TODO: move into presentation package

--- a/pkg/gui/controllers/options_menu_action.go
+++ b/pkg/gui/controllers/options_menu_action.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jesseduffield/generics/slices"
 	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
 )
 
@@ -37,9 +38,10 @@ func (self *OptionsMenuAction) Call() error {
 	})
 
 	return self.c.Menu(types.CreateMenuOptions{
-		Title:      self.c.Tr.Keybindings,
-		Items:      menuItems,
-		HideCancel: true,
+		Title:           self.c.Tr.Keybindings,
+		Items:           menuItems,
+		HideCancel:      true,
+		ColumnAlignment: []utils.Alignment{utils.AlignRight, utils.AlignLeft},
 	})
 }
 

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -41,7 +41,7 @@ func (gui *Gui) createMenu(opts types.CreateMenuOptions) error {
 		}
 	}
 
-	gui.State.Contexts.Menu.SetMenuItems(opts.Items)
+	gui.State.Contexts.Menu.SetMenuItems(opts.Items, opts.ColumnAlignment)
 	gui.State.Contexts.Menu.SetSelectedLineIdx(0)
 
 	gui.Views.Menu.Title = opts.Title

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -133,9 +133,10 @@ type IPopupHandler interface {
 }
 
 type CreateMenuOptions struct {
-	Title      string
-	Items      []*MenuItem
-	HideCancel bool
+	Title           string
+	Items           []*MenuItem
+	HideCancel      bool
+	ColumnAlignment []utils.Alignment
 }
 
 type CreatePopupPanelOpts struct {


### PR DESCRIPTION
Previously we applied a right-align on the first column of _all_ menus, even though we really only intended for it to be on the first column of the keybindings menu (that you get from pressing '?')

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc
