### PR TITLE
Add command to show divergence from upstream

### DIFF
--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -137,9 +137,7 @@ func (self *CommitLoader) GetCommits(opts GetCommitsOptions) ([]*models.Commit, 
 		return commits, nil
 	}
 
-	if ancestor != "" {
-		commits = setCommitMergedStatuses(ancestor, commits)
-	}
+	setCommitMergedStatuses(ancestor, commits)
 
 	return commits, nil
 }
@@ -495,7 +493,11 @@ func (self *CommitLoader) commitFromPatch(content string) *models.Commit {
 	}
 }
 
-func setCommitMergedStatuses(ancestor string, commits []*models.Commit) []*models.Commit {
+func setCommitMergedStatuses(ancestor string, commits []*models.Commit) {
+	if ancestor == "" {
+		return
+	}
+
 	passedAncestor := false
 	for i, commit := range commits {
 		// some commits aren't really commits and don't have sha's, such as the update-ref todo
@@ -509,7 +511,6 @@ func setCommitMergedStatuses(ancestor string, commits []*models.Commit) []*model
 			commits[i].Status = models.StatusMerged
 		}
 	}
-	return commits
 }
 
 func (self *CommitLoader) getMergeBase(refName string) string {

--- a/pkg/commands/git_commands/commit_loader_test.go
+++ b/pkg/commands/git_commands/commit_loader_test.go
@@ -548,7 +548,8 @@ func TestCommitLoader_setCommitMergedStatuses(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.testName, func(t *testing.T) {
-			expectedCommits := setCommitMergedStatuses(scenario.ancestor, scenario.commits)
+			expectedCommits := scenario.commits
+			setCommitMergedStatuses(scenario.ancestor, expectedCommits)
 			assert.Equal(t, scenario.expectedCommits, expectedCommits)
 		})
 	}

--- a/pkg/commands/git_commands/commit_loader_test.go
+++ b/pkg/commands/git_commands/commit_loader_test.go
@@ -45,7 +45,7 @@ func TestGetCommits(t *testing.T) {
 			opts:       GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: "mybranch", IncludeRebaseCommits: false},
 			runner: oscommands.NewFakeRunner(t).
 				ExpectGitArgs([]string{"merge-base", "mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
-				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
+				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s%x00%m", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
 
 			expectedCommits: []*models.Commit{},
 			expectedError:   nil,
@@ -57,7 +57,7 @@ func TestGetCommits(t *testing.T) {
 			opts:       GetCommitsOptions{RefName: "refs/heads/mybranch", RefForPushedStatus: "refs/heads/mybranch", IncludeRebaseCommits: false},
 			runner: oscommands.NewFakeRunner(t).
 				ExpectGitArgs([]string{"merge-base", "refs/heads/mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
-				ExpectGitArgs([]string{"log", "refs/heads/mybranch", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
+				ExpectGitArgs([]string{"log", "refs/heads/mybranch", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s%x00%m", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
 
 			expectedCommits: []*models.Commit{},
 			expectedError:   nil,
@@ -72,7 +72,7 @@ func TestGetCommits(t *testing.T) {
 				// here it's seeing which commits are yet to be pushed
 				ExpectGitArgs([]string{"merge-base", "mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
-				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s", "--abbrev=40", "--no-show-signature", "--"}, commitsOutput, nil).
+				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s%x00%m", "--abbrev=40", "--no-show-signature", "--"}, commitsOutput, nil).
 				// here it's testing which of the configured main branches have an upstream
 				ExpectGitArgs([]string{"rev-parse", "--symbolic-full-name", "master@{u}"}, "refs/remotes/origin/master", nil).       // this one does
 				ExpectGitArgs([]string{"rev-parse", "--symbolic-full-name", "main@{u}"}, "", errors.New("error")).                   // this one doesn't, so it checks origin instead
@@ -209,7 +209,7 @@ func TestGetCommits(t *testing.T) {
 				// here it's seeing which commits are yet to be pushed
 				ExpectGitArgs([]string{"merge-base", "mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
-				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s", "--abbrev=40", "--no-show-signature", "--"}, singleCommitOutput, nil).
+				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s%x00%m", "--abbrev=40", "--no-show-signature", "--"}, singleCommitOutput, nil).
 				// here it's testing which of the configured main branches exist; neither does
 				ExpectGitArgs([]string{"rev-parse", "--symbolic-full-name", "master@{u}"}, "", errors.New("error")).
 				ExpectGitArgs([]string{"rev-parse", "--verify", "--quiet", "refs/remotes/origin/master"}, "", errors.New("error")).
@@ -246,7 +246,7 @@ func TestGetCommits(t *testing.T) {
 				// here it's seeing which commits are yet to be pushed
 				ExpectGitArgs([]string{"merge-base", "mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
-				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s", "--abbrev=40", "--no-show-signature", "--"}, singleCommitOutput, nil).
+				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s%x00%m", "--abbrev=40", "--no-show-signature", "--"}, singleCommitOutput, nil).
 				// here it's testing which of the configured main branches exist
 				ExpectGitArgs([]string{"rev-parse", "--symbolic-full-name", "master@{u}"}, "refs/remotes/origin/master", nil).
 				ExpectGitArgs([]string{"rev-parse", "--symbolic-full-name", "main@{u}"}, "", errors.New("error")).
@@ -282,7 +282,7 @@ func TestGetCommits(t *testing.T) {
 			opts:       GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: "mybranch", IncludeRebaseCommits: false},
 			runner: oscommands.NewFakeRunner(t).
 				ExpectGitArgs([]string{"merge-base", "mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
-				ExpectGitArgs([]string{"log", "HEAD", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
+				ExpectGitArgs([]string{"log", "HEAD", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s%x00%m", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
 
 			expectedCommits: []*models.Commit{},
 			expectedError:   nil,
@@ -294,7 +294,7 @@ func TestGetCommits(t *testing.T) {
 			opts:       GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: "mybranch", FilterPath: "src"},
 			runner: oscommands.NewFakeRunner(t).
 				ExpectGitArgs([]string{"merge-base", "mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
-				ExpectGitArgs([]string{"log", "HEAD", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s", "--abbrev=40", "--follow", "--no-show-signature", "--", "src"}, "", nil),
+				ExpectGitArgs([]string{"log", "HEAD", "--oneline", "--pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%s%x00%m", "--abbrev=40", "--follow", "--no-show-signature", "--", "src"}, "", nil),
 
 			expectedCommits: []*models.Commit{},
 			expectedError:   nil,

--- a/pkg/commands/models/branch.go
+++ b/pkg/commands/models/branch.go
@@ -1,5 +1,7 @@
 package models
 
+import "fmt"
+
 // Branch : A git branch
 // duplicating this for now
 type Branch struct {
@@ -41,6 +43,22 @@ func (b *Branch) RefName() string {
 
 func (b *Branch) ParentRefName() string {
 	return b.RefName() + "^"
+}
+
+func (b *Branch) FullUpstreamRefName() string {
+	if b.UpstreamRemote == "" || b.UpstreamBranch == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("refs/remotes/%s/%s", b.UpstreamRemote, b.UpstreamBranch)
+}
+
+func (b *Branch) ShortUpstreamRefName() string {
+	if b.UpstreamRemote == "" || b.UpstreamBranch == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/%s", b.UpstreamRemote, b.UpstreamBranch)
 }
 
 func (b *Branch) ID() string {

--- a/pkg/commands/models/commit.go
+++ b/pkg/commands/models/commit.go
@@ -30,6 +30,17 @@ const (
 	ActionConflict = todo.Comment + 1
 )
 
+type Divergence int
+
+// For a divergence log (left/right comparison of two refs) this is set to
+// either DivergenceLeft or DivergenceRight for each commit; for normal
+// commit views it is always DivergenceNone.
+const (
+	DivergenceNone Divergence = iota
+	DivergenceLeft
+	DivergenceRight
+)
+
 // Commit : A git commit
 type Commit struct {
 	Sha           string
@@ -41,6 +52,7 @@ type Commit struct {
 	AuthorName    string // something like 'Jesse Duffield'
 	AuthorEmail   string // something like 'jessedduffield@gmail.com'
 	UnixTimestamp int64
+	Divergence    Divergence // set to DivergenceNone unless we are showing the divergence view
 
 	// SHAs of parent commits (will be multiple if it's a merge commit)
 	Parents []string

--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -1,14 +1,12 @@
 package context
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
-	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 type SubCommitsContext struct {
@@ -158,10 +156,6 @@ func (self *SubCommitsContext) GetSelectedRef() types.Ref {
 
 func (self *SubCommitsContext) GetCommits() []*models.Commit {
 	return self.getModel()
-}
-
-func (self *SubCommitsContext) Title() string {
-	return fmt.Sprintf(self.c.Tr.SubCommitsDynamicTitle, utils.TruncateWithEllipsis(self.ref.RefName(), 50))
 }
 
 func (self *SubCommitsContext) SetLimitCommits(value bool) {

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
+	"github.com/jesseduffield/lazygit/pkg/gui/controllers/helpers"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
@@ -141,6 +142,27 @@ func (self *BranchesController) setUpstream(selectedBranch *models.Branch) error
 	return self.c.Menu(types.CreateMenuOptions{
 		Title: self.c.Tr.Actions.SetUnsetUpstream,
 		Items: []*types.MenuItem{
+			{
+				LabelColumns: []string{self.c.Tr.ViewDivergenceFromUpstream},
+				OnPress: func() error {
+					branch := self.context().GetSelected()
+					if branch == nil {
+						return nil
+					}
+
+					if !branch.RemoteBranchStoredLocally() {
+						return self.c.ErrorMsg(self.c.Tr.DivergenceNoUpstream)
+					}
+					return self.c.Helpers().SubCommits.ViewSubCommits(helpers.ViewSubCommitsOpts{
+						Ref:                     branch,
+						TitleRef:                fmt.Sprintf("%s <-> %s", branch.RefName(), branch.ShortUpstreamRefName()),
+						RefToShowDivergenceFrom: branch.FullUpstreamRefName(),
+						Context:                 self.context(),
+						ShowBranchHeads:         false,
+					})
+				},
+				Key: 'v',
+			},
 			{
 				LabelColumns: []string{self.c.Tr.UnsetUpstream},
 				OnPress: func() error {

--- a/pkg/gui/controllers/helpers/helpers.go
+++ b/pkg/gui/controllers/helpers/helpers.go
@@ -49,6 +49,7 @@ type Helpers struct {
 	WindowArrangement *WindowArrangementHelper
 	Search            *SearchHelper
 	Worktree          *WorktreeHelper
+	SubCommits        *SubCommitsHelper
 }
 
 func NewStubHelpers() *Helpers {
@@ -83,5 +84,6 @@ func NewStubHelpers() *Helpers {
 		WindowArrangement: &WindowArrangementHelper{},
 		Search:            &SearchHelper{},
 		Worktree:          &WorktreeHelper{},
+		SubCommits:        &SubCommitsHelper{},
 	}
 }

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -334,11 +334,12 @@ func (self *RefreshHelper) refreshSubCommitsWithLimit() error {
 
 	commits, err := self.c.Git().Loaders.CommitLoader.GetCommits(
 		git_commands.GetCommitsOptions{
-			Limit:                self.c.Contexts().SubCommits.GetLimitCommits(),
-			FilterPath:           self.c.Modes().Filtering.GetPath(),
-			IncludeRebaseCommits: false,
-			RefName:              self.c.Contexts().SubCommits.GetRef().FullRefName(),
-			RefForPushedStatus:   self.c.Contexts().SubCommits.GetRef().FullRefName(),
+			Limit:                   self.c.Contexts().SubCommits.GetLimitCommits(),
+			FilterPath:              self.c.Modes().Filtering.GetPath(),
+			IncludeRebaseCommits:    false,
+			RefName:                 self.c.Contexts().SubCommits.GetRef().FullRefName(),
+			RefToShowDivergenceFrom: self.c.Contexts().SubCommits.GetRefToShowDivergenceFrom(),
+			RefForPushedStatus:      self.c.Contexts().SubCommits.GetRef().FullRefName(),
 		},
 	)
 	if err != nil {

--- a/pkg/gui/controllers/helpers/sub_commits_helper.go
+++ b/pkg/gui/controllers/helpers/sub_commits_helper.go
@@ -1,0 +1,69 @@
+package helpers
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/utils"
+)
+
+type SubCommitsHelper struct {
+	c *HelperCommon
+
+	refreshHelper *RefreshHelper
+	setSubCommits func([]*models.Commit)
+}
+
+func NewSubCommitsHelper(
+	c *HelperCommon,
+	refreshHelper *RefreshHelper,
+	setSubCommits func([]*models.Commit),
+) *SubCommitsHelper {
+	return &SubCommitsHelper{
+		c:             c,
+		refreshHelper: refreshHelper,
+		setSubCommits: setSubCommits,
+	}
+}
+
+type ViewSubCommitsOpts struct {
+	Ref             types.Ref
+	Context         types.Context
+	ShowBranchHeads bool
+}
+
+func (self *SubCommitsHelper) ViewSubCommits(opts ViewSubCommitsOpts) error {
+	commits, err := self.c.Git().Loaders.CommitLoader.GetCommits(
+		git_commands.GetCommitsOptions{
+			Limit:                true,
+			FilterPath:           self.c.Modes().Filtering.GetPath(),
+			IncludeRebaseCommits: false,
+			RefName:              opts.Ref.FullRefName(),
+			RefForPushedStatus:   opts.Ref.FullRefName(),
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	self.setSubCommits(commits)
+	self.refreshHelper.RefreshAuthors(commits)
+
+	subCommitsContext := self.c.Contexts().SubCommits
+	subCommitsContext.SetSelectedLineIdx(0)
+	subCommitsContext.SetParentContext(opts.Context)
+	subCommitsContext.SetWindowName(opts.Context.GetWindowName())
+	subCommitsContext.SetTitleRef(utils.TruncateWithEllipsis(opts.Ref.RefName(), 50))
+	subCommitsContext.SetRef(opts.Ref)
+	subCommitsContext.SetLimitCommits(true)
+	subCommitsContext.SetShowBranchHeads(opts.ShowBranchHeads)
+	subCommitsContext.ClearSearchString()
+	subCommitsContext.GetView().ClearSearch()
+
+	err = self.c.PostRefreshUpdate(self.c.Contexts().SubCommits)
+	if err != nil {
+		return err
+	}
+
+	return self.c.PushContext(self.c.Contexts().SubCommits)
+}

--- a/pkg/gui/controllers/helpers/sub_commits_helper.go
+++ b/pkg/gui/controllers/helpers/sub_commits_helper.go
@@ -27,19 +27,22 @@ func NewSubCommitsHelper(
 }
 
 type ViewSubCommitsOpts struct {
-	Ref             types.Ref
-	Context         types.Context
-	ShowBranchHeads bool
+	Ref                     types.Ref
+	RefToShowDivergenceFrom string
+	TitleRef                string
+	Context                 types.Context
+	ShowBranchHeads         bool
 }
 
 func (self *SubCommitsHelper) ViewSubCommits(opts ViewSubCommitsOpts) error {
 	commits, err := self.c.Git().Loaders.CommitLoader.GetCommits(
 		git_commands.GetCommitsOptions{
-			Limit:                true,
-			FilterPath:           self.c.Modes().Filtering.GetPath(),
-			IncludeRebaseCommits: false,
-			RefName:              opts.Ref.FullRefName(),
-			RefForPushedStatus:   opts.Ref.FullRefName(),
+			Limit:                   true,
+			FilterPath:              self.c.Modes().Filtering.GetPath(),
+			IncludeRebaseCommits:    false,
+			RefName:                 opts.Ref.FullRefName(),
+			RefForPushedStatus:      opts.Ref.FullRefName(),
+			RefToShowDivergenceFrom: opts.RefToShowDivergenceFrom,
 		},
 	)
 	if err != nil {
@@ -53,8 +56,9 @@ func (self *SubCommitsHelper) ViewSubCommits(opts ViewSubCommitsOpts) error {
 	subCommitsContext.SetSelectedLineIdx(0)
 	subCommitsContext.SetParentContext(opts.Context)
 	subCommitsContext.SetWindowName(opts.Context.GetWindowName())
-	subCommitsContext.SetTitleRef(utils.TruncateWithEllipsis(opts.Ref.RefName(), 50))
+	subCommitsContext.SetTitleRef(utils.TruncateWithEllipsis(opts.TitleRef, 50))
 	subCommitsContext.SetRef(opts.Ref)
+	subCommitsContext.SetRefToShowDivergenceFrom(opts.RefToShowDivergenceFrom)
 	subCommitsContext.SetLimitCommits(true)
 	subCommitsContext.SetShowBranchHeads(opts.ShowBranchHeads)
 	subCommitsContext.ClearSearchString()

--- a/pkg/gui/controllers/switch_to_sub_commits_controller.go
+++ b/pkg/gui/controllers/switch_to_sub_commits_controller.go
@@ -54,6 +54,7 @@ func (self *SwitchToSubCommitsController) viewCommits() error {
 
 	return self.c.Helpers().SubCommits.ViewSubCommits(helpers.ViewSubCommitsOpts{
 		Ref:             ref,
+		TitleRef:        ref.RefName(),
 		Context:         self.context,
 		ShowBranchHeads: self.context.ShowBranchHeadsInSubCommits(),
 	})

--- a/pkg/gui/controllers/switch_to_sub_commits_controller.go
+++ b/pkg/gui/controllers/switch_to_sub_commits_controller.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 var _ types.IController = &SwitchToSubCommitsController{}
@@ -78,7 +79,7 @@ func (self *SwitchToSubCommitsController) viewCommits() error {
 	subCommitsContext.SetSelectedLineIdx(0)
 	subCommitsContext.SetParentContext(self.context)
 	subCommitsContext.SetWindowName(self.context.GetWindowName())
-	subCommitsContext.SetTitleRef(ref.Description())
+	subCommitsContext.SetTitleRef(utils.TruncateWithEllipsis(ref.RefName(), 50))
 	subCommitsContext.SetRef(ref)
 	subCommitsContext.SetLimitCommits(true)
 	subCommitsContext.SetShowBranchHeads(self.context.ShowBranchHeadsInSubCommits())

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -359,7 +359,9 @@ func displayCommit(
 	}
 
 	cols := make([]string, 0, 7)
-	if icons.IsIconEnabled() {
+	if commit.Divergence != models.DivergenceNone {
+		cols = append(cols, shaColor.Sprint(lo.Ternary(commit.Divergence == models.DivergenceLeft, "↑", "↓")))
+	} else if icons.IsIconEnabled() {
 		cols = append(cols, shaColor.Sprint(icons.IconForCommit(commit)))
 	}
 	cols = append(cols, shaColor.Sprint(commit.ShortSha()))
@@ -430,6 +432,8 @@ func getShaColor(
 		shaColor = theme.DiffTerminalColor
 	} else if cherryPickedCommitShaSet.Includes(commit.Sha) {
 		shaColor = theme.CherryPickedCommitTextStyle
+	} else if commit.Divergence == models.DivergenceRight && commit.Status != models.StatusMerged {
+		shaColor = style.FgBlue
 	}
 
 	return shaColor

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -348,6 +348,10 @@ type TranslationSet struct {
 	SetAsUpstream                       string
 	SetUpstream                         string
 	UnsetUpstream                       string
+	ViewDivergenceFromUpstream          string
+	DivergenceNoUpstream                string
+	DivergenceSectionHeaderLocal        string
+	DivergenceSectionHeaderRemote       string
 	SetUpstreamTitle                    string
 	SetUpstreamMessage                  string
 	EditRemote                          string
@@ -1128,6 +1132,10 @@ func EnglishTranslationSet() TranslationSet {
 		SetAsUpstream:                       "Set as upstream of checked-out branch",
 		SetUpstream:                         "Set upstream of selected branch",
 		UnsetUpstream:                       "Unset upstream of selected branch",
+		ViewDivergenceFromUpstream:          "View divergence from upstream",
+		DivergenceNoUpstream:                "Cannot show divergence of a branch that has no (locally tracked) upstream",
+		DivergenceSectionHeaderLocal:        "Local",
+		DivergenceSectionHeaderRemote:       "Remote",
 		SetUpstreamTitle:                    "Set upstream branch",
 		SetUpstreamMessage:                  "Are you sure you want to set the upstream branch of '{{.checkedOut}}' to '{{.selected}}'",
 		EditRemote:                          "Edit remote",

--- a/pkg/integration/components/text_matcher.go
+++ b/pkg/integration/components/text_matcher.go
@@ -39,6 +39,18 @@ func (self *TextMatcher) DoesNotContain(target string) *TextMatcher {
 	return self
 }
 
+func (self *TextMatcher) DoesNotContainAnyOf(targets []string) *TextMatcher {
+	self.appendRule(matcherRule[string]{
+		name: fmt.Sprintf("does not contain any of '%s'", targets),
+		testFn: func(value string) (bool, string) {
+			return lo.NoneBy(targets, func(target string) bool { return strings.Contains(value, target) }),
+				fmt.Sprintf("Expected none of '%s' to be found in '%s'", targets, value)
+		},
+	})
+
+	return self
+}
+
 func (self *TextMatcher) MatchesRegexp(target string) *TextMatcher {
 	self.appendRule(matcherRule[string]{
 		name: fmt.Sprintf("matches regular expression '%s'", target),
@@ -105,6 +117,10 @@ func Contains(target string) *TextMatcher {
 
 func DoesNotContain(target string) *TextMatcher {
 	return AnyString().DoesNotContain(target)
+}
+
+func DoesNotContainAnyOf(targets ...string) *TextMatcher {
+	return AnyString().DoesNotContainAnyOf(targets)
 }
 
 func MatchesRegexp(target string) *TextMatcher {

--- a/pkg/integration/tests/branch/show_divergence_from_upstream.go
+++ b/pkg/integration/tests/branch/show_divergence_from_upstream.go
@@ -1,0 +1,54 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ShowDivergenceFromUpstream = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Show divergence from upstream",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file", "content1")
+		shell.Commit("one")
+		shell.UpdateFileAndAdd("file", "content2")
+		shell.Commit("two")
+		shell.CreateFileAndAdd("file3", "content3")
+		shell.Commit("three")
+
+		shell.CloneIntoRemote("origin")
+
+		shell.SetBranchUpstream("master", "origin/master")
+
+		shell.HardReset("HEAD^^")
+		shell.CreateFileAndAdd("file4", "content4")
+		shell.Commit("four")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Lines(
+				Contains("four"),
+				Contains("one"),
+			)
+
+		t.Views().Branches().
+			Focus().
+			Lines(Contains("master")).
+			Press(keys.Branches.SetUpstream)
+
+		t.ExpectPopup().Menu().Title(Contains("upstream")).Select(Contains("View divergence from upstream")).Confirm()
+
+		t.Views().SubCommits().
+			IsFocused().
+			Title(Contains("Commits (master <-> origin/master)")).
+			Lines(
+				DoesNotContainAnyOf("↓", "↑").Contains("--- Remote ---"),
+				Contains("↓").Contains("three"),
+				Contains("↓").Contains("two"),
+				DoesNotContainAnyOf("↓", "↑").Contains("--- Local ---"),
+				Contains("↑").Contains("four"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -49,6 +49,7 @@ var tests = []*components.IntegrationTest{
 	branch.Reset,
 	branch.ResetUpstream,
 	branch.SetUpstream,
+	branch.ShowDivergenceFromUpstream,
 	branch.Suggestions,
 	cherry_pick.CherryPick,
 	cherry_pick.CherryPickConflicts,


### PR DESCRIPTION
- **PR Description**

This adds a new command to the "upstream" menu (available by pressing `u` in the branches panel) that lets you see what git calls the "symmetric difference" of a branch against its upstream. I find this useful in two situations:
- when a branch has diverged from its upstream (i.e. it shows `mybranch ↑3↓5`) it allows you to tell whether this is because you and your coworker have both added commits (in which case you want to pull), or because you rebased the branch locally, in which case you want to force-push. Or both, in which case you want to maybe cherry-pick the upstream commit (which is easy from this new view), and then force-push.
- when master has new commits (i.e. it shows `master ↓7`), this lets you see which commits you would fetch before actually doing it.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
