### PR TITLE
Fix infinite wait on push/pull on windows

### DIFF
--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -312,7 +312,9 @@ func (self *cmdObjRunner) runAndDetectCredentialRequest(
 	return self.runAndStreamAux(cmdObj, func(handler *cmdHandler, cmdWriter io.Writer) {
 		tr := io.TeeReader(handler.stdoutPipe, cmdWriter)
 
-		self.processOutput(tr, handler.stdinPipe, promptUserForCredential, cmdObj.GetTask())
+		go utils.Safe(func() {
+			self.processOutput(tr, handler.stdinPipe, promptUserForCredential, cmdObj.GetTask())
+		})
 	})
 }
 


### PR DESCRIPTION
- **PR Description**

This reverts commit 90613056cef95fe32d19198d88a0d71f00c5f6ae, or the part that removed a goroutine at least.

Reverting because this has caused an infinite wait for push/pull on windows. We'll need to find out why that happens separately

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
