### PR TITLE
Add 'lvim' editor preset for lunarvim

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -319,7 +319,7 @@ os:
   editPreset: 'vscode'
 ```
 
-Supported presets are `vim`, `nvim`, `nvim-remote`, `emacs`, `nano`, `micro`, `vscode`, `sublime`, `bbedit`, `kakoune`, `helix`, and `xcode`. In many cases lazygit will be able to guess the right preset from your $(git config core.editor), or an environment variable such as $VISUAL or $EDITOR.
+Supported presets are `vim`, `nvim`, `nvim-remote`, `lvim`, `emacs`, `nano`, `micro`, `vscode`, `sublime`, `bbedit`, `kakoune`, `helix`, and `xcode`. In many cases lazygit will be able to guess the right preset from your $(git config core.editor), or an environment variable such as $VISUAL or $EDITOR.
 
 `nvim-remote` is an experimental preset for when you have invoked lazygit from within a neovim process, allowing lazygit to open the file from within the parent process rather than spawning a new one.
 

--- a/pkg/config/editor_presets.go
+++ b/pkg/config/editor_presets.go
@@ -59,6 +59,7 @@ func getPreset(osConfig *OSConfig, guessDefaultEditor func() string) *editPreset
 			openDirInEditorTemplate:   `nvim --server "$NVIM" --remote-tab {{dir}}`,
 			suspend:                   false,
 		},
+		"lvim":    standardTerminalEditorPreset("lvim"),
 		"emacs":   standardTerminalEditorPreset("emacs"),
 		"micro":   standardTerminalEditorPreset("micro"),
 		"nano":    standardTerminalEditorPreset("nano"),


### PR DESCRIPTION
Add 'lvim' as a new standardTerminalEditorPreset, since lunarvim uses an alias for nvim.

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc