### PR TITLE
Add icons for files with .mdx and .svelte file extensions

### DIFF
--- a/pkg/gui/presentation/icons/file_icons.go
+++ b/pkg/gui/presentation/icons/file_icons.go
@@ -199,6 +199,7 @@ var extIconMap = map[string]string{
 	".m4a":            "\uf001",     // 
 	".markdown":       "\uf48a",     // 
 	".md":             "\uf48a",     // 
+	".mdx":            "\uf48a",     // 
 	".mjs":            "\ue74e",     // 
 	".mk":             "\uf489",     // 
 	".mkd":            "\uf48a",     // 
@@ -267,6 +268,7 @@ var extIconMap = map[string]string{
 	".sty":            "\uf034",     // 
 	".styl":           "\ue600",     // 
 	".stylus":         "\ue600",     // 
+	".svelte":         "\ue697",     // 
 	".svg":            "\uf1c5",     // 
 	".swift":          "\ue755",     // 
 	".tar":            "\uf410",     // 


### PR DESCRIPTION
- **PR Description**
Added icons for files with `.mdx` and `.svelte` file extensions.
- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
