### PR TITLE
Support typing special characters like '[' on non-english keyboards

### DIFF
--- a/pkg/gui/editors.go
+++ b/pkg/gui/editors.go
@@ -47,8 +47,7 @@ func (gui *Gui) handleEditorKeypress(textArea *gocui.TextArea, key gocui.Key, ch
 	case key == gocui.KeyCtrlY:
 		textArea.Yank()
 
-		// TODO: see if we need all three of these conditions: maybe the final one is sufficient
-	case ch != 0 && mod == 0 && unicode.IsPrint(ch):
+	case unicode.IsPrint(ch):
 		textArea.TypeRune(ch)
 	default:
 		return false


### PR DESCRIPTION
On german/french/spanish keyboards, typing [ requires modifier keys like AltGr, so the `mod==0` condition is wrong.

Fixes #2573

ch != 0 is useless because IsPrint is implemented this way:
	if uint32(r) <= MaxLatin1 {
		return properties[uint8(r)]&128 != 0
	}
with properties[0] set to 1 (so, bit 7 not set)
-> 0 is not printable.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide) -> /components.TestNameFromFilePath crashes with or without this commit
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
