### PR TITLE
Add squash merge support

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -227,6 +227,7 @@ keybinding:
     rebaseBranch: 'r'
     renameBranch: 'R'
     mergeIntoCurrentBranch: 'M'
+    squashIntoWorkingTree: 'S'
     viewGitFlowOptions: 'i'
     fastForward: 'f' # fast-forward this branch from its upstream
     createTag: 'T'

--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -205,6 +205,7 @@ func (self *BranchCommands) Rename(oldName string, newName string) error {
 
 type MergeOpts struct {
 	FastForwardOnly bool
+	Squash          bool
 }
 
 func (self *BranchCommands) Merge(branchName string, opts MergeOpts) error {
@@ -212,6 +213,7 @@ func (self *BranchCommands) Merge(branchName string, opts MergeOpts) error {
 		Arg("--no-edit").
 		ArgIf(self.UserConfig.Git.Merging.Args != "", self.UserConfig.Git.Merging.Args).
 		ArgIf(opts.FastForwardOnly, "--ff-only").
+		ArgIf(opts.Squash, "--squash").
 		Arg(branchName).
 		ToArgv()
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -370,6 +370,7 @@ type KeybindingBranchesConfig struct {
 	RebaseBranch           string `yaml:"rebaseBranch"`
 	RenameBranch           string `yaml:"renameBranch"`
 	MergeIntoCurrentBranch string `yaml:"mergeIntoCurrentBranch"`
+	SquashIntoWorkingTree  string `yaml:"squashIntoWorkingTree"`
 	ViewGitFlowOptions     string `yaml:"viewGitFlowOptions"`
 	FastForward            string `yaml:"fastForward"`
 	CreateTag              string `yaml:"createTag"`
@@ -761,6 +762,7 @@ func GetDefaultConfig() *UserConfig {
 				RebaseBranch:           "r",
 				RenameBranch:           "R",
 				MergeIntoCurrentBranch: "M",
+				SquashIntoWorkingTree:  "S",
 				ViewGitFlowOptions:     "i",
 				FastForward:            "f",
 				CreateTag:              "T",

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -88,6 +88,11 @@ func (self *BranchesController) GetKeybindings(opts types.KeybindingsOpts) []*ty
 			Description: self.c.Tr.MergeIntoCurrentBranch,
 		},
 		{
+			Key:         opts.GetKey(opts.Config.Branches.SquashIntoWorkingTree),
+			Handler:     opts.Guards.OutsideFilterMode(self.squash),
+			Description: self.c.Tr.SquashIntoWorkingTree,
+		},
+		{
 			Key:         opts.GetKey(opts.Config.Branches.FastForward),
 			Handler:     self.checkSelectedAndReal(self.fastForward),
 			Description: self.c.Tr.FastForward,
@@ -546,6 +551,11 @@ func (self *BranchesController) delete(branch *models.Branch) error {
 func (self *BranchesController) merge() error {
 	selectedBranchName := self.context().GetSelected().Name
 	return self.c.Helpers().MergeAndRebase.MergeRefIntoCheckedOutBranch(selectedBranchName)
+}
+
+func (self *BranchesController) squash() error {
+	selectedBranchName := self.context().GetSelected().Name
+	return self.c.Helpers().MergeAndRebase.SquashRefIntoWorkingTree(selectedBranchName)
 }
 
 func (self *BranchesController) rebase() error {

--- a/pkg/gui/controllers/helpers/merge_and_rebase_helper.go
+++ b/pkg/gui/controllers/helpers/merge_and_rebase_helper.go
@@ -309,6 +309,30 @@ func (self *MergeAndRebaseHelper) MergeRefIntoCheckedOutBranch(refName string) e
 	})
 }
 
+func (self *MergeAndRebaseHelper) SquashRefIntoWorkingTree(refName string) error {
+	checkedOutBranchName := self.refsHelper.GetCheckedOutRef().Name
+	if checkedOutBranchName == refName {
+		return self.c.ErrorMsg(self.c.Tr.CantMergeBranchIntoItself)
+	}
+
+	prompt := utils.ResolvePlaceholderString(
+		self.c.Tr.ConfirmSquash,
+		map[string]string{
+			"selectedBranch": refName,
+		},
+	)
+
+	return self.c.Confirm(types.ConfirmOpts{
+		Title:  self.c.Tr.SquashConfirmTitle,
+		Prompt: prompt,
+		HandleConfirm: func() error {
+			self.c.LogAction(self.c.Tr.Actions.SquashBranch)
+			err := self.c.Git().Branch.Merge(refName, git_commands.MergeOpts{Squash: true})
+			return self.CheckMergeOrRebase(err)
+		},
+	})
+}
+
 func (self *MergeAndRebaseHelper) ResetMarkedBaseCommit() error {
 	self.c.Modes().MarkedBaseCommit.Reset()
 	return self.c.PostRefreshUpdate(self.c.Contexts().LocalCommits)

--- a/pkg/gui/controllers/remote_branches_controller.go
+++ b/pkg/gui/controllers/remote_branches_controller.go
@@ -44,6 +44,11 @@ func (self *RemoteBranchesController) GetKeybindings(opts types.KeybindingsOpts)
 			Description: self.c.Tr.MergeIntoCurrentBranch,
 		},
 		{
+			Key:         opts.GetKey(opts.Config.Branches.SquashIntoWorkingTree),
+			Handler:     opts.Guards.OutsideFilterMode(self.checkSelected(self.squash)),
+			Description: self.c.Tr.SquashIntoWorkingTree,
+		},
+		{
 			Key:         opts.GetKey(opts.Config.Branches.RebaseBranch),
 			Handler:     opts.Guards.OutsideFilterMode(self.checkSelected(self.rebase)),
 			Description: self.c.Tr.RebaseBranch,
@@ -111,6 +116,10 @@ func (self *RemoteBranchesController) checkSelected(callback func(*models.Remote
 
 func (self *RemoteBranchesController) delete(selectedBranch *models.RemoteBranch) error {
 	return self.c.Helpers().BranchesHelper.ConfirmDeleteRemote(selectedBranch.RemoteName, selectedBranch.Name)
+}
+
+func (self *RemoteBranchesController) squash(selectedBranch *models.RemoteBranch) error {
+	return self.c.Helpers().MergeAndRebase.SquashRefIntoWorkingTree(selectedBranch.FullName())
 }
 
 func (self *RemoteBranchesController) merge(selectedBranch *models.RemoteBranch) error {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -25,6 +25,7 @@ type TranslationSet struct {
 	StagingTitle                        string
 	MergingTitle                        string
 	MergeConfirmTitle                   string
+	SquashConfirmTitle                  string
 	NormalTitle                         string
 	LogTitle                            string
 	CommitSummary                       string
@@ -166,6 +167,7 @@ type TranslationSet struct {
 	ExcludeFile                         string
 	RefreshFiles                        string
 	MergeIntoCurrentBranch              string
+	SquashIntoWorkingTree               string
 	ConfirmQuit                         string
 	SwitchRepo                          string
 	AllBranchesLogGraph                 string
@@ -220,6 +222,7 @@ type TranslationSet struct {
 	InteractiveRebase                   string
 	InteractiveRebaseTooltip            string
 	ConfirmMerge                        string
+	ConfirmSquash                       string
 	FwdNoUpstream                       string
 	FwdNoLocalUpstream                  string
 	FwdCommitsToPush                    string
@@ -668,6 +671,7 @@ type Actions struct {
 	DeleteLocalBranch                 string
 	DeleteBranch                      string
 	Merge                             string
+	SquashBranch                      string
 	RebaseBranch                      string
 	RenameBranch                      string
 	CreateBranch                      string
@@ -819,6 +823,7 @@ func EnglishTranslationSet() TranslationSet {
 		StagedChanges:                       "Staged changes",
 		MainTitle:                           "Main",
 		MergeConfirmTitle:                   "Merge",
+		SquashConfirmTitle:                  "Squash",
 		StagingTitle:                        "Main panel (staging)",
 		MergingTitle:                        "Main panel (merging)",
 		NormalTitle:                         "Main panel (normal)",
@@ -963,6 +968,7 @@ func EnglishTranslationSet() TranslationSet {
 		ExcludeFile:                         `Add to .git/info/exclude`,
 		RefreshFiles:                        `Refresh files`,
 		MergeIntoCurrentBranch:              `Merge into currently checked out branch`,
+		SquashIntoWorkingTree:               `Squash into working tree`,
 		ConfirmQuit:                         `Are you sure you want to quit?`,
 		SwitchRepo:                          `Switch to a recent repo`,
 		AllBranchesLogGraph:                 `Show all branch logs`,
@@ -1021,6 +1027,7 @@ func EnglishTranslationSet() TranslationSet {
 		InteractiveRebase:                   "Interactive rebase",
 		InteractiveRebaseTooltip:            "Begin an interactive rebase with a break at the start, so you can update the TODO commits before continuing",
 		ConfirmMerge:                        "Are you sure you want to merge '{{.selectedBranch}}' into '{{.checkedOutBranch}}'?",
+		ConfirmSquash:                       "Are you sure you want to squash '{{.selectedBranch}}' into working tree?",
 		FwdNoUpstream:                       "Cannot fast-forward a branch with no upstream",
 		FwdNoLocalUpstream:                  "Cannot fast-forward a branch whose remote is not registered locally",
 		FwdCommitsToPush:                    "Cannot fast-forward a branch with commits to push",


### PR DESCRIPTION
- **PR Description**

I do `git merge --squash branch` a lot so I've added this shortcut for myself. I think some people may want this too so here it is.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
