### PR TITLE
Respect $GIT_WORK_TREE and $GIT_DIR env vars (fix #3010).

### DIFF
--- a/pkg/app/entry_point.go
+++ b/pkg/app/entry_point.go
@@ -180,10 +180,10 @@ func parseCliArgsAndEnvVars() *cliArgs {
 	useConfigDir := ""
 	flaggy.String(&useConfigDir, "ucd", "use-config-dir", "override default config directory with provided directory")
 
-	workTree := ""
+	workTree := os.Getenv("GIT_WORK_TREE")
 	flaggy.String(&workTree, "w", "work-tree", "equivalent of the --work-tree git argument")
 
-	gitDir := ""
+	gitDir := os.Getenv("GIT_DIR")
 	flaggy.String(&gitDir, "g", "git-dir", "equivalent of the --git-dir git argument")
 
 	customConfigFile := ""


### PR DESCRIPTION
- **PR Description**

Lazygit is currently ignoring `$GIT_WORK_TREE` and `$GIT_DIR` env vars resulting in discrepancy with git.
This PR initializes `--work-tree` and `--git-dir` args with  `$GIT_WORK_TREE` and `$GIT_DIR` respectively while giving higher priority to cli args. 
