### PR TITLE
Handle trailing slash in worktree path

### DIFF
--- a/pkg/commands/git_commands/repo_paths.go
+++ b/pkg/commands/git_commands/repo_paths.go
@@ -223,7 +223,7 @@ func getCurrentRepoGitDirPath(
 
 	// If this error causes issues, we could relax the constraint and just always
 	// return the path
-	return "", "", errors.Errorf("could not find git dir for %s: path is not under `worktrees` or `modules` directories", currentPath)
+	return "", "", errors.Errorf("could not find git dir for %s: path '%s' is not under `worktrees` or `modules` directories.", currentPath, worktreeGitPath)
 }
 
 // takes a path containing a symlink and returns the true path

--- a/pkg/commands/git_commands/repo_paths.go
+++ b/pkg/commands/git_commands/repo_paths.go
@@ -158,6 +158,7 @@ func linkedWorktreeGitDirPath(fs afero.Fs, worktreePath string) (string, error) 
 
 	gitDir := strings.TrimPrefix(gitDirLine[0], "gitdir: ")
 
+	gitDir = filepath.Clean(gitDir)
 	// For windows support
 	gitDir = filepath.ToSlash(gitDir)
 
@@ -208,7 +209,7 @@ func getCurrentRepoGitDirPath(
 	}
 
 	// confirm whether the next directory up is the worktrees directory
-	parent := path.Dir(path.Clean(worktreeGitPath))
+	parent := path.Dir(worktreeGitPath)
 	if path.Base(parent) == "worktrees" {
 		gitDirPath := path.Dir(parent)
 		return gitDirPath, path.Dir(gitDirPath), nil

--- a/pkg/commands/git_commands/repo_paths.go
+++ b/pkg/commands/git_commands/repo_paths.go
@@ -208,7 +208,7 @@ func getCurrentRepoGitDirPath(
 	}
 
 	// confirm whether the next directory up is the worktrees directory
-	parent := path.Dir(path.Clean((worktreeGitPath)))
+	parent := path.Dir(path.Clean(worktreeGitPath))
 	if path.Base(parent) == "worktrees" {
 		gitDirPath := path.Dir(parent)
 		return gitDirPath, path.Dir(gitDirPath), nil
@@ -223,7 +223,7 @@ func getCurrentRepoGitDirPath(
 
 	// If this error causes issues, we could relax the constraint and just always
 	// return the path
-	return "", "", errors.Errorf("could not find git dir for %s: path '%s' is not under `worktrees` or `modules` directories.", currentPath, worktreeGitPath)
+	return "", "", errors.Errorf("could not find git dir for %s: the path '%s' is not under `worktrees` or `modules` directories.", currentPath, worktreeGitPath)
 }
 
 // takes a path containing a symlink and returns the true path

--- a/pkg/commands/git_commands/repo_paths.go
+++ b/pkg/commands/git_commands/repo_paths.go
@@ -208,7 +208,7 @@ func getCurrentRepoGitDirPath(
 	}
 
 	// confirm whether the next directory up is the worktrees directory
-	parent := path.Dir(worktreeGitPath)
+	parent := path.Dir(path.Clean((worktreeGitPath)))
 	if path.Base(parent) == "worktrees" {
 		gitDirPath := path.Dir(parent)
 		return gitDirPath, path.Dir(gitDirPath), nil

--- a/pkg/commands/git_commands/repo_paths.go
+++ b/pkg/commands/git_commands/repo_paths.go
@@ -224,7 +224,7 @@ func getCurrentRepoGitDirPath(
 
 	// If this error causes issues, we could relax the constraint and just always
 	// return the path
-	return "", "", errors.Errorf("could not find git dir for %s: the path '%s' is not under `worktrees` or `modules` directories.", currentPath, worktreeGitPath)
+	return "", "", errors.Errorf("could not find git dir for %s: the path '%s' is not under `worktrees` or `modules` directories", currentPath, worktreeGitPath)
 }
 
 // takes a path containing a symlink and returns the true path

--- a/pkg/commands/git_commands/repo_paths_test.go
+++ b/pkg/commands/git_commands/repo_paths_test.go
@@ -56,6 +56,24 @@ func TestGetRepoPathsAux(t *testing.T) {
 			Err: nil,
 		},
 		{
+			Name: "worktree with trailing separator in path",
+			BeforeFunc: func(fs afero.Fs) {
+				// setup for linked worktree
+				_ = fs.MkdirAll("/path/to/repo/.git/worktrees/worktree1", 0o755)
+				_ = afero.WriteFile(fs, "/path/to/repo/worktree1/.git", []byte("gitdir: /path/to/repo/.git/worktrees/worktree1/"), 0o644)
+			},
+			Path: "/path/to/repo/worktree1",
+			Expected: &RepoPaths{
+				currentPath:        "/path/to/repo/worktree1",
+				worktreePath:       "/path/to/repo/worktree1",
+				worktreeGitDirPath: "/path/to/repo/.git/worktrees/worktree1",
+				repoPath:           "/path/to/repo",
+				repoGitDirPath:     "/path/to/repo/.git",
+				repoName:           "repo",
+			},
+			Err: nil,
+		},
+		{
 			Name: "worktree .git file missing gitdir directive",
 			BeforeFunc: func(fs afero.Fs) {
 				_ = fs.MkdirAll("/path/to/repo/.git/worktrees/worktree2", 0o755)

--- a/pkg/commands/git_commands/repo_paths_test.go
+++ b/pkg/commands/git_commands/repo_paths_test.go
@@ -135,7 +135,7 @@ func TestGetRepoPathsAux(t *testing.T) {
 			},
 			Path:     "/path/to/repo/my/submodule1",
 			Expected: nil,
-			Err:      errors.New("failed to get repo git dir path: could not find git dir for /path/to/repo/my/submodule1: path is not under `worktrees` or `modules` directories"),
+			Err:      errors.New("failed to get repo git dir path: could not find git dir for /path/to/repo/my/submodule1: the path '/random/submodule1' is not under `worktrees` or `modules` directories"),
 		},
 	}
 

--- a/pkg/commands/git_commands/worktree_loader_test.go
+++ b/pkg/commands/git_commands/worktree_loader_test.go
@@ -186,7 +186,7 @@ branch refs/heads/mybranch-worktree
 				assert.EqualError(t, errors.New(s.expectedErr), err.Error())
 			} else {
 				assert.NoError(t, err)
-				assert.EqualValues(t, worktrees, s.expectedWorktrees)
+				assert.EqualValues(t, s.expectedWorktrees, worktrees)
 			}
 		})
 	}

--- a/pkg/utils/formatting_test.go
+++ b/pkg/utils/formatting_test.go
@@ -79,7 +79,7 @@ func TestGetPadWidths(t *testing.T) {
 
 	for _, test := range tests {
 		output := getPadWidths(test.input)
-		assert.EqualValues(t, output, test.expected)
+		assert.EqualValues(t, test.expected, output)
 	}
 }
 
@@ -217,6 +217,6 @@ func TestRenderDisplayStrings(t *testing.T) {
 
 	for _, test := range tests {
 		output := RenderDisplayStrings(test.input, test.columnAlignments)
-		assert.EqualValues(t, output, test.expected)
+		assert.EqualValues(t, test.expected, output)
 	}
 }

--- a/pkg/utils/rebase_todo_test.go
+++ b/pkg/utils/rebase_todo_test.go
@@ -326,7 +326,7 @@ func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
 				assert.EqualError(t, actualErr, scenario.expectedErr.Error())
 			}
 
-			assert.EqualValues(t, actualTodos, scenario.expectedTodos)
+			assert.EqualValues(t, scenario.expectedTodos, actualTodos)
 		})
 	}
 }


### PR DESCRIPTION
- **PR Description**

Handle trailing slashes in worktree path

Changes:
- Remove trailing slashes in worktree path.
- Fix argument order to assertions
- Slightly adjust the error message (initially I thought `lazygit` is not correctly handling the worktree nested in a separate folder)

Example stacktrace of error encountered:
```
2023/08/19 19:21:29 An error occurred! Please create an issue at: https://github.com/jesseduffield/lazygit/issues

*errors.errorString Error getting repo paths: failed to get repo git dir path: could not find git dir for /home/user/my-project/feature/test: path is not under `worktrees` or `modules` directories
github.com/jesseduffield/lazygit/pkg/commands/git.go:100 (0x560586a52a13)
github.com/jesseduffield/lazygit/pkg/gui/gui.go:271 (0x560586b826eb)
github.com/jesseduffield/lazygit/pkg/gui/gui.go:656 (0x560586b852db)
github.com/jesseduffield/lazygit/pkg/gui/gui.go:675 (0x560586b859c5)
github.com/jesseduffield/lazygit/pkg/utils/utils.go:108 (0x5605868e10fc)
github.com/jesseduffield/lazygit/pkg/gui/gui.go:674 (0x560586b8590e)
github.com/jesseduffield/lazygit/pkg/app/app.go:263 (0x560586bb157d)
github.com/jesseduffield/lazygit/pkg/app/app.go:48 (0x560586bb1512)
github.com/jesseduffield/lazygit/pkg/app/entry_point.go:150 (0x560586bb36ea)
github.com/jesseduffield/lazygit/main.go:23 (0x560586bb4e78)
runtime/internal/atomic/types.go:194 (0x56058650eeb2)
runtime/asm_amd64.s:1650 (0x56058653f121)
```
I use a custom CLI (which uses libgit2 under the hood, not the `git` cli) to create worktrees in a project, and the path it outputted in the `.git` file of the worktree contained a trailing slash, e.g. `/home/user/my-project/.bare/worktrees/feature_test/`.
The problem seems to be that [`path.Dir`](https://github.com/jesseduffield/lazygit/blob/7a4a0c85c433fd29185c05d0021cd0db87284f23/pkg/commands/git_commands/repo_paths.go#L212) does not check if there is any text after the separator, and outputs the same path without the trailing slash, which then does not pass the `path.Base(parent) == "worktrees"` condition.

I think the fact that I use a bare repo setup had an effect here, as I did not observe this issue when the worktree is nested under the "main" branch (the project was configured similar to this blog https://infrequently.org/2021/07/worktrees-step-by-step/).

I added a unit test, which fails on `master` and passes with the fix.
I haven't verified the fix on Windows, but I think it should work.
PS. Not a go developer, so feedback is more than welcome :)

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
