### PR TITLE
use browser environment variable to open link

### DIFF
--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
@@ -26,15 +27,19 @@ func isContainer() bool {
 
 // GetPlatformDefaultConfig gets the defaults for the platform
 func GetPlatformDefaultConfig() OSConfig {
+	osConfig := OSConfig{}
+
 	if isWSL() && !isContainer() {
-		return OSConfig{
-			Open:     `powershell.exe start explorer.exe {{filename}} >/dev/null`,
-			OpenLink: `powershell.exe start {{link}} >/dev/null`,
-		}
+		osConfig.Open = `powershell.exe start explorer.exe {{filename}} >/dev/null`
+		osConfig.OpenLink = `powershell.exe start {{link}} >/dev/null`
+	} else {
+		osConfig.Open = `xdg-open {{filename}} >/dev/null`
+		osConfig.OpenLink = `xdg-open {{link}} >/dev/null`
 	}
 
-	return OSConfig{
-		Open:     `xdg-open {{filename}} >/dev/null`,
-		OpenLink: `xdg-open {{link}} >/dev/null`,
+	if browser, ok := os.LookupEnv("BROWSER"); ok {
+		osConfig.OpenLink = fmt.Sprintf(`"%s" {{link}} >/dev/null`, browser)
 	}
+
+	return osConfig
 }


### PR DESCRIPTION
- **PR Description**

  - This PR allows user to use `BROWSER` environment variable to OpenLink (e.g. when open pull request).
  - ``fmt.Sprintf(`"%s" {{link}} >/dev/null`, browser)``, the `browser` is double quoted to allow space in path, especially for WSL user (e.g. `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe`)

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
