### PR TITLE
Add instruction in PR template to start PRs with an imperative

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,3 +8,8 @@
 * [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
 * [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
 * [ ] You've read through your own file changes for silly mistakes etc
+
+<!--
+Be sure to name your PR with an imperative e.g. 'Add worktrees view'
+see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
+-->


### PR DESCRIPTION
This spares me effort when it comes to making release notes.

Yes, sometimes it may be easier to start a message without an imperative e.g. 'When X happens, do Y' but I don't want to overwhelm the contributor with details.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc
