### PR TITLE
fix: MacOS default path misspelling

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -3,7 +3,7 @@
 Default path for the config file:
 
 - Linux: `~/.config/lazygit/config.yml`
-- MacOS: `~/Library/Application Support/lazygit/config.yml`
+- MacOS: `~/Library/Application\ Support/lazygit/config.yml`
 - Windows: `%APPDATA%\lazygit\config.yml`
 
 For old installations (slightly embarrassing: I didn't realise at the time that you didn't need to supply a vendor name to the path so I just used my name):


### PR DESCRIPTION
- **PR Description**

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
