### PR TITLE
Replace whitespace with '-' when renaming a branch

### DIFF
--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -557,7 +557,7 @@ func (self *BranchesController) rename(branch *models.Branch) error {
 			InitialContent: branch.Name,
 			HandleConfirm: func(newBranchName string) error {
 				self.c.LogAction(self.c.Tr.Actions.RenameBranch)
-				if err := self.c.Git().Branch.Rename(branch.Name, newBranchName); err != nil {
+				if err := self.c.Git().Branch.Rename(branch.Name, helpers.SanitizedBranchName(newBranchName)); err != nil {
 					return self.c.Error(err)
 				}
 

--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -165,7 +165,7 @@ func (self *RefsHelper) NewBranch(from string, fromFormattedName string, suggest
 		InitialContent: suggestedBranchName,
 		HandleConfirm: func(response string) error {
 			self.c.LogAction(self.c.Tr.Actions.CreateBranch)
-			if err := self.c.Git().Branch.New(sanitizedBranchName(response), from); err != nil {
+			if err := self.c.Git().Branch.New(SanitizedBranchName(response), from); err != nil {
 				return err
 			}
 
@@ -183,8 +183,8 @@ func (self *RefsHelper) NewBranch(from string, fromFormattedName string, suggest
 	})
 }
 
-// sanitizedBranchName will remove all spaces in favor of a dash "-" to meet
+// SanitizedBranchName will remove all spaces in favor of a dash "-" to meet
 // git's branch naming requirement.
-func sanitizedBranchName(input string) string {
+func SanitizedBranchName(input string) string {
 	return strings.Replace(input, " ", "-", -1)
 }

--- a/pkg/integration/tests/branch/rename.go
+++ b/pkg/integration/tests/branch/rename.go
@@ -1,0 +1,35 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var Rename = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Rename a branch, replacing spaces in the name with dashes",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("commit")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("master"),
+			).
+			Press(keys.Branches.RenameBranch).
+			Tap(func() {
+				t.ExpectPopup().Prompt().
+					Title(Contains("Enter new branch name")).
+					InitialText(Equals("master")).
+					Clear().
+					Type("new branch name").
+					Confirm()
+			}).
+			Lines(
+				Contains("new-branch-name"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -46,6 +46,7 @@ var tests = []*components.IntegrationTest{
 	branch.RebaseCancelOnConflict,
 	branch.RebaseDoesNotAutosquash,
 	branch.RebaseFromMarkedBase,
+	branch.Rename,
 	branch.Reset,
 	branch.ResetUpstream,
 	branch.SetUpstream,


### PR DESCRIPTION
- **PR Description**
This PR replaces all `' '`s with `'-'`s when renaming a branch. This will keep it consistent with the behaviour when creating a new branch. 

Closes the following issues:
https://github.com/jesseduffield/lazygit/issues/2988
https://github.com/jesseduffield/lazygit/issues/2101

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
