### PR TITLE
Fall back to WithWaitingStatus if item is not visible

### DIFF
--- a/pkg/gui/context/list_context_trait.go
+++ b/pkg/gui/context/list_context_trait.go
@@ -97,3 +97,16 @@ func (self *ListContextTrait) OnSearchSelect(selectedLineIdx int) error {
 	self.GetList().SetSelectedLineIdx(selectedLineIdx)
 	return self.HandleFocus(types.OnFocusOpts{})
 }
+
+func (self *ListContextTrait) IsItemVisible(item types.HasUrn) bool {
+	startIdx, length := self.GetViewTrait().ViewPortYBounds()
+	selectionStart := self.ViewIndexToModelIndex(startIdx)
+	selectionEnd := self.ViewIndexToModelIndex(startIdx + length)
+	for i := selectionStart; i < selectionEnd; i++ {
+		iterItem := self.GetList().GetItem(i)
+		if iterItem != nil && iterItem.URN() == item.URN() {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/gui/context/list_view_model.go
+++ b/pkg/gui/context/list_view_model.go
@@ -1,6 +1,9 @@
 package context
 
-import "github.com/jesseduffield/lazygit/pkg/gui/context/traits"
+import (
+	"github.com/jesseduffield/lazygit/pkg/gui/context/traits"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+)
 
 type ListViewModel[T any] struct {
 	*traits.ListCursor
@@ -35,4 +38,9 @@ func (self *ListViewModel[T]) GetItems() []T {
 
 func Zero[T any]() T {
 	return *new(T)
+}
+
+func (self *ListViewModel[T]) GetItem(index int) types.HasUrn {
+	item := self.getModel()[index]
+	return any(item).(types.HasUrn)
 }

--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -115,7 +115,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 		Confirmation:    helpers.NewConfirmationHelper(helperCommon),
 		Mode:            modeHelper,
 		AppStatus:       appStatusHelper,
-		InlineStatus:    helpers.NewInlineStatusHelper(helperCommon),
+		InlineStatus:    helpers.NewInlineStatusHelper(helperCommon, windowHelper),
 		WindowArrangement: helpers.NewWindowArrangementHelper(
 			gui.c,
 			windowHelper,

--- a/pkg/gui/controllers/helpers/inline_status_helper.go
+++ b/pkg/gui/controllers/helpers/inline_status_helper.go
@@ -64,10 +64,10 @@ func (self inlineStatusHelperTask) Continue() {
 }
 
 func (self *InlineStatusHelper) WithInlineStatus(opts InlineStatusOpts, f func(gocui.Task) error) {
-	context := self.c.ContextForKey(opts.ContextKey)
+	context := self.c.ContextForKey(opts.ContextKey).(types.IListContext)
 	view := context.GetView()
 	visible := view.Visible && self.windowHelper.TopViewInWindow(context.GetWindowName()) == view
-	if visible {
+	if visible && context.IsItemVisible(opts.Item) {
 		self.c.OnWorker(func(task gocui.Task) {
 			self.start(opts)
 

--- a/pkg/gui/controllers/helpers/window_helper.go
+++ b/pkg/gui/controllers/helpers/window_helper.go
@@ -92,7 +92,7 @@ func (self *WindowHelper) MoveToTopOfWindow(context types.Context) {
 
 	topView := self.TopViewInWindow(window)
 
-	if view.Name() != topView.Name() {
+	if topView != nil && view.Name() != topView.Name() {
 		if err := self.c.GocuiGui().SetViewOnTopOf(view.Name(), topView.Name()); err != nil {
 			self.c.Log.Error(err)
 		}
@@ -106,7 +106,7 @@ func (self *WindowHelper) TopViewInWindow(windowName string) *gocui.View {
 	// The views list is ordered highest-last, so we're grabbing the last view of the window
 	var topView *gocui.View
 	for _, currentView := range self.c.GocuiGui().Views() {
-		if lo.Contains(viewNamesInWindow, currentView.Name()) {
+		if lo.Contains(viewNamesInWindow, currentView.Name()) && currentView.Visible {
 			topView = currentView
 		}
 	}

--- a/pkg/gui/filetree/commit_file_tree.go
+++ b/pkg/gui/filetree/commit_file_tree.go
@@ -2,6 +2,7 @@ package filetree
 
 import (
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
@@ -67,6 +68,11 @@ func (self *CommitFileTree) GetAllItems() []*CommitFileNode {
 
 func (self *CommitFileTree) Len() int {
 	return self.tree.Size(self.collapsedPaths) - 1 // ignoring root
+}
+
+func (self *CommitFileTree) GetItem(index int) types.HasUrn {
+	// Unimplemented because we don't yet need to show inlines statuses in commit file views
+	return nil
 }
 
 func (self *CommitFileTree) GetAllFiles() []*models.CommitFile {

--- a/pkg/gui/filetree/file_tree.go
+++ b/pkg/gui/filetree/file_tree.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
@@ -24,6 +25,7 @@ type ITree[T any] interface {
 	ToggleShowTree()
 	GetIndexForPath(path string) (int, bool)
 	Len() int
+	GetItem(index int) types.HasUrn
 	SetTree()
 	IsCollapsed(path string) bool
 	ToggleCollapsed(path string)
@@ -137,6 +139,11 @@ func (self *FileTree) GetAllItems() []*FileNode {
 
 func (self *FileTree) Len() int {
 	return self.tree.Size(self.collapsedPaths) - 1 // ignoring root
+}
+
+func (self *FileTree) GetItem(index int) types.HasUrn {
+	// Unimplemented because we don't yet need to show inlines statuses in commit file views
+	return nil
 }
 
 func (self *FileTree) GetAllFiles() []*models.File {

--- a/pkg/gui/main_panels.go
+++ b/pkg/gui/main_panels.go
@@ -39,12 +39,8 @@ func (gui *Gui) moveMainContextToTop(context types.Context) {
 	view := context.GetView()
 
 	topView := gui.helpers.Window.TopViewInWindow(context.GetWindowName())
-	if topView == nil {
-		gui.Log.Error("unexpected: topView is nil")
-		return
-	}
 
-	if topView != view {
+	if topView != nil && topView != view {
 		// We need to copy the content to avoid a flicker effect: If we're flicking
 		// through files in the files panel, we use a different view to render the
 		// files vs the directories, and if you select dir A, then file B, then dir

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -163,7 +163,7 @@ func ColoredBranchStatus(branch *models.Branch, itemOperation types.ItemOperatio
 }
 
 func BranchStatus(branch *models.Branch, itemOperation types.ItemOperation, tr *i18n.TranslationSet, now time.Time) string {
-	itemOperationStr := itemOperationToString(itemOperation, tr)
+	itemOperationStr := ItemOperationToString(itemOperation, tr)
 	if itemOperationStr != "" {
 		return itemOperationStr + " " + utils.Loader(now)
 	}

--- a/pkg/gui/presentation/item_operations.go
+++ b/pkg/gui/presentation/item_operations.go
@@ -5,7 +5,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/i18n"
 )
 
-func itemOperationToString(itemOperation types.ItemOperation, tr *i18n.TranslationSet) string {
+func ItemOperationToString(itemOperation types.ItemOperation, tr *i18n.TranslationSet) string {
 	switch itemOperation {
 	case types.ItemOperationNone:
 		return ""

--- a/pkg/gui/presentation/tags.go
+++ b/pkg/gui/presentation/tags.go
@@ -37,7 +37,7 @@ func getTagDisplayStrings(t *models.Tag, itemOperation types.ItemOperation, diff
 	}
 	descriptionColor := style.FgYellow
 	descriptionStr := descriptionColor.Sprint(t.Description())
-	itemOperationStr := itemOperationToString(itemOperation, tr)
+	itemOperationStr := ItemOperationToString(itemOperation, tr)
 	if itemOperationStr != "" {
 		descriptionStr = style.FgCyan.Sprint(itemOperationStr+" "+utils.Loader(time.Now())) + " " + descriptionStr
 	}

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -136,6 +136,7 @@ type IListContext interface {
 	Context
 
 	GetSelectedItemId() string
+	IsItemVisible(item HasUrn) bool
 
 	GetList() IList
 	ViewIndexToModelIndex(int) int
@@ -215,6 +216,7 @@ type IController interface {
 type IList interface {
 	IListCursor
 	Len() int
+	GetItem(index int) HasUrn
 }
 
 type IListCursor interface {


### PR DESCRIPTION
When using WithInlineStatus, but the item being operated on is not visible (either because the entire view is invisible, or because the item is just scrolled out of view), we show the status as a waiting status in the bottom line instead.

Examples of this are pulling or pushing the current branch while the tags or remotes view is visible.