### PR TITLE
fix(config): add `yaml:"options"` struct tag to `CustomCommandPrompt`.`[]Options`

### DIFF
--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -557,7 +557,7 @@ type CustomCommandPrompt struct {
 
 	// Menu options.
 	// Only for menu prompts.
-	Options []CustomCommandMenuOption
+	Options []CustomCommandMenuOption `yaml:"options"`
 
 	// The command to run to generate menu options
 	// Only for menuFromCommand prompts.

--- a/schema/config.json
+++ b/schema/config.json
@@ -1378,7 +1378,7 @@
                     "Are you sure you want to push to the remote?"
                   ]
                 },
-                "Options": {
+                "options": {
                   "items": {
                     "properties": {
                       "name": {


### PR DESCRIPTION
- **PR Description**

Added `yaml:"options"` struct tag to `CustomCommandPrompt.[]Options` for json schema generation. The first character should have been written lowercase instead of uppercase otherwise custom command options properly not working.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
