### PR TITLE
update worktree icons for NerdFont V3

### DIFF
--- a/pkg/gui/presentation/icons/git_icons.go
+++ b/pkg/gui/presentation/icons/git_icons.go
@@ -14,8 +14,8 @@ var (
 	MERGE_COMMIT_ICON            = "\U000f062d" // 󰘭
 	DEFAULT_REMOTE_ICON          = "\uf02a2"    // 󰊢
 	STASH_ICON                   = "\uf01c"     // 
-	LINKED_WORKTREE_ICON         = "\uf838"     // 
-	MISSING_LINKED_WORKTREE_ICON = "\uf839"     // 
+	LINKED_WORKTREE_ICON         = "\U000f0339" // 󰌹
+	MISSING_LINKED_WORKTREE_ICON = "\U000f033a" // 󰌺
 )
 
 var remoteIcons = map[string]string{
@@ -26,10 +26,12 @@ var remoteIcons = map[string]string{
 }
 
 func patchGitIconsForNerdFontsV2() {
-	BRANCH_ICON = "\ufb2b"         // שׂ
-	COMMIT_ICON = "\ufc16"         // ﰖ
-	MERGE_COMMIT_ICON = "\ufb2c"   // שּׁ
-	DEFAULT_REMOTE_ICON = "\uf7a1" // 
+	BRANCH_ICON = "\ufb2b"                  // שׂ
+	COMMIT_ICON = "\ufc16"                  // ﰖ
+	MERGE_COMMIT_ICON = "\ufb2c"            // שּׁ
+	DEFAULT_REMOTE_ICON = "\uf7a1"          // 
+	LINKED_WORKTREE_ICON = "\uf838"         // 
+	MISSING_LINKED_WORKTREE_ICON = "\uf839" // 
 
 	remoteIcons["dev.azure.com"] = "\ufd03" // ﴃ
 }


### PR DESCRIPTION
- **PR Description**

The new worktree feature is interesting, but I cannot see the worktree icon in the status area (which leaves a blank space there). I found it's caused by the outdated icons at the end. Now I want to update the worktree icons.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
