### PR TITLE
Use a PTY when calling external diff command

### DIFF
--- a/pkg/gui/pty.go
+++ b/pkg/gui/pty.go
@@ -45,8 +45,9 @@ func (gui *Gui) onResize() error {
 func (gui *Gui) newPtyTask(view *gocui.View, cmd *exec.Cmd, prefix string) error {
 	width, _ := gui.Views.Main.Size()
 	pager := gui.git.Config.GetPager(width)
+	externalDiffCommand := gui.Config.GetUserConfig().Git.Paging.ExternalDiffCommand
 
-	if pager == "" {
+	if pager == "" && externalDiffCommand == "" {
 		// if we're not using a custom pager we don't need to use a pty
 		return gui.newCmdTask(view, cmd, prefix)
 	}


### PR DESCRIPTION
- **PR Description**

The external diff command support was introduce by #2868, and this PR try to solve #3119.

In the configuration file, the pager is not set, but the externalDiffCommand is set, which will cause Git to only execute through CmdTask. At this time, the view information required by externalDiffCommand is not updated.

Additional Info:
1. Command without pager will than use `gui.newCmdTask` instead of `gui.newPtyTask`
2. `gui.newPtyTask` depend on `gui.desiredPtySize` to refresh some info include view size.
3. When `ShowCmdObj` tries to run, all controllers using `gui.newPtyTask` to execute. But when the task invoke,  the [if condition](https://github.com/jesseduffield/lazygit/blob/bb87642aee6bf6f599607e771d7a238a21eb4d81/pkg/gui/pty.go#L49C10-L49C10), find there is no page , so it using  `gui.newCmdTask` instead, and view info now pass to the environment.

Result:
![CleanShot 2023-11-19 at 14 13 03@2x](https://github.com/jesseduffield/lazygit/assets/17228538/9de20a19-bf2f-4ecb-8972-63025e858957)


- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
