### PR TITLE
Fix merge status for update-ref command

### DIFF
--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -495,7 +495,8 @@ func (self *CommitLoader) commitFromPatch(content string) *models.Commit {
 func setCommitMergedStatuses(ancestor string, commits []*models.Commit) []*models.Commit {
 	passedAncestor := false
 	for i, commit := range commits {
-		if strings.HasPrefix(ancestor, commit.Sha) {
+		// some commits aren't really commits and don't have sha's, such as the update-ref todo
+		if commit.Sha != "" && strings.HasPrefix(ancestor, commit.Sha) {
 			passedAncestor = true
 		}
 		if commit.Status != models.StatusPushed && commit.Status != models.StatusUnpushed {

--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -135,7 +135,7 @@ func (self *CommitLoader) GetCommits(opts GetCommitsOptions) ([]*models.Commit, 
 	}
 
 	if ancestor != "" {
-		commits = self.setCommitMergedStatuses(ancestor, commits)
+		commits = setCommitMergedStatuses(ancestor, commits)
 	}
 
 	return commits, nil
@@ -492,7 +492,7 @@ func (self *CommitLoader) commitFromPatch(content string) *models.Commit {
 	}
 }
 
-func (self *CommitLoader) setCommitMergedStatuses(ancestor string, commits []*models.Commit) []*models.Commit {
+func setCommitMergedStatuses(ancestor string, commits []*models.Commit) []*models.Commit {
 	passedAncestor := false
 	for i, commit := range commits {
 		if strings.HasPrefix(ancestor, commit.Sha) {

--- a/pkg/commands/git_commands/commit_loader_test.go
+++ b/pkg/commands/git_commands/commit_loader_test.go
@@ -541,7 +541,7 @@ func TestCommitLoader_setCommitMergedStatuses(t *testing.T) {
 			expectedCommits: []*models.Commit{
 				{Sha: "12345", Name: "1", Action: models.ActionNone, Status: models.StatusUnpushed},
 				{Sha: "", Name: "", Action: todo.UpdateRef, Status: models.StatusNone},
-				{Sha: "abcde", Name: "3", Action: models.ActionNone, Status: models.StatusMerged}, // Wrong, expect Pushed
+				{Sha: "abcde", Name: "3", Action: models.ActionNone, Status: models.StatusPushed},
 			},
 		},
 	}


### PR DESCRIPTION
- **PR Description**

When there was an update-ref command in an interactive rebase (meaning that there's a stack of branches being rebased), all commits from the update-ref on down were incorrectly drawn with a green sha.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
