### PR TITLE
Change Makefile to build non-optimized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 
 .PHONY: build
 build:
-	go build
+	go build -gcflags='all=-N -l'
 
 .PHONY: install
 install:


### PR DESCRIPTION
This change might be controversial, I'm putting it out there to see what people think.

We [recently](https://github.com/jesseduffield/lazygit/pull/3000/commits/28d12e4e5d72f087d23544de44b2af87d59bab95) added a launch configuration that allows attaching VS Code's debugger to a running lazygit process; I prefer this over having the debugger launch a new process. Trouble is, builds are optimized by default, so the debugging experience is non-optimal; e.g. often is has trouble showing the correct variable values, and the current position jumps back and forth when single-stepping because of the compiler moving code around for optimizations.

This is greatly improved by turning off optimizations (`-N`) and inlining (`-l`). The question is whether this should be the default for the `build` and `run` target. Other options would be to add special targets for these (e.g. `build-for-debug` and `run-for-debug`, or `build-non-optimized` etc.; it could also be a make flag like many other makefiles do). All these would make it less convenient to use, though.

For me personally, changing the default is great because the only reason I use `make run` is in order to debug. I rarely use `make build` at all. I use `make install` often, but this is unaffected, it still builds optimized as before.

Oh btw, I can't really tell much of a difference between using the optimized vs. non-optimized build, anyway; lazygit does few things that are CPU bound.