### PR TITLE
Show commit mark before showing extra info

### DIFF
--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -341,16 +341,17 @@ func displayCommit(
 		name = emoji.Sprint(name)
 	}
 
+	mark := ""
 	if isYouAreHereCommit {
 		color := lo.Ternary(commit.Action == models.ActionConflict, style.FgRed, style.FgYellow)
 		youAreHere := color.Sprintf("<-- %s ---", common.Tr.YouAreHere)
-		name = fmt.Sprintf("%s %s", youAreHere, name)
+		mark = fmt.Sprintf("%s ", youAreHere)
 	} else if isMarkedBaseCommit {
 		rebaseFromHere := style.FgYellow.Sprint(common.Tr.MarkedCommitMarker)
-		name = fmt.Sprintf("%s %s", rebaseFromHere, name)
+		mark = fmt.Sprintf("%s ", rebaseFromHere)
 	} else if !willBeRebased {
 		willBeRebased := style.FgYellow.Sprint("✓")
-		name = fmt.Sprintf("%s %s", willBeRebased, name)
+		mark = fmt.Sprintf("%s ", willBeRebased)
 	}
 
 	authorFunc := authors.ShortAuthor
@@ -373,7 +374,7 @@ func displayCommit(
 		cols,
 		actionString,
 		authorFunc(commit.AuthorName),
-		graphLine+tagString+theme.DefaultTextColor.Sprint(name),
+		graphLine+mark+tagString+theme.DefaultTextColor.Sprint(name),
 	)
 
 	return cols


### PR DESCRIPTION
The 'YOU ARE HERE' marking should be shown before we show things like the current tag, otherwise it could be missed

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
