### PR TITLE
Rename `test/results` to `test/_results`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ lazygit.exe
 
 test/git_server/data
 
-test/results/**
+test/_results/**
 
 oryxBuildBinary
 __debug_bin

--- a/pkg/integration/README.md
+++ b/pkg/integration/README.md
@@ -50,7 +50,7 @@ The name of a test is based on its path, so the name of the test at `pkg/integra
 
 You can pass the INPUT_DELAY env var to the test runner in order to set a delay in milliseconds between keypresses or mouse clicks, which helps for watching a test at a realistic speed to understand what it's doing. Or you can pass the '--slow' flag which sets a pre-set 'slow' key delay. In the tui you can press 't' to run the test in slow mode.
 
-The resultant repo will be stored in `test/results`, so if you're not sure what went wrong you can go there and inspect the repo.
+The resultant repo will be stored in `test/_results`, so if you're not sure what went wrong you can go there and inspect the repo.
 
 ### Running tests in VSCode
 

--- a/pkg/integration/clients/tui.go
+++ b/pkg/integration/clients/tui.go
@@ -153,7 +153,7 @@ func RunTUI() {
 			return nil
 		}
 
-		cmd := exec.Command("sh", "-c", fmt.Sprintf("code test/results/%s", currentTest.Name()))
+		cmd := exec.Command("sh", "-c", fmt.Sprintf("code test/_results/%s", currentTest.Name()))
 		if err := cmd.Run(); err != nil {
 			return err
 		}

--- a/pkg/integration/components/paths.go
+++ b/pkg/integration/components/paths.go
@@ -3,9 +3,9 @@ package components
 import "path/filepath"
 
 // convenience struct for easily getting directories within our test directory.
-// We have one test directory for each test, found in test/results.
+// We have one test directory for each test, found in test/_results.
 type Paths struct {
-	// e.g. test/results/test_name
+	// e.g. test/_results/test_name
 	root string
 }
 

--- a/pkg/integration/components/runner.go
+++ b/pkg/integration/components/runner.go
@@ -39,7 +39,7 @@ func RunTests(
 		return err
 	}
 
-	testDir := filepath.Join(projectRootDir, "test", "results")
+	testDir := filepath.Join(projectRootDir, "test", "_results")
 
 	if err := buildLazygit(); err != nil {
 		return err


### PR DESCRIPTION
This prevents commands like "go test ./..." from looking into it, and it prevents VS Code's Problems panel from showing errors about the go files in that folder.
