### PR TITLE
Add nerdfont icons for .bicep & .bicepparam files

### DIFF
--- a/pkg/gui/presentation/icons/file_icons.go
+++ b/pkg/gui/presentation/icons/file_icons.go
@@ -328,12 +328,7 @@ func patchFileIconsForNerdFontsV2() {
 	extIconMap[".vue"] = IconProperties{Icon: "\ufd42", Color: 113}     // ﵂
 }
 
-func IconForFile(
-	name string,
-	isSubmodule bool,
-	isLinkedWorktree bool,
-	isDirectory bool,
-) IconProperties {
+func IconForFile(name string, isSubmodule bool, isLinkedWorktree bool, isDirectory bool) IconProperties {
 	base := filepath.Base(name)
 	if icon, ok := nameIconMap[base]; ok {
 		return icon

--- a/pkg/gui/presentation/icons/file_icons.go
+++ b/pkg/gui/presentation/icons/file_icons.go
@@ -98,6 +98,8 @@ var extIconMap = map[string]IconProperties{
 	".csv":            {Icon: "\uf1c3", Color: 113},     // 
 	".csx":            {Icon: "\U000f031b", Color: 58},  // 󰌛
 	".cxx":            {Icon: "\ue61d", Color: 74},      // 
+	".bicep":          {Icon: "\ue63b", Color: 32},      // 
+	".bicepparam":     {Icon: "\ue63b", Color: 103},     // 
 	".d":              {Icon: "\ue7af", Color: 28},      // 
 	".dart":           {Icon: "\ue798", Color: 25},      // 
 	".db":             {Icon: "\uf1c0", Color: 188},     // 
@@ -326,7 +328,12 @@ func patchFileIconsForNerdFontsV2() {
 	extIconMap[".vue"] = IconProperties{Icon: "\ufd42", Color: 113}     // ﵂
 }
 
-func IconForFile(name string, isSubmodule bool, isLinkedWorktree bool, isDirectory bool) IconProperties {
+func IconForFile(
+	name string,
+	isSubmodule bool,
+	isLinkedWorktree bool,
+	isDirectory bool,
+) IconProperties {
 	base := filepath.Base(name)
 	if icon, ok := nameIconMap[base]; ok {
 		return icon


### PR DESCRIPTION
- **PR Description**
As the title says, I've added the v3 nerd font icons for [Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview?tabs=bicep). 

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
