### PR TITLE
Add history for search view

### DIFF
--- a/pkg/gui/context/filtered_list_view_model.go
+++ b/pkg/gui/context/filtered_list_view_model.go
@@ -3,13 +3,15 @@ package context
 type FilteredListViewModel[T any] struct {
 	*FilteredList[T]
 	*ListViewModel[T]
+	*SearchHistory
 }
 
 func NewFilteredListViewModel[T any](getList func() []T, getFilterFields func(T) []string) *FilteredListViewModel[T] {
 	filteredList := NewFilteredList(getList, getFilterFields)
 
 	self := &FilteredListViewModel[T]{
-		FilteredList: filteredList,
+		FilteredList:  filteredList,
+		SearchHistory: NewSearchHistory(),
 	}
 
 	listViewModel := NewListViewModel(filteredList.GetFilteredList)

--- a/pkg/gui/context/history_trait.go
+++ b/pkg/gui/context/history_trait.go
@@ -1,0 +1,20 @@
+package context
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/utils"
+)
+
+// Maintains a list of strings that have previously been searched/filtered for
+type SearchHistory struct {
+	history *utils.HistoryBuffer[string]
+}
+
+func NewSearchHistory() *SearchHistory {
+	return &SearchHistory{
+		history: utils.NewHistoryBuffer[string](1000),
+	}
+}
+
+func (self *SearchHistory) GetSearchHistory() *utils.HistoryBuffer[string] {
+	return self.history
+}

--- a/pkg/gui/context/remotes_context.go
+++ b/pkg/gui/context/remotes_context.go
@@ -9,6 +9,7 @@ import (
 type RemotesContext struct {
 	*FilteredListViewModel[*models.Remote]
 	*ListContextTrait
+	*SearchHistory
 }
 
 var (

--- a/pkg/gui/context/search_trait.go
+++ b/pkg/gui/context/search_trait.go
@@ -9,12 +9,16 @@ import (
 
 type SearchTrait struct {
 	c *ContextCommon
+	*SearchHistory
 
 	searchString string
 }
 
 func NewSearchTrait(c *ContextCommon) *SearchTrait {
-	return &SearchTrait{c: c}
+	return &SearchTrait{
+		c:             c,
+		SearchHistory: NewSearchHistory(),
+	}
 }
 
 func (self *SearchTrait) GetSearchString() string {

--- a/pkg/gui/controllers/search_prompt_controller.go
+++ b/pkg/gui/controllers/search_prompt_controller.go
@@ -33,6 +33,16 @@ func (self *SearchPromptController) GetKeybindings(opts types.KeybindingsOpts) [
 			Modifier: gocui.ModNone,
 			Handler:  self.cancel,
 		},
+		{
+			Key:      opts.GetKey(opts.Config.Universal.PrevItem),
+			Modifier: gocui.ModNone,
+			Handler:  self.prevHistory,
+		},
+		{
+			Key:      opts.GetKey(opts.Config.Universal.NextItem),
+			Modifier: gocui.ModNone,
+			Handler:  self.nextHistory,
+		},
 	}
 }
 
@@ -50,4 +60,14 @@ func (self *SearchPromptController) confirm() error {
 
 func (self *SearchPromptController) cancel() error {
 	return self.c.Helpers().Search.CancelPrompt()
+}
+
+func (self *SearchPromptController) prevHistory() error {
+	self.c.Helpers().Search.ScrollHistory(1)
+	return nil
+}
+
+func (self *SearchPromptController) nextHistory() error {
+	self.c.Helpers().Search.ScrollHistory(-1)
+	return nil
 }

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/gui/patch_exploring"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/sasha-s/go-deadlock"
 )
 
@@ -87,9 +88,16 @@ type Context interface {
 	HandleRenderToMain() error
 }
 
+type ISearchHistoryContext interface {
+	Context
+
+	GetSearchHistory() *utils.HistoryBuffer[string]
+}
+
 type IFilterableContext interface {
 	Context
 	IListPanelState
+	ISearchHistoryContext
 
 	SetFilter(string)
 	GetFilter() string
@@ -100,6 +108,7 @@ type IFilterableContext interface {
 
 type ISearchableContext interface {
 	Context
+	ISearchHistoryContext
 
 	SetSearchString(string)
 	GetSearchString() string

--- a/pkg/gui/types/search_state.go
+++ b/pkg/gui/types/search_state.go
@@ -12,11 +12,12 @@ const (
 
 // TODO: could we remove this entirely?
 type SearchState struct {
-	Context Context
+	Context         Context
+	PrevSearchIndex int
 }
 
 func NewSearchState() *SearchState {
-	return &SearchState{}
+	return &SearchState{PrevSearchIndex: -1}
 }
 
 func (self *SearchState) SearchType() SearchType {

--- a/pkg/integration/tests/filter_and_search/filter_search_history.go
+++ b/pkg/integration/tests/filter_and_search/filter_search_history.go
@@ -1,0 +1,77 @@
+package filter_and_search
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var FilterSearchHistory = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Navigating search history",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo:    func(shell *Shell) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			// populate search history with some values
+			FilterOrSearch("1").
+			FilterOrSearch("2").
+			FilterOrSearch("3").
+			Press(keys.Universal.StartSearch).
+			// clear initial search value
+			Tap(func() {
+				t.ExpectSearch().Clear()
+			}).
+			// test main search history functionality
+			Tap(func() {
+				t.Views().Search().
+					Press(keys.Universal.PrevItem).
+					Content(Contains("3")).
+					Press(keys.Universal.PrevItem).
+					Content(Contains("2")).
+					Press(keys.Universal.PrevItem).
+					Content(Contains("1")).
+					Press(keys.Universal.PrevItem).
+					Content(Contains("1")).
+					Press(keys.Universal.NextItem).
+					Content(Contains("2")).
+					Press(keys.Universal.NextItem).
+					Content(Contains("3")).
+					Press(keys.Universal.NextItem).
+					Content(Contains("")).
+					Press(keys.Universal.NextItem).
+					Content(Contains("")).
+					Press(keys.Universal.PrevItem).
+					Content(Contains("3")).
+					PressEscape()
+			}).
+			// test that it resets after you enter and exit a search
+			Press(keys.Universal.StartSearch).
+			Tap(func() {
+				t.Views().Search().
+					Press(keys.Universal.PrevItem).
+					Content(Contains("3")).
+					PressEscape()
+			})
+
+		// test that the histories are separate for each view
+		t.Views().Commits().
+			Focus().
+			FilterOrSearch("a").
+			FilterOrSearch("b").
+			FilterOrSearch("c").
+			Press(keys.Universal.StartSearch).
+			Tap(func() {
+				t.ExpectSearch().Clear()
+			}).
+			Tap(func() {
+				t.Views().Search().
+					Press(keys.Universal.PrevItem).
+					Content(Contains("c")).
+					Press(keys.Universal.PrevItem).
+					Content(Contains("b")).
+					Press(keys.Universal.PrevItem).
+					Content(Contains("a"))
+			})
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -118,6 +118,7 @@ var tests = []*components.IntegrationTest{
 	filter_and_search.FilterFuzzy,
 	filter_and_search.FilterMenu,
 	filter_and_search.FilterRemoteBranches,
+	filter_and_search.FilterSearchHistory,
 	filter_and_search.NestedFilter,
 	filter_and_search.NestedFilterTransient,
 	filter_by_path.CliArg,

--- a/pkg/utils/history_buffer.go
+++ b/pkg/utils/history_buffer.go
@@ -1,0 +1,36 @@
+package utils
+
+import "fmt"
+
+type HistoryBuffer[T any] struct {
+	maxSize int
+	items   []T
+}
+
+func NewHistoryBuffer[T any](maxSize int) *HistoryBuffer[T] {
+	return &HistoryBuffer[T]{
+		maxSize: maxSize,
+		items:   make([]T, 0, maxSize),
+	}
+}
+
+func (self *HistoryBuffer[T]) Push(item T) {
+	if len(self.items) == self.maxSize {
+		self.items = self.items[:len(self.items)-1]
+	}
+	self.items = append([]T{item}, self.items...)
+}
+
+func (self *HistoryBuffer[T]) PeekAt(index int) (T, error) {
+	var item T
+	if len(self.items) == 0 {
+		return item, fmt.Errorf("Buffer is empty")
+	}
+	if len(self.items) <= index || index < -1 {
+		return item, fmt.Errorf("Index out of range")
+	}
+	if index == -1 {
+		return item, nil
+	}
+	return self.items[index], nil
+}

--- a/pkg/utils/history_buffer_test.go
+++ b/pkg/utils/history_buffer_test.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHistoryBuffer(t *testing.T) {
+	hb := NewHistoryBuffer[int](5)
+	assert.NotNil(t, hb)
+	assert.Equal(t, 5, hb.maxSize)
+	assert.Equal(t, 0, len(hb.items))
+}
+
+func TestPush(t *testing.T) {
+	hb := NewHistoryBuffer[int](3)
+	hb.Push(1)
+	hb.Push(2)
+	hb.Push(3)
+	hb.Push(4)
+
+	assert.Equal(t, 3, len(hb.items))
+	assert.Equal(t, []int{4, 3, 2}, hb.items)
+}
+
+func TestPeekAt(t *testing.T) {
+	hb := NewHistoryBuffer[int](3)
+	hb.Push(1)
+	hb.Push(2)
+	hb.Push(3)
+
+	item, err := hb.PeekAt(0)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, item)
+
+	item, err = hb.PeekAt(1)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, item)
+
+	item, err = hb.PeekAt(2)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, item)
+
+	item, err = hb.PeekAt(-1)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, item)
+
+	_, err = hb.PeekAt(3)
+	assert.NotNil(t, err)
+	assert.Equal(t, "Index out of range", err.Error())
+
+	_, err = hb.PeekAt(-2)
+	assert.NotNil(t, err)
+	assert.Equal(t, "Index out of range", err.Error())
+}
+
+func TestPeekAtEmptyBuffer(t *testing.T) {
+	hb := NewHistoryBuffer[int](3)
+
+	_, err := hb.PeekAt(0)
+	assert.NotNil(t, err)
+	assert.Equal(t, "Buffer is empty", err.Error())
+}


### PR DESCRIPTION
- **PR Description**
When interacting with the search view I often find myself wanting to scroll back through the search history using the arrow keys. This is my attempt at implementing this enhancement for the search view. An independent search history is created for each searchable view. 

Some notes:
* It only works for searchable and not filterable views. I am not sure if I want something like that for the filterable views.
* The state of the search history is not preserved through separate launches of lazygit.
* History is capped at 10. Not sure what would be a good number for this, but it works for me.

Feedback is very much appreciated. I am new to go and this awesome project :)

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary 
* [x] You've read through your own file changes for silly mistakes etc
