### PR TITLE
Support custom keybindings for confirm discard

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -207,6 +207,7 @@ keybinding:
     commitChangesWithoutHook: 'w' # commit changes without pre-commit hook
     amendLastCommit: 'A'
     commitChangesWithEditor: 'C'
+    confirmDiscard: 'x'
     ignoreFile: 'i'
     refreshFiles: 'r'
     stashAllChanges: 's'

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -223,6 +223,7 @@ type KeybindingFilesConfig struct {
 	CommitChangesWithoutHook string `yaml:"commitChangesWithoutHook"`
 	AmendLastCommit          string `yaml:"amendLastCommit"`
 	CommitChangesWithEditor  string `yaml:"commitChangesWithEditor"`
+	ConfirmDiscard           string `yaml:"confirmDiscard"`
 	IgnoreFile               string `yaml:"ignoreFile"`
 	RefreshFiles             string `yaml:"refreshFiles"`
 	StashAllChanges          string `yaml:"stashAllChanges"`
@@ -592,6 +593,7 @@ func GetDefaultConfig() *UserConfig {
 				ToggleTreeView:           "`",
 				OpenMergeTool:            "M",
 				OpenStatusFilter:         "<c-b>",
+				ConfirmDiscard:           "x",
 			},
 			Branches: KeybindingBranchesConfig{
 				CopyPullRequestURL:     "<c-y>",

--- a/pkg/gui/controllers/files_remove_controller.go
+++ b/pkg/gui/controllers/files_remove_controller.go
@@ -53,7 +53,7 @@ func (self *FilesRemoveController) remove(node *filetree.FileNode) error {
 					}
 					return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES, types.WORKTREES}})
 				},
-				Key: 'x',
+				Key: self.c.KeybindingsOpts().GetKey(self.c.UserConfig.Keybinding.Files.ConfirmDiscard),
 				Tooltip: utils.ResolvePlaceholderString(
 					self.c.Tr.DiscardAllTooltip,
 					map[string]string{
@@ -109,7 +109,7 @@ func (self *FilesRemoveController) remove(node *filetree.FileNode) error {
 						}
 						return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES, types.WORKTREES}})
 					},
-					Key: 'x',
+					Key: self.c.KeybindingsOpts().GetKey(self.c.UserConfig.Keybinding.Files.ConfirmDiscard),
 					Tooltip: utils.ResolvePlaceholderString(
 						self.c.Tr.DiscardAllTooltip,
 						map[string]string{


### PR DESCRIPTION
- **PR Description**

The change to `dx` for discarding files was kind of a pain since I'm very use to using `dd` in Vim. This PR allows customizing the keybinding for confirming discarding of files.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
