### PR TITLE
Fix escape not cancelling filter mode, but closing the menu instead

### DIFF
--- a/pkg/gui/controllers/menu_controller.go
+++ b/pkg/gui/controllers/menu_controller.go
@@ -65,6 +65,11 @@ func (self *MenuController) press() error {
 }
 
 func (self *MenuController) close() error {
+	if self.context().IsFiltering() {
+		self.c.Helpers().Search.Cancel()
+		return nil
+	}
+
 	return self.c.PopContext()
 }
 

--- a/pkg/integration/tests/filter_and_search/filter_menu_cancel_filter_with_escape.go
+++ b/pkg/integration/tests/filter_and_search/filter_menu_cancel_filter_with_escape.go
@@ -1,0 +1,36 @@
+package filter_and_search
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var FilterMenuCancelFilterWithEscape = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Filtering the keybindings menu, then pressing esc to turn off the filter",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo:    func(shell *Shell) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().IsFocused().
+			Press(keys.Universal.OptionMenu)
+
+		t.ExpectPopup().Menu().
+			Title(Equals("Keybindings")).
+			Filter("Toggle staged").
+			Lines(
+				// menu has filtered down to the one item that matches the filter
+				Contains(`Toggle staged`).IsSelected(),
+			)
+
+		// Escape should cancel the filter, not close the menu
+		t.GlobalPress(keys.Universal.Return)
+		t.ExpectPopup().Menu().
+			Title(Equals("Keybindings")).
+			LineCount(GreaterThan(1))
+
+		// Another escape closes the menu
+		t.GlobalPress(keys.Universal.Return)
+		t.Views().Files().IsFocused()
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -122,6 +122,7 @@ var tests = []*components.IntegrationTest{
 	filter_and_search.FilterFiles,
 	filter_and_search.FilterFuzzy,
 	filter_and_search.FilterMenu,
+	filter_and_search.FilterMenuCancelFilterWithEscape,
 	filter_and_search.FilterRemoteBranches,
 	filter_and_search.NestedFilter,
 	filter_and_search.NestedFilterTransient,


### PR DESCRIPTION
- **PR Description**

When filtering is on in a menu, pressing esc should only cancel the filter, but not close the menu.

Fixes #2802.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
