### PR TITLE
Fix preserving the commit message when description contains blank lines

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -137,12 +137,11 @@ func (self *CommitCommands) signoffFlag() string {
 }
 
 func (self *CommitCommands) GetCommitMessage(commitSha string) (string, error) {
-	cmdArgs := NewGitCmd("rev-list").
+	cmdArgs := NewGitCmd("log").
 		Arg("--format=%B", "--max-count=1", commitSha).
 		ToArgv()
 
-	messageWithHeader, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
-	message := strings.Join(strings.SplitAfter(messageWithHeader, "\n")[1:], "")
+	message, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
 	return strings.TrimSpace(message), err
 }
 

--- a/pkg/commands/git_commands/commit_test.go
+++ b/pkg/commands/git_commands/commit_test.go
@@ -260,19 +260,17 @@ func TestGetCommitMsg(t *testing.T) {
 	scenarios := []scenario{
 		{
 			"empty",
-			` commit deadbeef`,
+			``,
 			``,
 		},
 		{
 			"no line breaks (single line)",
-			`commit deadbeef
-use generics to DRY up context code`,
+			`use generics to DRY up context code`,
 			`use generics to DRY up context code`,
 		},
 		{
 			"with line breaks",
-			`commit deadbeef
-Merge pull request #1750 from mark2185/fix-issue-template
+			`Merge pull request #1750 from mark2185/fix-issue-template
 
 'git-rev parse' should be 'git rev-parse'`,
 			`Merge pull request #1750 from mark2185/fix-issue-template
@@ -285,7 +283,7 @@ Merge pull request #1750 from mark2185/fix-issue-template
 		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildCommitCommands(commonDeps{
-				runner: oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"rev-list", "--format=%B", "--max-count=1", "deadbeef"}, s.input, nil),
+				runner: oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"log", "--format=%B", "--max-count=1", "deadbeef"}, s.input, nil),
 			})
 
 			output, err := instance.GetCommitMessage("deadbeef")
@@ -306,15 +304,14 @@ func TestGetCommitMessageFromHistory(t *testing.T) {
 	scenarios := []scenario{
 		{
 			"Empty message",
-			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"log", "-1", "--skip=2", "--pretty=%H"}, "", nil).ExpectGitArgs([]string{"rev-list", "--format=%B", "--max-count=1"}, "", nil),
+			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"log", "-1", "--skip=2", "--pretty=%H"}, "", nil).ExpectGitArgs([]string{"log", "--format=%B", "--max-count=1"}, "", nil),
 			func(output string, err error) {
 				assert.Error(t, err)
 			},
 		},
 		{
 			"Default case to retrieve a commit in history",
-			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"log", "-1", "--skip=2", "--pretty=%H"}, "sha3 \n", nil).ExpectGitArgs([]string{"rev-list", "--format=%B", "--max-count=1", "sha3"}, `commit sha3
-				use generics to DRY up context code`, nil),
+			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"log", "-1", "--skip=2", "--pretty=%H"}, "sha3 \n", nil).ExpectGitArgs([]string{"log", "--format=%B", "--max-count=1", "sha3"}, `use generics to DRY up context code`, nil),
 			func(output string, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, "use generics to DRY up context code", output)

--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -41,13 +41,8 @@ func NewCommitsHelper(
 }
 
 func (self *CommitsHelper) SplitCommitMessageAndDescription(message string) (string, string) {
-	for _, separator := range []string{"\n\n", "\n\r\n\r", "\n", "\n\r"} {
-		msg, description, found := strings.Cut(message, separator)
-		if found {
-			return msg, description
-		}
-	}
-	return message, ""
+	msg, description, _ := strings.Cut(message, "\n")
+	return msg, strings.TrimSpace(description)
 }
 
 func (self *CommitsHelper) SetMessageAndDescriptionInView(message string) {

--- a/pkg/integration/components/commit_description_panel_driver.go
+++ b/pkg/integration/components/commit_description_panel_driver.go
@@ -8,6 +8,13 @@ func (self *CommitDescriptionPanelDriver) getViewDriver() *ViewDriver {
 	return self.t.Views().CommitDescription()
 }
 
+// asserts on the current context of the description
+func (self *CommitDescriptionPanelDriver) Content(expected *TextMatcher) *CommitDescriptionPanelDriver {
+	self.getViewDriver().Content(expected)
+
+	return self
+}
+
 func (self *CommitDescriptionPanelDriver) Type(value string) *CommitDescriptionPanelDriver {
 	self.t.typeContent(value)
 
@@ -28,4 +35,8 @@ func (self *CommitDescriptionPanelDriver) Title(expected *TextMatcher) *CommitDe
 	self.getViewDriver().Title(expected)
 
 	return self
+}
+
+func (self *CommitDescriptionPanelDriver) Cancel() {
+	self.getViewDriver().PressEscape()
 }

--- a/pkg/integration/components/commit_message_panel_driver.go
+++ b/pkg/integration/components/commit_message_panel_driver.go
@@ -38,12 +38,6 @@ func (self *CommitMessagePanelDriver) SwitchToDescription() *CommitDescriptionPa
 	return &CommitDescriptionPanelDriver{t: self.t}
 }
 
-func (self *CommitMessagePanelDriver) AddNewline() *CommitMessagePanelDriver {
-	self.t.press(self.t.keys.Universal.Confirm)
-
-	return self
-}
-
 func (self *CommitMessagePanelDriver) Clear() *CommitMessagePanelDriver {
 	// clearing multiple times in case there's multiple lines
 	//  (the clear button only clears a single line at a time)

--- a/pkg/integration/tests/commit/preserve_commit_message.go
+++ b/pkg/integration/tests/commit/preserve_commit_message.go
@@ -32,17 +32,9 @@ var PreserveCommitMessage = NewIntegrationTest(NewIntegrationTestArgs{
 			IsFocused().
 			Press(keys.Files.CommitChanges)
 
-		/* EXPECTED:
 		t.ExpectPopup().CommitMessagePanel().
 			Content(Equals("my commit message")).
 			SwitchToDescription().
 			Content(Equals("first paragraph\n\nsecond paragraph"))
-
-		   ACTUAL:
-		*/
-		t.ExpectPopup().CommitMessagePanel().
-			Content(Equals("my commit message\nfirst paragraph")).
-			SwitchToDescription().
-			Content(Equals("second paragraph"))
 	},
 })

--- a/pkg/integration/tests/commit/preserve_commit_message.go
+++ b/pkg/integration/tests/commit/preserve_commit_message.go
@@ -1,0 +1,48 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var PreserveCommitMessage = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Test that the commit message is preserved correctly when canceling the commit message panel",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("myfile", "myfile content")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			IsFocused().
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			InitialText(Equals("")).
+			Type("my commit message").
+			SwitchToDescription().
+			Type("first paragraph").
+			AddNewline().
+			AddNewline().
+			Type("second paragraph").
+			Cancel()
+
+		t.Views().Files().
+			IsFocused().
+			Press(keys.Files.CommitChanges)
+
+		/* EXPECTED:
+		t.ExpectPopup().CommitMessagePanel().
+			Content(Equals("my commit message")).
+			SwitchToDescription().
+			Content(Equals("first paragraph\n\nsecond paragraph"))
+
+		   ACTUAL:
+		*/
+		t.ExpectPopup().CommitMessagePanel().
+			Content(Equals("my commit message\nfirst paragraph")).
+			SwitchToDescription().
+			Content(Equals("second paragraph"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -74,6 +74,7 @@ var tests = []*components.IntegrationTest{
 	commit.History,
 	commit.HistoryComplex,
 	commit.NewBranch,
+	commit.PreserveCommitMessage,
 	commit.ResetAuthor,
 	commit.Revert,
 	commit.RevertMerge,


### PR DESCRIPTION
- **PR Description**

This fixes a bug whereby the commit message and description weren't preserved correctly if the description contains blank lines. See the added test and the commit message of the last commit for details.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
