### PR TITLE
Check for staged files for "Amend commit" and "Create fixup commit"

### DIFF
--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -615,19 +615,13 @@ func (self *FilesController) refresh() error {
 }
 
 func (self *FilesController) handleAmendCommitPress() error {
-	if len(self.c.Model().Files) == 0 {
-		return self.c.ErrorMsg(self.c.Tr.NoFilesStagedTitle)
-	}
+	return self.c.Helpers().WorkingTree.WithEnsureCommitableFiles(func() error {
+		if len(self.c.Model().Commits) == 0 {
+			return self.c.ErrorMsg(self.c.Tr.NoCommitToAmend)
+		}
 
-	if !self.c.Helpers().WorkingTree.AnyStagedFiles() {
-		return self.c.Helpers().WorkingTree.PromptToStageAllAndRetry(self.handleAmendCommitPress)
-	}
-
-	if len(self.c.Model().Commits) == 0 {
-		return self.c.ErrorMsg(self.c.Tr.NoCommitToAmend)
-	}
-
-	return self.c.Helpers().AmendHelper.AmendHead()
+		return self.c.Helpers().AmendHelper.AmendHead()
+	})
 }
 
 func (self *FilesController) handleStatusFilterPressed() error {


### PR DESCRIPTION
- **PR Description**

1. There are three commands that can prompt you whether you want to stage all changes before committing: "Commit", "Commit with editor", and "Amend". Of these, only "Commit" respected the `SkipNoStagedFilesWarning` config. Now they all do.
2. The commands "Amend commit with staged changes" (in the commits view) and "Create fixup commit for this commit" would fail with confusing error messages when no files are staged. Now they prompt you whether you want to stage all files, like a normal commit does. (And they also respect the `SkipNoStagedFilesWarning` config, of course.)

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
