### PR TITLE
Band-aid fix for submodule/reset.go test failure

### DIFF
--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -449,9 +449,11 @@ func (self *RefreshHelper) refreshBranches() {
 
 	// Need to re-render the commits view because the visualization of local
 	// branch heads might have changed
+	self.c.Mutexes().LocalCommitsMutex.Lock()
 	if err := self.c.Contexts().LocalCommits.HandleRender(); err != nil {
 		self.c.Log.Error(err)
 	}
+	self.c.Mutexes().LocalCommitsMutex.Unlock()
 
 	self.refreshStatus()
 }


### PR DESCRIPTION
This is not a complete fix, but it's good enough to fix the spurious test failures of submodule/reset.go. We have some vague hope to fix this in a more sustainable way by somehow improving our concurrency model fundamentally (see #2974 for some discussion about that), but that's a more long-term undertaking, and it's annoying that this test fails so often, so let's fix it in this way for now.
