### PR TITLE
Don't run the check-required-label check on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,7 @@ jobs:
         if: ${{ failure() }}
   check-required-label:
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
     steps:
       - uses: mheap/github-action-required-labels@v5
         with:


### PR DESCRIPTION
CI for master currently always fails; fix this by not running the required-label check for master, since it doesn't have one.