### PR TITLE
Add ability to force portrait mode

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -85,6 +85,7 @@ gui:
   skipRewordInEditorWarning: false # for skipping the confirmation before launching the reword editor
   border: 'rounded' # one of 'single' | 'double' | 'rounded' | 'hidden'
   animateExplosion: true # shows an explosion animation when nuking the working tree
+  portraitMode: 'auto' # one of 'auto' | 'never' | 'always'
 git:
   paging:
     colorArg: always

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -130,6 +130,9 @@ type GuiConfig struct {
 	Border string `yaml:"border"`
 	// If true, show a seriously epic explosion animation when nuking the working tree.
 	AnimateExplosion bool `yaml:"animateExplosion"`
+	// Whether to stack UI components on top of each other.
+	// One of 'auto' (default) | 'always' | 'never'
+	PortraitMode string `yaml:"portraitMode"`
 }
 
 type ThemeConfig struct {
@@ -619,6 +622,7 @@ func GetDefaultConfig() *UserConfig {
 			SkipRewordInEditorWarning: false,
 			Border:                    "rounded",
 			AnimateExplosion:          true,
+			PortraitMode:              "auto",
 		},
 		Git: GitConfig{
 			Paging: PagingConfig{

--- a/pkg/gui/controllers/helpers/window_arrangement_helper.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper.go
@@ -34,14 +34,24 @@ func NewWindowArrangementHelper(
 
 const INFO_SECTION_PADDING = " "
 
+func (self *WindowArrangementHelper) shouldUsePortraitMode(width, height int) bool {
+	switch self.c.UserConfig.Gui.PortraitMode {
+	case "never":
+		return false
+	case "always":
+		return true
+	default: // "auto" or any garbage values in PortraitMode value
+		return width <= 84 && height > 45
+	}
+}
+
 func (self *WindowArrangementHelper) GetWindowDimensions(informationStr string, appStatus string) map[string]boxlayout.Dimensions {
 	width, height := self.c.GocuiGui().Size()
 
 	sideSectionWeight, mainSectionWeight := self.getMidSectionWeights()
 
 	sidePanelsDirection := boxlayout.COLUMN
-	portraitMode := width <= 84 && height > 45
-	if portraitMode {
+	if self.shouldUsePortraitMode(width, height) {
 		sidePanelsDirection = boxlayout.ROW
 	}
 


### PR DESCRIPTION
- **PR Description**
A new gui config flag 'portraitMode':<bool> is added.

When set to true LazyGit will always use the stacked layout typically only seen when the terminal window becomes narrow enough.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go run scripts/cheatsheet/main.go generate`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
