### PR TITLE
Add config setting for splitting window vertically in half screen mode

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -40,6 +40,7 @@ gui:
   sidePanelWidth: 0.3333 # number from 0 to 1
   expandFocusedSidePanel: false
   mainPanelSplitMode: 'flexible' # one of 'horizontal' | 'flexible' | 'vertical'
+  enlargedSideViewLocation: 'left' # one of 'left' | 'top'
   language: 'auto' # one of 'auto' | 'en' | 'zh-CN' | 'zh-TW' | 'pl' | 'nl' | 'ja' | 'ko' | 'ru'
   timeFormat: '02 Jan 06' # https://pkg.go.dev/time#Time.Format
   shortTimeFormat: '3:04PM'

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -84,6 +84,11 @@ type GuiConfig struct {
 	// - 'vertical': split the window vertically
 	// - 'flexible': (default) split the window horizontally if the window is wide enough, otherwise split vertically
 	MainPanelSplitMode string `yaml:"mainPanelSplitMode" jsonschema:"enum=horizontal,enum=flexible,enum=vertical"`
+	// How the window is split when in half screen mode (i.e. after hitting '+' once).
+	// Possible values:
+	// - 'left': split the window horizontally (side panel on the left, main view on the right)
+	// - 'top': split the window vertically (side panel on top, main view below)
+	EnlargedSideViewLocation string `yaml:"enlargedSideViewLocation"`
 	// One of 'auto' (default) | 'en' | 'zh-CN' | 'zh-TW' | 'pl' | 'nl' | 'ja' | 'ko' | 'ru'
 	Language string `yaml:"language" jsonschema:"enum=auto,enum=en,enum=zh-TW,enum=zh-CN,enum=pl,enum=nl,enum=ja,enum=ko,enum=ru"`
 	// Format used when displaying time e.g. commit time.
@@ -604,6 +609,7 @@ func GetDefaultConfig() *UserConfig {
 			SidePanelWidth:           0.3333,
 			ExpandFocusedSidePanel:   false,
 			MainPanelSplitMode:       "flexible",
+			EnlargedSideViewLocation: "left",
 			Language:                 "auto",
 			TimeFormat:               "02 Jan 06",
 			ShortTimeFormat:          time.Kitchen,

--- a/pkg/gui/controllers/helpers/window_arrangement_helper.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper.go
@@ -107,6 +107,10 @@ func (self *WindowArrangementHelper) GetWindowDimensions(informationStr string, 
 }
 
 func shouldUsePortraitMode(args WindowArrangementArgs) bool {
+	if args.ScreenMode == types.SCREEN_HALF {
+		return args.UserConfig.Gui.EnlargedSideViewLocation == "top"
+	}
+
 	switch args.UserConfig.Gui.PortraitMode {
 	case "never":
 		return false
@@ -241,7 +245,11 @@ func getMidSectionWeights(args WindowArrangementArgs) (int, int) {
 		}
 	} else {
 		if args.ScreenMode == types.SCREEN_HALF {
-			mainSectionWeight = 1
+			if args.UserConfig.Gui.EnlargedSideViewLocation == "top" {
+				mainSectionWeight = 2
+			} else {
+				mainSectionWeight = 1
+			}
 		} else if args.ScreenMode == types.SCREEN_FULL {
 			mainSectionWeight = 0
 		}

--- a/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
@@ -122,6 +122,70 @@ func TestGetWindowDimensions(t *testing.T) {
 			`,
 		},
 		{
+			name: "half screen mode, enlargedSideViewLocation left",
+			mutateArgs: func(args *WindowArrangementArgs) {
+				args.Height = 20 // smaller height because we don't more here
+				args.ScreenMode = types.SCREEN_HALF
+				args.UserConfig.Gui.EnlargedSideViewLocation = "left"
+			},
+			expected: `
+			╭status──────────────────────────────╮╭main───────────────────────────────╮
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			╰────────────────────────────────────╯╰───────────────────────────────────╯
+			<options──────────────────────────────────────────────────────>A<B────────>
+			A: statusSpacer1
+			B: information
+			`,
+		},
+		{
+			name: "half screen mode, enlargedSideViewLocation top",
+			mutateArgs: func(args *WindowArrangementArgs) {
+				args.Height = 20 // smaller height because we don't more here
+				args.ScreenMode = types.SCREEN_HALF
+				args.UserConfig.Gui.EnlargedSideViewLocation = "top"
+			},
+			expected: `
+			╭status───────────────────────────────────────────────────────────────────╮
+			│                                                                         │
+			│                                                                         │
+			│                                                                         │
+			│                                                                         │
+			│                                                                         │
+			╰─────────────────────────────────────────────────────────────────────────╯
+			╭main─────────────────────────────────────────────────────────────────────╮
+			│                                                                         │
+			│                                                                         │
+			│                                                                         │
+			│                                                                         │
+			│                                                                         │
+			│                                                                         │
+			│                                                                         │
+			│                                                                         │
+			│                                                                         │
+			│                                                                         │
+			╰─────────────────────────────────────────────────────────────────────────╯
+			<options──────────────────────────────────────────────────────>A<B────────>
+			A: statusSpacer1
+			B: information
+			`,
+		},
+		{
 			name: "search mode",
 			mutateArgs: func(args *WindowArrangementArgs) {
 				args.InSearchPrompt = true

--- a/schema/config.json
+++ b/schema/config.json
@@ -81,6 +81,11 @@
           "description": "Sometimes the main window is split in two (e.g. when the selected file has both staged and unstaged changes). This setting controls how the two sections are split.\nOptions are:\n- 'horizontal': split the window horizontally\n- 'vertical': split the window vertically\n- 'flexible': (default) split the window horizontally if the window is wide enough, otherwise split vertically",
           "default": "flexible"
         },
+        "enlargedSideViewLocation": {
+          "type": "string",
+          "description": "How the window is split when in half screen mode (i.e. after hitting '+' once).\nPossible values:\n- 'left': split the window horizontally (side panel on the left, main view on the right)\n- 'top': split the window vertically (side panel on top, main view below)",
+          "default": "left"
+        },
         "language": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
- **PR Description**

Add a config setting `gui.halfScreenSplitMode` that allows views to be stacked vertically in half screen mode.

I decided not to introduce a config setting for configuring the ration between side panel and main view in half screen mode for now; it's hard-coded to 1:1 in horizontal split mode (as before), and 1:2 in vertical split mode.

Addresses #1962.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
