### PR TITLE
Add bisect menu entry that lets you choose bisect terms

### DIFF
--- a/pkg/commands/git_commands/bisect.go
+++ b/pkg/commands/git_commands/bisect.go
@@ -121,6 +121,15 @@ func (self *BisectCommands) Start() error {
 	return self.cmd.New(cmdArgs).StreamOutput().Run()
 }
 
+func (self *BisectCommands) StartWithTerms(oldTerm string, newTerm string) error {
+	cmdArgs := NewGitCmd("bisect").Arg("start").
+		Arg("--term-old=" + oldTerm).
+		Arg("--term-new=" + newTerm).
+		ToArgv()
+
+	return self.cmd.New(cmdArgs).StreamOutput().Run()
+}
+
 // tells us whether we've found our problem commit(s). We return a string slice of
 // commit sha's if we're done, and that slice may have more that one item if
 // skipped commits are involved.

--- a/pkg/gui/controllers/bisect_controller.go
+++ b/pkg/gui/controllers/bisect_controller.go
@@ -153,6 +153,28 @@ func (self *BisectController) openStartBisectMenu(info *git_commands.BisectInfo,
 				},
 				Key: 'g',
 			},
+			{
+				Label: self.c.Tr.Bisect.ChooseTerms,
+				OnPress: func() error {
+					return self.c.Prompt(types.PromptOpts{
+						Title: self.c.Tr.Bisect.OldTermPrompt,
+						HandleConfirm: func(oldTerm string) error {
+							return self.c.Prompt(types.PromptOpts{
+								Title: self.c.Tr.Bisect.NewTermPrompt,
+								HandleConfirm: func(newTerm string) error {
+									self.c.LogAction(self.c.Tr.Actions.StartBisect)
+									if err := self.c.Git().Bisect.StartWithTerms(oldTerm, newTerm); err != nil {
+										return self.c.Error(err)
+									}
+
+									return self.c.Helpers().Bisect.PostBisectCommandRefresh()
+								},
+							})
+						},
+					})
+				},
+				Key: 't',
+			},
 		},
 	})
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -552,6 +552,9 @@ type Bisect struct {
 	ResetTitle                  string
 	ResetPrompt                 string
 	ResetOption                 string
+	ChooseTerms                 string
+	OldTermPrompt               string
+	NewTermPrompt               string
 	BisectMenuTitle             string
 	Mark                        string
 	Skip                        string
@@ -1350,6 +1353,9 @@ func EnglishTranslationSet() TranslationSet {
 			ResetTitle:                  "Reset 'git bisect'",
 			ResetPrompt:                 "Are you sure you want to reset 'git bisect'?",
 			ResetOption:                 "Reset bisect",
+			ChooseTerms:                 "Choose bisect terms",
+			OldTermPrompt:               "Term for old/good commit:",
+			NewTermPrompt:               "Term for new/bad commit:",
 			BisectMenuTitle:             "Bisect",
 			CompleteTitle:               "Bisect complete",
 			CompletePrompt:              "Bisect complete! The following commit introduced the change:\n\n%s\n\nDo you want to reset 'git bisect' now?",

--- a/pkg/integration/tests/bisect/choose_terms.go
+++ b/pkg/integration/tests/bisect/choose_terms.go
@@ -1,0 +1,72 @@
+package bisect
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ChooseTerms = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Start a git bisect by choosing 'broken/fixed' as bisect terms",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo: func(shell *Shell) {
+		shell.
+			NewBranch("mybranch").
+			CreateNCommits(10)
+	},
+	SetupConfig: func(cfg *config.AppConfig) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		markCommitAsFixed := func() {
+			t.Views().Commits().
+				Press(keys.Commits.ViewBisectOptions)
+
+			t.ExpectPopup().Menu().Title(Equals("Bisect")).Select(MatchesRegexp(`Mark .* as fixed`)).Confirm()
+		}
+
+		markCommitAsBroken := func() {
+			t.Views().Commits().
+				Press(keys.Commits.ViewBisectOptions)
+
+			t.ExpectPopup().Menu().Title(Equals("Bisect")).Select(MatchesRegexp(`Mark .* as broken`)).Confirm()
+		}
+
+		t.Views().Commits().
+			Focus().
+			SelectedLine(Contains("CI commit 10")).
+			Press(keys.Commits.ViewBisectOptions).
+			Tap(func() {
+				t.ExpectPopup().Menu().Title(Equals("Bisect")).Select(Contains("Choose bisect terms")).Confirm()
+				t.ExpectPopup().Prompt().Title(Equals("Term for old/good commit:")).Type("broken").Confirm()
+				t.ExpectPopup().Prompt().Title(Equals("Term for new/bad commit:")).Type("fixed").Confirm()
+			}).
+			NavigateToLine(Contains("CI commit 09")).
+			Tap(markCommitAsFixed).
+			SelectedLine(Contains("<-- fixed")).
+			NavigateToLine(Contains("CI commit 02")).
+			Tap(markCommitAsBroken).
+			Lines(
+				Contains("CI commit 10").DoesNotContain("<--"),
+				Contains("CI commit 09").Contains("<-- fixed"),
+				Contains("CI commit 08").DoesNotContain("<--"),
+				Contains("CI commit 07").DoesNotContain("<--"),
+				Contains("CI commit 06").DoesNotContain("<--"),
+				Contains("CI commit 05").Contains("<-- current").IsSelected(),
+				Contains("CI commit 04").DoesNotContain("<--"),
+				Contains("CI commit 03").DoesNotContain("<--"),
+				Contains("CI commit 02").Contains("<-- broken"),
+				Contains("CI commit 01").DoesNotContain("<--"),
+			).
+			Tap(markCommitAsFixed).
+			SelectedLine(Contains("CI commit 04").Contains("<-- current")).
+			Tap(func() {
+				markCommitAsBroken()
+
+				// commit 5 is the culprit because we marked 4 as broken and 5 as fixed.
+				t.ExpectPopup().Alert().Title(Equals("Bisect complete")).Content(MatchesRegexp("(?s)commit 05.*Do you want to reset")).Confirm()
+			}).
+			IsFocused().
+			Content(Contains("CI commit 04"))
+
+		t.Views().Information().Content(DoesNotContain("Bisecting"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -30,6 +30,7 @@ import (
 
 var tests = []*components.IntegrationTest{
 	bisect.Basic,
+	bisect.ChooseTerms,
 	bisect.FromOtherBranch,
 	branch.CheckoutByName,
 	branch.CreateTag,


### PR DESCRIPTION
This can be useful if you want to find the commit that fixed a bug (you'd use "broken/fixed" instead of "good/bad" in this case), or if you want to find the commit that brought a big performance improvement (use "slow/fast"). It's pretty mind-bending to have to use "good/bad" in these cases, and swap their meanings in your head.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
