### PR TITLE
fix GitHub Actions warnings

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Unshallow repo
         run: git fetch --prune --unshallow
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
       - name: Run goreleaser

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.20.x
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: v1.17.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,18 +30,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
-      - name: Cache build
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{matrix.cache_path}}
-            ~/go/pkg/mod
-          key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-test
-          restore-keys: |
-            ${{runner.os}}-go-
       - name: Test code
         # we're passing -short so that we skip the integration tests, which will be run in parallel below
         run: |
@@ -89,18 +80,9 @@ jobs:
           path: ~/git-${{matrix.git-version}}
           key: ${{runner.os}}-git-${{matrix.git-version}}
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
-      - name: Cache build
-        uses: actions/cache@v1
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-test
-          restore-keys: |
-            ${{runner.os}}-go-
       - name: Print git version
         run: git --version
       - name: Test code
@@ -115,18 +97,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
-      - name: Cache build
-        uses: actions/cache@v1
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-build
-          restore-keys: |
-            ${{runner.os}}-go-
       - name: Build linux binary
         run: |
           GOOS=linux go build
@@ -151,18 +124,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
-      - name: Cache build
-        uses: actions/cache@v1
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-build
-          restore-keys: |
-            ${{runner.os}}-go-
       - name: Check Cheatsheet
         run: |
           go run scripts/cheatsheet/main.go check
@@ -185,18 +149,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
-      - name: Cache build
-        uses: actions/cache@v1
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-test
-          restore-keys: |
-            ${{runner.os}}-go-
       - name: Lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           go-version: 1.20.x
       - name: Lint
-        uses: golangci/golangci-lint-action@v3.1.0
+        uses: golangci/golangci-lint-action@v3.7.0
         with:
           version: latest
       - name: errors

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Generate Sponsors 💖
-        uses: JamesIves/github-sponsors-readme-action@v1.0.8
+        uses: JamesIves/github-sponsors-readme-action@v1.2.2
         with:
           token: ${{ secrets.SPONSORS_TOKEN }}
           file: 'README.md'


### PR DESCRIPTION
## **PR Description**

I ran GitHub Actions on my forked repository and confirmed no warnings.
- Execution history of `cd.yml` https://github.com/kyu08/lazygit/actions/runs/5922395968
- Execution history of `ci.yml` https://github.com/kyu08/lazygit/actions/runs/5922371384
- Execution history of `sponsors.yml` https://github.com/kyu08/lazygit/actions/runs/5922388548

As for the execution results of `cd.yml`, I have not been able to run it because it needed the goreleaser environment.

I separated the commits by actions that changed the version to make it easier to roll back in case of problems.

closes #2949