### PR TITLE
Internationalise logging of commands

### DIFF
--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -105,7 +105,7 @@ func (self *RebaseCommands) MoveCommitDown(commits []*models.Commit, index int) 
 	sha := commits[index].Sha
 
 	msg := utils.ResolvePlaceholderString(
-		self.Tr.Actions.LogMoveCommitDown,
+		self.Tr.Log.MoveCommitDown,
 		map[string]string{
 			"shortSha": utils.ShortSha(sha),
 		},
@@ -125,7 +125,7 @@ func (self *RebaseCommands) MoveCommitUp(commits []*models.Commit, index int) er
 	sha := commits[index].Sha
 
 	msg := utils.ResolvePlaceholderString(
-		self.Tr.Actions.LogMoveCommitUp,
+		self.Tr.Log.MoveCommitUp,
 		map[string]string{
 			"shortSha": utils.ShortSha(sha),
 		},
@@ -162,7 +162,7 @@ func (self *RebaseCommands) InteractiveRebase(commits []*models.Commit, index in
 
 func (self *RebaseCommands) EditRebase(branchRef string) error {
 	msg := utils.ResolvePlaceholderString(
-		self.Tr.Actions.LogEditRebase,
+		self.Tr.Log.EditRebase,
 		map[string]string{
 			"ref": branchRef,
 		},
@@ -431,7 +431,7 @@ func (self *RebaseCommands) CherryPickCommits(commits []*models.Commit) error {
 		return fmt.Sprintf("%s %s", utils.ShortSha(commit.Sha), commit.Name)
 	})
 	msg := utils.ResolvePlaceholderString(
-		self.Tr.Actions.LogCherryPickCommits,
+		self.Tr.Log.CherryPickCommits,
 		map[string]string{
 			"commitLines": strings.Join(commitLines, "\n"),
 		},

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -104,7 +104,13 @@ func (self *RebaseCommands) MoveCommitDown(commits []*models.Commit, index int) 
 
 	sha := commits[index].Sha
 
-	self.os.LogCommand(fmt.Sprintf("Moving TODO down: %s", utils.ShortSha(sha)), false)
+	msg := utils.ResolvePlaceholderString(
+		self.Tr.Actions.LogMoveCommitDown,
+		map[string]string{
+			"shortSha": utils.ShortSha(sha),
+		},
+	)
+	self.os.LogCommand(msg, false)
 
 	return self.PrepareInteractiveRebaseCommand(PrepareInteractiveRebaseCommandOpts{
 		baseShaOrRoot:  baseShaOrRoot,
@@ -118,7 +124,13 @@ func (self *RebaseCommands) MoveCommitUp(commits []*models.Commit, index int) er
 
 	sha := commits[index].Sha
 
-	self.os.LogCommand(fmt.Sprintf("Moving TODO up: %s", utils.ShortSha(sha)), false)
+	msg := utils.ResolvePlaceholderString(
+		self.Tr.Actions.LogMoveCommitUp,
+		map[string]string{
+			"shortSha": utils.ShortSha(sha),
+		},
+	)
+	self.os.LogCommand(msg, false)
 
 	return self.PrepareInteractiveRebaseCommand(PrepareInteractiveRebaseCommandOpts{
 		baseShaOrRoot:  baseShaOrRoot,
@@ -149,7 +161,13 @@ func (self *RebaseCommands) InteractiveRebase(commits []*models.Commit, index in
 }
 
 func (self *RebaseCommands) EditRebase(branchRef string) error {
-	self.os.LogCommand(fmt.Sprintf("Beginning interactive rebase at '%s'", branchRef), false)
+	msg := utils.ResolvePlaceholderString(
+		self.Tr.Actions.LogEditRebase,
+		map[string]string{
+			"ref": branchRef,
+		},
+	)
+	self.os.LogCommand(msg, false)
 	return self.PrepareInteractiveRebaseCommand(PrepareInteractiveRebaseCommandOpts{
 		baseShaOrRoot: branchRef,
 		instruction:   daemon.NewInsertBreakInstruction(),
@@ -412,7 +430,13 @@ func (self *RebaseCommands) CherryPickCommits(commits []*models.Commit) error {
 	commitLines := lo.Map(commits, func(commit *models.Commit, _ int) string {
 		return fmt.Sprintf("%s %s", utils.ShortSha(commit.Sha), commit.Name)
 	})
-	self.os.LogCommand(fmt.Sprintf("Cherry-picking commits:\n%s", strings.Join(commitLines, "\n")), false)
+	msg := utils.ResolvePlaceholderString(
+		self.Tr.Actions.LogCherryPickCommits,
+		map[string]string{
+			"commitLines": strings.Join(commitLines, "\n"),
+		},
+	)
+	self.os.LogCommand(msg, false)
 
 	return self.PrepareInteractiveRebaseCommand(PrepareInteractiveRebaseCommandOpts{
 		baseShaOrRoot: "HEAD",

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -175,7 +175,14 @@ func (self *RebaseCommands) EditRebase(branchRef string) error {
 }
 
 func (self *RebaseCommands) EditRebaseFromBaseCommit(targetBranchName string, baseCommit string) error {
-	self.os.LogCommand(fmt.Sprintf("Beginning interactive rebase from '%s' onto '%s", baseCommit, targetBranchName), false)
+	msg := utils.ResolvePlaceholderString(
+		self.Tr.Log.EditRebaseFromBaseCommit,
+		map[string]string{
+			"baseCommit":       baseCommit,
+			"targetBranchName": targetBranchName,
+		},
+	)
+	self.os.LogCommand(msg, false)
 	return self.PrepareInteractiveRebaseCommand(PrepareInteractiveRebaseCommandOpts{
 		baseShaOrRoot: baseCommit,
 		onto:          targetBranchName,

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -118,7 +118,7 @@ func (c *OSCommand) Quote(message string) string {
 // AppendLineToFile adds a new line in file
 func (c *OSCommand) AppendLineToFile(filename, line string) error {
 	msg := utils.ResolvePlaceholderString(
-		c.Tr.Actions.LogAppendingLineToFile,
+		c.Tr.Log.AppendingLineToFile,
 		map[string]string{
 			"line":     line,
 			"filename": filename,
@@ -163,7 +163,7 @@ func (c *OSCommand) AppendLineToFile(filename, line string) error {
 // CreateFileWithContent creates a file with the given content
 func (c *OSCommand) CreateFileWithContent(path string, content string) error {
 	msg := utils.ResolvePlaceholderString(
-		c.Tr.Actions.LogCreateFileWithContent,
+		c.Tr.Log.CreateFileWithContent,
 		map[string]string{
 			"path": path,
 		},
@@ -185,7 +185,7 @@ func (c *OSCommand) CreateFileWithContent(path string, content string) error {
 // Remove removes a file or directory at the specified path
 func (c *OSCommand) Remove(filename string) error {
 	msg := utils.ResolvePlaceholderString(
-		c.Tr.Actions.LogRemove,
+		c.Tr.Log.Remove,
 		map[string]string{
 			"filename": filename,
 		},
@@ -287,7 +287,7 @@ func (c *OSCommand) CopyToClipboard(str string) error {
 	truncated := utils.TruncateWithEllipsis(escaped, 40)
 
 	msg := utils.ResolvePlaceholderString(
-		c.Tr.Actions.LogCopyToClipboard,
+		c.Tr.Log.CopyToClipboard,
 		map[string]string{
 			"str": truncated,
 		},
@@ -305,7 +305,7 @@ func (c *OSCommand) CopyToClipboard(str string) error {
 
 func (c *OSCommand) RemoveFile(path string) error {
 	msg := utils.ResolvePlaceholderString(
-		c.Tr.Actions.LogRemoveFile,
+		c.Tr.Log.RemoveFile,
 		map[string]string{
 			"path": path,
 		},

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -117,7 +117,15 @@ func (c *OSCommand) Quote(message string) string {
 
 // AppendLineToFile adds a new line in file
 func (c *OSCommand) AppendLineToFile(filename, line string) error {
-	c.LogCommand(fmt.Sprintf("Appending '%s' to file '%s'", line, filename), false)
+	msg := utils.ResolvePlaceholderString(
+		c.Tr.Actions.LogAppendingLineToFile,
+		map[string]string{
+			"line":     line,
+			"filename": filename,
+		},
+	)
+	c.LogCommand(msg, false)
+
 	f, err := os.OpenFile(filename, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return utils.WrapError(err)
@@ -154,7 +162,13 @@ func (c *OSCommand) AppendLineToFile(filename, line string) error {
 
 // CreateFileWithContent creates a file with the given content
 func (c *OSCommand) CreateFileWithContent(path string, content string) error {
-	c.LogCommand(fmt.Sprintf("Creating file '%s'", path), false)
+	msg := utils.ResolvePlaceholderString(
+		c.Tr.Actions.LogCreateFileWithContent,
+		map[string]string{
+			"path": path,
+		},
+	)
+	c.LogCommand(msg, false)
 	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
 		c.Log.Error(err)
 		return err
@@ -170,7 +184,13 @@ func (c *OSCommand) CreateFileWithContent(path string, content string) error {
 
 // Remove removes a file or directory at the specified path
 func (c *OSCommand) Remove(filename string) error {
-	c.LogCommand(fmt.Sprintf("Removing '%s'", filename), false)
+	msg := utils.ResolvePlaceholderString(
+		c.Tr.Actions.LogRemove,
+		map[string]string{
+			"filename": filename,
+		},
+	)
+	c.LogCommand(msg, false)
 	err := os.RemoveAll(filename)
 	return utils.WrapError(err)
 }
@@ -265,7 +285,14 @@ func PrepareForChildren(cmd *exec.Cmd) {
 func (c *OSCommand) CopyToClipboard(str string) error {
 	escaped := strings.Replace(str, "\n", "\\n", -1)
 	truncated := utils.TruncateWithEllipsis(escaped, 40)
-	c.LogCommand(fmt.Sprintf("Copying '%s' to clipboard", truncated), false)
+
+	msg := utils.ResolvePlaceholderString(
+		c.Tr.Actions.LogCopyToClipboard,
+		map[string]string{
+			"str": truncated,
+		},
+	)
+	c.LogCommand(msg, false)
 	if c.UserConfig.OS.CopyToClipboardCmd != "" {
 		cmdStr := utils.ResolvePlaceholderString(c.UserConfig.OS.CopyToClipboardCmd, map[string]string{
 			"text": c.Cmd.Quote(str),
@@ -277,7 +304,13 @@ func (c *OSCommand) CopyToClipboard(str string) error {
 }
 
 func (c *OSCommand) RemoveFile(path string) error {
-	c.LogCommand(fmt.Sprintf("Deleting path '%s'", path), false)
+	msg := utils.ResolvePlaceholderString(
+		c.Tr.Actions.LogRemoveFile,
+		map[string]string{
+			"path": path,
+		},
+	)
+	c.LogCommand(msg, false)
 
 	return c.removeFileFn(path)
 }

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -421,10 +421,15 @@ func (self *LocalCommitsController) handleMidRebaseCommand(action todo.TodoComma
 	}
 
 	self.c.LogAction("Update rebase TODO")
-	self.c.LogCommand(
-		fmt.Sprintf("Updating rebase action of commit %s to '%s'", commit.ShortSha(), action.String()),
-		false,
+
+	msg := utils.ResolvePlaceholderString(
+		self.c.Tr.Actions.LogHandleMidRebaseCommand,
+		map[string]string{
+			"shortSha": commit.ShortSha(),
+			"action":   action.String(),
+		},
 	)
+	self.c.LogCommand(msg, false)
 
 	if err := self.c.Git().Rebase.EditRebaseTodo(commit, action); err != nil {
 		return false, self.c.Error(err)
@@ -452,7 +457,14 @@ func (self *LocalCommitsController) moveDown(commit *models.Commit) error {
 		// logging directly here because MoveTodoDown doesn't have enough information
 		// to provide a useful log
 		self.c.LogAction(self.c.Tr.Actions.MoveCommitDown)
-		self.c.LogCommand(fmt.Sprintf("Moving commit %s down", commit.ShortSha()), false)
+
+		msg := utils.ResolvePlaceholderString(
+			self.c.Tr.Actions.LogMovingCommitDown,
+			map[string]string{
+				"shortSha": commit.ShortSha(),
+			},
+		)
+		self.c.LogCommand(msg, false)
 
 		if err := self.c.Git().Rebase.MoveTodoDown(commit); err != nil {
 			return self.c.Error(err)
@@ -487,10 +499,13 @@ func (self *LocalCommitsController) moveUp(commit *models.Commit) error {
 		// logging directly here because MoveTodoDown doesn't have enough information
 		// to provide a useful log
 		self.c.LogAction(self.c.Tr.Actions.MoveCommitUp)
-		self.c.LogCommand(
-			fmt.Sprintf("Moving commit %s up", commit.ShortSha()),
-			false,
+		msg := utils.ResolvePlaceholderString(
+			self.c.Tr.Actions.LogMovingCommitUp,
+			map[string]string{
+				"shortSha": commit.ShortSha(),
+			},
 		)
+		self.c.LogCommand(msg, false)
 
 		if err := self.c.Git().Rebase.MoveTodoUp(self.c.Model().Commits[index]); err != nil {
 			return self.c.Error(err)

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -423,7 +423,7 @@ func (self *LocalCommitsController) handleMidRebaseCommand(action todo.TodoComma
 	self.c.LogAction("Update rebase TODO")
 
 	msg := utils.ResolvePlaceholderString(
-		self.c.Tr.Actions.LogHandleMidRebaseCommand,
+		self.c.Tr.Log.HandleMidRebaseCommand,
 		map[string]string{
 			"shortSha": commit.ShortSha(),
 			"action":   action.String(),
@@ -459,7 +459,7 @@ func (self *LocalCommitsController) moveDown(commit *models.Commit) error {
 		self.c.LogAction(self.c.Tr.Actions.MoveCommitDown)
 
 		msg := utils.ResolvePlaceholderString(
-			self.c.Tr.Actions.LogMovingCommitDown,
+			self.c.Tr.Log.MovingCommitDown,
 			map[string]string{
 				"shortSha": commit.ShortSha(),
 			},
@@ -500,7 +500,7 @@ func (self *LocalCommitsController) moveUp(commit *models.Commit) error {
 		// to provide a useful log
 		self.c.LogAction(self.c.Tr.Actions.MoveCommitUp)
 		msg := utils.ResolvePlaceholderString(
-			self.c.Tr.Actions.LogMovingCommitUp,
+			self.c.Tr.Log.MovingCommitUp,
 			map[string]string{
 				"shortSha": commit.ShortSha(),
 			},

--- a/pkg/gui/controllers/merge_conflicts_controller.go
+++ b/pkg/gui/controllers/merge_conflicts_controller.go
@@ -215,7 +215,7 @@ func (self *MergeConflictsController) HandleUndo() error {
 	}
 
 	self.c.LogAction("Restoring file to previous state")
-	self.c.LogCommand(self.c.Tr.Actions.LogHandleUndo, false)
+	self.c.LogCommand(self.c.Tr.Log.HandleUndo, false)
 	if err := os.WriteFile(state.GetPath(), []byte(state.GetContent()), 0o644); err != nil {
 		return err
 	}

--- a/pkg/gui/controllers/merge_conflicts_controller.go
+++ b/pkg/gui/controllers/merge_conflicts_controller.go
@@ -215,7 +215,7 @@ func (self *MergeConflictsController) HandleUndo() error {
 	}
 
 	self.c.LogAction("Restoring file to previous state")
-	self.c.LogCommand("Undoing last conflict resolution", false)
+	self.c.LogCommand(self.c.Tr.Actions.LogHandleUndo, false)
 	if err := os.WriteFile(state.GetPath(), []byte(state.GetContent()), 0o644); err != nil {
 		return err
 	}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -587,6 +587,7 @@ type TranslationSet struct {
 	MarkedCommitMarker                  string
 	Actions                             Actions
 	Bisect                              Bisect
+	Log                                 Log
 }
 
 type Bisect struct {
@@ -607,6 +608,22 @@ type Bisect struct {
 	CompletePrompt              string
 	CompletePromptIndeterminate string
 	Bisecting                   string
+}
+
+type Log struct {
+	EditRebase             string
+	MoveCommitUp           string
+	MoveCommitDown         string
+	CherryPickCommits      string
+	HandleUndo             string
+	HandleMidRebaseCommand string
+	MovingCommitUp         string
+	MovingCommitDown       string
+	RemoveFile             string
+	CopyToClipboard        string
+	Remove                 string
+	CreateFileWithContent  string
+	AppendingLineToFile    string
 }
 
 type Actions struct {
@@ -717,19 +734,6 @@ type Actions struct {
 	BisectMark                        string
 	RemoveWorktree                    string
 	AddWorktree                       string
-	LogEditRebase                     string
-	LogMoveCommitUp                   string
-	LogMoveCommitDown                 string
-	LogCherryPickCommits              string
-	LogHandleUndo                     string
-	LogHandleMidRebaseCommand         string
-	LogMovingCommitUp                 string
-	LogMovingCommitDown               string
-	LogRemoveFile                     string
-	LogCopyToClipboard                string
-	LogRemove                         string
-	LogCreateFileWithContent          string
-	LogAppendingLineToFile            string
 }
 
 const englishIntroPopupMessage = `
@@ -1451,19 +1455,6 @@ func EnglishTranslationSet() TranslationSet {
 			BisectMark:                        "Bisect mark",
 			RemoveWorktree:                    "Remove worktree",
 			AddWorktree:                       "Add worktree",
-			LogEditRebase:                     "Beginning interactive rebase at '{{.ref}}'",
-			LogMoveCommitUp:                   "Moving TODO down: '{{.shortSha}}'",
-			LogMoveCommitDown:                 "Moving TODO down: '{{.shortSha}}'",
-			LogCherryPickCommits:              "Cherry-picking commits:\n'{{.commitLines}}'",
-			LogHandleUndo:                     "Undoing last conflict resolution",
-			LogHandleMidRebaseCommand:         "Updating rebase action of commit {{.shortSha}} to '{{.action}}'",
-			LogMovingCommitUp:                 "Moving commit {{.shortSha}} up",
-			LogMovingCommitDown:               "Moving commit {{.shortSha}} down",
-			LogRemoveFile:                     "Deleting path '{{.path}}'",
-			LogCopyToClipboard:                "Copying '{{.str}}' to clipboard",
-			LogRemove:                         "Removing '{{.filename}}'",
-			LogCreateFileWithContent:          "Creating file '{{.path}}'",
-			LogAppendingLineToFile:            "Appending '{{.line}}' to file '{{.filename}}'",
 		},
 		Bisect: Bisect{
 			Mark:                        "Mark current commit (%s) as %s",
@@ -1481,6 +1472,21 @@ func EnglishTranslationSet() TranslationSet {
 			CompletePrompt:              "Bisect complete! The following commit introduced the change:\n\n%s\n\nDo you want to reset 'git bisect' now?",
 			CompletePromptIndeterminate: "Bisect complete! Some commits were skipped, so any of the following commits may have introduced the change:\n\n%s\n\nDo you want to reset 'git bisect' now?",
 			Bisecting:                   "Bisecting",
+		},
+		Log: Log{
+			EditRebase:             "Beginning interactive rebase at '{{.ref}}'",
+			MoveCommitUp:           "Moving TODO down: '{{.shortSha}}'",
+			MoveCommitDown:         "Moving TODO down: '{{.shortSha}}'",
+			CherryPickCommits:      "Cherry-picking commits:\n'{{.commitLines}}'",
+			HandleUndo:             "Undoing last conflict resolution",
+			HandleMidRebaseCommand: "Updating rebase action of commit {{.shortSha}} to '{{.action}}'",
+			MovingCommitUp:         "Moving commit {{.shortSha}} up",
+			MovingCommitDown:       "Moving commit {{.shortSha}} down",
+			RemoveFile:             "Deleting path '{{.path}}'",
+			CopyToClipboard:        "Copying '{{.str}}' to clipboard",
+			Remove:                 "Removing '{{.filename}}'",
+			CreateFileWithContent:  "Creating file '{{.path}}'",
+			AppendingLineToFile:    "Appending '{{.line}}' to file '{{.filename}}'",
 		},
 	}
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -611,19 +611,20 @@ type Bisect struct {
 }
 
 type Log struct {
-	EditRebase             string
-	MoveCommitUp           string
-	MoveCommitDown         string
-	CherryPickCommits      string
-	HandleUndo             string
-	HandleMidRebaseCommand string
-	MovingCommitUp         string
-	MovingCommitDown       string
-	RemoveFile             string
-	CopyToClipboard        string
-	Remove                 string
-	CreateFileWithContent  string
-	AppendingLineToFile    string
+	EditRebase               string
+	MoveCommitUp             string
+	MoveCommitDown           string
+	CherryPickCommits        string
+	HandleUndo               string
+	HandleMidRebaseCommand   string
+	MovingCommitUp           string
+	MovingCommitDown         string
+	RemoveFile               string
+	CopyToClipboard          string
+	Remove                   string
+	CreateFileWithContent    string
+	AppendingLineToFile      string
+	EditRebaseFromBaseCommit string
 }
 
 type Actions struct {
@@ -1474,19 +1475,20 @@ func EnglishTranslationSet() TranslationSet {
 			Bisecting:                   "Bisecting",
 		},
 		Log: Log{
-			EditRebase:             "Beginning interactive rebase at '{{.ref}}'",
-			MoveCommitUp:           "Moving TODO down: '{{.shortSha}}'",
-			MoveCommitDown:         "Moving TODO down: '{{.shortSha}}'",
-			CherryPickCommits:      "Cherry-picking commits:\n'{{.commitLines}}'",
-			HandleUndo:             "Undoing last conflict resolution",
-			HandleMidRebaseCommand: "Updating rebase action of commit {{.shortSha}} to '{{.action}}'",
-			MovingCommitUp:         "Moving commit {{.shortSha}} up",
-			MovingCommitDown:       "Moving commit {{.shortSha}} down",
-			RemoveFile:             "Deleting path '{{.path}}'",
-			CopyToClipboard:        "Copying '{{.str}}' to clipboard",
-			Remove:                 "Removing '{{.filename}}'",
-			CreateFileWithContent:  "Creating file '{{.path}}'",
-			AppendingLineToFile:    "Appending '{{.line}}' to file '{{.filename}}'",
+			EditRebase:               "Beginning interactive rebase at '{{.ref}}'",
+			MoveCommitUp:             "Moving TODO down: '{{.shortSha}}'",
+			MoveCommitDown:           "Moving TODO down: '{{.shortSha}}'",
+			CherryPickCommits:        "Cherry-picking commits:\n'{{.commitLines}}'",
+			HandleUndo:               "Undoing last conflict resolution",
+			HandleMidRebaseCommand:   "Updating rebase action of commit {{.shortSha}} to '{{.action}}'",
+			MovingCommitUp:           "Moving commit {{.shortSha}} up",
+			MovingCommitDown:         "Moving commit {{.shortSha}} down",
+			RemoveFile:               "Deleting path '{{.path}}'",
+			CopyToClipboard:          "Copying '{{.str}}' to clipboard",
+			Remove:                   "Removing '{{.filename}}'",
+			CreateFileWithContent:    "Creating file '{{.path}}'",
+			AppendingLineToFile:      "Appending '{{.line}}' to file '{{.filename}}'",
+			EditRebaseFromBaseCommit: "Beginning interactive rebase from '{{.baseCommit}}' onto '{{.targetBranchName}}",
 		},
 	}
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -717,6 +717,19 @@ type Actions struct {
 	BisectMark                        string
 	RemoveWorktree                    string
 	AddWorktree                       string
+	LogEditRebase                     string
+	LogMoveCommitUp                   string
+	LogMoveCommitDown                 string
+	LogCherryPickCommits              string
+	LogHandleUndo                     string
+	LogHandleMidRebaseCommand         string
+	LogMovingCommitUp                 string
+	LogMovingCommitDown               string
+	LogRemoveFile                     string
+	LogCopyToClipboard                string
+	LogRemove                         string
+	LogCreateFileWithContent          string
+	LogAppendingLineToFile            string
 }
 
 const englishIntroPopupMessage = `
@@ -1438,6 +1451,19 @@ func EnglishTranslationSet() TranslationSet {
 			BisectMark:                        "Bisect mark",
 			RemoveWorktree:                    "Remove worktree",
 			AddWorktree:                       "Add worktree",
+			LogEditRebase:                     "Beginning interactive rebase at '{{.ref}}'",
+			LogMoveCommitUp:                   "Moving TODO down: '{{.shortSha}}'",
+			LogMoveCommitDown:                 "Moving TODO down: '{{.shortSha}}'",
+			LogCherryPickCommits:              "Cherry-picking commits:\n'{{.commitLines}}'",
+			LogHandleUndo:                     "Undoing last conflict resolution",
+			LogHandleMidRebaseCommand:         "Updating rebase action of commit {{.shortSha}} to '{{.action}}'",
+			LogMovingCommitUp:                 "Moving commit {{.shortSha}} up",
+			LogMovingCommitDown:               "Moving commit {{.shortSha}} down",
+			LogRemoveFile:                     "Deleting path '{{.path}}'",
+			LogCopyToClipboard:                "Copying '{{.str}}' to clipboard",
+			LogRemove:                         "Removing '{{.filename}}'",
+			LogCreateFileWithContent:          "Creating file '{{.path}}'",
+			LogAppendingLineToFile:            "Appending '{{.line}}' to file '{{.filename}}'",
 		},
 		Bisect: Bisect{
 			Mark:                        "Mark current commit (%s) as %s",


### PR DESCRIPTION
- **PR Description**

These code changes addresses #2848 

I took the example @jesseduffield left on that issue and took that as a starting point to do the rest of the code changes.

I am not yet so familiar with lazygit and its features, so I don't know how to trigger all the places that logs the hard coded messages. I have reviewed my code changes and I ~ think ~ that I have not made any silly mistake. But a second pair of eyes would be very helpful, please review the changes with attention because I mostly relied here on linter and compiler (have compiled the code and it works)

The name of the i18n strings may be better. Any suggestion is welcome.

Note that I've added the `Log` suffix to all the new strings defined in `pkg/i18n/english.go` and named the strings ~ like ~ the function that calls it. Would it be better to add a namespace for these king of log strings? Since you have an [Actions](https://github.com/jesseduffield/lazygit/blob/7cfbfb7183934dd9c2106dc7b521a7e1d6419741/pkg/i18n/english.go#L605) namespace, a [Bisect](https://github.com/jesseduffield/lazygit/blob/7cfbfb7183934dd9c2106dc7b521a7e1d6419741/pkg/i18n/english.go#L585C6-L585C12) namespace, etc. Would it be better to add a `Log` namespace for this purpose? Any other suggestion is welcome.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
