### PR TITLE
Add history for search view

### DIFF
--- a/pkg/gui/context/search_trait.go
+++ b/pkg/gui/context/search_trait.go
@@ -5,16 +5,21 @@ import (
 
 	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/theme"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 type SearchTrait struct {
 	c *ContextCommon
 
-	searchString string
+	searchHistory *utils.CircularBuffer[string]
+	searchString  string
 }
 
 func NewSearchTrait(c *ContextCommon) *SearchTrait {
-	return &SearchTrait{c: c}
+	return &SearchTrait{
+		c:             c,
+		searchHistory: utils.NewCircularBuffer[string](10),
+	}
 }
 
 func (self *SearchTrait) GetSearchString() string {
@@ -23,6 +28,13 @@ func (self *SearchTrait) GetSearchString() string {
 
 func (self *SearchTrait) SetSearchString(searchString string) {
 	self.searchString = searchString
+	if searchString != "" {
+		self.searchHistory.Push(searchString)
+	}
+}
+
+func (self *SearchTrait) GetSearchHistory() *utils.CircularBuffer[string] {
+	return self.searchHistory
 }
 
 func (self *SearchTrait) ClearSearchString() {

--- a/pkg/gui/controllers/search_prompt_controller.go
+++ b/pkg/gui/controllers/search_prompt_controller.go
@@ -33,6 +33,16 @@ func (self *SearchPromptController) GetKeybindings(opts types.KeybindingsOpts) [
 			Modifier: gocui.ModNone,
 			Handler:  self.cancel,
 		},
+		{
+			Key:      opts.GetKey(opts.Config.Universal.PrevItem),
+			Modifier: gocui.ModNone,
+			Handler:  self.prevHistory,
+		},
+		{
+			Key:      opts.GetKey(opts.Config.Universal.NextItem),
+			Modifier: gocui.ModNone,
+			Handler:  self.nextHistory,
+		},
 	}
 }
 
@@ -50,4 +60,12 @@ func (self *SearchPromptController) confirm() error {
 
 func (self *SearchPromptController) cancel() error {
 	return self.c.Helpers().Search.CancelPrompt()
+}
+
+func (self *SearchPromptController) prevHistory() error {
+	return self.c.Helpers().Search.ScrollHistory(1)
+}
+
+func (self *SearchPromptController) nextHistory() error {
+	return self.c.Helpers().Search.ScrollHistory(-1)
 }

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/gui/patch_exploring"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/sasha-s/go-deadlock"
 )
 
@@ -104,6 +105,7 @@ type ISearchableContext interface {
 	SetSearchString(string)
 	GetSearchString() string
 	ClearSearchString()
+	GetSearchHistory() *utils.CircularBuffer[string]
 	IsSearching() bool
 	IsSearchableContext()
 }

--- a/pkg/gui/types/search_state.go
+++ b/pkg/gui/types/search_state.go
@@ -12,11 +12,12 @@ const (
 
 // TODO: could we remove this entirely?
 type SearchState struct {
-	Context Context
+	Context         Context
+	PrevSearchIndex int
 }
 
 func NewSearchState() *SearchState {
-	return &SearchState{}
+	return &SearchState{PrevSearchIndex: -1}
 }
 
 func (self *SearchState) SearchType() SearchType {

--- a/pkg/integration/tests/filter_and_search/filter_search_history.go
+++ b/pkg/integration/tests/filter_and_search/filter_search_history.go
@@ -1,0 +1,77 @@
+package filter_and_search
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var FilterSearchHistory = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Navigating search history",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo:    func(shell *Shell) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			// populate search history with some values
+			FilterOrSearch("1").
+			FilterOrSearch("2").
+			FilterOrSearch("3").
+			Press(keys.Universal.StartSearch).
+			// clear initial search value
+			Tap(func() {
+				t.ExpectSearch().Clear()
+			}).
+			// test main search history functionality
+			Tap(func() {
+				t.Views().Search().
+					Press(keys.Universal.PrevItem).
+					Content(Contains("3")).
+					Press(keys.Universal.PrevItem).
+					Content(Contains("2")).
+					Press(keys.Universal.PrevItem).
+					Content(Contains("1")).
+					Press(keys.Universal.PrevItem).
+					Content(Contains("3")).
+					Press(keys.Universal.NextItem).
+					Content(Contains("1")).
+					Press(keys.Universal.NextItem).
+					Content(Contains("2")).
+					Press(keys.Universal.NextItem).
+					Content(Contains("3")).
+					Press(keys.Universal.NextItem).
+					Content(Contains("3")).
+					Press(keys.Universal.PrevItem).
+					Content(Contains("2")).
+					PressEscape()
+			}).
+			// test that it resets after you enter and exit a search
+			Press(keys.Universal.StartSearch).
+			Tap(func() {
+				t.Views().Search().
+					Press(keys.Universal.PrevItem).
+					Content(Contains("3")).
+					PressEscape()
+			})
+
+		// test that the histories are separate for each view
+		t.Views().Commits().
+			Focus().
+			FilterOrSearch("a").
+			FilterOrSearch("b").
+			FilterOrSearch("c").
+			Press(keys.Universal.StartSearch).
+			Tap(func() {
+				t.ExpectSearch().Clear()
+			}).
+			Tap(func() {
+				t.Views().Search().
+					Press(keys.Universal.PrevItem).
+					Content(Contains("c")).
+					Press(keys.Universal.PrevItem).
+					Content(Contains("b")).
+					Press(keys.Universal.PrevItem).
+					Content(Contains("a"))
+			})
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -118,6 +118,7 @@ var tests = []*components.IntegrationTest{
 	filter_and_search.FilterFuzzy,
 	filter_and_search.FilterMenu,
 	filter_and_search.FilterRemoteBranches,
+	filter_and_search.FilterSearchHistory,
 	filter_and_search.NestedFilter,
 	filter_and_search.NestedFilterTransient,
 	filter_by_path.CliArg,

--- a/pkg/utils/circular_buffer.go
+++ b/pkg/utils/circular_buffer.go
@@ -1,0 +1,45 @@
+package utils
+
+import "fmt"
+
+type CircularBuffer[T any] struct {
+	maxSize int
+	Items   []T
+}
+
+func NewCircularBuffer[T any](maxSize int) *CircularBuffer[T] {
+	return &CircularBuffer[T]{
+		maxSize: maxSize,
+		Items:   make([]T, 0, maxSize),
+	}
+}
+
+func (self *CircularBuffer[T]) Push(item T) {
+	if len(self.Items) == self.maxSize {
+		self.Items = self.Items[:len(self.Items)-1]
+	}
+	self.Items = append([]T{item}, self.Items...)
+}
+
+func (self *CircularBuffer[T]) Pop() (T, error) {
+	var item T
+	if len(self.Items) == 0 {
+		return item, fmt.Errorf("Queue is empty")
+	}
+	item = self.Items[0]
+	self.Items = self.Items[1:]
+	return item, nil
+}
+
+func (self *CircularBuffer[T]) PeekAt(index int) (T, error) {
+	var item T
+	if len(self.Items) == 0 {
+		return item, fmt.Errorf("Queue is empty")
+	}
+	length := len(self.Items)
+	index = index % length
+	if index < 0 {
+		index += length
+	}
+	return self.Items[index], nil
+}


### PR DESCRIPTION
- **PR Description**
When interacting with the search view I often find myself wanting to scroll back through the search history using the arrow keys. This is my attempt at implementing this enhancement for the search view. An independent search history is created for each searchable view. 

Some notes:
* It only works for searchable and not filterable views. I am not sure if I want something like that for the filterable views.
* The state of the search history is not preserved through separate launches of lazygit.
* History is capped at 10. Not sure what would be a good number for this, but it works for me.

Feedback is very much appreciated. I am new to go and this awesome project :)

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary 
* [x] You've read through your own file changes for silly mistakes etc
