### PR TITLE
Add command to open git difftool

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -52,6 +52,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>d</kbd>: Discard this commit's changes to this file
   <kbd>o</kbd>: Open file
   <kbd>e</kbd>: Edit file
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;space&gt;</kbd>: Toggle file included in patch
   <kbd>a</kbd>: Toggle all files included in patch
   <kbd>&lt;enter&gt;</kbd>: Enter file to add selected lines to the patch (or toggle directory collapsed)
@@ -98,6 +99,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>g</kbd>: View reset options
   <kbd>c</kbd>: Copy commit (cherry-pick)
   <kbd>C</kbd>: Copy commit range (cherry-pick)
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: View selected item's files
   <kbd>/</kbd>: Search the current view by text
 </pre>
@@ -132,6 +134,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>g</kbd>: View upstream reset options
   <kbd>D</kbd>: View reset options
   <kbd>`</kbd>: Toggle file tree view
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>M</kbd>: Open external merge tool (git mergetool)
   <kbd>f</kbd>: Fetch
   <kbd>/</kbd>: Search the current view by text
@@ -245,6 +248,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>c</kbd>: Copy commit (cherry-pick)
   <kbd>C</kbd>: Copy commit range (cherry-pick)
   <kbd>&lt;c-r&gt;</kbd>: Reset cherry-picked (copied) commits selection
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: View commits
   <kbd>/</kbd>: Filter the current view by text
 </pre>
@@ -312,6 +316,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>c</kbd>: Copy commit (cherry-pick)
   <kbd>C</kbd>: Copy commit range (cherry-pick)
   <kbd>&lt;c-r&gt;</kbd>: Reset cherry-picked (copied) commits selection
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: View selected item's files
   <kbd>/</kbd>: Search the current view by text
 </pre>

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -70,6 +70,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>c</kbd>: コミットをコピー (cherry-pick)
   <kbd>C</kbd>: コミットを範囲コピー (cherry-pick)
   <kbd>&lt;c-r&gt;</kbd>: Reset cherry-picked (copied) commits selection
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: View selected item's files
   <kbd>/</kbd>: 検索を開始
 </pre>
@@ -117,6 +118,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>g</kbd>: View reset options
   <kbd>c</kbd>: コミットをコピー (cherry-pick)
   <kbd>C</kbd>: コミットを範囲コピー (cherry-pick)
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: View selected item's files
   <kbd>/</kbd>: 検索を開始
 </pre>
@@ -129,6 +131,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>d</kbd>: Discard this commit's changes to this file
   <kbd>o</kbd>: ファイルを開く
   <kbd>e</kbd>: ファイルを編集
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;space&gt;</kbd>: Toggle file included in patch
   <kbd>a</kbd>: Toggle all files included in patch
   <kbd>&lt;enter&gt;</kbd>: Enter file to add selected lines to the patch (or toggle directory collapsed)
@@ -204,6 +207,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>g</kbd>: View upstream reset options
   <kbd>D</kbd>: View reset options
   <kbd>`</kbd>: ファイルツリーの表示を切り替え
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>M</kbd>: Git mergetoolを開く
   <kbd>f</kbd>: Fetch
   <kbd>/</kbd>: 検索を開始
@@ -344,6 +348,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>c</kbd>: コミットをコピー (cherry-pick)
   <kbd>C</kbd>: コミットを範囲コピー (cherry-pick)
   <kbd>&lt;c-r&gt;</kbd>: Reset cherry-picked (copied) commits selection
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: コミットを閲覧
   <kbd>/</kbd>: Filter the current view by text
 </pre>

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -57,6 +57,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>c</kbd>: 커밋을 복사 (cherry-pick)
   <kbd>C</kbd>: 커밋을 범위로 복사 (cherry-pick)
   <kbd>&lt;c-r&gt;</kbd>: Reset cherry-picked (copied) commits selection
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: 커밋 보기
   <kbd>/</kbd>: Filter the current view by text
 </pre>
@@ -87,6 +88,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>c</kbd>: 커밋을 복사 (cherry-pick)
   <kbd>C</kbd>: 커밋을 범위로 복사 (cherry-pick)
   <kbd>&lt;c-r&gt;</kbd>: Reset cherry-picked (copied) commits selection
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: View selected item's files
   <kbd>/</kbd>: 검색 시작
 </pre>
@@ -281,6 +283,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>g</kbd>: View reset options
   <kbd>c</kbd>: 커밋을 복사 (cherry-pick)
   <kbd>C</kbd>: 커밋을 범위로 복사 (cherry-pick)
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: View selected item's files
   <kbd>/</kbd>: 검색 시작
 </pre>
@@ -293,6 +296,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>d</kbd>: Discard this commit's changes to this file
   <kbd>o</kbd>: 파일 닫기
   <kbd>e</kbd>: 파일 편집
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;space&gt;</kbd>: Toggle file included in patch
   <kbd>a</kbd>: Toggle all files included in patch
   <kbd>&lt;enter&gt;</kbd>: Enter file to add selected lines to the patch (or toggle directory collapsed)
@@ -343,6 +347,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>g</kbd>: View upstream reset options
   <kbd>D</kbd>: View reset options
   <kbd>`</kbd>: 파일 트리뷰로 전환
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>M</kbd>: Git mergetool를 열기
   <kbd>f</kbd>: Fetch
   <kbd>/</kbd>: 검색 시작

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -67,6 +67,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>g</kbd>: Bekijk upstream reset opties
   <kbd>D</kbd>: Bekijk reset opties
   <kbd>`</kbd>: Toggle bestandsboom weergave
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>M</kbd>: Open external merge tool (git mergetool)
   <kbd>f</kbd>: Fetch
   <kbd>/</kbd>: Start met zoeken
@@ -120,6 +121,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>d</kbd>: Uitsluit deze commit zijn veranderingen aan dit bestand
   <kbd>o</kbd>: Open bestand
   <kbd>e</kbd>: Verander bestand
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;space&gt;</kbd>: Toggle bestand inbegrepen in patch
   <kbd>a</kbd>: Toggle all files included in patch
   <kbd>&lt;enter&gt;</kbd>: Enter bestand om geselecteerde regels toe te voegen aan de patch
@@ -159,6 +161,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>g</kbd>: Bekijk reset opties
   <kbd>c</kbd>: Kopieer commit (cherry-pick)
   <kbd>C</kbd>: Kopieer commit reeks (cherry-pick)
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: Bekijk gecommite bestanden
   <kbd>/</kbd>: Start met zoeken
 </pre>
@@ -223,6 +226,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>c</kbd>: Kopieer commit (cherry-pick)
   <kbd>C</kbd>: Kopieer commit reeks (cherry-pick)
   <kbd>&lt;c-r&gt;</kbd>: Reset cherry-picked (gekopieerde) commits selectie
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: Bekijk commits
   <kbd>/</kbd>: Filter the current view by text
 </pre>
@@ -312,6 +316,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>c</kbd>: Kopieer commit (cherry-pick)
   <kbd>C</kbd>: Kopieer commit reeks (cherry-pick)
   <kbd>&lt;c-r&gt;</kbd>: Reset cherry-picked (gekopieerde) commits selectie
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: Bekijk gecommite bestanden
   <kbd>/</kbd>: Start met zoeken
 </pre>

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -83,6 +83,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>g</kbd>: Wyświetl opcje resetu
   <kbd>c</kbd>: Kopiuj commit (przebieranie)
   <kbd>C</kbd>: Kopiuj zakres commitów (przebieranie)
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: Przeglądaj pliki commita
   <kbd>/</kbd>: Search the current view by text
 </pre>
@@ -167,6 +168,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>g</kbd>: View upstream reset options
   <kbd>D</kbd>: Wyświetl opcje resetu
   <kbd>`</kbd>: Toggle file tree view
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>M</kbd>: Open external merge tool (git mergetool)
   <kbd>f</kbd>: Pobierz
   <kbd>/</kbd>: Search the current view by text
@@ -180,6 +182,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>d</kbd>: Porzuć zmiany commita dla tego pliku
   <kbd>o</kbd>: Otwórz plik
   <kbd>e</kbd>: Edytuj plik
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;space&gt;</kbd>: Toggle file included in patch
   <kbd>a</kbd>: Toggle all files included in patch
   <kbd>&lt;enter&gt;</kbd>: Enter file to add selected lines to the patch (or toggle directory collapsed)
@@ -222,6 +225,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>c</kbd>: Kopiuj commit (przebieranie)
   <kbd>C</kbd>: Kopiuj zakres commitów (przebieranie)
   <kbd>&lt;c-r&gt;</kbd>: Reset cherry-picked (copied) commits selection
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: View commits
   <kbd>/</kbd>: Filter the current view by text
 </pre>
@@ -305,6 +309,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>c</kbd>: Kopiuj commit (przebieranie)
   <kbd>C</kbd>: Kopiuj zakres commitów (przebieranie)
   <kbd>&lt;c-r&gt;</kbd>: Reset cherry-picked (copied) commits selection
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: Przeglądaj pliki commita
   <kbd>/</kbd>: Search the current view by text
 </pre>

--- a/docs/keybindings/Keybindings_ru.md
+++ b/docs/keybindings/Keybindings_ru.md
@@ -129,6 +129,7 @@ _Связки клавиш_
   <kbd>c</kbd>: Скопировать отобранные коммит (cherry-pick)
   <kbd>C</kbd>: Скопировать несколько отобранных коммитов (cherry-pick)
   <kbd>&lt;c-r&gt;</kbd>: Сбросить отобранную (скопированную | cherry-picked) выборку коммитов
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: Просмотреть коммиты
   <kbd>/</kbd>: Filter the current view by text
 </pre>
@@ -165,6 +166,7 @@ _Связки клавиш_
   <kbd>g</kbd>: Просмотреть параметры сброса
   <kbd>c</kbd>: Скопировать отобранные коммит (cherry-pick)
   <kbd>C</kbd>: Скопировать несколько отобранных коммитов (cherry-pick)
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: Просмотреть файлы выбранного элемента
   <kbd>/</kbd>: Найти
 </pre>
@@ -223,6 +225,7 @@ _Связки клавиш_
   <kbd>c</kbd>: Скопировать отобранные коммит (cherry-pick)
   <kbd>C</kbd>: Скопировать несколько отобранных коммитов (cherry-pick)
   <kbd>&lt;c-r&gt;</kbd>: Сбросить отобранную (скопированную | cherry-picked) выборку коммитов
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: Просмотреть файлы выбранного элемента
   <kbd>/</kbd>: Найти
 </pre>
@@ -257,6 +260,7 @@ _Связки клавиш_
   <kbd>d</kbd>: Отменить изменения коммита в этом файле
   <kbd>o</kbd>: Открыть файл
   <kbd>e</kbd>: Редактировать файл
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;space&gt;</kbd>: Переключить файлы включённые в патч
   <kbd>a</kbd>: Переключить все файлы, включённые в патч
   <kbd>&lt;enter&gt;</kbd>: Введите файл, чтобы добавить выбранные строки в патч (или свернуть каталог переключения)
@@ -337,6 +341,7 @@ _Связки клавиш_
   <kbd>g</kbd>: Просмотреть параметры сброса upstream-ветки
   <kbd>D</kbd>: Просмотреть параметры сброса
   <kbd>`</kbd>: Переключить вид дерева файлов
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>M</kbd>: Открыть внешний инструмент слияния (git mergetool)
   <kbd>f</kbd>: Получить изменения
   <kbd>/</kbd>: Найти

--- a/docs/keybindings/Keybindings_zh-CN.md
+++ b/docs/keybindings/Keybindings_zh-CN.md
@@ -57,6 +57,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>c</kbd>: 复制提交（拣选）
   <kbd>C</kbd>: 复制提交范围（拣选）
   <kbd>&lt;c-r&gt;</kbd>: 重置已拣选（复制）的提交
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: 查看提交
   <kbd>/</kbd>: Filter the current view by text
 </pre>
@@ -111,6 +112,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>c</kbd>: 复制提交（拣选）
   <kbd>C</kbd>: 复制提交范围（拣选）
   <kbd>&lt;c-r&gt;</kbd>: 重置已拣选（复制）的提交
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: 查看提交的文件
   <kbd>/</kbd>: 开始搜索
 </pre>
@@ -162,6 +164,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>g</kbd>: 查看重置选项
   <kbd>c</kbd>: 复制提交（拣选）
   <kbd>C</kbd>: 复制提交范围（拣选）
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: 查看提交的文件
   <kbd>/</kbd>: 开始搜索
 </pre>
@@ -174,6 +177,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>d</kbd>: 放弃对此文件的提交更改
   <kbd>o</kbd>: 打开文件
   <kbd>e</kbd>: 编辑文件
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;space&gt;</kbd>: 补丁中包含的切换文件
   <kbd>a</kbd>: Toggle all files included in patch
   <kbd>&lt;enter&gt;</kbd>: 输入文件以将所选行添加到补丁中（或切换目录折叠）
@@ -211,6 +215,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
   <kbd>g</kbd>: 查看上游重置选项
   <kbd>D</kbd>: 查看重置选项
   <kbd>`</kbd>: 切换文件树视图
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>M</kbd>: 打开外部合并工具 (git mergetool)
   <kbd>f</kbd>: 抓取
   <kbd>/</kbd>: 开始搜索

--- a/docs/keybindings/Keybindings_zh-TW.md
+++ b/docs/keybindings/Keybindings_zh-TW.md
@@ -57,6 +57,7 @@ _說明：`<c-b>` 表示 Ctrl+B、`<a-b>` 表示 Alt+B，`B`表示 Shift+B_
   <kbd>c</kbd>: 複製提交 (揀選)
   <kbd>C</kbd>: 複製提交範圍 (揀選)
   <kbd>&lt;c-r&gt;</kbd>: 重設選定的揀選 (複製) 提交
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: 檢視提交
   <kbd>/</kbd>: Filter the current view by text
 </pre>
@@ -154,6 +155,7 @@ _說明：`<c-b>` 表示 Ctrl+B、`<a-b>` 表示 Alt+B，`B`表示 Shift+B_
   <kbd>c</kbd>: 複製提交 (揀選)
   <kbd>C</kbd>: 複製提交範圍 (揀選)
   <kbd>&lt;c-r&gt;</kbd>: 重設選定的揀選 (複製) 提交
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: 檢視所選項目的檔案
   <kbd>/</kbd>: 開始搜尋
 </pre>
@@ -205,6 +207,7 @@ _說明：`<c-b>` 表示 Ctrl+B、`<a-b>` 表示 Alt+B，`B`表示 Shift+B_
   <kbd>g</kbd>: 檢視重設選項
   <kbd>c</kbd>: 複製提交 (揀選)
   <kbd>C</kbd>: 複製提交範圍 (揀選)
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;enter&gt;</kbd>: 檢視所選項目的檔案
   <kbd>/</kbd>: 開始搜尋
 </pre>
@@ -224,6 +227,7 @@ _說明：`<c-b>` 表示 Ctrl+B、`<a-b>` 表示 Alt+B，`B`表示 Shift+B_
   <kbd>d</kbd>: 捨棄此提交對此檔案的更改
   <kbd>o</kbd>: 開啟檔案
   <kbd>e</kbd>: 編輯檔案
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>&lt;space&gt;</kbd>: 切換檔案是否包含在補丁中
   <kbd>a</kbd>: 切換所有檔案是否包含在補丁中
   <kbd>&lt;enter&gt;</kbd>: 輸入檔案以將選定的行添加至補丁（或切換目錄折疊）
@@ -306,6 +310,7 @@ _說明：`<c-b>` 表示 Ctrl+B、`<a-b>` 表示 Alt+B，`B`表示 Shift+B_
   <kbd>g</kbd>: 檢視上游重設選項
   <kbd>D</kbd>: 檢視重設選項
   <kbd>`</kbd>: 切換檔案樹狀視圖
+  <kbd>&lt;c-t&gt;</kbd>: Open external diff tool (git difftool)
   <kbd>M</kbd>: 開啟外部合併工具 (git mergetool)
   <kbd>f</kbd>: 擷取
   <kbd>/</kbd>: 開始搜尋

--- a/pkg/commands/git_commands/diff.go
+++ b/pkg/commands/git_commands/diff.go
@@ -40,3 +40,41 @@ func (self *DiffCommands) GetAllDiff(staged bool) (string, error) {
 			ToArgv(),
 	).RunWithOutput()
 }
+
+type DiffToolCmdOptions struct {
+	// The path to show a diff for. Pass "." for the entire repo.
+	Filepath string
+
+	// The commit against which to show the diff. Leave empty to show a diff of
+	// the working copy.
+	FromCommit string
+
+	// The commit to diff against FromCommit. Leave empty to diff the working
+	// copy against FromCommit. Leave both FromCommit and ToCommit empty to show
+	// the diff of the unstaged working copy changes against the index if Staged
+	// is false, or the staged changes against HEAD if Staged is true.
+	ToCommit string
+
+	// Whether to reverse the left and right sides of the diff.
+	Reverse bool
+
+	// Whether the given Filepath is a directory. We'll pass --dir-diff to
+	// git-difftool in that case.
+	IsDirectory bool
+
+	// Whether to show the staged or the unstaged changes. Must be false if both
+	// FromCommit and ToCommit are non-empty.
+	Staged bool
+}
+
+func (self *DiffCommands) OpenDiffToolCmdObj(opts DiffToolCmdOptions) oscommands.ICmdObj {
+	return self.cmd.New(NewGitCmd("difftool").
+		Arg("--no-prompt").
+		ArgIf(opts.IsDirectory, "--dir-diff").
+		ArgIf(opts.Staged, "--cached").
+		ArgIf(opts.FromCommit != "", opts.FromCommit).
+		ArgIf(opts.ToCommit != "", opts.ToCommit).
+		ArgIf(opts.Reverse, "-R").
+		Arg("--", opts.Filepath).
+		ToArgv())
+}

--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -31,10 +31,6 @@ func (self *WorkingTreeCommands) OpenMergeToolCmdObj() oscommands.ICmdObj {
 	return self.cmd.New(NewGitCmd("mergetool").ToArgv())
 }
 
-func (self *WorkingTreeCommands) OpenMergeTool() error {
-	return self.OpenMergeToolCmdObj().Run()
-}
-
 // StageFile stages a file
 func (self *WorkingTreeCommands) StageFile(path string) error {
 	return self.StageFiles([]string{path})

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -347,6 +347,7 @@ type KeybindingUniversalConfig struct {
 	ToggleWhitespaceInDiffView   string   `yaml:"toggleWhitespaceInDiffView"`
 	IncreaseContextInDiffView    string   `yaml:"increaseContextInDiffView"`
 	DecreaseContextInDiffView    string   `yaml:"decreaseContextInDiffView"`
+	OpenDiffTool                 string   `yaml:"openDiffTool"`
 }
 
 type KeybindingStatusConfig struct {
@@ -743,6 +744,7 @@ func GetDefaultConfig() *UserConfig {
 				ToggleWhitespaceInDiffView:   "<c-w>",
 				IncreaseContextInDiffView:    "}",
 				DecreaseContextInDiffView:    "{",
+				OpenDiffTool:                 "<c-t>",
 			},
 			Status: KeybindingStatusConfig{
 				CheckForUpdate:      "u",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -46,6 +46,7 @@ type TranslationSet struct {
 	ToggleStaged                        string
 	ToggleStagedAll                     string
 	ToggleTreeView                      string
+	OpenDiffTool                        string
 	OpenMergeTool                       string
 	Refresh                             string
 	Push                                string
@@ -782,6 +783,7 @@ type Actions struct {
 	Undo                              string
 	Redo                              string
 	CopyPullRequestURL                string
+	OpenDiffTool                      string
 	OpenMergeTool                     string
 	OpenCommitInBrowser               string
 	OpenPullRequest                   string
@@ -862,6 +864,7 @@ func EnglishTranslationSet() TranslationSet {
 		ToggleStaged:                        "Toggle staged",
 		ToggleStagedAll:                     "Stage/unstage all",
 		ToggleTreeView:                      "Toggle file tree view",
+		OpenDiffTool:                        "Open external diff tool (git difftool)",
 		OpenMergeTool:                       "Open external merge tool (git mergetool)",
 		Refresh:                             "Refresh",
 		Push:                                "Push",
@@ -1558,6 +1561,7 @@ func EnglishTranslationSet() TranslationSet {
 			Undo:                              "Undo",
 			Redo:                              "Redo",
 			CopyPullRequestURL:                "Copy pull request URL",
+			OpenDiffTool:                      "Open diff tool",
 			OpenMergeTool:                     "Open merge tool",
 			OpenCommitInBrowser:               "Open commit in browser",
 			OpenPullRequest:                   "Open pull request in browser",

--- a/schema/config.json
+++ b/schema/config.json
@@ -864,6 +864,10 @@
             "decreaseContextInDiffView": {
               "type": "string",
               "default": "{"
+            },
+            "openDiffTool": {
+              "type": "string",
+              "default": "\u003cc-t\u003e"
             }
           },
           "additionalProperties": false,


### PR DESCRIPTION
- **PR Description**

Add a command to open git difftool on the selected path (file or directory) either in the files panel or in the commit files panel.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
