### PR TITLE
Add disabled compat for user config (#2833)

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -163,7 +163,7 @@ keybinding:
     jumpToBlock: ['1', '2', '3', '4', '5'] # goto the Nth block / panel
     nextMatch: 'n'
     prevMatch: 'N'
-    optionMenu: null # show help menu
+    optionMenu: <disabled> # show help menu
     optionMenu-alt1: '?' # show help menu
     select: '<space>'
     goInto: '<enter>'
@@ -462,12 +462,12 @@ Supported versions are "2" and "3". The deprecated config `showIcons` sets the v
 
 For all possible keybinding options, check [Custom_Keybindings.md](https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Custom_Keybindings.md)
 
-You can disable certain key bindings by specifying `null`.
+You can disable certain key bindings by specifying `<disabled>`.
 
 ```yaml
 keybinding:
   universal:
-    edit: null # disable 'edit file'
+    edit: <disabled> # disable 'edit file'
 ```
 
 ### Example Keybindings For Colemak Users

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -691,7 +691,7 @@ func GetDefaultConfig() *UserConfig {
 				NextMatch:                    "n",
 				PrevMatch:                    "N",
 				StartSearch:                  "/",
-				OptionMenu:                   "",
+				OptionMenu:                   "<disabled>",
 				OptionMenuAlt1:               "?",
 				Select:                       "<space>",
 				GoInto:                       "<enter>",

--- a/pkg/gui/keybindings/keybindings.go
+++ b/pkg/gui/keybindings/keybindings.go
@@ -100,7 +100,9 @@ func LabelFromKey(key types.Key) string {
 
 func GetKey(key string) types.Key {
 	runeCount := utf8.RuneCountInString(key)
-	if runeCount > 1 {
+	if key == "<disabled>" {
+		return nil
+	} else if runeCount > 1 {
 		binding, ok := keyByLabel[strings.ToLower(key)]
 		if !ok {
 			log.Fatalf("Unrecognized key %s for keybinding. For permitted values see %s", strings.ToLower(key), constants.Links.Docs.CustomKeybindings)

--- a/pkg/integration/tests/misc/disabled_keybindings.go
+++ b/pkg/integration/tests/misc/disabled_keybindings.go
@@ -1,0 +1,26 @@
+package misc
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var DisabledKeybindings = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Confirms You can set keybindings to blank to disable them",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.UserConfig.Keybinding.Universal.PrevItem = "<disabled>"
+		config.UserConfig.Keybinding.Universal.NextItem = "<disabled>"
+		config.UserConfig.Keybinding.Universal.NextTab = "<up>"
+		config.UserConfig.Keybinding.Universal.PrevTab = "<down>"
+	},
+	SetupRepo: func(shell *Shell) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			IsFocused().
+			Press("<up>")
+
+		t.Views().Worktrees().IsFocused()
+	},
+})

--- a/pkg/integration/tests/misc/disabled_keybindings.go
+++ b/pkg/integration/tests/misc/disabled_keybindings.go
@@ -6,7 +6,7 @@ import (
 )
 
 var DisabledKeybindings = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Confirms You can set keybindings to blank to disable them",
+	Description:  "Confirms you can disable keybindings by setting them to <disabled>",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -170,6 +170,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.SwapWithConflict,
 	misc.ConfirmOnQuit,
 	misc.CopyToClipboard,
+	misc.DisabledKeybindings,
 	misc.InitialOpen,
 	misc.RecentReposOnLaunch,
 	patch_building.Apply,


### PR DESCRIPTION
Treat `<disabled>` setting as equivalent to `null` in keybindings user configs.

- **PR Description**

This PR aims to make `<disabled>` compatible with `null` in the keybindings section of the user config.

The change is minimal and is located in the `GetKey` function of the keybindings module. It simply checks if the passed-in key string is equivalent to `"<disabled>"`.

I encountered an issue with the initial test that @jesseduffield linked in #2833. Interestingly, I couldn't get that test to work even when setting the `ScrollRight` to `null`.

Fixed up the documentation and default config as well. Would probably only want to merge this simultaneously with https://github.com/jesseduffield/lazygit/pull/3039

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
