### PR TITLE
Make IgnoreWhitespace a user config

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -105,6 +105,7 @@ git:
   disableForcePushing: false
   parseEmoji: false
   diffContextSize: 3 # how many lines of context are shown around a change in diffs
+  ignoreWhitespace: false # whether whitespace is ignored in diffs; can be toggled at runtime
 os:
   editPreset: '' # see 'Configuring File Editing' section
   edit: ''

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -91,9 +91,10 @@ type GitConfig struct {
 	DisableForcePushing bool                          `yaml:"disableForcePushing"`
 	CommitPrefixes      map[string]CommitPrefixConfig `yaml:"commitPrefixes"`
 	// this should really be under 'gui', not 'git'
-	ParseEmoji      bool      `yaml:"parseEmoji"`
-	Log             LogConfig `yaml:"log"`
-	DiffContextSize int       `yaml:"diffContextSize"`
+	ParseEmoji       bool      `yaml:"parseEmoji"`
+	Log              LogConfig `yaml:"log"`
+	DiffContextSize  int       `yaml:"diffContextSize"`
+	IgnoreWhitespace bool      `yaml:"ignoreWhitespace"`
 }
 
 type PagingConfig struct {

--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -114,7 +114,7 @@ func (self *CommitFilesController) GetOnRenderToMain() func() error {
 		from, reverse := self.c.Modes().Diffing.GetFromAndReverseArgsForDiff(ref.ParentRefName())
 
 		cmdObj := self.c.Git().WorkingTree.ShowFileDiffCmdObj(
-			from, to, reverse, node.GetPath(), false, self.c.State().GetIgnoreWhitespaceInDiffView(),
+			from, to, reverse, node.GetPath(), false, self.c.UserConfig.Git.IgnoreWhitespace,
 		)
 		task := types.NewRunPtyTask(cmdObj.GetCmd())
 

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -201,7 +201,7 @@ func (self *FilesController) GetOnRenderToMain() func() error {
 			split := self.c.UserConfig.Gui.SplitDiff == "always" || (node.GetHasUnstagedChanges() && node.GetHasStagedChanges())
 			mainShowsStaged := !split && node.GetHasStagedChanges()
 
-			cmdObj := self.c.Git().WorkingTree.WorktreeFileDiffCmdObj(node, false, mainShowsStaged, self.c.State().GetIgnoreWhitespaceInDiffView())
+			cmdObj := self.c.Git().WorkingTree.WorktreeFileDiffCmdObj(node, false, mainShowsStaged, self.c.UserConfig.Git.IgnoreWhitespace)
 			title := self.c.Tr.UnstagedChanges
 			if mainShowsStaged {
 				title = self.c.Tr.StagedChanges
@@ -216,7 +216,7 @@ func (self *FilesController) GetOnRenderToMain() func() error {
 			}
 
 			if split {
-				cmdObj := self.c.Git().WorkingTree.WorktreeFileDiffCmdObj(node, false, true, self.c.State().GetIgnoreWhitespaceInDiffView())
+				cmdObj := self.c.Git().WorkingTree.WorktreeFileDiffCmdObj(node, false, true, self.c.UserConfig.Git.IgnoreWhitespace)
 
 				title := self.c.Tr.StagedChanges
 				if mainShowsStaged {

--- a/pkg/gui/controllers/helpers/diff_helper.go
+++ b/pkg/gui/controllers/helpers/diff_helper.go
@@ -29,7 +29,7 @@ func (self *DiffHelper) DiffArgs() []string {
 		output = append(output, "-R")
 	}
 
-	if self.c.State().GetIgnoreWhitespaceInDiffView() {
+	if self.c.UserConfig.Git.IgnoreWhitespace {
 		output = append(output, "--ignore-all-space")
 	}
 
@@ -113,7 +113,7 @@ func (self *DiffHelper) WithDiffModeCheck(f func() error) error {
 }
 
 func (self *DiffHelper) IgnoringWhitespaceSubTitle() string {
-	if self.c.State().GetIgnoreWhitespaceInDiffView() {
+	if self.c.UserConfig.Git.IgnoreWhitespace {
 		return self.c.Tr.IgnoreWhitespaceDiffViewSubTitle
 	}
 

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -171,7 +171,7 @@ func (self *LocalCommitsController) GetOnRenderToMain() func() error {
 							"ref": commit.Name,
 						}))
 			} else {
-				cmdObj := self.c.Git().Commit.ShowCmdObj(commit.Sha, self.c.Modes().Filtering.GetPath(), self.c.State().GetIgnoreWhitespaceInDiffView())
+				cmdObj := self.c.Git().Commit.ShowCmdObj(commit.Sha, self.c.Modes().Filtering.GetPath(), self.c.UserConfig.Git.IgnoreWhitespace)
 				task = types.NewRunPtyTask(cmdObj.GetCmd())
 			}
 

--- a/pkg/gui/controllers/reflog_commits_controller.go
+++ b/pkg/gui/controllers/reflog_commits_controller.go
@@ -37,7 +37,7 @@ func (self *ReflogCommitsController) GetOnRenderToMain() func() error {
 			if commit == nil {
 				task = types.NewRenderStringTask("No reflog history")
 			} else {
-				cmdObj := self.c.Git().Commit.ShowCmdObj(commit.Sha, self.c.Modes().Filtering.GetPath(), self.c.State().GetIgnoreWhitespaceInDiffView())
+				cmdObj := self.c.Git().Commit.ShowCmdObj(commit.Sha, self.c.Modes().Filtering.GetPath(), self.c.UserConfig.Git.IgnoreWhitespace)
 
 				task = types.NewRunPtyTask(cmdObj.GetCmd())
 			}

--- a/pkg/gui/controllers/stash_controller.go
+++ b/pkg/gui/controllers/stash_controller.go
@@ -66,7 +66,7 @@ func (self *StashController) GetOnRenderToMain() func() error {
 				task = types.NewRunPtyTask(
 					self.c.Git().Stash.ShowStashEntryCmdObj(
 						stashEntry.Index,
-						self.c.State().GetIgnoreWhitespaceInDiffView(),
+						self.c.UserConfig.Git.IgnoreWhitespace,
 					).GetCmd(),
 				)
 			}

--- a/pkg/gui/controllers/sub_commits_controller.go
+++ b/pkg/gui/controllers/sub_commits_controller.go
@@ -38,7 +38,7 @@ func (self *SubCommitsController) GetOnRenderToMain() func() error {
 			if commit == nil {
 				task = types.NewRenderStringTask("No commits")
 			} else {
-				cmdObj := self.c.Git().Commit.ShowCmdObj(commit.Sha, self.c.Modes().Filtering.GetPath(), self.c.State().GetIgnoreWhitespaceInDiffView())
+				cmdObj := self.c.Git().Commit.ShowCmdObj(commit.Sha, self.c.Modes().Filtering.GetPath(), self.c.UserConfig.Git.IgnoreWhitespace)
 
 				task = types.NewRunPtyTask(cmdObj.GetCmd())
 			}

--- a/pkg/gui/controllers/submodules_controller.go
+++ b/pkg/gui/controllers/submodules_controller.go
@@ -97,7 +97,7 @@ func (self *SubmodulesController) GetOnRenderToMain() func() error {
 				if file == nil {
 					task = types.NewRenderStringTask(prefix)
 				} else {
-					cmdObj := self.c.Git().WorkingTree.WorktreeFileDiffCmdObj(file, false, !file.HasUnstagedChanges && file.HasStagedChanges, self.c.State().GetIgnoreWhitespaceInDiffView())
+					cmdObj := self.c.Git().WorkingTree.WorktreeFileDiffCmdObj(file, false, !file.HasUnstagedChanges && file.HasStagedChanges, self.c.UserConfig.Git.IgnoreWhitespace)
 					task = types.NewRunCommandTaskWithPrefix(cmdObj.GetCmd(), prefix)
 				}
 			}

--- a/pkg/gui/controllers/toggle_whitespace_action.go
+++ b/pkg/gui/controllers/toggle_whitespace_action.go
@@ -23,7 +23,7 @@ func (self *ToggleWhitespaceAction) Call() error {
 		return self.c.ErrorMsg(self.c.Tr.IgnoreWhitespaceNotSupportedHere)
 	}
 
-	self.c.State().SetIgnoreWhitespaceInDiffView(!self.c.State().GetIgnoreWhitespaceInDiffView())
+	self.c.UserConfig.Git.IgnoreWhitespace = !self.c.UserConfig.Git.IgnoreWhitespace
 
 	return self.c.CurrentSideContext().HandleFocus(types.OnFocusOpts{})
 }

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -103,9 +103,6 @@ type Gui struct {
 
 	IsNewRepo bool
 
-	// flag as to whether or not the diff view should ignore whitespace
-	IgnoreWhitespaceInDiffView bool
-
 	IsRefreshingFiles bool
 
 	// we use this to decide whether we'll return to the original directory that
@@ -141,14 +138,6 @@ type StateAccessor struct {
 }
 
 var _ types.IStateAccessor = new(StateAccessor)
-
-func (self *StateAccessor) GetIgnoreWhitespaceInDiffView() bool {
-	return self.gui.IgnoreWhitespaceInDiffView
-}
-
-func (self *StateAccessor) SetIgnoreWhitespaceInDiffView(value bool) {
-	self.gui.IgnoreWhitespaceInDiffView = value
-}
 
 func (self *StateAccessor) GetRepoPathStack() *utils.StringStack {
 	return self.gui.RepoPathStack

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -237,8 +237,6 @@ type Mutexes struct {
 }
 
 type IStateAccessor interface {
-	GetIgnoreWhitespaceInDiffView() bool
-	SetIgnoreWhitespaceInDiffView(value bool)
 	GetRepoPathStack() *utils.StringStack
 	GetRepoState() IRepoStateAccessor
 	// tells us whether we're currently updating lazygit


### PR DESCRIPTION
- **PR Description**

Make "ignoreWhitespace" a user config, so people can set the initial value to their preference. It can still be toggled at runtime as before, but the user config takes effect again at the next restart.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
