### PR TITLE
Select same commit again after pressing "e" to edit a commit

### DIFF
--- a/pkg/gui/controllers/helpers/merge_and_rebase_helper.go
+++ b/pkg/gui/controllers/helpers/merge_and_rebase_helper.go
@@ -125,8 +125,8 @@ func isMergeConflictErr(errStr string) bool {
 	return false
 }
 
-func (self *MergeAndRebaseHelper) CheckMergeOrRebase(result error) error {
-	if err := self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC}); err != nil {
+func (self *MergeAndRebaseHelper) CheckMergeOrRebaseWithRefreshOptions(result error, refreshOptions types.RefreshOptions) error {
+	if err := self.c.Refresh(refreshOptions); err != nil {
 		return err
 	}
 	if result == nil {
@@ -141,6 +141,10 @@ func (self *MergeAndRebaseHelper) CheckMergeOrRebase(result error) error {
 	} else {
 		return self.CheckForConflicts(result)
 	}
+}
+
+func (self *MergeAndRebaseHelper) CheckMergeOrRebase(result error) error {
+	return self.CheckMergeOrRebaseWithRefreshOptions(result, types.RefreshOptions{Mode: types.ASYNC})
 }
 
 func (self *MergeAndRebaseHelper) CheckForConflicts(result error) error {

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -178,11 +178,11 @@ func (self *RefreshHelper) Refresh(options types.RefreshOptions) error {
 
 		self.refreshStatus()
 
+		wg.Wait()
+
 		if options.Then != nil {
 			options.Then()
 		}
-
-		wg.Wait()
 	}
 
 	if options.Mode == types.BLOCK_UI {

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -51,6 +51,10 @@ func NewRefreshHelper(
 }
 
 func (self *RefreshHelper) Refresh(options types.RefreshOptions) error {
+	if options.Mode == types.ASYNC && options.Then != nil {
+		panic("RefreshOptions.Then doesn't work with mode ASYNC")
+	}
+
 	t := time.Now()
 	defer func() {
 		self.c.Log.Infof(fmt.Sprintf("Refresh took %s", time.Since(t)))

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
@@ -44,8 +44,8 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("pick").Contains("CI commit 05"),
 				Contains("update-ref").Contains("branch1").DoesNotContain("*"),
 				Contains("pick").Contains("CI * commit 04"),
-				Contains("pick").Contains("CI commit 03").IsSelected(), // wrong line selected
-				Contains("<-- YOU ARE HERE --- commit 02"),
+				Contains("pick").Contains("CI commit 03"),
+				Contains("<-- YOU ARE HERE --- commit 02").IsSelected(),
 				Contains("CI commit 01"),
 			).
 			NavigateToLine(Contains("commit 06")).

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
@@ -44,7 +44,7 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("pick").Contains("CI commit 05"),
 				Contains("update-ref").Contains("branch1").DoesNotContain("*"),
 				Contains("pick").Contains("CI * commit 04"),
-				Contains("pick").Contains("CI commit 03"),
+				Contains("pick").Contains("CI commit 03").IsSelected(), // wrong line selected
 				Contains("<-- YOU ARE HERE --- commit 02"),
 				Contains("CI commit 01"),
 			).


### PR DESCRIPTION
- **PR Description**

When editing a commit, the index of the current commit can change; for example,
when merge commits are involved, or when working with stacked branches where
"update-ref" commands may be added above the selected commit.

With this PR we reselect the current commit after pressing "e".

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
