### PR TITLE
Allow adding a port to webDomain part of services config

### DIFF
--- a/pkg/commands/hosting_service/hosting_service.go
+++ b/pkg/commands/hosting_service/hosting_service.go
@@ -101,14 +101,13 @@ func (self *HostingServiceMgr) getCandidateServiceDomains() []ServiceDomain {
 
 	if len(self.configServiceDomains) > 0 {
 		for gitDomain, typeAndDomain := range self.configServiceDomains {
-			splitData := strings.Split(typeAndDomain, ":")
-			if len(splitData) != 2 {
+			provider, webDomain, success := strings.Cut(typeAndDomain, ":")
+
+			// we allow for one ':' for specifying the TCP port
+			if !success || strings.Count(webDomain, ":") > 1 {
 				self.log.Errorf("Unexpected format for git service: '%s'. Expected something like 'github.com:github.com'", typeAndDomain)
 				continue
 			}
-
-			provider := splitData[0]
-			webDomain := splitData[1]
 
 			serviceDefinition, ok := serviceDefinitionByProvider[provider]
 			if !ok {

--- a/pkg/commands/hosting_service/hosting_service_test.go
+++ b/pkg/commands/hosting_service/hosting_service_test.go
@@ -341,6 +341,30 @@ func TestGetPullRequestURL(t *testing.T) {
 			expectedLoggedErrors: nil,
 		},
 		{
+			testName:  "Does not log error when config service webDomain contains a port",
+			from:      "feature/profile-page",
+			remoteUrl: "git@my.domain.test:johndoe/social_network.git",
+			configServiceDomains: map[string]string{
+				"my.domain.test": "gitlab:my.domain.test:1111",
+			},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://my.domain.test:1111/johndoe/social_network/-/merge_requests/new?merge_request[source_branch]=feature%2Fprofile-page", url)
+			},
+		},
+		{
+			testName:  "Logs error when webDomain contains more than one colon",
+			from:      "feature/profile-page",
+			remoteUrl: "git@my.domain.test:johndoe/social_network.git",
+			configServiceDomains: map[string]string{
+				"my.domain.test": "gitlab:my.domain.test:1111:2222",
+			},
+			test: func(url string, err error) {
+				assert.Error(t, err)
+			},
+			expectedLoggedErrors: []string{"Unexpected format for git service: 'gitlab:my.domain.test:1111:2222'. Expected something like 'github.com:github.com'"},
+		},
+		{
 			testName:  "Logs error when config service domain is malformed",
 			from:      "feature/profile-page",
 			remoteUrl: "git@bitbucket.org:johndoe/social_network.git",


### PR DESCRIPTION
### PR Description
This PR aims to fix the current inability for the configuration file to accept configurations like:

```yml
services:
    'my.git.host': 'gitlab:my.git.host:8080'
```

All other code downstream of cutting the configuration string seems to support this behavior, therefore this PR only changes how the configuration value is split up.

**PS. This is my first public PR, assume I know nothing about anything.**

### Please check if the PR fulfills these requirements

I deemed all unchecked requirements as not applicable.
As for the "Docs" item - I don't think it makes sense to make the documentation more complex to cover this case.
Those who need it will attempt to use it and it will simply work.

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

