### PR TITLE
Use nerdfont version 3 in demos

### DIFF
--- a/demo/config.yml
+++ b/demo/config.yml
@@ -75,7 +75,10 @@ cursorStyle: block
 # Font family
 # You can use any font that is installed on your machine
 # in CSS-like syntax
-fontFamily: "DejaVuSansMono Nerd Font"
+# Download from:
+# https://github.com/ryanoasis/nerd-fonts/releases/download/v3.0.2/DejaVuSansMono.zip
+# Not using the mono font because it makes icons too small.
+fontFamily: "DejaVuSansM Nerd Font"
 
 # The size of the font
 fontSize: 8

--- a/pkg/integration/tests/demo/amend_old_commit.go
+++ b/pkg/integration/tests/demo/amend_old_commit.go
@@ -11,9 +11,7 @@ var AmendOldCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {
-		// No idea why I had to use version 2: it should be using my own computer's
-		// font and the one iterm uses is version 3.
-		config.UserConfig.Gui.NerdFontsVersion = "2"
+		config.UserConfig.Gui.NerdFontsVersion = "3"
 		config.UserConfig.Gui.ShowFileTree = false
 	},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/demo/bisect.go
+++ b/pkg/integration/tests/demo/bisect.go
@@ -11,9 +11,7 @@ var Bisect = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {
-		// No idea why I had to use version 2: it should be using my own computer's
-		// font and the one iterm uses is version 3.
-		config.UserConfig.Gui.NerdFontsVersion = "2"
+		config.UserConfig.Gui.NerdFontsVersion = "3"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateFile("my-file.txt", "myfile content")

--- a/pkg/integration/tests/demo/cherry_pick.go
+++ b/pkg/integration/tests/demo/cherry_pick.go
@@ -11,9 +11,7 @@ var CherryPick = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {
-		// No idea why I had to use version 2: it should be using my own computer's
-		// font and the one iterm uses is version 3.
-		config.UserConfig.Gui.NerdFontsVersion = "2"
+		config.UserConfig.Gui.NerdFontsVersion = "3"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateNCommitsWithRandomMessages(50)

--- a/pkg/integration/tests/demo/commit_and_push.go
+++ b/pkg/integration/tests/demo/commit_and_push.go
@@ -11,9 +11,7 @@ var CommitAndPush = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {
-		// No idea why I had to use version 2: it should be using my own computer's
-		// font and the one iterm uses is version 3.
-		config.UserConfig.Gui.NerdFontsVersion = "2"
+		config.UserConfig.Gui.NerdFontsVersion = "3"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateFile("my-file.txt", "myfile content")

--- a/pkg/integration/tests/demo/custom_patch.go
+++ b/pkg/integration/tests/demo/custom_patch.go
@@ -21,9 +21,7 @@ var CustomPatch = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(cfg *config.AppConfig) {
-		// No idea why I had to use version 2: it should be using my own computer's
-		// font and the one iterm uses is version 3.
-		cfg.UserConfig.Gui.NerdFontsVersion = "2"
+		cfg.UserConfig.Gui.NerdFontsVersion = "3"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateNCommitsWithRandomMessages(30)

--- a/pkg/integration/tests/demo/filter.go
+++ b/pkg/integration/tests/demo/filter.go
@@ -11,9 +11,7 @@ var Filter = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {
-		// No idea why I had to use version 2: it should be using my own computer's
-		// font and the one iterm uses is version 3.
-		config.UserConfig.Gui.NerdFontsVersion = "2"
+		config.UserConfig.Gui.NerdFontsVersion = "3"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateNCommitsWithRandomMessages(30)

--- a/pkg/integration/tests/demo/interactive_rebase.go
+++ b/pkg/integration/tests/demo/interactive_rebase.go
@@ -11,9 +11,7 @@ var InteractiveRebase = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {
-		// No idea why I had to use version 2: it should be using my own computer's
-		// font and the one iterm uses is version 3.
-		config.UserConfig.Gui.NerdFontsVersion = "2"
+		config.UserConfig.Gui.NerdFontsVersion = "3"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateFile("my-file.txt", "myfile content")

--- a/pkg/integration/tests/demo/nuke_working_tree.go
+++ b/pkg/integration/tests/demo/nuke_working_tree.go
@@ -11,9 +11,7 @@ var NukeWorkingTree = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {
-		// No idea why I had to use version 2: it should be using my own computer's
-		// font and the one iterm uses is version 3.
-		config.UserConfig.Gui.NerdFontsVersion = "2"
+		config.UserConfig.Gui.NerdFontsVersion = "3"
 		config.UserConfig.Gui.AnimateExplosion = true
 	},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/demo/stage_lines.go
+++ b/pkg/integration/tests/demo/stage_lines.go
@@ -39,9 +39,7 @@ var StageLines = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {
-		// No idea why I had to use version 2: it should be using my own computer's
-		// font and the one iterm uses is version 3.
-		config.UserConfig.Gui.NerdFontsVersion = "2"
+		config.UserConfig.Gui.NerdFontsVersion = "3"
 		config.UserConfig.Gui.ShowFileTree = false
 		config.UserConfig.Gui.ShowCommandLog = false
 	},

--- a/pkg/integration/tests/demo/undo.go
+++ b/pkg/integration/tests/demo/undo.go
@@ -13,9 +13,7 @@ var Undo = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {
-		// No idea why I had to use version 2: it should be using my own computer's
-		// font and the one iterm uses is version 3.
-		config.UserConfig.Gui.NerdFontsVersion = "2"
+		config.UserConfig.Gui.NerdFontsVersion = "3"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateNCommitsWithRandomMessages(30)


### PR DESCRIPTION
Turns out I was on version 2 when recording these. I've switched to v3 now.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
