### PR TITLE
Allow force-tagging if tag exists

### DIFF
--- a/pkg/commands/git_commands/tag.go
+++ b/pkg/commands/git_commands/tag.go
@@ -12,21 +12,33 @@ func NewTagCommands(gitCommon *GitCommon) *TagCommands {
 	}
 }
 
-func (self *TagCommands) CreateLightweight(tagName string, ref string) error {
-	cmdArgs := NewGitCmd("tag").Arg("--", tagName).
+func (self *TagCommands) CreateLightweight(tagName string, ref string, force bool) error {
+	cmdArgs := NewGitCmd("tag").
+		ArgIf(force, "--force").
+		Arg("--", tagName).
 		ArgIf(len(ref) > 0, ref).
 		ToArgv()
 
 	return self.cmd.New(cmdArgs).Run()
 }
 
-func (self *TagCommands) CreateAnnotated(tagName, ref, msg string) error {
+func (self *TagCommands) CreateAnnotated(tagName, ref, msg string, force bool) error {
 	cmdArgs := NewGitCmd("tag").Arg(tagName).
+		ArgIf(force, "--force").
 		ArgIf(len(ref) > 0, ref).
 		Arg("-m", msg).
 		ToArgv()
 
 	return self.cmd.New(cmdArgs).Run()
+}
+
+func (self *TagCommands) HasTag(tagName string) bool {
+	cmdArgs := NewGitCmd("show-ref").
+		Arg("--tags", "--quiet", "--verify", "--").
+		Arg("refs/tags/" + tagName).
+		ToArgv()
+
+	return self.cmd.New(cmdArgs).Run() == nil
 }
 
 func (self *TagCommands) Delete(tagName string) error {

--- a/pkg/gui/controllers/helpers/tags_helper.go
+++ b/pkg/gui/controllers/helpers/tags_helper.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 type TagsHelper struct {
@@ -19,16 +20,16 @@ func NewTagsHelper(c *HelperCommon, commitsHelper *CommitsHelper) *TagsHelper {
 }
 
 func (self *TagsHelper) OpenCreateTagPrompt(ref string, onCreate func()) error {
-	onConfirm := func(tagName string, description string) error {
+	doCreateTag := func(tagName string, description string, force bool) error {
 		return self.c.WithWaitingStatus(self.c.Tr.CreatingTag, func(gocui.Task) error {
 			if description != "" {
 				self.c.LogAction(self.c.Tr.Actions.CreateAnnotatedTag)
-				if err := self.c.Git().Tag.CreateAnnotated(tagName, ref, description); err != nil {
+				if err := self.c.Git().Tag.CreateAnnotated(tagName, ref, description, force); err != nil {
 					return self.c.Error(err)
 				}
 			} else {
 				self.c.LogAction(self.c.Tr.Actions.CreateLightweightTag)
-				if err := self.c.Git().Tag.CreateLightweight(tagName, ref); err != nil {
+				if err := self.c.Git().Tag.CreateLightweight(tagName, ref, force); err != nil {
 					return self.c.Error(err)
 				}
 			}
@@ -39,6 +40,28 @@ func (self *TagsHelper) OpenCreateTagPrompt(ref string, onCreate func()) error {
 				Mode: types.ASYNC, Scope: []types.RefreshableView{types.COMMITS, types.TAGS},
 			})
 		})
+	}
+
+	onConfirm := func(tagName string, description string) error {
+		if self.c.Git().Tag.HasTag(tagName) {
+			prompt := utils.ResolvePlaceholderString(
+				self.c.Tr.ForceTagPrompt,
+				map[string]string{
+					"tagName":    tagName,
+					"cancelKey":  self.c.UserConfig.Keybinding.Universal.Return,
+					"confirmKey": self.c.UserConfig.Keybinding.Universal.Confirm,
+				},
+			)
+			return self.c.Confirm(types.ConfirmOpts{
+				Title:  self.c.Tr.ForceTag,
+				Prompt: prompt,
+				HandleConfirm: func() error {
+					return doCreateTag(tagName, description, true)
+				},
+			})
+		} else {
+			return doCreateTag(tagName, description, false)
+		}
 	}
 
 	return self.commitsHelper.OpenCommitMessagePanel(

--- a/pkg/gui/controllers/sync_controller.go
+++ b/pkg/gui/controllers/sync_controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 type SyncController struct {
@@ -186,7 +187,7 @@ func (self *SyncController) pushAux(opts pushOpts) error {
 				}
 				_ = self.c.Confirm(types.ConfirmOpts{
 					Title:  self.c.Tr.ForcePush,
-					Prompt: self.c.Tr.ForcePushPrompt,
+					Prompt: self.forcePushPrompt(),
 					HandleConfirm: func() error {
 						newOpts := opts
 						newOpts.force = true
@@ -210,10 +211,20 @@ func (self *SyncController) requestToForcePush(opts pushOpts) error {
 
 	return self.c.Confirm(types.ConfirmOpts{
 		Title:  self.c.Tr.ForcePush,
-		Prompt: self.c.Tr.ForcePushPrompt,
+		Prompt: self.forcePushPrompt(),
 		HandleConfirm: func() error {
 			opts.force = true
 			return self.pushAux(opts)
 		},
 	})
+}
+
+func (self *SyncController) forcePushPrompt() string {
+	return utils.ResolvePlaceholderString(
+		self.c.Tr.ForcePushPrompt,
+		map[string]string{
+			"cancelKey":  self.c.UserConfig.Keybinding.Universal.Return,
+			"confirmKey": self.c.UserConfig.Keybinding.Universal.Confirm,
+		},
+	)
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -359,6 +359,8 @@ type TranslationSet struct {
 	PushTag                             string
 	CreateTag                           string
 	CreatingTag                         string
+	ForceTag                            string
+	ForceTagPrompt                      string
 	FetchRemote                         string
 	FetchingRemoteStatus                string
 	CheckoutCommit                      string
@@ -1102,6 +1104,8 @@ func EnglishTranslationSet() TranslationSet {
 		PushTag:                             "Push tag",
 		CreateTag:                           "Create tag",
 		CreatingTag:                         "Creating tag",
+		ForceTag:                            "Force Tag",
+		ForceTagPrompt:                      "The tag '{{.tagName}}' exists already. Press {{.cancelKey}} to cancel, or {{.confirmKey}} to overwrite.",
 		FetchRemote:                         "Fetch remote",
 		FetchingRemoteStatus:                "Fetching remote",
 		CheckoutCommit:                      "Checkout commit",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -876,7 +876,7 @@ func EnglishTranslationSet() TranslationSet {
 		OpenConfig:                          "Open config file",
 		EditConfig:                          "Edit config file",
 		ForcePush:                           "Force push",
-		ForcePushPrompt:                     "Your branch has diverged from the remote branch. Press 'esc' to cancel, or 'enter' to force push.",
+		ForcePushPrompt:                     "Your branch has diverged from the remote branch. Press {{.cancelKey}} to cancel, or {{.confirmKey}} to force push.",
 		ForcePushDisabled:                   "Your branch has diverged from the remote branch and you've disabled force pushing",
 		UpdatesRejectedAndForcePushDisabled: "Updates were rejected and you have disabled force pushing",
 		CheckForUpdate:                      "Check for update",

--- a/pkg/integration/tests/sync/force_push.go
+++ b/pkg/integration/tests/sync/force_push.go
@@ -32,7 +32,7 @@ var ForcePush = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().Confirmation().
 			Title(Equals("Force push")).
-			Content(Equals("Your branch has diverged from the remote branch. Press 'esc' to cancel, or 'enter' to force push.")).
+			Content(Equals("Your branch has diverged from the remote branch. Press <esc> to cancel, or <enter> to force push.")).
 			Confirm()
 
 		t.Views().Commits().

--- a/pkg/integration/tests/sync/force_push_multiple_matching.go
+++ b/pkg/integration/tests/sync/force_push_multiple_matching.go
@@ -34,7 +34,7 @@ var ForcePushMultipleMatching = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().Confirmation().
 			Title(Equals("Force push")).
-			Content(Equals("Your branch has diverged from the remote branch. Press 'esc' to cancel, or 'enter' to force push.")).
+			Content(Equals("Your branch has diverged from the remote branch. Press <esc> to cancel, or <enter> to force push.")).
 			Confirm()
 
 		t.Views().Commits().

--- a/pkg/integration/tests/sync/force_push_multiple_upstream.go
+++ b/pkg/integration/tests/sync/force_push_multiple_upstream.go
@@ -33,7 +33,7 @@ var ForcePushMultipleUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().Confirmation().
 			Title(Equals("Force push")).
-			Content(Equals("Your branch has diverged from the remote branch. Press 'esc' to cancel, or 'enter' to force push.")).
+			Content(Equals("Your branch has diverged from the remote branch. Press <esc> to cancel, or <enter> to force push.")).
 			Confirm()
 
 		t.Views().Commits().

--- a/pkg/integration/tests/tag/force_tag_annotated.go
+++ b/pkg/integration/tests/tag/force_tag_annotated.go
@@ -1,0 +1,47 @@
+package tag
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ForceTagAnnotated = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Overwrite an annotated tag that already exists",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("first commit")
+		shell.CreateAnnotatedTag("new-tag", "message", "HEAD")
+		shell.EmptyCommit("second commit")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("second commit").IsSelected(),
+				Contains("new-tag").Contains("first commit"),
+			).
+			Press(keys.Commits.CreateTag).
+			Tap(func() {
+				t.ExpectPopup().CommitMessagePanel().
+					Title(Equals("Tag name")).
+					Type("new-tag").
+					SwitchToDescription().
+					Title(Equals("Tag description")).
+					Type("message").
+					SwitchToSummary().
+					Confirm()
+			}).
+			Tap(func() {
+				t.ExpectPopup().Confirmation().
+					Title(Equals("Force Tag")).
+					Content(Contains("The tag 'new-tag' exists already. Press <esc> to cancel, or <enter> to overwrite.")).
+					Confirm()
+			}).
+			Lines(
+				Contains("new-tag").Contains("second commit"),
+				DoesNotContain("new-tag").Contains("first commit"),
+			)
+	},
+})

--- a/pkg/integration/tests/tag/force_tag_lightweight.go
+++ b/pkg/integration/tests/tag/force_tag_lightweight.go
@@ -1,0 +1,43 @@
+package tag
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ForceTagLightweight = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Overwrite a lightweight tag that already exists",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("first commit")
+		shell.CreateLightweightTag("new-tag", "HEAD")
+		shell.EmptyCommit("second commit")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("second commit").IsSelected(),
+				Contains("new-tag").Contains("first commit"),
+			).
+			Press(keys.Commits.CreateTag).
+			Tap(func() {
+				t.ExpectPopup().CommitMessagePanel().
+					Title(Equals("Tag name")).
+					Type("new-tag").
+					Confirm()
+			}).
+			Tap(func() {
+				t.ExpectPopup().Confirmation().
+					Title(Equals("Force Tag")).
+					Content(Contains("The tag 'new-tag' exists already. Press <esc> to cancel, or <enter> to overwrite.")).
+					Confirm()
+			}).
+			Lines(
+				Contains("new-tag").Contains("second commit"),
+				DoesNotContain("new-tag").Contains("first commit"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -214,6 +214,8 @@ var tests = []*components.IntegrationTest{
 	tag.CreateWhileCommitting,
 	tag.CrudAnnotated,
 	tag.CrudLightweight,
+	tag.ForceTagAnnotated,
+	tag.ForceTagLightweight,
 	tag.Reset,
 	ui.Accordion,
 	ui.DoublePopup,


### PR DESCRIPTION
- **PR Description**

When trying to create a tag that already exists, you are asked whether you want to overwrite it; this is the same UX that we use for force-pushing a branch that has diverged from upstream.

This is mostly useful for light-weight tags that are used for short-term purposes. For example, I often tag the current head with something like "tmp" before starting a complicated series of rebases, so that I can reset-hard back to it if the experiment fails. I tend to reuse these tags all the time. It's probably less common for annotated tags (especially when they have been pushed already), but since the code is almost the same for both, I thought it doesn't hurt to offer it for both in the same way.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
