### PR TITLE
documentation - describe os.openLink

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -659,6 +659,13 @@ os:
   open: 'open {{filename}}'
 ```
 
+## Custom Command for Opening a Link
+```yaml
+os:
+  openLink: 'bash -C /path/to/your/shell-script.sh {{link}}'
+```
+Specify the external command to invoke when opening URL links (i.e. creating MR/PR in GitLab, BitBucket or GitHub). `{{link}}` will be replaced by the URL to be opened. A simple shell script can be used to further mangle the passed URL.
+
 ## Custom Command for Copying to and Pasting from Clipboard
 ```yaml
 os:


### PR DESCRIPTION
- this helps to solve issues as in #3052
- provide an example of how to pass a link to a bash script

- **PR Description** 

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
