### PR TITLE
Add menu to rebase onto selected branch remote upstream

### DIFF
--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -109,7 +109,7 @@ func (self *BranchesController) GetKeybindings(opts types.KeybindingsOpts) []*ty
 		},
 		{
 			Key:         opts.GetKey(opts.Config.Branches.SetUpstream),
-			Handler:     self.checkSelected(self.setUpstream),
+			Handler:     self.checkSelected(self.viewUpstreamOptions),
 			Description: self.c.Tr.ViewBranchUpstreamOptions,
 			Tooltip:     self.c.Tr.ViewBranchUpstreamOptionsTooltip,
 			OpensMenu:   true,
@@ -141,7 +141,7 @@ func (self *BranchesController) GetOnRenderToMain() func() error {
 	}
 }
 
-func (self *BranchesController) setUpstream(selectedBranch *models.Branch) error {
+func (self *BranchesController) viewUpstreamOptions(selectedBranch *models.Branch) error {
 	viewDivergenceItem := &types.MenuItem{
 		LabelColumns: []string{self.c.Tr.ViewDivergenceFromUpstream},
 		OnPress: func() error {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -356,6 +356,8 @@ type TranslationSet struct {
 	DivergenceSectionHeaderRemote       string
 	ViewUpstreamResetOptions            string
 	ViewUpstreamResetOptionsTooltip     string
+	ViewUpstreamRebaseOptions           string
+	ViewUpstreamRebaseOptionsTooltip    string
 	UpstreamGenericName                 string
 	SetUpstreamTitle                    string
 	SetUpstreamMessage                  string
@@ -1152,6 +1154,8 @@ func EnglishTranslationSet() TranslationSet {
 		DivergenceSectionHeaderRemote:       "Remote",
 		ViewUpstreamResetOptions:            "Reset checked-out branch onto {{.upstream}}",
 		ViewUpstreamResetOptionsTooltip:     "View options for resetting the checked-out branch onto {{upstream}}. Note: this will not reset the selected branch onto the upstream, it will reset the checked-out branch onto the upstream",
+		ViewUpstreamRebaseOptions:           "Rebase checked-out branch onto {{.upstream}}",
+		ViewUpstreamRebaseOptionsTooltip:    "View options for rebasing the checked-out branch onto {{upstream}}. Note: this will not rebase the selected branch onto the upstream, it will rebased the checked-out branch onto the upstream",
 		UpstreamGenericName:                 "upstream of selected branch",
 		SetUpstreamTitle:                    "Set upstream branch",
 		SetUpstreamMessage:                  "Are you sure you want to set the upstream branch of '{{.checkedOut}}' to '{{.selected}}'",

--- a/pkg/integration/tests/branch/rebase_to_upstream.go
+++ b/pkg/integration/tests/branch/rebase_to_upstream.go
@@ -1,0 +1,82 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var RebaseToUpstream = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Rebase the current branch to the selected branch upstream",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			CloneIntoRemote("origin").
+			EmptyCommit("ensure-master").
+			EmptyCommit("to-be-added"). // <- this will only exist remotely
+			PushBranch("origin", "master").
+			HardReset("HEAD~1").
+			NewBranchFrom("base-branch", "master").
+			EmptyCommit("base-branch-commit").
+			NewBranch("target").
+			EmptyCommit("target-commit")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().Lines(
+			Contains("target-commit"),
+			Contains("base-branch-commit"),
+			Contains("ensure-master"),
+		)
+
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("target").IsSelected(),
+				Contains("base-branch"),
+				Contains("master"),
+			).
+			SelectNextItem().
+			Lines(
+				Contains("target"),
+				Contains("base-branch").IsSelected(),
+				Contains("master"),
+			).
+			Press(keys.Branches.SetUpstream).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Upstream options")).
+					Select(Contains("Rebase checked-out branch onto upstream of selected branch")).
+					Tooltip(Contains("Disabled: The selected branch has no upstream (or the upstream is not stored locally)")).
+					Confirm()
+				t.ExpectPopup().Alert().
+					Title(Equals("Error")).
+					Content(Equals("The selected branch has no upstream (or the upstream is not stored locally)")).
+					Confirm()
+			}).
+			SelectNextItem().
+			Lines(
+				Contains("target"),
+				Contains("base-branch"),
+				Contains("master").IsSelected(),
+			).
+			Press(keys.Branches.SetUpstream).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Upstream options")).
+					Select(Contains("Rebase checked-out branch onto origin/master...")).
+					Confirm()
+				t.ExpectPopup().Menu().
+					Title(Equals("Rebase 'target' onto 'origin/master'")).
+					Select(Contains("Simple rebase")).
+					Confirm()
+			})
+
+		t.Views().Commits().Lines(
+			Contains("target-commit"),
+			Contains("base-branch-commit"),
+			Contains("to-be-added"),
+			Contains("ensure-master"),
+		)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -47,6 +47,7 @@ var tests = []*components.IntegrationTest{
 	branch.RebaseCancelOnConflict,
 	branch.RebaseDoesNotAutosquash,
 	branch.RebaseFromMarkedBase,
+	branch.RebaseToUpstream,
 	branch.Rename,
 	branch.Reset,
 	branch.ResetToUpstream,


### PR DESCRIPTION
- **PR Description**
This PR gives the users the possibility to rebase the currently checked-out branch onto the selected branch remote upstream. I followed the same pattern used for the reset operation to keep it consistent with the already existing UX.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

This PR closes #2938 

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
