### PR TITLE
Add co-author to commits

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -38,6 +38,22 @@ func (self *CommitCommands) SetAuthor(value string) error {
 	return self.cmd.New(cmdArgs).Run()
 }
 
+// Add a commit's coauthor using Github/Gitlab Co-authored-by metadata. Value is expected to be of the form 'Name <Email>'
+func (self *CommitCommands) AddCoAuthor(sha string, value string) error {
+	message, err := self.GetCommitMessage(sha)
+	if err != nil {
+		return err
+	}
+
+	message = message + fmt.Sprintf("\nCo-authored-by: %s", value)
+
+	cmdArgs := NewGitCmd("commit").
+		Arg("--allow-empty", "--amend", "--only", "-m", message).
+		ToArgv()
+
+	return self.cmd.New(cmdArgs).Run()
+}
+
 // ResetToCommit reset to commit
 func (self *CommitCommands) ResetToCommit(sha string, strength string, envVars []string) error {
 	cmdArgs := NewGitCmd("reset").Arg("--"+strength, sha).ToArgv()

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -79,6 +79,12 @@ func (self *RebaseCommands) SetCommitAuthor(commits []*models.Commit, index int,
 	})
 }
 
+func (self *RebaseCommands) AddCommitCoAuthor(commits []*models.Commit, index int, value string) error {
+	return self.GenericAmend(commits, index, func() error {
+		return self.commit.AddCoAuthor(commits[index].Sha, value)
+	})
+}
+
 func (self *RebaseCommands) GenericAmend(commits []*models.Commit, index int, f func() error) error {
 	if models.IsHeadCommit(commits, index) {
 		// we've selected the top commit so no rebase is required

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -103,8 +103,11 @@ type TranslationSet struct {
 	AmendToCommit                       string
 	ResetAuthor                         string
 	SetAuthor                           string
+	AddCoAuthor                         string
 	SetResetCommitAuthor                string
 	SetAuthorPromptTitle                string
+	AddCoAuthorPromptTitle              string
+	AddCoAuthorTooltip                  string
 	SureResetCommitAuthor               string
 	RenameCommitEditor                  string
 	NoCommitsThisBranch                 string
@@ -674,6 +677,7 @@ type Actions struct {
 	AmendCommit                       string
 	ResetCommitAuthor                 string
 	SetCommitAuthor                   string
+	AddCommitCoAuthor                 string
 	RevertCommit                      string
 	CreateFixupCommit                 string
 	SquashAllAboveFixupCommits        string
@@ -890,8 +894,11 @@ func EnglishTranslationSet() TranslationSet {
 		AmendToCommit:                       "Amend commit with staged changes",
 		ResetAuthor:                         "Reset author",
 		SetAuthor:                           "Set author",
+		AddCoAuthor:                         "Add co-author",
 		SetResetCommitAuthor:                "Set/Reset commit author",
 		SetAuthorPromptTitle:                "Set author (must look like 'Name <Email>')",
+		AddCoAuthorPromptTitle:              "Add co-author (must look like 'Name <Email>')",
+		AddCoAuthorTooltip:                  "Add co-author using the Github/Gitlab metadata Co-authored-by",
 		SureResetCommitAuthor:               "The author field of this commit will be updated to match the configured user. This also renews the author timestamp. Continue?",
 		RenameCommitEditor:                  "Reword commit with editor",
 		Error:                               "Error",

--- a/pkg/integration/tests/commit/add_co_author.go
+++ b/pkg/integration/tests/commit/add_co_author.go
@@ -1,0 +1,40 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var AddCoAuthor = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Add co-author on a commit",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("initial commit")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("initial commit").IsSelected(),
+			).
+			Press(keys.Commits.ResetCommitAuthor).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Amend commit attribute")).
+					Select(Contains("Add co-author")).
+					Confirm()
+
+				t.ExpectPopup().Prompt().
+					Title(Contains("Add co-author")).
+					Type("John Smith <jsmith@gmail.com>").
+					Confirm()
+			})
+
+		t.Views().Main().ContainsLines(
+			Contains("initial commit"),
+			Contains("Co-authored-by: John Smith <jsmith@gmail.com>"),
+		)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -55,6 +55,7 @@ var tests = []*components.IntegrationTest{
 	branch.Suggestions,
 	cherry_pick.CherryPick,
 	cherry_pick.CherryPickConflicts,
+	commit.AddCoAuthor,
 	commit.Amend,
 	commit.Commit,
 	commit.CommitMultiline,


### PR DESCRIPTION
Add addCoAuthor command for commits

- Implement the `addCoAuthor` command to add co-authors to commits.
- Utilize suggestions helpers to populate author names from the suggestions list.
- Added command to gui at `LocalCommitsController`.

This commit introduces the `addCoAuthor` command, which allows users to easily add co-authors to their commits. The co-author names are populated from the suggestions list, minimizing the chances of user input errors. The co-authors are added using the Co-authored-by metadata format recognized by GitHub and GitLab.

- **PR Description**
Addresses part of #2713 .

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc


https://github.com/jesseduffield/lazygit/assets/11657396/251656fb-8116-4618-8109-f2dfa7216be4