### PR TITLE
Fix info link crash

### DIFF
--- a/pkg/gui/information_panel.go
+++ b/pkg/gui/information_panel.go
@@ -52,6 +52,12 @@ func (gui *Gui) handleInfoClick() error {
 	}
 	err := gui.os.OpenLink(url)
 	if err != nil {
+		// Opening the link via the OS failed for some reason. (For example, this
+		// can happen if the `os.openLink` config key references a command that
+		// doesn't exist, or that errors when called.)
+		//
+		// In that case, rather than crash the app, fall back to simply showing a
+		// dialog asking the user to visit the URL.
 		placeholders := map[string]string{"url": url}
 		message := utils.ResolvePlaceholderString(gui.c.Tr.PleaseGoToURL, placeholders)
 		return gui.PopupHandler.Alert(title, message)

--- a/pkg/gui/information_panel.go
+++ b/pkg/gui/information_panel.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jesseduffield/lazygit/pkg/constants"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/mattn/go-runewidth"
 )
 
@@ -39,11 +40,22 @@ func (gui *Gui) handleInfoClick() error {
 		return activeMode.Reset()
 	}
 
+	var title, url string
+
 	// if we're not in an active mode we show the donate button
 	if cx <= runewidth.StringWidth(gui.c.Tr.Donate) {
-		return gui.os.OpenLink(constants.Links.Donate)
+		url = constants.Links.Donate
+		title = gui.c.Tr.Donate
 	} else if cx <= runewidth.StringWidth(gui.c.Tr.Donate)+1+runewidth.StringWidth(gui.c.Tr.AskQuestion) {
-		return gui.os.OpenLink(constants.Links.Discussions)
+		url = constants.Links.Discussions
+		title = gui.c.Tr.AskQuestion
 	}
+	err := gui.os.OpenLink(url)
+	if err != nil {
+		placeholders := map[string]string{"url": url}
+		message := utils.ResolvePlaceholderString(gui.c.Tr.PleaseGoToURL, placeholders)
+		return gui.PopupHandler.Alert(title, message)
+	}
+
 	return nil
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -585,6 +585,7 @@ type TranslationSet struct {
 	MarkAsBaseCommit                    string
 	MarkAsBaseCommitTooltip             string
 	MarkedCommitMarker                  string
+	PleaseGoToURL                       string
 	Actions                             Actions
 	Bisect                              Bisect
 	Log                                 Log
@@ -1347,6 +1348,7 @@ func EnglishTranslationSet() TranslationSet {
 		MarkAsBaseCommit:                    "Mark commit as base commit for rebase",
 		MarkAsBaseCommitTooltip:             "Select a base commit for the next rebase; this will effectively perform a 'git rebase --onto'.",
 		MarkedCommitMarker:                  "↑↑↑ Will rebase from here ↑↑↑",
+		PleaseGoToURL:                       "Please go to {{.url}}",
 		Actions: Actions{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)
 			CheckoutCommit:                    "Checkout commit",


### PR DESCRIPTION
- **PR Description**

If the command used by OSCommand.OpenLink fails, lazygit crashes. With this change, if the OpenLink command fails, lazygit just shows a dialog inviting the user to visit the relevant URL.

Fixes #2882

Here's how it looks:

![CleanShot 2023-08-05 at 6  26 23@2x](https://github.com/jesseduffield/lazygit/assets/116432/669d2840-13b6-4bdf-aa0e-407f507e941c)

https://github.com/jesseduffield/lazygit/assets/116432/e731e36d-c297-4df8-a515-314a6f60ab17

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
