### PR TITLE
Remove redundant `len` check

### DIFF
--- a/pkg/commands/hosting_service/hosting_service.go
+++ b/pkg/commands/hosting_service/hosting_service.go
@@ -99,32 +99,30 @@ func (self *HostingServiceMgr) getCandidateServiceDomains() []ServiceDomain {
 
 	serviceDomains := slices.Clone(defaultServiceDomains)
 
-	if len(self.configServiceDomains) > 0 {
-		for gitDomain, typeAndDomain := range self.configServiceDomains {
-			provider, webDomain, success := strings.Cut(typeAndDomain, ":")
+	for gitDomain, typeAndDomain := range self.configServiceDomains {
+		provider, webDomain, success := strings.Cut(typeAndDomain, ":")
 
-			// we allow for one ':' for specifying the TCP port
-			if !success || strings.Count(webDomain, ":") > 1 {
-				self.log.Errorf("Unexpected format for git service: '%s'. Expected something like 'github.com:github.com'", typeAndDomain)
-				continue
-			}
-
-			serviceDefinition, ok := serviceDefinitionByProvider[provider]
-			if !ok {
-				providerNames := lo.Map(serviceDefinitions, func(serviceDefinition ServiceDefinition, _ int) string {
-					return serviceDefinition.provider
-				})
-
-				self.log.Errorf("Unknown git service type: '%s'. Expected one of %s", provider, strings.Join(providerNames, ", "))
-				continue
-			}
-
-			serviceDomains = append(serviceDomains, ServiceDomain{
-				gitDomain:         gitDomain,
-				webDomain:         webDomain,
-				serviceDefinition: serviceDefinition,
-			})
+		// we allow for one ':' for specifying the TCP port
+		if !success || strings.Count(webDomain, ":") > 1 {
+			self.log.Errorf("Unexpected format for git service: '%s'. Expected something like 'github.com:github.com'", typeAndDomain)
+			continue
 		}
+
+		serviceDefinition, ok := serviceDefinitionByProvider[provider]
+		if !ok {
+			providerNames := lo.Map(serviceDefinitions, func(serviceDefinition ServiceDefinition, _ int) string {
+				return serviceDefinition.provider
+			})
+
+			self.log.Errorf("Unknown git service type: '%s'. Expected one of %s", provider, strings.Join(providerNames, ", "))
+			continue
+		}
+
+		serviceDomains = append(serviceDomains, ServiceDomain{
+			gitDomain:         gitDomain,
+			webDomain:         webDomain,
+			serviceDefinition: serviceDefinition,
+		})
 	}
 
 	return serviceDomains


### PR DESCRIPTION
- **PR Description**

This pull request is a minor code cleanup.

From the Go specification (https://go.dev/ref/spec#For_range):

> "3. If the map is nil, the number of iterations is 0."

`len` returns 0 if the map is nil (https://pkg.go.dev/builtin#len). Therefore, checking `len(v) > 0` before a loop is unnecessary.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
