### PR TITLE
Include more commit authors in author suggestions

### DIFF
--- a/pkg/commands/models/author.go
+++ b/pkg/commands/models/author.go
@@ -1,0 +1,13 @@
+package models
+
+import "fmt"
+
+// A commit author
+type Author struct {
+	Name  string
+	Email string
+}
+
+func (self *Author) Combined() string {
+	return fmt.Sprintf("%s <%s>", self.Name, self.Email)
+}

--- a/pkg/gui/controllers/helpers/suggestions_helper.go
+++ b/pkg/gui/controllers/helpers/suggestions_helper.go
@@ -176,9 +176,11 @@ func (self *SuggestionsHelper) GetRefsSuggestionsFunc() func(string) []*types.Su
 }
 
 func (self *SuggestionsHelper) GetAuthorsSuggestionsFunc() func(string) []*types.Suggestion {
-	authors := lo.Uniq(slices.Map(self.c.Model().Commits, func(commit *models.Commit) string {
-		return fmt.Sprintf("%s <%s>", commit.AuthorName, commit.AuthorEmail)
-	}))
+	authors := lo.Map(lo.Values(self.c.Model().Authors), func(author *models.Author, _ int) string {
+		return author.Combined()
+	})
+
+	slices.Sort(authors)
 
 	return FuzzySearchFunc(authors)
 }

--- a/pkg/gui/controllers/switch_to_sub_commits_controller.go
+++ b/pkg/gui/controllers/switch_to_sub_commits_controller.go
@@ -70,6 +70,7 @@ func (self *SwitchToSubCommitsController) viewCommits() error {
 	}
 
 	self.setSubCommits(commits)
+	self.c.Helpers().Refresh.RefreshAuthors(commits)
 
 	subCommitsContext := self.c.Contexts().SubCommits
 	subCommitsContext.SetSelectedLineIdx(0)

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -349,6 +349,7 @@ func (gui *Gui) resetState(startArgs appTypes.StartArgs, reuseState bool) types.
 			ReflogCommits:         make([]*models.Commit, 0),
 			BisectInfo:            git_commands.NewNullBisectInfo(),
 			FilesTrie:             patricia.NewTrie(),
+			Authors:               map[string]*models.Author{},
 		},
 		Modes: &types.Modes{
 			Filtering:     filtering.New(startArgs.FilterPath),
@@ -456,6 +457,7 @@ func NewGui(
 			SyncMutex:               &deadlock.Mutex{},
 			LocalCommitsMutex:       &deadlock.Mutex{},
 			SubCommitsMutex:         &deadlock.Mutex{},
+			AuthorsMutex:            &deadlock.Mutex{},
 			SubprocessMutex:         &deadlock.Mutex{},
 			PopupMutex:              &deadlock.Mutex{},
 			PtyMutex:                &deadlock.Mutex{},

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -217,6 +217,8 @@ type Model struct {
 
 	// for displaying suggestions while typing in a file name
 	FilesTrie *patricia.Trie
+
+	Authors map[string]*models.Author
 }
 
 // if you add a new mutex here be sure to instantiate it. We're using pointers to
@@ -228,6 +230,7 @@ type Mutexes struct {
 	SyncMutex               *deadlock.Mutex
 	LocalCommitsMutex       *deadlock.Mutex
 	SubCommitsMutex         *deadlock.Mutex
+	AuthorsMutex            *deadlock.Mutex
 	SubprocessMutex         *deadlock.Mutex
 	PopupMutex              *deadlock.Mutex
 	PtyMutex                *deadlock.Mutex

--- a/pkg/integration/tests/commit/set_author.go
+++ b/pkg/integration/tests/commit/set_author.go
@@ -5,29 +5,58 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
+// Originally we only suggested authors present in the current branch, but now
+// we include authors from other branches whose commits you've looked at in the
+// lazygit session.
+
 var SetAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Set author on a commit",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
+		shell.NewBranch("original")
+
 		shell.SetConfig("user.email", "Bill@example.com")
 		shell.SetConfig("user.name", "Bill Smith")
 
 		shell.EmptyCommit("one")
 
+		shell.NewBranch("other")
+
 		shell.SetConfig("user.email", "John@example.com")
 		shell.SetConfig("user.name", "John Smith")
 
 		shell.EmptyCommit("two")
+
+		shell.Checkout("original")
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().
 			Focus().
 			Lines(
+				Contains("BS").Contains("one").IsSelected(),
+			)
+
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("original").IsSelected(),
+				Contains("other"),
+			).
+			NavigateToLine(Contains("other")).
+			PressEnter()
+
+		// ensuring we get these commit authors as suggestions
+		t.Views().SubCommits().
+			IsFocused().
+			Lines(
 				Contains("JS").Contains("two").IsSelected(),
 				Contains("BS").Contains("one"),
-			).
+			)
+
+		t.Views().Commits().
+			Focus().
 			Press(keys.Commits.ResetCommitAuthor).
 			Tap(func() {
 				t.ExpectPopup().Menu().
@@ -38,14 +67,13 @@ var SetAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 				t.ExpectPopup().Prompt().
 					Title(Contains("Set author")).
 					SuggestionLines(
-						Contains("John Smith"),
 						Contains("Bill Smith"),
+						Contains("John Smith"),
 					).
 					ConfirmSuggestion(Contains("John Smith"))
 			}).
 			Lines(
-				Contains("JS").Contains("two").IsSelected(),
-				Contains("BS").Contains("one"),
+				Contains("JS").Contains("one").IsSelected(),
 			)
 	},
 })


### PR DESCRIPTION
- **PR Description**

Previously, we would only show the authors based on local commits, but sometimes you want to set a commit author to that of a commit on another branch. Now, so long as you've viewed the branch's commits, the author will appear as a suggestion.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
