### PR TITLE
Fix checking out a tag when there is a branch with the same name

### DIFF
--- a/pkg/gui/controllers/tags_controller.go
+++ b/pkg/gui/controllers/tags_controller.go
@@ -83,7 +83,7 @@ func (self *TagsController) GetOnRenderToMain() func() error {
 
 func (self *TagsController) checkout(tag *models.Tag) error {
 	self.c.LogAction(self.c.Tr.Actions.CheckoutTag)
-	if err := self.c.Helpers().Refs.CheckoutRef(tag.Name, types.CheckoutRefOptions{}); err != nil {
+	if err := self.c.Helpers().Refs.CheckoutRef(tag.FullRefName(), types.CheckoutRefOptions{}); err != nil {
 		return err
 	}
 	return self.c.PushContext(self.c.Contexts().Branches)

--- a/pkg/integration/tests/tag/checkout_when_branch_with_same_name_exists.go
+++ b/pkg/integration/tests/tag/checkout_when_branch_with_same_name_exists.go
@@ -1,0 +1,38 @@
+package tag
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CheckoutWhenBranchWithSameNameExists = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Checkout a tag when there's a branch with the same name",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("one")
+		shell.NewBranch("tag")
+		shell.Checkout("master")
+		shell.EmptyCommit("two")
+		shell.CreateLightweightTag("tag", "HEAD")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Tags().
+			Focus().
+			Lines(
+				Contains("tag").IsSelected(),
+			).
+			PressPrimaryAction() // checkout tag
+
+		t.Views().Branches().IsFocused().Lines(
+			/* EXPECTED:
+			Contains("HEAD detached at tag").IsSelected(),
+			Contains("master"),
+			Contains("tag"),
+			ACTUAL: */
+			Contains("* tag").DoesNotContain("HEAD detached").IsSelected(),
+			Contains("master"),
+		)
+	},
+})

--- a/pkg/integration/tests/tag/checkout_when_branch_with_same_name_exists.go
+++ b/pkg/integration/tests/tag/checkout_when_branch_with_same_name_exists.go
@@ -26,13 +26,9 @@ var CheckoutWhenBranchWithSameNameExists = NewIntegrationTest(NewIntegrationTest
 			PressPrimaryAction() // checkout tag
 
 		t.Views().Branches().IsFocused().Lines(
-			/* EXPECTED:
 			Contains("HEAD detached at tag").IsSelected(),
 			Contains("master"),
 			Contains("tag"),
-			ACTUAL: */
-			Contains("* tag").DoesNotContain("HEAD detached").IsSelected(),
-			Contains("master"),
 		)
 	},
 })

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -245,6 +245,7 @@ var tests = []*components.IntegrationTest{
 	sync.PushWithCredentialPrompt,
 	sync.RenameBranchAndPull,
 	tag.Checkout,
+	tag.CheckoutWhenBranchWithSameNameExists,
 	tag.CreateWhileCommitting,
 	tag.CrudAnnotated,
 	tag.CrudLightweight,


### PR DESCRIPTION
- **PR Description**

Fix the bug that when checking out a tag, and a branch with the same name exists, we would check out the branch instead of a detached head at the tag.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
