### PR TITLE
Add age to stash entries

### DIFF
--- a/pkg/commands/git_commands/stash_loader.go
+++ b/pkg/commands/git_commands/stash_loader.go
@@ -32,14 +32,14 @@ func (self *StashLoader) GetStashEntries(filterPath string) []*models.StashEntry
 		return self.getUnfilteredStashEntries()
 	}
 
-	cmdArgs := NewGitCmd("stash").Arg("list", "--name-only", "--pretty=%ct|%gs").ToArgv()
+	cmdArgs := NewGitCmd("stash").Arg("list", "-z", "--name-only", "--pretty=%ct|%gs").ToArgv()
 	rawString, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
 	if err != nil {
 		return self.getUnfilteredStashEntries()
 	}
 	stashEntries := []*models.StashEntry{}
 	var currentStashEntry *models.StashEntry
-	lines := utils.SplitLines(rawString)
+	lines := utils.SplitNul(rawString)
 	isAStash := func(line string) bool { return strings.HasPrefix(line, "stash@{") }
 	re := regexp.MustCompile(`stash@\{(\d+)\}`)
 

--- a/pkg/commands/git_commands/stash_loader_test.go
+++ b/pkg/commands/git_commands/stash_loader_test.go
@@ -22,14 +22,14 @@ func TestGetStashEntries(t *testing.T) {
 			"No stash entries found",
 			"",
 			oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"stash", "list", "-z", "--pretty=%gs"}, "", nil),
+				ExpectGitArgs([]string{"stash", "list", "-z", "--pretty=%ct|%gs"}, "", nil),
 			[]*models.StashEntry{},
 		},
 		{
 			"Several stash entries found",
 			"",
 			oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"stash", "list", "-z", "--pretty=%gs"},
+				ExpectGitArgs([]string{"stash", "list", "-z", "--pretty=%ct|%gs"},
 					"WIP on add-pkg-commands-test: 55c6af2 increase parallel build\x00WIP on master: bb86a3f update github template\x00",
 					nil,
 				),

--- a/pkg/commands/models/stash_entry.go
+++ b/pkg/commands/models/stash_entry.go
@@ -4,8 +4,9 @@ import "fmt"
 
 // StashEntry : A git stash entry
 type StashEntry struct {
-	Index int
-	Name  string
+	Index   int
+	Recency string
+	Name    string
 }
 
 func (s *StashEntry) FullRefName() string {

--- a/pkg/gui/presentation/stash_entries.go
+++ b/pkg/gui/presentation/stash_entries.go
@@ -3,6 +3,7 @@ package presentation
 import (
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation/icons"
+	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/theme"
 	"github.com/samber/lo"
 )
@@ -21,10 +22,13 @@ func getStashEntryDisplayStrings(s *models.StashEntry, diffed bool) []string {
 		textStyle = theme.DiffTerminalColor
 	}
 
-	res := make([]string, 0, 2)
+	res := make([]string, 0, 3)
+	res = append(res, style.FgCyan.Sprint(s.Recency))
+
 	if icons.IsIconEnabled() {
 		res = append(res, textStyle.Sprint(icons.IconForStash(s)))
 	}
+
 	res = append(res, textStyle.Sprint(s.Name))
 	return res
 }

--- a/pkg/integration/tests/stash/rename.go
+++ b/pkg/integration/tests/stash/rename.go
@@ -22,14 +22,14 @@ var Rename = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Stash().
 			Focus().
 			Lines(
-				Equals("On master: bar"),
-				Equals("On master: foo"),
+				Contains("On master: bar"),
+				Contains("On master: foo"),
 			).
 			SelectNextItem().
 			Press(keys.Stash.RenameStash).
 			Tap(func() {
 				t.ExpectPopup().Prompt().Title(Equals("Rename stash: stash@{1}")).Type(" baz").Confirm()
 			}).
-			SelectedLine(Equals("On master: foo baz"))
+			SelectedLine(Contains("On master: foo baz"))
 	},
 })

--- a/pkg/integration/tests/stash/stash.go
+++ b/pkg/integration/tests/stash/stash.go
@@ -29,7 +29,7 @@ var Stash = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Stash().
 			Lines(
-				Contains("my stashed file"),
+				MatchesRegexp(`\ds .* my stashed file`),
 			)
 
 		t.Views().Files().


### PR DESCRIPTION
- **PR Description**
This PR shows the age (time of creation) of each entry inside the stash panel.
Closes #2445

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
