### PR TITLE
Fix #1265

### DIFF
--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -149,6 +149,11 @@ func (self *ViewBufferManager) NewCmdTask(start func() (*exec.Cmd, io.Reader), p
 
 		data := make(chan []byte)
 
+		// We're reading from the scanner in a separate goroutine because on windows
+		// if running git through a shim, we sometimes kill the parent process without
+		// killing its children, meaning the scanner blocks forever. This solution
+		// leaves us with a dead goroutine, but it's better than blocking all
+		// rendering to main views.
 		go utils.Safe(func() {
 			for scanner.Scan() {
 				data <- scanner.Bytes()

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -147,6 +147,15 @@ func (self *ViewBufferManager) NewCmdTask(start func() (*exec.Cmd, io.Reader), p
 		scanner := bufio.NewScanner(r)
 		scanner.Split(bufio.ScanLines)
 
+		data := make(chan []byte)
+
+		go utils.Safe(func() {
+			for scanner.Scan() {
+				data <- scanner.Bytes()
+			}
+			close(data)
+		})
+
 		loaded := false
 
 		go utils.Safe(func() {
@@ -186,13 +195,15 @@ func (self *ViewBufferManager) NewCmdTask(start func() (*exec.Cmd, io.Reader), p
 					break outer
 				case linesToRead := <-self.readLines:
 					for i := 0; i < linesToRead.Total; i++ {
+						var ok bool
+						var line []byte
 						select {
 						case <-stop:
 							break outer
-						default:
+						case line, ok = <-data:
+							break
 						}
 
-						ok := scanner.Scan()
 						loadingMutex.Lock()
 						if !loaded {
 							self.beforeStart()
@@ -209,7 +220,7 @@ func (self *ViewBufferManager) NewCmdTask(start func() (*exec.Cmd, io.Reader), p
 							self.onEndOfInput()
 							break outer
 						}
-						writeToView(append(scanner.Bytes(), '\n'))
+						writeToView(append(line, '\n'))
 
 						if i+1 == linesToRead.InitialRefreshAfter {
 							// We have read enough lines to fill the view, so do a first refresh


### PR DESCRIPTION
This is an attempt to fix #1265. I've used this patch for the last 5 days and did not notice any abnormalities. I discussed the findings in the linked issue thread. I checked that the tests return the same result before and after the bugfix and ran `gofumt` no cheat sheets or documentation are affected.

Note that there seems to be an [issue](https://github.com/jesseduffield/lazygit/issues/2804) on master that makes lazygit hang on push or pull, so this PR is forked off latest working tag which is v0.38.2. Some code had changed so it cannot be rebased without a conflict, but conflict resolution should in theory be easy once the [issue](https://github.com/jesseduffield/lazygit/issues/2804) is solved.


@Aziks0 [has discovered](https://github.com/jesseduffield/lazygit/issues/1265#issuecomment-1159092978) that a scanner hangs - huge thanks here, most of my work was based on this finding. This is what preventing the panel from updating. The fix is attempting to workaround this by making the scanner non-blocking. We are wrapping it inside a channel and then putting the channel and the stop condition in the same select. That is making sure that while we are waiting on the scanner we still can stop, so we do not block forever on an attempt to stop a prior panel update anymore.

I  also wrote  some code in the same select that waits for `time.After` and then checks for a broken pipe condition. This code relied on a third party library [gopsutil](https://github.com/shirou/gopsutil). If a check for broken pipe succeeds I used to execute "stop" by calling `break outer`. It turned out that this was not actually required because the natural "stop" event would come anyway and and let the code proceed successfully, so I removed that bit after testing.

Disclaimer: not a go programmer, susceptible to silly mistakes.