### PR TITLE
Fix the commit graph display after selection jumps in commits view

### DIFF
--- a/pkg/gui/context/list_context_trait.go
+++ b/pkg/gui/context/list_context_trait.go
@@ -35,7 +35,18 @@ func (self *ListContextTrait) FocusLine() {
 	// resized before we focus the line, otherwise if we're in accordion mode
 	// the view could be squashed and won't how to adjust the cursor/origin
 	self.c.AfterLayout(func() error {
+		oldOrigin, _ := self.GetViewTrait().ViewPortYBounds()
+
 		self.GetViewTrait().FocusPoint(self.list.GetSelectedLineIdx())
+
+		// If FocusPoint() caused the view to scroll (because the selected line
+		// was out of view before), we need to rerender the view port again.
+		// This can happen when pressing , or . to scroll by pages, or < or > to
+		// jump to the top or bottom.
+		newOrigin, _ := self.GetViewTrait().ViewPortYBounds()
+		if self.refreshViewportOnChange && oldOrigin != newOrigin {
+			self.refreshViewport()
+		}
 		return nil
 	})
 


### PR DESCRIPTION
- **PR Description**

When navigating in the commits view to a line that is out of view (e.g. by pressing `,` or `.` to scroll by page, or `<` or `>` to scroll to the top or bottom), the commit graph was not correctly highlighted. Fix this by rerendering the viewport in this case.

This fixes a regression introduced by a5ee61c117.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
