### PR TITLE
Use `Error` method to handle commits url copy from unknown service

### DIFF
--- a/pkg/gui/controllers/basic_commits_controller.go
+++ b/pkg/gui/controllers/basic_commits_controller.go
@@ -152,7 +152,7 @@ func (self *BasicCommitsController) copyCommitSHAToClipboard(commit *models.Comm
 func (self *BasicCommitsController) copyCommitURLToClipboard(commit *models.Commit) error {
 	url, err := self.c.Helpers().Host.GetCommitURL(commit.Sha)
 	if err != nil {
-		return err
+		return self.c.Error(err)
 	}
 
 	self.c.LogAction(self.c.Tr.Actions.CopyCommitURLToClipboard)


### PR DESCRIPTION
- **PR Description**
This PR adds a missing `self.c.Error()` method call on the `basic_commits_controller` to handle unsupported git service. Sorry for not asking @jesseduffield - I could reproduce the issue, and it was a very easy fix.

This PR closes #3002.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
