### PR TITLE
Added git50/72-like formating on keybind Ctrl-G

### DIFF
--- a/pkg/gui/editors.go
+++ b/pkg/gui/editors.go
@@ -46,6 +46,8 @@ func (gui *Gui) handleEditorKeypress(textArea *gocui.TextArea, key gocui.Key, ch
 		textArea.BackSpaceWord()
 	case key == gocui.KeyCtrlY:
 		textArea.Yank()
+	case key == gocui.KeyCtrlG:
+		textArea.Format()
 
 	case unicode.IsPrint(ch):
 		textArea.TypeRune(ch)

--- a/pkg/gui/formaters.go
+++ b/pkg/gui/formaters.go
@@ -1,0 +1,33 @@
+package gui
+
+// formatGit72 after the git best practices where
+// the line should newline at max 72 columns. It formats
+// similarly to how git does by breaking the row on the ' '
+// before the word that's overflowing
+func formatGit72(content []rune) ([]rune, error) {
+	// Max length is the same as content length, as only the space
+	// at the end of a word may be converted into a newline
+	cpy := make([]rune, len(content))
+	c := 0
+	prevSpace := -1
+	for i := 0; i < len(content); i++ {
+		nextRune := content[i]
+		nextIsNewline := nextRune == '\n'
+		if nextRune == ' ' {
+			prevSpace = i
+		}
+		if c == 72 && !nextIsNewline {
+			cpy[prevSpace] = '\n'
+			// set next as newline, as it just has been injected
+			nextIsNewline = true
+		} else {
+			cpy[i] = nextRune
+		}
+		if nextIsNewline {
+			c = 0
+		} else {
+			c++
+		}
+	}
+	return cpy, nil
+}

--- a/pkg/gui/formaters_test.go
+++ b/pkg/gui/formaters_test.go
@@ -1,0 +1,70 @@
+package gui
+
+import "testing"
+
+func generateWord(amRunes int) []rune {
+	charSlice := "abcåäö🐣⛽🌳"
+	runeSlice := make([]rune, 0)
+	for _, c := range charSlice {
+		runeSlice = append(runeSlice, c)
+	}
+	ret := make([]rune, amRunes)
+	for i := 0; i < amRunes; i++ {
+		runeSliceLen := len(runeSlice)
+		runeIdx := i % runeSliceLen
+		ret[i] = []rune(runeSlice)[runeIdx]
+	}
+	return ret
+}
+
+func Test_formatGit72(t *testing.T) {
+	t.Run("it should insert a newline if word is detected after col 72", func(t *testing.T) {
+		w0 := generateWord(72)
+		w1 := generateWord(1)
+		given := append(w0, ' ')
+		given = append(given, w1...)
+		givenLen := len(given)
+		//         w0  ' '  w1
+		wantLen := 72 + 1 + 1
+		if givenLen != wantLen {
+			t.Fatalf("test setup failed, want: %v, got: %v", wantLen, givenLen)
+		}
+
+		gotRunes, err := formatGit72(given)
+		if err != nil {
+			t.Fatalf("failed to format: %v", err)
+		}
+		gotLen := len(gotRunes)
+		// expect space rune to have been changed to a newline, keeping total length the same
+		if wantLen != gotLen {
+			t.Fatalf("expected: %v, got: %v", wantLen, gotLen)
+		}
+
+		// 73'd rune should be newline, as 72 runes are allowed per line
+		want := '\n'
+		got := gotRunes[72]
+		if got != want {
+			t.Fatalf("expected: %v, got: %v, given: %v, gotRunes: %v", want, got, given[68:wantLen], gotRunes[68:wantLen])
+		}
+	})
+
+	// The vim git-plugin doesn't break mid-word, but rather breaks on the previous space
+	// to the word which is overflowing. This generates a much more aesteticly pleasing format.
+	t.Run("it should break on space behind overflowing word", func(t *testing.T) {
+		w0 := generateWord(65)
+		w1 := generateWord(10)
+		given := append(w0, ' ')
+		given = append(given, w1...)
+		gotRunes, err := formatGit72(given)
+		if err != nil {
+			t.Fatalf("failed to format: %v", err)
+		}
+		if gotRunes[72] == '\n' {
+			t.Fatal("expected break to not occur mid rune")
+		}
+
+		if gotRunes[65] != '\n' {
+			t.Fatal("expected newline after previous space")
+		}
+	})
+}

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -167,6 +167,7 @@ func (gui *Gui) createAllViews() error {
 	gui.Views.CommitDescription.FgColor = theme.GocuiDefaultTextColor
 	gui.Views.CommitDescription.Editable = true
 	gui.Views.CommitDescription.Editor = gocui.EditorFunc(gui.commitDescriptionEditor)
+	gui.Views.CommitDescription.TextArea.SetFormater(formatGit72)
 
 	gui.Views.Confirmation.Visible = false
 	gui.Views.Confirmation.Editor = gocui.EditorFunc(gui.promptEditor)


### PR DESCRIPTION
Lines may now be formatted within the commit description by pressing ctrl-G (G for Git... ctrl-F was taken)

- **PR Description**

I created [this issue ](https://github.com/jesseduffield/lazygit/issues/3087)about enforcing or encouraging 50/72 formating in the git commits. Haven't looked at highlighting yet, but that could be a next step.

### To test: 
1. Write a commit message which has lines that are wider than 72 columns
2. Press Ctrl-G

Doing it opt-in like this has many benefits, most of all that the text area doesn't need to bother with cursor placement and efficiency becomes far less of a factor.

The biggest detriment to this system is that the feature is absolutely hidden. Unless you know that this is a thing, you won't find it. I don't know where or how to document this in a good way, any guidance would be much appreciated. 

If you decide to merge, gocui PR here needs to be merged first and version updated in this repo: https://github.com/jesseduffield/gocui/pull/41

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [-] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [-] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
