### PR TITLE
Don't show toasts when running integration tests

### DIFF
--- a/pkg/gui/controllers/helpers/app_status_helper.go
+++ b/pkg/gui/controllers/helpers/app_status_helper.go
@@ -21,6 +21,13 @@ func NewAppStatusHelper(c *HelperCommon, statusMgr func() *status.StatusManager)
 }
 
 func (self *AppStatusHelper) Toast(message string) {
+	if self.c.RunningIntegrationTest() {
+		// Don't bother showing toasts in integration tests. You can't check for
+		// them anyway, and they would only slow down the test unnecessarily by
+		// two seconds.
+		return
+	}
+
 	self.statusMgr().AddToastStatus(message)
 
 	self.renderAppStatus()

--- a/pkg/gui/gui_common.go
+++ b/pkg/gui/gui_common.go
@@ -182,6 +182,10 @@ func (self *guiCommon) AfterLayout(f func() error) {
 	}
 }
 
+func (self *guiCommon) RunningIntegrationTest() bool {
+	return self.gui.integrationTest != nil
+}
+
 func (self *guiCommon) InDemo() bool {
 	return self.gui.integrationTest != nil && self.gui.integrationTest.IsDemo()
 }

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -107,6 +107,9 @@ type IGuiCommon interface {
 	// hopefully we can remove this once we've moved all our keybinding stuff out of the gui god struct.
 	GetInitialKeybindingsWithCustomCommands() ([]*Binding, []*gocui.ViewMouseBinding)
 
+	// Returns true if we're running an integration test
+	RunningIntegrationTest() bool
+
 	// Returns true if we're in a demo recording/playback
 	InDemo() bool
 }


### PR DESCRIPTION
It's pointless because you can't check for them in tests anyway, so they unnecessarily slow down the test run by two seconds for no reason.

Interestingly, this has almost no effect on the total runtime of all tests (on my machine), but the difference is very noticeable when running a single test that shows a toast (e.g. `tag/crud_lightweight.go`), so I guess it's still worth it.

It makes me a bit sad that integration test requirements now leak into production code, but we have precedence for this already with the InDemo function.