### PR TITLE
Added row length in commit description title

### DIFF
--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -95,6 +95,8 @@ type GuiConfig struct {
 	Theme ThemeConfig `yaml:"theme"`
 	// Config relating to the commit length indicator
 	CommitLength CommitLengthConfig `yaml:"commitLength"`
+	// Config relating to the commit description lenght indicator, which  will be appended at end of ordinary description
+	CommitDescriptionLength CommitLengthConfig `yaml:"commitDescriptionLength"`
 	// If true, show the '5 of 20' footer at the bottom of list views
 	ShowListFooter bool `yaml:"showListFooter"`
 	// If true, display the files in the file views as a tree. If false, display the files as a flat list.
@@ -607,6 +609,7 @@ func GetDefaultConfig() *UserConfig {
 				DefaultFgColor:             []string{"default"},
 			},
 			CommitLength:              CommitLengthConfig{Show: true},
+			CommitDescriptionLength:   CommitLengthConfig{Show: true},
 			SkipNoStagedFilesWarning:  false,
 			ShowListFooter:            true,
 			ShowCommandLog:            true,

--- a/pkg/gui/context/commit_message_context.go
+++ b/pkg/gui/context/commit_message_context.go
@@ -140,7 +140,7 @@ func getBufferLength(view *gocui.View) string {
 // getRowLength by checking the cursor row and counts the length of the string on that line
 // returns a string with length surrounded by two spaces, to follow previous convention: " <row-length> "
 func getRowLength(view *gocui.View) string {
-	return fmt.Sprintf(" %v ", strings.Count(view.BufferLines()[view.CursorY()], "")-1)
+	return fmt.Sprintf("%*d ", 3, strings.Count(view.BufferLines()[view.CursorY()], "")-1)
 }
 
 func (self *CommitMessageContext) SwitchToEditor(message string) error {

--- a/pkg/gui/context/commit_message_context.go
+++ b/pkg/gui/context/commit_message_context.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -121,15 +122,25 @@ func (self *CommitMessageContext) SetPanelState(
 }
 
 func (self *CommitMessageContext) RenderCommitLength() {
-	if !self.c.UserConfig.Gui.CommitLength.Show {
-		return
+	if self.c.UserConfig.Gui.CommitLength.Show {
+		self.c.Views().CommitMessage.Subtitle = getBufferLength(self.c.Views().CommitMessage)
 	}
 
-	self.c.Views().CommitMessage.Subtitle = getBufferLength(self.c.Views().CommitMessage)
+	if self.c.UserConfig.Gui.CommitDescriptionLength.Show {
+		// Split away the previous part to only update the length
+		prev := strings.Split(self.c.Views().CommitDescription.Subtitle, " |")
+		self.c.Views().CommitDescription.Subtitle = prev[0] + " |" + getRowLength(self.c.Views().CommitDescription)
+	}
 }
 
 func getBufferLength(view *gocui.View) string {
 	return " " + strconv.Itoa(strings.Count(view.TextArea.GetContent(), "")-1) + " "
+}
+
+// getRowLength by checking the cursor row and counts the length of the string on that line
+// returns a string with length surrounded by two spaces, to follow previous convention: " <row-length> "
+func getRowLength(view *gocui.View) string {
+	return fmt.Sprintf(" %v ", strings.Count(view.BufferLines()[view.CursorY()], "")-1)
 }
 
 func (self *CommitMessageContext) SwitchToEditor(message string) error {


### PR DESCRIPTION
- **PR Description**

Simple but effective implementation which allows the users to see the amount of characters for each row. PR is stemming from discussions on how to encourage/enforce git best practices [here](https://github.com/jesseduffield/lazygit/issues/3087) and [here](https://github.com/jesseduffield/lazygit/pull/3095).

I think this can be a good start towards providing further aid for the users to break their rows at a reasonable limits.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
