### PR TITLE
Fix jumping to the correct line from the staging view

### DIFF
--- a/pkg/commands/patch/patch.go
+++ b/pkg/commands/patch/patch.go
@@ -97,12 +97,12 @@ func (self *Patch) LineNumberOfLine(idx int) int {
 	idxInHunk := idx - hunkStartIdx
 
 	if idxInHunk == 0 {
-		return hunk.oldStart
+		return hunk.newStart
 	}
 
 	lines := hunk.bodyLines[:idxInHunk-1]
 	offset := nLinesWithKind(lines, []PatchLineKind{ADDITION, CONTEXT})
-	return hunk.oldStart + offset
+	return hunk.newStart + offset
 }
 
 // Returns hunk index containing the line at the given patch line index

--- a/pkg/commands/patch/patch_test.go
+++ b/pkg/commands/patch/patch_test.go
@@ -599,7 +599,7 @@ func TestLineNumberOfLine(t *testing.T) {
 			testName:  "twoHunksWithMoreAdditionsThanRemovals",
 			patchStr:  twoHunksWithMoreAdditionsThanRemovals,
 			indexes:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 1000},
-			expecteds: []int{1, 1, 1, 1, 1, 1, 2, 2, 3, 4, 5, 6, 8, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 16, 16, 16},
+			expecteds: []int{1, 1, 1, 1, 1, 1, 2, 2, 3, 4, 5, 6, 9, 9, 10, 11, 12, 13, 14, 15, 16, 16, 16, 16, 16, 16},
 		},
 	}
 

--- a/pkg/commands/patch/patch_test.go
+++ b/pkg/commands/patch/patch_test.go
@@ -67,6 +67,29 @@ index e48a11c..b2ab81b 100644
  ...
 `
 
+const twoHunksWithMoreAdditionsThanRemovals = `diff --git a/filename b/filename
+index bac359d75..6e5b89f36 100644
+--- a/filename
++++ b/filename
+@@ -1,5 +1,6 @@
+ apple
+-grape
++orange
++kiwi
+ ...
+ ...
+ ...
+@@ -8,6 +9,8 @@ grape
+ ...
+ ...
+ ...
++pear
++lemon
+ ...
+ ...
+ ...
+`
+
 const twoChangesInOneHunk = `diff --git a/filename b/filename
 index 9320895..6d79956 100644
 --- a/filename
@@ -571,6 +594,12 @@ func TestLineNumberOfLine(t *testing.T) {
 			// this is really more of a characteristic test than anything.
 			indexes:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 1000},
 			expecteds: []int{1, 1, 1, 1, 1, 1, 2, 2, 3, 4, 5, 8, 8, 9, 10, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15},
+		},
+		{
+			testName:  "twoHunksWithMoreAdditionsThanRemovals",
+			patchStr:  twoHunksWithMoreAdditionsThanRemovals,
+			indexes:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 1000},
+			expecteds: []int{1, 1, 1, 1, 1, 1, 2, 2, 3, 4, 5, 6, 8, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 16, 16, 16},
 		},
 	}
 


### PR DESCRIPTION
- **PR Description**

When pressing `e` in the staging view to jump to the selected line, it would often jump to the wrong line (depending on how many added or removed lines there are in hunks before the current one). This fixes a regression introduced in 73c7dc9c5d00.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
