### PR TITLE
Fix opening lazygit in a bare repo with specified worktree

### DIFF
--- a/pkg/app/entry_point.go
+++ b/pkg/app/entry_point.go
@@ -63,8 +63,17 @@ func Start(buildInfo *BuildInfo, integrationTest integrationTypes.IntegrationTes
 			log.Fatal(absRepoPath + " is not a valid git repository.")
 		}
 
-		cliArgs.WorkTree = absRepoPath
 		cliArgs.GitDir = filepath.Join(absRepoPath, ".git")
+		err = os.Chdir(absRepoPath)
+		if err != nil {
+			log.Fatalf("Failed to change directory to %s: %v", absRepoPath, err)
+		}
+	} else if cliArgs.WorkTree != "" {
+		env.SetWorkTreeEnv(cliArgs.WorkTree)
+
+		if err := os.Chdir(cliArgs.WorkTree); err != nil {
+			log.Fatalf("Failed to change directory to %s: %v", cliArgs.WorkTree, err)
+		}
 	}
 
 	if cliArgs.CustomConfigFile != "" {
@@ -73,13 +82,6 @@ func Start(buildInfo *BuildInfo, integrationTest integrationTypes.IntegrationTes
 
 	if cliArgs.UseConfigDir != "" {
 		os.Setenv("CONFIG_DIR", cliArgs.UseConfigDir)
-	}
-
-	if cliArgs.WorkTree != "" {
-		err := os.Chdir(cliArgs.WorkTree)
-		if err != nil {
-			log.Fatalf("Failed to change directory to %s: %v", cliArgs.WorkTree, err)
-		}
 	}
 
 	if cliArgs.GitDir != "" {
@@ -116,12 +118,6 @@ func Start(buildInfo *BuildInfo, integrationTest integrationTypes.IntegrationTes
 
 		tail.TailLogs(logPath)
 		os.Exit(0)
-	}
-
-	if cliArgs.WorkTree != "" {
-		if err := os.Chdir(cliArgs.WorkTree); err != nil {
-			log.Fatal(err.Error())
-		}
 	}
 
 	tempDir, err := os.MkdirTemp("", "lazygit-*")

--- a/pkg/commands/git_commands/worktree_loader.go
+++ b/pkg/commands/git_commands/worktree_loader.go
@@ -58,7 +58,7 @@ func (self *WorktreeLoader) GetWorktrees() ([]*models.Worktree, error) {
 			isPathMissing := self.pathExists(path)
 
 			var gitDir string
-			gitDir, err := worktreeGitDirPath(self.Fs, path)
+			gitDir, err := getWorktreeGitDirPath(self.Fs, path)
 			if err != nil {
 				self.Log.Warnf("Could not find git dir for worktree %s: %v", path, err)
 			}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -14,6 +14,15 @@ func SetGitDirEnv(value string) {
 	os.Setenv("GIT_DIR", value)
 }
 
-func UnsetGitDirEnv() {
+func GetWorkTreeEnv() string {
+	return os.Getenv("GIT_WORK_TREE")
+}
+
+func SetWorkTreeEnv(value string) {
+	os.Setenv("GIT_WORK_TREE", value)
+}
+
+func UnsetGitLocationEnvVars() {
 	_ = os.Unsetenv("GIT_DIR")
+	_ = os.Unsetenv("GIT_WORK_TREE")
 }

--- a/pkg/gui/controllers/helpers/repos_helper.go
+++ b/pkg/gui/controllers/helpers/repos_helper.go
@@ -145,7 +145,7 @@ func (self *ReposHelper) DispatchSwitchToRepo(path string, contextKey types.Cont
 
 func (self *ReposHelper) DispatchSwitchTo(path string, errMsg string, contextKey types.ContextKey) error {
 	return self.c.WithWaitingStatus(self.c.Tr.Switching, func(gocui.Task) error {
-		env.UnsetGitDirEnv()
+		env.UnsetGitLocationEnvVars()
 		originalPath, err := os.Getwd()
 		if err != nil {
 			return nil

--- a/pkg/integration/components/paths.go
+++ b/pkg/integration/components/paths.go
@@ -27,13 +27,6 @@ func (self Paths) ActualRepo() string {
 	return filepath.Join(self.Actual(), "repo")
 }
 
-// When an integration test first runs, we copy everything in the 'actual' directory,
-// and copy it into the 'expected' directory so that future runs can be compared
-// against what we expect.
-func (self Paths) Expected() string {
-	return filepath.Join(self.root, "expected")
-}
-
 func (self Paths) Config() string {
 	return filepath.Join(self.root, "used_config")
 }

--- a/pkg/integration/components/test.go
+++ b/pkg/integration/components/test.go
@@ -35,10 +35,11 @@ type IntegrationTest struct {
 		testDriver *TestDriver,
 		keys config.KeybindingConfig,
 	)
-	gitVersion GitVersionRestriction
-	width      int
-	height     int
-	isDemo     bool
+	gitVersion    GitVersionRestriction
+	width         int
+	height        int
+	isDemo        bool
+	useCustomPath bool
 }
 
 var _ integrationTypes.IntegrationTest = &IntegrationTest{}
@@ -66,6 +67,10 @@ type NewIntegrationTestArgs struct {
 	Height int
 	// If true, this is not a test but a demo to be added to our docs
 	IsDemo bool
+	// If true, the test won't invoke lazygit with the --path arg.
+	// Useful for when we're passing --git-dir and --work-tree (because --path is
+	// incompatible with those args)
+	UseCustomPath bool
 }
 
 type GitVersionRestriction struct {
@@ -125,18 +130,19 @@ func NewIntegrationTest(args NewIntegrationTestArgs) *IntegrationTest {
 	}
 
 	return &IntegrationTest{
-		name:         name,
-		description:  args.Description,
-		extraCmdArgs: args.ExtraCmdArgs,
-		extraEnvVars: args.ExtraEnvVars,
-		skip:         args.Skip,
-		setupRepo:    args.SetupRepo,
-		setupConfig:  args.SetupConfig,
-		run:          args.Run,
-		gitVersion:   args.GitVersion,
-		width:        args.Width,
-		height:       args.Height,
-		isDemo:       args.IsDemo,
+		name:          name,
+		description:   args.Description,
+		extraCmdArgs:  args.ExtraCmdArgs,
+		extraEnvVars:  args.ExtraEnvVars,
+		skip:          args.Skip,
+		setupRepo:     args.SetupRepo,
+		setupConfig:   args.SetupConfig,
+		run:           args.Run,
+		gitVersion:    args.GitVersion,
+		width:         args.Width,
+		height:        args.Height,
+		isDemo:        args.IsDemo,
+		useCustomPath: args.UseCustomPath,
 	}
 }
 

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -245,6 +245,7 @@ var tests = []*components.IntegrationTest{
 	worktree.Crud,
 	worktree.CustomCommand,
 	worktree.DetachWorktreeFromBranch,
+	worktree.DotfileBareRepo,
 	worktree.FastForwardWorktreeBranch,
 	worktree.ForceRemoveWorktree,
 	worktree.RemoveWorktreeFromBranch,

--- a/pkg/integration/tests/worktree/dotfile_bare_repo.go
+++ b/pkg/integration/tests/worktree/dotfile_bare_repo.go
@@ -1,0 +1,74 @@
+package worktree
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+// Can't think of a better name than 'dotfile' repo: I'm using that
+// because that's the case we're typically dealing with.
+
+var DotfileBareRepo = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Open lazygit in the worktree of a dotfile bare repo and add a file and commit",
+	ExtraCmdArgs: []string{"--git-dir={{.actualPath}}/.bare", "--work-tree={{.actualPath}}/repo"},
+	Skip:         true,
+	// passing this because we're explicitly passing --git-dir and --work-tree args
+	UseCustomPath: true,
+	SetupConfig:   func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		// we're going to have a directory structure like this:
+		// project
+		//  - .bare
+		//  - repo (the worktree)
+		//
+		// The first repo is called 'repo' because that's the
+		// directory that all lazygit tests start in
+
+		// Delete the .git dir that all tests start with by default
+		shell.DeleteFile(".git")
+
+		// Create a bare repo in the parent directory
+		shell.RunCommand([]string{"git", "init", "--bare", "../.bare"})
+		shell.RunCommand([]string{"git", "--git-dir=../.bare", "--work-tree=.", "checkout", "-b", "mybranch"})
+		shell.CreateFile("blah", "original content\n")
+
+		// Add a file and commit
+		shell.RunCommand([]string{"git", "--git-dir=../.bare", "--work-tree=.", "add", "blah"})
+		shell.RunCommand([]string{"git", "--git-dir=../.bare", "--work-tree=.", "commit", "-m", "initial commit"})
+
+		shell.UpdateFile("blah", "updated content\n")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Lines(
+				Contains("mybranch"),
+			)
+
+		t.Views().Commits().
+			Lines(
+				Contains("initial commit"),
+			)
+
+		t.Views().Files().
+			IsFocused().
+			Lines(
+				Contains(" M blah"), // shows as modified
+			).
+			PressPrimaryAction().
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			Title(Equals("Commit summary")).
+			Type("Add blah").
+			Confirm()
+
+		t.Views().Files().
+			IsEmpty()
+
+		t.Views().Commits().
+			Lines(
+				Contains("Add blah"),
+				Contains("initial commit"),
+			)
+	},
+})

--- a/pkg/integration/tests/worktree/dotfile_bare_repo.go
+++ b/pkg/integration/tests/worktree/dotfile_bare_repo.go
@@ -11,7 +11,7 @@ import (
 var DotfileBareRepo = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Open lazygit in the worktree of a dotfile bare repo and add a file and commit",
 	ExtraCmdArgs: []string{"--git-dir={{.actualPath}}/.bare", "--work-tree={{.actualPath}}/repo"},
-	Skip:         true,
+	Skip:         false,
 	// passing this because we're explicitly passing --git-dir and --work-tree args
 	UseCustomPath: true,
 	SetupConfig:   func(config *config.AppConfig) {},


### PR DESCRIPTION
- **PR Description**

I am confused. So far I've been working under the assumption that there are two kinds of worktrees:
* main worktree in a non-bare repo
* linked worktree in a bare or non-bare repo (which has a .git file pointing to its git-dir in the repo's own git-dir)

But there's a third kind of worktree which I'm calling a 'specified' worktree. This is used with dotfiles where you do `git --git-dir=$HOME/.cfg --work-tree=$HOME <command>`. You're specifying the worktree as part of each git command. The worktree has no idea that it's a worktree: it has no .git file and no entry in the bare repo's worktrees/ folder. I could `git add` a file in this worktree and then run `git --git-dir=$HOME/.cfg --work-tree=/random/path status` and it would say that the file has now been deleted.

Googling for this, I can't find anybody making this distinction.

This has got me thinking that we're in dire need of sorting out the right terminology here. It's bad enough that there are two senses of the word 'git-dir': one for the repo and one for each linked worktree.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
