### PR TITLE
When bisecting, always mark the current commit as good/bad, not the selected

### DIFF
--- a/pkg/i18n/chinese.go
+++ b/pkg/i18n/chinese.go
@@ -544,7 +544,7 @@ func chineseTranslationSet() TranslationSet {
 		Bisect: Bisect{
 			Mark:                        "将 %s 标记为 %s",
 			MarkStart:                   "将 %s 标记为 %s (start bisect)",
-			Skip:                        "跳过 %s",
+			SkipCurrent:                 "跳过 %s",
 			ResetTitle:                  "重置 'git bisect'",
 			ResetPrompt:                 "您确定要重置 'git bisect' 吗？",
 			ResetOption:                 "重置二分查找",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -557,7 +557,8 @@ type Bisect struct {
 	NewTermPrompt               string
 	BisectMenuTitle             string
 	Mark                        string
-	Skip                        string
+	SkipCurrent                 string
+	SkipSelected                string
 	CompleteTitle               string
 	CompletePrompt              string
 	CompletePromptIndeterminate string
@@ -1347,9 +1348,10 @@ func EnglishTranslationSet() TranslationSet {
 			BisectMark:                        "Bisect mark",
 		},
 		Bisect: Bisect{
-			Mark:                        "Mark %s as %s",
+			Mark:                        "Mark current commit (%s) as %s",
 			MarkStart:                   "Mark %s as %s (start bisect)",
-			Skip:                        "Skip %s",
+			SkipCurrent:                 "Skip current commit (%s)",
+			SkipSelected:                "Skip selected commit (%s)",
 			ResetTitle:                  "Reset 'git bisect'",
 			ResetPrompt:                 "Are you sure you want to reset 'git bisect'?",
 			ResetOption:                 "Reset bisect",

--- a/pkg/i18n/japanese.go
+++ b/pkg/i18n/japanese.go
@@ -577,7 +577,7 @@ func japaneseTranslationSet() TranslationSet {
 		Bisect: Bisect{
 			// Mark:                        "Mark %s as %s",
 			// MarkStart:                   "Mark %s as %s (start bisect)",
-			Skip:            "%s をスキップする",
+			SkipCurrent:     "%s をスキップする",
 			ResetTitle:      "'git bisect' をリセット",
 			ResetPrompt:     "'git bisect' をリセットします。よろしいですか?",
 			ResetOption:     "Bisectをリセット",

--- a/pkg/i18n/korean.go
+++ b/pkg/i18n/korean.go
@@ -576,7 +576,7 @@ func koreanTranslationSet() TranslationSet {
 		Bisect: Bisect{
 			Mark:                        "Mark %s as %s",
 			MarkStart:                   "Mark %s as %s (start bisect)",
-			Skip:                        "%s 를 스킵",
+			SkipCurrent:                 "%s 를 스킵",
 			ResetTitle:                  "'git bisect' 를 리셋",
 			ResetPrompt:                 "정말로 'git bisect' 를 리셋하시겠습니까?",
 			ResetOption:                 "Bisect를 리셋",

--- a/pkg/i18n/russian.go
+++ b/pkg/i18n/russian.go
@@ -671,7 +671,7 @@ func RussianTranslationSet() TranslationSet {
 		Bisect: Bisect{
 			Mark:                        "Отметить %s как %s",
 			MarkStart:                   "Отметить %s как %s (начать бинарный поиск)",
-			Skip:                        "Пропустить %s",
+			SkipCurrent:                 "Пропустить %s",
 			ResetTitle:                  "Сбросить 'git bisect'",
 			ResetPrompt:                 "Вы уверены, что хотите сбросить 'git bisect'?",
 			ResetOption:                 "Сбросить бинарный поиск",

--- a/pkg/i18n/traditional_chinese.go
+++ b/pkg/i18n/traditional_chinese.go
@@ -698,7 +698,7 @@ func traditionalChineseTranslationSet() TranslationSet {
 		Bisect: Bisect{
 			Mark:                        "將 %s 標記為 %s",
 			MarkStart:                   "將 %s 標記為 %s（開始二分查找）",
-			Skip:                        "跳過 %s",
+			SkipCurrent:                 "跳過 %s",
 			ResetTitle:                  "重設 'git bisect'",
 			ResetPrompt:                 "你確定要重設 'git bisect' 嗎？",
 			ResetOption:                 "重設二分查找",

--- a/pkg/integration/tests/bisect/skip.go
+++ b/pkg/integration/tests/bisect/skip.go
@@ -1,0 +1,88 @@
+package bisect
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var Skip = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Start a git bisect and skip a few commits (selected or current)",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo: func(shell *Shell) {
+		shell.
+			CreateNCommits(10)
+	},
+	SetupConfig: func(cfg *config.AppConfig) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			SelectedLine(Contains("commit 10")).
+			Press(keys.Commits.ViewBisectOptions).
+			Tap(func() {
+				t.ExpectPopup().Menu().Title(Equals("Bisect")).Select(MatchesRegexp(`Mark .* as bad`)).Confirm()
+			}).
+			NavigateToLine(Contains("commit 01")).
+			Press(keys.Commits.ViewBisectOptions).
+			Tap(func() {
+				t.ExpectPopup().Menu().Title(Equals("Bisect")).Select(MatchesRegexp(`Mark .* as good`)).Confirm()
+				t.Views().Information().Content(Contains("Bisecting"))
+			}).
+			Lines(
+				Contains("CI commit 10").Contains("<-- bad"),
+				Contains("CI commit 09").DoesNotContain("<--"),
+				Contains("CI commit 08").DoesNotContain("<--"),
+				Contains("CI commit 07").DoesNotContain("<--"),
+				Contains("CI commit 06").DoesNotContain("<--"),
+				Contains("CI commit 05").Contains("<-- current").IsSelected(),
+				Contains("CI commit 04").DoesNotContain("<--"),
+				Contains("CI commit 03").DoesNotContain("<--"),
+				Contains("CI commit 02").DoesNotContain("<--"),
+				Contains("CI commit 01").Contains("<-- good"),
+			).
+			Press(keys.Commits.ViewBisectOptions).
+			Tap(func() {
+				t.ExpectPopup().Menu().Title(Equals("Bisect")).
+					// Does not show a "Skip selected commit" entry:
+					Lines(
+						Contains("b Mark current commit").Contains("as bad"),
+						Contains("g Mark current commit").Contains("as good"),
+						Contains("s Skip current commit"),
+						Contains("r Reset bisect"),
+						Contains("Cancel"),
+					).
+					Select(Contains("Skip current commit")).Confirm()
+			}).
+			// Skipping the current commit selects the new current commit:
+			Lines(
+				Contains("CI commit 10").Contains("<-- bad"),
+				Contains("CI commit 09").DoesNotContain("<--"),
+				Contains("CI commit 08").DoesNotContain("<--"),
+				Contains("CI commit 07").DoesNotContain("<--"),
+				Contains("CI commit 06").Contains("<-- current").IsSelected(),
+				Contains("CI commit 05").Contains("<-- skipped"),
+				Contains("CI commit 04").DoesNotContain("<--"),
+				Contains("CI commit 03").DoesNotContain("<--"),
+				Contains("CI commit 02").DoesNotContain("<--"),
+				Contains("CI commit 01").Contains("<-- good"),
+			).
+			NavigateToLine(Contains("commit 07")).
+			Press(keys.Commits.ViewBisectOptions).
+			Tap(func() {
+				t.ExpectPopup().Menu().Title(Equals("Bisect")).
+					// Does show a "Skip selected commit" entry:
+					Lines(
+						Contains("b Mark current commit").Contains("as bad"),
+						Contains("g Mark current commit").Contains("as good"),
+						Contains("s Skip current commit"),
+						Contains("S Skip selected commit"),
+						Contains("r Reset bisect"),
+						Contains("Cancel"),
+					).
+					Select(Contains("Skip selected commit")).Confirm()
+			}).
+			// Skipping a selected, non-current commit keeps the selection
+			// there:
+			SelectedLine(Contains("CI commit 07").Contains("<-- skipped"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -32,6 +32,7 @@ var tests = []*components.IntegrationTest{
 	bisect.Basic,
 	bisect.ChooseTerms,
 	bisect.FromOtherBranch,
+	bisect.Skip,
 	branch.CheckoutByName,
 	branch.CreateTag,
 	branch.Delete,


### PR DESCRIPTION
For marking as good or bad, the current commit is pretty much always the one you want to mark, not the selected. It's different for skipping; sometimes you know already that a certain commit doesn't compile, for example, so you might navigate there and mark it as skipped. So in the case that the current commit is not the selected one, we now offer two separate menu entries for skipping, one for the current commit and one for the selected.

Fixes #2836.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
