### PR TITLE
Add `gui.scrollOffBehavior` config for scrolling list views by half-pages

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -291,7 +291,7 @@ os:
   open: 'open {{filename}}'
 ```
 
-### Custom Command for Copying to Clipboard
+## Custom Command for Copying to Clipboard
 ```yaml
 os:
   copyToClipboardCmd: ''
@@ -305,7 +305,7 @@ os:
 ```
 
 
-### Configuring File Editing
+## Configuring File Editing
 
 There are two commands for opening files, `o` for "open" and `e` for "edit". `o` acts as if the file was double-clicked in the Finder/Explorer, so it also works for non-text files, whereas `e` opens the file in an editor. `e` can also jump to the right line in the file if you invoke it from the staging panel, for example.
 
@@ -335,7 +335,7 @@ The `editInTerminal` option is used to decide whether lazygit needs to suspend i
 
 Contributions of new editor presets are welcome; see the `getPreset` function in [`editor_presets.go`](https://github.com/jesseduffield/lazygit/blob/master/pkg/config/editor_presets.go).
 
-### Overriding default config file location
+## Overriding default config file location
 
 To override the default config directory, use `CONFIG_DIR="$HOME/.config/lazygit"`. This directory contains the config file in addition to some other files lazygit uses to keep track of state across sessions.
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -35,7 +35,8 @@ gui:
   windowSize: 'normal' # one of 'normal' | 'half' | 'full' default is 'normal'
   scrollHeight: 2 # how many lines you scroll by
   scrollPastBottom: true # enable scrolling past the bottom
-  scrollOffMargin: 2 # how many lines to keep before/after the cursor when it reaches the top/bottom of the view
+  scrollOffMargin: 2 # how many lines to keep before/after the cursor when it reaches the top/bottom of the view; see 'Scroll-off Margin' section below
+  scrollOffBehavior: 'margin' # one of 'margin' | 'jump'; see 'Scroll-off Margin' section below
   sidePanelWidth: 0.3333 # number from 0 to 1
   expandFocusedSidePanel: false
   mainPanelSplitMode: 'flexible' # one of 'horizontal' | 'flexible' | 'vertical'
@@ -348,6 +349,14 @@ lazygit --use-config-file="$HOME/.base_lg_conf,$HOME/.light_theme_lg_conf"
 or
 LG_CONFIG_FILE="$HOME/.base_lg_conf,$HOME/.light_theme_lg_conf" lazygit
 ```
+
+## Scroll-off Margin
+
+When the selected line gets close to the bottom of the window and you hit down-arrow, there's a feature called "scroll-off margin" that lets the view scroll a little earlier so that you can see a bit of what's coming in the direction that you are moving. This is controlled by the `gui.scrollOffMargin` setting (default: 2), so it keeps 2 lines below the selection visible as you scroll down. It can be set to 0 to scroll only when the selection reaches the bottom of the window.
+
+That's the behavior when `gui.scrollOffBehavior` is set to "margin" (the default). If you set `gui.scrollOffBehavior` to "jump", then upon reaching the last line of a view and hitting down-arrow the view will scroll by half a page so that the selection ends up in the middle of the view. This may feel a little jarring because the cursor jumps around when continuously moving down, but it has the advantage that the view doesn't scroll as often.
+
+This setting applies both to all list views (e.g. commits and branches etc), and to the staging view.
 
 ## Color Attributes
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -32,6 +32,7 @@ type GuiConfig struct {
 	ScrollHeight              int                `yaml:"scrollHeight"`
 	ScrollPastBottom          bool               `yaml:"scrollPastBottom"`
 	ScrollOffMargin           int                `yaml:"scrollOffMargin"`
+	ScrollOffBehavior         string             `yaml:"scrollOffBehavior"`
 	MouseEvents               bool               `yaml:"mouseEvents"`
 	SkipDiscardChangeWarning  bool               `yaml:"skipDiscardChangeWarning"`
 	SkipStashWarning          bool               `yaml:"skipStashWarning"`
@@ -420,6 +421,7 @@ func GetDefaultConfig() *UserConfig {
 			ScrollHeight:             2,
 			ScrollPastBottom:         true,
 			ScrollOffMargin:          2,
+			ScrollOffBehavior:        "margin",
 			MouseEvents:              true,
 			SkipDiscardChangeWarning: false,
 			SkipStashWarning:         false,

--- a/pkg/gui/controllers/list_controller.go
+++ b/pkg/gui/controllers/list_controller.go
@@ -83,9 +83,9 @@ func (self *ListController) handleLineChange(change int) error {
 	// we're not constantly re-rendering the main view.
 	if before != after {
 		if change == -1 {
-			checkScrollUp(self.context.GetViewTrait(), self.c.UserConfig.Gui.ScrollOffMargin, before, after)
+			checkScrollUp(self.context.GetViewTrait(), self.c.UserConfig, before, after)
 		} else if change == 1 {
-			checkScrollDown(self.context.GetViewTrait(), self.c.UserConfig.Gui.ScrollOffMargin, before, after)
+			checkScrollDown(self.context.GetViewTrait(), self.c.UserConfig, before, after)
 		}
 
 		return self.context.HandleFocus(types.OnFocusOpts{})

--- a/pkg/gui/controllers/patch_explorer_controller.go
+++ b/pkg/gui/controllers/patch_explorer_controller.go
@@ -164,7 +164,7 @@ func (self *PatchExplorerController) HandlePrevLine() error {
 	after := self.context.GetState().GetSelectedLineIdx()
 
 	if self.context.GetState().SelectingLine() {
-		checkScrollUp(self.context.GetViewTrait(), self.c.UserConfig.Gui.ScrollOffMargin, before, after)
+		checkScrollUp(self.context.GetViewTrait(), self.c.UserConfig, before, after)
 	}
 
 	return nil
@@ -176,7 +176,7 @@ func (self *PatchExplorerController) HandleNextLine() error {
 	after := self.context.GetState().GetSelectedLineIdx()
 
 	if self.context.GetState().SelectingLine() {
-		checkScrollDown(self.context.GetViewTrait(), self.c.UserConfig.Gui.ScrollOffMargin, before, after)
+		checkScrollDown(self.context.GetViewTrait(), self.c.UserConfig, before, after)
 	}
 
 	return nil

--- a/pkg/gui/controllers/scroll_off_margin.go
+++ b/pkg/gui/controllers/scroll_off_margin.go
@@ -1,17 +1,18 @@
 package controllers
 
 import (
+	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 // To be called after pressing up-arrow; checks whether the cursor entered the
 // top scroll-off margin, and so the view needs to be scrolled up one line
-func checkScrollUp(view types.IViewTrait, scrollOffMargin int, lineIdxBefore int, lineIdxAfter int) {
+func checkScrollUp(view types.IViewTrait, userConfig *config.UserConfig, lineIdxBefore int, lineIdxAfter int) {
 	viewPortStart, viewPortHeight := view.ViewPortYBounds()
 
 	linesToScroll := calculateLinesToScrollUp(
-		viewPortStart, viewPortHeight, scrollOffMargin, lineIdxBefore, lineIdxAfter)
+		viewPortStart, viewPortHeight, userConfig.Gui.ScrollOffMargin, lineIdxBefore, lineIdxAfter)
 	if linesToScroll != 0 {
 		view.ScrollUp(linesToScroll)
 	}
@@ -19,11 +20,11 @@ func checkScrollUp(view types.IViewTrait, scrollOffMargin int, lineIdxBefore int
 
 // To be called after pressing down-arrow; checks whether the cursor entered the
 // bottom scroll-off margin, and so the view needs to be scrolled down one line
-func checkScrollDown(view types.IViewTrait, scrollOffMargin int, lineIdxBefore int, lineIdxAfter int) {
+func checkScrollDown(view types.IViewTrait, userConfig *config.UserConfig, lineIdxBefore int, lineIdxAfter int) {
 	viewPortStart, viewPortHeight := view.ViewPortYBounds()
 
 	linesToScroll := calculateLinesToScrollDown(
-		viewPortStart, viewPortHeight, scrollOffMargin, lineIdxBefore, lineIdxAfter)
+		viewPortStart, viewPortHeight, userConfig.Gui.ScrollOffMargin, lineIdxBefore, lineIdxAfter)
 	if linesToScroll != 0 {
 		view.ScrollDown(linesToScroll)
 	}

--- a/pkg/gui/controllers/scroll_off_margin.go
+++ b/pkg/gui/controllers/scroll_off_margin.go
@@ -9,24 +9,28 @@ import (
 // To be called after pressing up-arrow; checks whether the cursor entered the
 // top scroll-off margin, and so the view needs to be scrolled up one line
 func checkScrollUp(view types.IViewTrait, userConfig *config.UserConfig, lineIdxBefore int, lineIdxAfter int) {
-	viewPortStart, viewPortHeight := view.ViewPortYBounds()
+	if userConfig.Gui.ScrollOffBehavior != "jump" {
+		viewPortStart, viewPortHeight := view.ViewPortYBounds()
 
-	linesToScroll := calculateLinesToScrollUp(
-		viewPortStart, viewPortHeight, userConfig.Gui.ScrollOffMargin, lineIdxBefore, lineIdxAfter)
-	if linesToScroll != 0 {
-		view.ScrollUp(linesToScroll)
+		linesToScroll := calculateLinesToScrollUp(
+			viewPortStart, viewPortHeight, userConfig.Gui.ScrollOffMargin, lineIdxBefore, lineIdxAfter)
+		if linesToScroll != 0 {
+			view.ScrollUp(linesToScroll)
+		}
 	}
 }
 
 // To be called after pressing down-arrow; checks whether the cursor entered the
 // bottom scroll-off margin, and so the view needs to be scrolled down one line
 func checkScrollDown(view types.IViewTrait, userConfig *config.UserConfig, lineIdxBefore int, lineIdxAfter int) {
-	viewPortStart, viewPortHeight := view.ViewPortYBounds()
+	if userConfig.Gui.ScrollOffBehavior != "jump" {
+		viewPortStart, viewPortHeight := view.ViewPortYBounds()
 
-	linesToScroll := calculateLinesToScrollDown(
-		viewPortStart, viewPortHeight, userConfig.Gui.ScrollOffMargin, lineIdxBefore, lineIdxAfter)
-	if linesToScroll != 0 {
-		view.ScrollDown(linesToScroll)
+		linesToScroll := calculateLinesToScrollDown(
+			viewPortStart, viewPortHeight, userConfig.Gui.ScrollOffMargin, lineIdxBefore, lineIdxAfter)
+		if linesToScroll != 0 {
+			view.ScrollDown(linesToScroll)
+		}
 	}
 }
 

--- a/pkg/gui/controllers/scroll_off_margin_test.go
+++ b/pkg/gui/controllers/scroll_off_margin_test.go
@@ -53,6 +53,15 @@ func Test_calculateLinesToScrollUp(t *testing.T) {
 			expectedLinesToScroll: 1,
 		},
 		{
+			name:                  "scroll-off margin is zero - scroll by 1 at end of view",
+			viewPortStart:         10,
+			viewPortHeight:        10,
+			scrollOffMargin:       0,
+			lineIdxBefore:         10,
+			lineIdxAfter:          9,
+			expectedLinesToScroll: 1,
+		},
+		{
 			name:                  "before inside scroll-off margin - scroll by more than 1",
 			viewPortStart:         10,
 			viewPortHeight:        10,
@@ -132,6 +141,15 @@ func Test_calculateLinesToScrollDown(t *testing.T) {
 			scrollOffMargin:       3,
 			lineIdxBefore:         16,
 			lineIdxAfter:          17,
+			expectedLinesToScroll: 1,
+		},
+		{
+			name:                  "scroll-off margin is zero - scroll by 1 at end of view",
+			viewPortStart:         10,
+			viewPortHeight:        10,
+			scrollOffMargin:       0,
+			lineIdxBefore:         19,
+			lineIdxAfter:          20,
 			expectedLinesToScroll: 1,
 		},
 		{


### PR DESCRIPTION
Add a scrollOffBehavior config that lets you turn off the scroll-off margin feature, causing the view to scroll by half a page when the cursor leaves the window.