### PR TITLE
Add remoteBranchOrder config

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -116,6 +116,7 @@ git:
   fetchAll: true # Pass --all flag when running git fetch. Set to false to fetch only origin (or the current branch's upstream remote if there is one)
   branchLogCmd: 'git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --'
   allBranchesLogCmd: 'git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium'
+  remoteBranchOrder: 'alphabetical' # one of: 'alphabetical' | 'lastCommit'
   overrideGpg: false # prevents lazygit from spawning a separate process when using GPG
   disableForcePushing: false
   parseEmoji: false

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -192,6 +192,8 @@ type GitConfig struct {
 	BranchLogCmd string `yaml:"branchLogCmd"`
 	// Command used to display git log of all branches in the main window
 	AllBranchesLogCmd string `yaml:"allBranchesLogCmd"`
+	// One of: 'alphabetical' (default) | 'lastCommit'
+	RemoteBranchOrder string `yaml:"remoteBranchOrder" jsonschema:"enum=alphabetical,enum=lastCommit"`
 	// If true, do not spawn a separate process when using GPG
 	OverrideGpg bool `yaml:"overrideGpg"`
 	// If true, do not allow force pushes
@@ -663,6 +665,7 @@ func GetDefaultConfig() *UserConfig {
 			FetchAll:            true,
 			BranchLogCmd:        "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",
 			AllBranchesLogCmd:   "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium",
+			RemoteBranchOrder:   "alphabetical",
 			DisableForcePushing: false,
 			CommitPrefixes:      map[string]CommitPrefixConfig(nil),
 			ParseEmoji:          false,

--- a/schema/config.json
+++ b/schema/config.json
@@ -473,6 +473,15 @@
           "description": "Command used to display git log of all branches in the main window",
           "default": "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium"
         },
+        "remoteBranchOrder": {
+          "type": "string",
+          "enum": [
+            "alphabetical",
+            "lastCommit"
+          ],
+          "description": "One of: 'alphabetical' (default) | 'lastCommit'",
+          "default": "alphabetical"
+        },
         "overrideGpg": {
           "type": "boolean",
           "description": "If true, do not spawn a separate process when using GPG"


### PR DESCRIPTION
- **PR Description**
As requested in #1412 and PR'd but abandoned in #2011. This PR takes the suggestions from @jesseduffield and makes the config prop an enum with `alphabetical` sort order being the default and an alternative `lastCommit`.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->


