### PR TITLE
Show Toast instead of error panel when invoking a disabled command

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/env"
 	"github.com/jesseduffield/lazygit/pkg/gui"
 	"github.com/jesseduffield/lazygit/pkg/i18n"
+	integrationTypes "github.com/jesseduffield/lazygit/pkg/integration/types"
 	"github.com/jesseduffield/lazygit/pkg/logs"
 	"github.com/jesseduffield/lazygit/pkg/updates"
 )
@@ -42,7 +43,7 @@ func Run(
 	common *common.Common,
 	startArgs appTypes.StartArgs,
 ) {
-	app, err := NewApp(config, common)
+	app, err := NewApp(config, startArgs.IntegrationTest, common)
 
 	if err == nil {
 		err = app.Run(startArgs)
@@ -94,7 +95,7 @@ func newLogger(cfg config.AppConfigurer) *logrus.Entry {
 }
 
 // NewApp bootstrap a new application
-func NewApp(config config.AppConfigurer, common *common.Common) (*App, error) {
+func NewApp(config config.AppConfigurer, test integrationTypes.IntegrationTest, common *common.Common) (*App, error) {
 	app := &App{
 		closers: []io.Closer{},
 		Config:  config,
@@ -128,7 +129,7 @@ func NewApp(config config.AppConfigurer, common *common.Common) (*App, error) {
 		showRecentRepos = true
 	}
 
-	app.Gui, err = gui.NewGui(common, config, gitVersion, updater, showRecentRepos, dirName)
+	app.Gui, err = gui.NewGui(common, config, gitVersion, updater, showRecentRepos, dirName, test)
 	if err != nil {
 		return app, err
 	}

--- a/pkg/cheatsheet/generate.go
+++ b/pkg/cheatsheet/generate.go
@@ -61,7 +61,7 @@ func generateAtDir(cheatsheetDir string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		mApp, _ := app.NewApp(mConfig, common)
+		mApp, _ := app.NewApp(mConfig, nil, common)
 		path := cheatsheetDir + "/Keybindings_" + lang + ".md"
 		file, err := os.Create(path)
 		if err != nil {

--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -173,7 +173,8 @@ func (self *MenuContext) GetKeybindings(opts types.KeybindingsOpts) []*types.Bin
 
 func (self *MenuContext) OnMenuPress(selectedItem *types.MenuItem) error {
 	if selectedItem != nil && selectedItem.DisabledReason != "" {
-		return self.c.ErrorMsg(selectedItem.DisabledReason)
+		self.c.ErrorToast(self.c.Tr.DisabledMenuItemPrefix + selectedItem.DisabledReason)
+		return nil
 	}
 
 	if err := self.c.PopContext(); err != nil {

--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -90,7 +90,7 @@ func (self *MenuViewModel) GetDisplayStrings(_ int, _ int) [][]string {
 
 	return lo.Map(menuItems, func(item *types.MenuItem, _ int) []string {
 		displayStrings := item.LabelColumns
-		if item.DisabledReason != "" {
+		if item.DisabledReason != nil {
 			displayStrings[0] = style.FgDefault.SetStrikethrough().Sprint(displayStrings[0])
 		}
 
@@ -172,8 +172,8 @@ func (self *MenuContext) GetKeybindings(opts types.KeybindingsOpts) []*types.Bin
 }
 
 func (self *MenuContext) OnMenuPress(selectedItem *types.MenuItem) error {
-	if selectedItem != nil && selectedItem.DisabledReason != "" {
-		self.c.ErrorToast(self.c.Tr.DisabledMenuItemPrefix + selectedItem.DisabledReason)
+	if selectedItem != nil && selectedItem.DisabledReason != nil {
+		self.c.ErrorToast(self.c.Tr.DisabledMenuItemPrefix + selectedItem.DisabledReason.Text)
 		return nil
 	}
 

--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -173,6 +173,10 @@ func (self *MenuContext) GetKeybindings(opts types.KeybindingsOpts) []*types.Bin
 
 func (self *MenuContext) OnMenuPress(selectedItem *types.MenuItem) error {
 	if selectedItem != nil && selectedItem.DisabledReason != nil {
+		if selectedItem.DisabledReason.ShowErrorInPanel {
+			return self.c.ErrorMsg(selectedItem.DisabledReason.Text)
+		}
+
 		self.c.ErrorToast(self.c.Tr.DisabledMenuItemPrefix + selectedItem.DisabledReason.Text)
 		return nil
 	}

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -264,13 +264,13 @@ func (self *BranchesController) viewUpstreamOptions(selectedBranch *models.Branc
 	}
 
 	if !selectedBranch.IsTrackingRemote() {
-		unsetUpstreamItem.DisabledReason = self.c.Tr.UpstreamNotSetError
+		unsetUpstreamItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.UpstreamNotSetError}
 	}
 
 	if !selectedBranch.RemoteBranchStoredLocally() {
-		viewDivergenceItem.DisabledReason = self.c.Tr.UpstreamNotSetError
-		upstreamResetItem.DisabledReason = self.c.Tr.UpstreamNotSetError
-		upstreamRebaseItem.DisabledReason = self.c.Tr.UpstreamNotSetError
+		viewDivergenceItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.UpstreamNotSetError}
+		upstreamResetItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.UpstreamNotSetError}
+		upstreamRebaseItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.UpstreamNotSetError}
 	}
 
 	options := []*types.MenuItem{
@@ -309,16 +309,16 @@ func (self *BranchesController) press(selectedBranch *models.Branch) error {
 	return self.c.Helpers().Refs.CheckoutRef(selectedBranch.Name, types.CheckoutRefOptions{})
 }
 
-func (self *BranchesController) getDisabledReasonForPress() string {
+func (self *BranchesController) getDisabledReasonForPress() *types.DisabledReason {
 	currentBranch := self.c.Helpers().Refs.GetCheckedOutRef()
 	if currentBranch != nil {
 		op := self.c.State().GetItemOperation(currentBranch)
 		if op == types.ItemOperationFastForwarding || op == types.ItemOperationPulling {
-			return self.c.Tr.CantCheckoutBranchWhilePulling
+			return &types.DisabledReason{Text: self.c.Tr.CantCheckoutBranchWhilePulling}
 		}
 	}
 
-	return ""
+	return nil
 }
 
 func (self *BranchesController) worktreeForBranch(branch *models.Branch) (*models.Worktree, bool) {
@@ -525,7 +525,7 @@ func (self *BranchesController) delete(branch *models.Branch) error {
 		},
 	}
 	if checkedOutBranch.Name == branch.Name {
-		localDeleteItem.DisabledReason = self.c.Tr.CantDeleteCheckOutBranch
+		localDeleteItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.CantDeleteCheckOutBranch}
 	}
 
 	remoteDeleteItem := &types.MenuItem{
@@ -536,7 +536,7 @@ func (self *BranchesController) delete(branch *models.Branch) error {
 		},
 	}
 	if !branch.IsTrackingRemote() || branch.UpstreamGone {
-		remoteDeleteItem.DisabledReason = self.c.Tr.UpstreamNotSetError
+		remoteDeleteItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.UpstreamNotSetError}
 	}
 
 	menuTitle := utils.ResolvePlaceholderString(
@@ -562,14 +562,14 @@ func (self *BranchesController) rebase() error {
 	return self.c.Helpers().MergeAndRebase.RebaseOntoRef(selectedBranchName)
 }
 
-func (self *BranchesController) getDisabledReasonForRebase() string {
+func (self *BranchesController) getDisabledReasonForRebase() *types.DisabledReason {
 	selectedBranchName := self.context().GetSelected().Name
 	checkedOutBranch := self.c.Helpers().Refs.GetCheckedOutRef().Name
 	if selectedBranchName == checkedOutBranch {
-		return self.c.Tr.CantRebaseOntoSelf
+		return &types.DisabledReason{Text: self.c.Tr.CantRebaseOntoSelf}
 	}
 
-	return ""
+	return nil
 }
 
 func (self *BranchesController) fastForward(branch *models.Branch) error {

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -848,15 +848,15 @@ func (self *FilesController) openCopyMenu() error {
 	}
 
 	if node == nil {
-		copyNameItem.DisabledReason = self.c.Tr.NoContentToCopyError
-		copyPathItem.DisabledReason = self.c.Tr.NoContentToCopyError
-		copyFileDiffItem.DisabledReason = self.c.Tr.NoContentToCopyError
+		copyNameItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.NoContentToCopyError}
+		copyPathItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.NoContentToCopyError}
+		copyFileDiffItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.NoContentToCopyError}
 	}
 	if node != nil && !node.GetHasStagedOrTrackedChanges() {
-		copyFileDiffItem.DisabledReason = self.c.Tr.NoContentToCopyError
+		copyFileDiffItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.NoContentToCopyError}
 	}
 	if !self.anyStagedOrTrackedFile() {
-		copyAllDiff.DisabledReason = self.c.Tr.NoContentToCopyError
+		copyAllDiff.DisabledReason = &types.DisabledReason{Text: self.c.Tr.NoContentToCopyError}
 	}
 
 	return self.c.Menu(types.CreateMenuOptions{

--- a/pkg/gui/controllers/helpers/confirmation_helper.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper.go
@@ -378,11 +378,11 @@ func (self *ConfirmationHelper) IsPopupPanelFocused() bool {
 
 func (self *ConfirmationHelper) TooltipForMenuItem(menuItem *types.MenuItem) string {
 	tooltip := menuItem.Tooltip
-	if menuItem.DisabledReason != "" {
+	if menuItem.DisabledReason != nil {
 		if tooltip != "" {
 			tooltip += "\n\n"
 		}
-		tooltip += style.FgRed.Sprintf(self.c.Tr.DisabledMenuItemPrefix) + menuItem.DisabledReason
+		tooltip += style.FgRed.Sprintf(self.c.Tr.DisabledMenuItemPrefix) + menuItem.DisabledReason.Text
 	}
 	return tooltip
 }

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -890,7 +890,7 @@ func (self *LocalCommitsController) notMidRebase() *types.DisabledReason {
 // For getting disabled reason
 func (self *LocalCommitsController) canFindCommitForQuickStart() *types.DisabledReason {
 	if _, err := self.findCommitForQuickStartInteractiveRebase(); err != nil {
-		return &types.DisabledReason{Text: err.Error()}
+		return &types.DisabledReason{Text: err.Error(), ShowErrorInPanel: true}
 	}
 
 	return nil

--- a/pkg/gui/controllers/options_menu_action.go
+++ b/pkg/gui/controllers/options_menu_action.go
@@ -25,7 +25,7 @@ func (self *OptionsMenuAction) Call() error {
 	appendBindings := func(bindings []*types.Binding, section *types.MenuSection) {
 		menuItems = append(menuItems,
 			lo.Map(bindings, func(binding *types.Binding, _ int) *types.MenuItem {
-				disabledReason := ""
+				var disabledReason *types.DisabledReason
 				if binding.GetDisabledReason != nil {
 					disabledReason = binding.GetDisabledReason()
 				}

--- a/pkg/gui/controllers/sync_controller.go
+++ b/pkg/gui/controllers/sync_controller.go
@@ -59,16 +59,16 @@ func (self *SyncController) HandlePull() error {
 	return self.branchCheckedOut(self.pull)()
 }
 
-func (self *SyncController) getDisabledReasonForPushOrPull() string {
+func (self *SyncController) getDisabledReasonForPushOrPull() *types.DisabledReason {
 	currentBranch := self.c.Helpers().Refs.GetCheckedOutRef()
 	if currentBranch != nil {
 		op := self.c.State().GetItemOperation(currentBranch)
 		if op != types.ItemOperationNone {
-			return self.c.Tr.CantPullOrPushSameBranchTwice
+			return &types.DisabledReason{Text: self.c.Tr.CantPullOrPushSameBranchTwice}
 		}
 	}
 
-	return ""
+	return nil
 }
 
 func (self *SyncController) branchCheckedOut(f func(*models.Branch) error) func() error {

--- a/pkg/gui/dummies.go
+++ b/pkg/gui/dummies.go
@@ -17,6 +17,6 @@ func NewDummyUpdater() *updates.Updater {
 
 func NewDummyGui() *Gui {
 	newAppConfig := config.NewDummyAppConfig()
-	dummyGui, _ := NewGui(utils.NewDummyCommon(), newAppConfig, &git_commands.GitVersion{}, NewDummyUpdater(), false, "")
+	dummyGui, _ := NewGui(utils.NewDummyCommon(), newAppConfig, &git_commands.GitVersion{}, NewDummyUpdater(), false, "", nil)
 	return dummyGui
 }

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -467,6 +467,7 @@ func NewGui(
 	updater *updates.Updater,
 	showRecentRepos bool,
 	initialDir string,
+	test integrationTypes.IntegrationTest,
 ) (*Gui, error) {
 	gui := &Gui{
 		Common:               cmn,

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -517,7 +517,7 @@ func NewGui(
 		func(message string, f func() error) {
 			gui.helpers.AppStatus.WithWaitingStatusSync(message, f)
 		},
-		func(message string) { gui.helpers.AppStatus.Toast(message) },
+		func(message string, kind types.ToastKind) { gui.helpers.AppStatus.Toast(message, kind) },
 		func() string { return gui.Views.Confirmation.TextArea.GetContent() },
 		func() bool { return gui.c.InDemo() },
 	)

--- a/pkg/gui/gui_driver.go
+++ b/pkg/gui/gui_driver.go
@@ -26,6 +26,8 @@ type GuiDriver struct {
 var _ integrationTypes.GuiDriver = &GuiDriver{}
 
 func (self *GuiDriver) PressKey(keyStr string) {
+	self.CheckAllToastsAcknowledged()
+
 	key := keybindings.GetKey(keyStr)
 
 	var r rune
@@ -47,6 +49,8 @@ func (self *GuiDriver) PressKey(keyStr string) {
 }
 
 func (self *GuiDriver) Click(x, y int) {
+	self.CheckAllToastsAcknowledged()
+
 	self.gui.g.ReplayedEvents.MouseEvents <- gocui.NewTcellMouseEventWrapper(
 		tcell.NewEventMouse(x, y, tcell.ButtonPrimary, 0),
 		0,
@@ -57,6 +61,12 @@ func (self *GuiDriver) Click(x, y int) {
 // wait until lazygit is idle (i.e. all processing is done) before continuing
 func (self *GuiDriver) waitTillIdle() {
 	<-self.isIdleChan
+}
+
+func (self *GuiDriver) CheckAllToastsAcknowledged() {
+	if t := self.NextToast(); t != nil {
+		self.Fail("Toast not acknowledged: " + *t)
+	}
 }
 
 func (self *GuiDriver) Keys() config.KeybindingConfig {

--- a/pkg/gui/gui_driver.go
+++ b/pkg/gui/gui_driver.go
@@ -20,6 +20,7 @@ import (
 type GuiDriver struct {
 	gui        *Gui
 	isIdleChan chan struct{}
+	toastChan  chan string
 }
 
 var _ integrationTypes.GuiDriver = &GuiDriver{}
@@ -132,4 +133,13 @@ func (self *GuiDriver) SetCaption(caption string) {
 func (self *GuiDriver) SetCaptionPrefix(prefix string) {
 	self.gui.setCaptionPrefix(prefix)
 	self.waitTillIdle()
+}
+
+func (self *GuiDriver) NextToast() *string {
+	select {
+	case t := <-self.toastChan:
+		return &t
+	default:
+		return nil
+	}
 }

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -416,7 +416,8 @@ func (gui *Gui) callKeybindingHandler(binding *types.Binding) error {
 		disabledReason = binding.GetDisabledReason()
 	}
 	if disabledReason != "" {
-		return gui.c.ErrorMsg(disabledReason)
+		gui.c.ErrorToast(gui.Tr.DisabledMenuItemPrefix + disabledReason)
+		return nil
 	}
 	return binding.Handler()
 }

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -416,6 +416,10 @@ func (gui *Gui) callKeybindingHandler(binding *types.Binding) error {
 		disabledReason = binding.GetDisabledReason()
 	}
 	if disabledReason != nil {
+		if disabledReason.ShowErrorInPanel {
+			return gui.c.ErrorMsg(disabledReason.Text)
+		}
+
 		gui.c.ErrorToast(gui.Tr.DisabledMenuItemPrefix + disabledReason.Text)
 		return nil
 	}

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -411,12 +411,12 @@ func (gui *Gui) SetMouseKeybinding(binding *gocui.ViewMouseBinding) error {
 }
 
 func (gui *Gui) callKeybindingHandler(binding *types.Binding) error {
-	disabledReason := ""
+	var disabledReason *types.DisabledReason
 	if binding.GetDisabledReason != nil {
 		disabledReason = binding.GetDisabledReason()
 	}
-	if disabledReason != "" {
-		gui.c.ErrorToast(gui.Tr.DisabledMenuItemPrefix + disabledReason)
+	if disabledReason != nil {
+		gui.c.ErrorToast(gui.Tr.DisabledMenuItemPrefix + disabledReason.Text)
 		return nil
 	}
 	return binding.Handler()

--- a/pkg/gui/popup/popup_handler.go
+++ b/pkg/gui/popup/popup_handler.go
@@ -66,6 +66,10 @@ func (self *PopupHandler) Toast(message string) {
 	self.toastFn(message)
 }
 
+func (self *PopupHandler) SetToastFunc(f func(string)) {
+	self.toastFn = f
+}
+
 func (self *PopupHandler) WithWaitingStatus(message string, f func(gocui.Task) error) error {
 	self.withWaitingStatusFn(message, f)
 	return nil

--- a/pkg/gui/popup/popup_handler.go
+++ b/pkg/gui/popup/popup_handler.go
@@ -22,7 +22,7 @@ type PopupHandler struct {
 	createMenuFn            func(types.CreateMenuOptions) error
 	withWaitingStatusFn     func(message string, f func(gocui.Task) error)
 	withWaitingStatusSyncFn func(message string, f func() error)
-	toastFn                 func(message string)
+	toastFn                 func(message string, kind types.ToastKind)
 	getPromptInputFn        func() string
 	inDemo                  func() bool
 }
@@ -38,7 +38,7 @@ func NewPopupHandler(
 	createMenuFn func(types.CreateMenuOptions) error,
 	withWaitingStatusFn func(message string, f func(gocui.Task) error),
 	withWaitingStatusSyncFn func(message string, f func() error),
-	toastFn func(message string),
+	toastFn func(message string, kind types.ToastKind),
 	getPromptInputFn func() string,
 	inDemo func() bool,
 ) *PopupHandler {
@@ -63,10 +63,14 @@ func (self *PopupHandler) Menu(opts types.CreateMenuOptions) error {
 }
 
 func (self *PopupHandler) Toast(message string) {
-	self.toastFn(message)
+	self.toastFn(message, types.ToastKindStatus)
 }
 
-func (self *PopupHandler) SetToastFunc(f func(string)) {
+func (self *PopupHandler) ErrorToast(message string) {
+	self.toastFn(message, types.ToastKindError)
+}
+
+func (self *PopupHandler) SetToastFunc(f func(string, types.ToastKind)) {
 	self.toastFn = f
 }
 

--- a/pkg/gui/status/status_manager.go
+++ b/pkg/gui/status/status_manager.go
@@ -3,6 +3,8 @@ package status
 import (
 	"time"
 
+	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
 	"github.com/sasha-s/go-deadlock"
@@ -26,7 +28,7 @@ type WaitingStatusHandle struct {
 }
 
 func (self *WaitingStatusHandle) Show() {
-	self.id = self.statusManager.addStatus(self.message, "waiting")
+	self.id = self.statusManager.addStatus(self.message, "waiting", types.ToastKindStatus)
 	self.renderFunc()
 }
 
@@ -37,6 +39,7 @@ func (self *WaitingStatusHandle) Hide() {
 type appStatus struct {
 	message    string
 	statusType string
+	color      gocui.Attribute
 	id         int
 }
 
@@ -53,8 +56,8 @@ func (self *StatusManager) WithWaitingStatus(message string, renderFunc func(), 
 	handle.Hide()
 }
 
-func (self *StatusManager) AddToastStatus(message string) int {
-	id := self.addStatus(message, "toast")
+func (self *StatusManager) AddToastStatus(message string, kind types.ToastKind) int {
+	id := self.addStatus(message, "toast", kind)
 
 	go func() {
 		time.Sleep(time.Second * 2)
@@ -65,31 +68,37 @@ func (self *StatusManager) AddToastStatus(message string) int {
 	return id
 }
 
-func (self *StatusManager) GetStatusString() string {
+func (self *StatusManager) GetStatusString() (string, gocui.Attribute) {
 	if len(self.statuses) == 0 {
-		return ""
+		return "", gocui.ColorDefault
 	}
 	topStatus := self.statuses[0]
 	if topStatus.statusType == "waiting" {
-		return topStatus.message + " " + utils.Loader(time.Now())
+		return topStatus.message + " " + utils.Loader(time.Now()), topStatus.color
 	}
-	return topStatus.message
+	return topStatus.message, topStatus.color
 }
 
 func (self *StatusManager) HasStatus() bool {
 	return len(self.statuses) > 0
 }
 
-func (self *StatusManager) addStatus(message string, statusType string) int {
+func (self *StatusManager) addStatus(message string, statusType string, kind types.ToastKind) int {
 	self.mutex.Lock()
 	defer self.mutex.Unlock()
 
 	self.nextId++
 	id := self.nextId
 
+	color := gocui.ColorCyan
+	if kind == types.ToastKindError {
+		color = gocui.ColorRed
+	}
+
 	newStatus := appStatus{
 		message:    message,
 		statusType: statusType,
+		color:      color,
 		id:         id,
 	}
 	self.statuses = append([]appStatus{newStatus}, self.statuses...)

--- a/pkg/gui/status/status_manager.go
+++ b/pkg/gui/status/status_manager.go
@@ -60,7 +60,8 @@ func (self *StatusManager) AddToastStatus(message string, kind types.ToastKind) 
 	id := self.addStatus(message, "toast", kind)
 
 	go func() {
-		time.Sleep(time.Second * 2)
+		delay := lo.Ternary(kind == types.ToastKindError, time.Second*4, time.Second*2)
+		time.Sleep(delay)
 
 		self.removeStatus(id)
 	}()

--- a/pkg/gui/test_mode.go
+++ b/pkg/gui/test_mode.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/popup"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/integration/components"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
@@ -35,7 +36,7 @@ func (gui *Gui) handleTestMode() {
 
 			toastChan := make(chan string, 100)
 			gui.PopupHandler.(*popup.PopupHandler).SetToastFunc(
-				func(message string) { toastChan <- message })
+				func(message string, kind types.ToastKind) { toastChan <- message })
 
 			test.Run(&GuiDriver{gui: gui, isIdleChan: isIdleChan, toastChan: toastChan})
 

--- a/pkg/gui/test_mode.go
+++ b/pkg/gui/test_mode.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazygit/pkg/gui/popup"
 	"github.com/jesseduffield/lazygit/pkg/integration/components"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
@@ -32,7 +33,11 @@ func (gui *Gui) handleTestMode() {
 		go func() {
 			waitUntilIdle()
 
-			test.Run(&GuiDriver{gui: gui, isIdleChan: isIdleChan})
+			toastChan := make(chan string, 100)
+			gui.PopupHandler.(*popup.PopupHandler).SetToastFunc(
+				func(message string) { toastChan <- message })
+
+			test.Run(&GuiDriver{gui: gui, isIdleChan: isIdleChan, toastChan: toastChan})
 
 			gui.g.Update(func(*gocui.Gui) error {
 				return gocui.ErrQuit

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -203,6 +203,12 @@ type MenuSection struct {
 
 type DisabledReason struct {
 	Text string
+
+	// When trying to invoke a disabled key binding or menu item, we normally
+	// show the disabled reason as a toast; setting this to true shows it as an
+	// error panel instead. This is useful if the text is very long, or if it is
+	// important enough to show it more prominently, or both.
+	ShowErrorInPanel bool
 }
 
 type MenuItem struct {

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -144,6 +144,7 @@ type IPopupHandler interface {
 	WithWaitingStatusSync(message string, f func() error) error
 	Menu(opts CreateMenuOptions) error
 	Toast(message string)
+	SetToastFunc(func(string))
 	GetPromptInput() string
 }
 

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -201,6 +201,10 @@ type MenuSection struct {
 	Column int // The column that this section title should be aligned with
 }
 
+type DisabledReason struct {
+	Text string
+}
+
 type MenuItem struct {
 	Label string
 
@@ -219,9 +223,9 @@ type MenuItem struct {
 	// The tooltip will be displayed upon highlighting the menu item
 	Tooltip string
 
-	// If non-empty, show this in a tooltip, style the menu item as disabled,
+	// If non-nil, show this in a tooltip, style the menu item as disabled,
 	// and refuse to invoke the command
-	DisabledReason string
+	DisabledReason *DisabledReason
 
 	// Can be used to group menu items into sections with headers. MenuItems
 	// with the same Section should be contiguous, and will automatically get a

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -144,9 +144,17 @@ type IPopupHandler interface {
 	WithWaitingStatusSync(message string, f func() error) error
 	Menu(opts CreateMenuOptions) error
 	Toast(message string)
-	SetToastFunc(func(string))
+	ErrorToast(message string)
+	SetToastFunc(func(string, ToastKind))
 	GetPromptInput() string
 }
+
+type ToastKind int
+
+const (
+	ToastKindStatus ToastKind = iota
+	ToastKindError
+)
 
 type CreateMenuOptions struct {
 	Title           string

--- a/pkg/gui/types/keybindings.go
+++ b/pkg/gui/types/keybindings.go
@@ -31,7 +31,7 @@ type Binding struct {
 	// disabled and we show the given text in an error message when trying to
 	// invoke it. When left nil, the command is always enabled. Note that this
 	// function must not do expensive calls.
-	GetDisabledReason func() string
+	GetDisabledReason func() *DisabledReason
 }
 
 // A guard is a decorator which checks something before executing a handler

--- a/pkg/integration/components/menu_driver.go
+++ b/pkg/integration/components/menu_driver.go
@@ -18,10 +18,12 @@ func (self *MenuDriver) Title(expected *TextMatcher) *MenuDriver {
 	return self
 }
 
-func (self *MenuDriver) Confirm() {
+func (self *MenuDriver) Confirm() *MenuDriver {
 	self.checkNecessaryChecksCompleted()
 
 	self.getViewDriver().PressEnter()
+
+	return self
 }
 
 func (self *MenuDriver) Cancel() {
@@ -69,6 +71,11 @@ func (self *MenuDriver) Wait(milliseconds int) *MenuDriver {
 func (self *MenuDriver) Tooltip(option *TextMatcher) *MenuDriver {
 	self.t.Views().Tooltip().Content(option)
 
+	return self
+}
+
+func (self *MenuDriver) Tap(f func()) *MenuDriver {
+	self.getViewDriver().Tap(f)
 	return self
 }
 

--- a/pkg/integration/components/test.go
+++ b/pkg/integration/components/test.go
@@ -194,6 +194,8 @@ func (self *IntegrationTest) Run(gui integrationTypes.GuiDriver) {
 
 	self.run(testDriver, keys)
 
+	gui.CheckAllToastsAcknowledged()
+
 	if InputDelay() > 0 {
 		// Clear whatever caption there was so it doesn't linger
 		testDriver.SetCaption("")

--- a/pkg/integration/components/test_driver.go
+++ b/pkg/integration/components/test_driver.go
@@ -102,8 +102,19 @@ func (self *TestDriver) ExpectPopup() *Popup {
 	return &Popup{t: self}
 }
 
-func (self *TestDriver) ExpectToast(matcher *TextMatcher) {
-	self.Views().AppStatus().Content(matcher)
+func (self *TestDriver) ExpectToast(matcher *TextMatcher) *TestDriver {
+	t := self.gui.NextToast()
+	if t == nil {
+		self.gui.Fail("Expected toast, but didn't get one")
+	} else {
+		self.matchString(matcher, "Unexpected toast message",
+			func() string {
+				return *t
+			},
+		)
+	}
+
+	return self
 }
 
 func (self *TestDriver) ExpectClipboard(matcher *TextMatcher) {

--- a/pkg/integration/components/test_test.go
+++ b/pkg/integration/components/test_test.go
@@ -82,6 +82,8 @@ func (self *fakeGuiDriver) NextToast() *string {
 	return nil
 }
 
+func (self *fakeGuiDriver) CheckAllToastsAcknowledged() {}
+
 func TestManualFailure(t *testing.T) {
 	test := NewIntegrationTest(NewIntegrationTestArgs{
 		Description: unitTestDescription,

--- a/pkg/integration/components/test_test.go
+++ b/pkg/integration/components/test_test.go
@@ -78,6 +78,10 @@ func (self *fakeGuiDriver) SetCaption(string) {
 func (self *fakeGuiDriver) SetCaptionPrefix(string) {
 }
 
+func (self *fakeGuiDriver) NextToast() *string {
+	return nil
+}
+
 func TestManualFailure(t *testing.T) {
 	test := NewIntegrationTest(NewIntegrationTestArgs{
 		Description: unitTestDescription,

--- a/pkg/integration/tests/branch/delete.go
+++ b/pkg/integration/tests/branch/delete.go
@@ -37,12 +37,11 @@ var Delete = NewIntegrationTest(NewIntegrationTestArgs{
 					Tooltip(Contains("You cannot delete the checked out branch!")).
 					Title(Equals("Delete branch 'branch-three'?")).
 					Select(Contains("Delete local branch")).
-					Confirm()
-				t.ExpectPopup().
-					Alert().
-					Title(Equals("Error")).
-					Content(Contains("You cannot delete the checked out branch!")).
-					Confirm()
+					Confirm().
+					Tap(func() {
+						t.ExpectToast(Contains("You cannot delete the checked out branch!"))
+					}).
+					Cancel()
 			}).
 			SelectNextItem().
 			Press(keys.Universal.Remove).

--- a/pkg/integration/tests/branch/rebase_to_upstream.go
+++ b/pkg/integration/tests/branch/rebase_to_upstream.go
@@ -48,11 +48,11 @@ var RebaseToUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 					Title(Equals("Upstream options")).
 					Select(Contains("Rebase checked-out branch onto upstream of selected branch")).
 					Tooltip(Contains("Disabled: The selected branch has no upstream (or the upstream is not stored locally)")).
-					Confirm()
-				t.ExpectPopup().Alert().
-					Title(Equals("Error")).
-					Content(Equals("The selected branch has no upstream (or the upstream is not stored locally)")).
-					Confirm()
+					Confirm().
+					Tap(func() {
+						t.ExpectToast(Equals("Disabled: The selected branch has no upstream (or the upstream is not stored locally)"))
+					}).
+					Cancel()
 			}).
 			SelectNextItem().
 			Lines(

--- a/pkg/integration/tests/branch/reset_to_upstream.go
+++ b/pkg/integration/tests/branch/reset_to_upstream.go
@@ -42,11 +42,11 @@ var ResetToUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 					Title(Equals("Upstream options")).
 					Select(Contains("Reset checked-out branch onto upstream of selected branch")).
 					Tooltip(Contains("Disabled: The selected branch has no upstream (or the upstream is not stored locally)")).
-					Confirm()
-				t.ExpectPopup().Alert().
-					Title(Equals("Error")).
-					Content(Equals("The selected branch has no upstream (or the upstream is not stored locally)")).
-					Confirm()
+					Confirm().
+					Tap(func() {
+						t.ExpectToast(Equals("Disabled: The selected branch has no upstream (or the upstream is not stored locally)"))
+					}).
+					Cancel()
 			}).
 			SelectNextItem().
 			Lines(

--- a/pkg/integration/tests/file/copy_menu.go
+++ b/pkg/integration/tests/file/copy_menu.go
@@ -101,6 +101,8 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 					Select(Contains("File name")).
 					Confirm()
 
+				t.ExpectToast(Equals("File name copied to clipboard"))
+
 				expectClipboard(t, Contains("unstaged_file"))
 			})
 
@@ -112,6 +114,8 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 					Title(Equals("Copy to clipboard")).
 					Select(Contains("Path")).
 					Confirm()
+
+				t.ExpectToast(Equals("File path copied to clipboard"))
 
 				expectClipboard(t, Contains("dir/1-unstaged_file"))
 			})
@@ -125,6 +129,8 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 					Select(Contains("Diff of selected file")).
 					Tooltip(Equals("If there are staged items, this command considers only them. Otherwise, it considers all the unstaged ones.")).
 					Confirm()
+
+				t.ExpectToast(Equals("File diff copied to clipboard"))
 
 				expectClipboard(t, Contains("+unstaged content (new)"))
 			})
@@ -145,6 +151,8 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 					Tooltip(Equals("If there are staged items, this command considers only them. Otherwise, it considers all the unstaged ones.")).
 					Confirm()
 
+				t.ExpectToast(Equals("File diff copied to clipboard"))
+
 				expectClipboard(t, Contains("+staged content (new)"))
 			})
 
@@ -157,6 +165,8 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 					Select(Contains("Diff of all files")).
 					Tooltip(Equals("If there are staged items, this command considers only them. Otherwise, it considers all the unstaged ones.")).
 					Confirm()
+
+				t.ExpectToast(Equals("All files diff copied to clipboard"))
 
 				expectClipboard(t, Contains("+staged content (new)"))
 			})
@@ -178,6 +188,8 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 					Select(Contains("Diff of all files")).
 					Tooltip(Equals("If there are staged items, this command considers only them. Otherwise, it considers all the unstaged ones.")).
 					Confirm()
+
+				t.ExpectToast(Equals("All files diff copied to clipboard"))
 
 				expectClipboard(t, Contains("+staged content (new)").Contains("+unstaged content (new)"))
 			})

--- a/pkg/integration/tests/file/copy_menu.go
+++ b/pkg/integration/tests/file/copy_menu.go
@@ -30,12 +30,11 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 					Title(Equals("Copy to clipboard")).
 					Select(Contains("File name")).
 					Tooltip(Equals("Disabled: Nothing to copy")).
-					Confirm()
-
-				t.ExpectPopup().Alert().
-					Title(Equals("Error")).
-					Content(Equals("Nothing to copy")).
-					Confirm()
+					Confirm().
+					Tap(func() {
+						t.ExpectToast(Equals("Disabled: Nothing to copy"))
+					}).
+					Cancel()
 			})
 
 		t.Shell().
@@ -56,12 +55,11 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 					Title(Equals("Copy to clipboard")).
 					Select(Contains("Diff of selected file")).
 					Tooltip(Contains("Disabled: Nothing to copy")).
-					Confirm()
-
-				t.ExpectPopup().Alert().
-					Title(Equals("Error")).
-					Content(Equals("Nothing to copy")).
-					Confirm()
+					Confirm().
+					Tap(func() {
+						t.ExpectToast(Equals("Disabled: Nothing to copy"))
+					}).
+					Cancel()
 			}).
 			Press(keys.Files.CopyFileInfoToClipboard).
 			Tap(func() {
@@ -69,12 +67,11 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 					Title(Equals("Copy to clipboard")).
 					Select(Contains("Diff of all files")).
 					Tooltip(Contains("Disabled: Nothing to copy")).
-					Confirm()
-
-				t.ExpectPopup().Alert().
-					Title(Equals("Error")).
-					Content(Equals("Nothing to copy")).
-					Confirm()
+					Confirm().
+					Tap(func() {
+						t.ExpectToast(Equals("Disabled: Nothing to copy"))
+					}).
+					Cancel()
 			})
 
 		t.Shell().

--- a/pkg/integration/tests/interactive_rebase/amend_non_head_commit_during_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/amend_non_head_commit_during_rebase.go
@@ -34,10 +34,7 @@ var AmendNonHeadCommitDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 				NavigateToLine(Contains(commit)).
 				Press(keys.Commits.AmendToCommit)
 
-			t.ExpectPopup().Alert().
-				Title(Equals("Error")).
-				Content(Contains("Can't perform this action during a rebase")).
-				Confirm()
+			t.ExpectToast(Contains("Can't perform this action during a rebase"))
 		}
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/edit_non_todo_commit_during_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/edit_non_todo_commit_during_rebase.go
@@ -29,9 +29,6 @@ var EditNonTodoCommitDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("commit 01")).
 			Press(keys.Universal.Edit)
 
-		t.ExpectPopup().Alert().
-			Title(Equals("Error")).
-			Content(Contains("Can't perform this action during a rebase")).
-			Confirm()
+		t.ExpectToast(Contains("Can't perform this action during a rebase"))
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/edit_the_confl_commit.go
+++ b/pkg/integration/tests/interactive_rebase/edit_the_confl_commit.go
@@ -39,9 +39,6 @@ var EditTheConflCommit = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("<-- YOU ARE HERE --- commit three")).
 			Press(keys.Commits.RenameCommit)
 
-		t.ExpectPopup().Alert().
-			Title(Equals("Error")).
-			Content(Contains("Changing this kind of rebase todo entry is not allowed")).
-			Confirm()
+		t.ExpectToast(Contains("Changing this kind of rebase todo entry is not allowed"))
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/fixup_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/fixup_first_commit.go
@@ -24,10 +24,7 @@ var FixupFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("commit 01")).
 			Press(keys.Commits.MarkCommitAsFixup).
 			Tap(func() {
-				t.ExpectPopup().Alert().
-					Title(Equals("Error")).
-					Content(Equals("There's no commit below to squash into")).
-					Confirm()
+				t.ExpectToast(Equals("Disabled: There's no commit below to squash into"))
 			}).
 			Lines(
 				Contains("commit 02"),

--- a/pkg/integration/tests/interactive_rebase/quick_start.go
+++ b/pkg/integration/tests/interactive_rebase/quick_start.go
@@ -52,7 +52,10 @@ var QuickStart = NewIntegrationTest(NewIntegrationTestArgs{
 			// Verify we can't quick start from main
 			Press(keys.Commits.StartInteractiveRebase)
 
-		t.ExpectToast(Equals("Disabled: Cannot start interactive rebase: the HEAD commit is a merge commit or is present on the main branch, so there is no appropriate base commit to start the rebase from. You can start an interactive rebase from a specific commit by selecting the commit and pressing `e`."))
+		t.ExpectPopup().Alert().
+			Title(Equals("Error")).
+			Content(Equals("Cannot start interactive rebase: the HEAD commit is a merge commit or is present on the main branch, so there is no appropriate base commit to start the rebase from. You can start an interactive rebase from a specific commit by selecting the commit and pressing `e`.")).
+			Confirm()
 
 		t.Views().Branches().
 			Focus().

--- a/pkg/integration/tests/interactive_rebase/quick_start.go
+++ b/pkg/integration/tests/interactive_rebase/quick_start.go
@@ -50,13 +50,9 @@ var QuickStart = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("initial commit"),
 			).
 			// Verify we can't quick start from main
-			Press(keys.Commits.StartInteractiveRebase).
-			Tap(func() {
-				t.ExpectPopup().Alert().
-					Title(Equals("Error")).
-					Content(Contains("Cannot start interactive rebase: the HEAD commit is a merge commit or is present on the main branch, so there is no appropriate base commit to start the rebase from. You can start an interactive rebase from a specific commit by selecting the commit and pressing `e`.")).
-					Confirm()
-			})
+			Press(keys.Commits.StartInteractiveRebase)
+
+		t.ExpectToast(Equals("Disabled: Cannot start interactive rebase: the HEAD commit is a merge commit or is present on the main branch, so there is no appropriate base commit to start the rebase from. You can start an interactive rebase from a specific commit by selecting the commit and pressing `e`."))
 
 		t.Views().Branches().
 			Focus().
@@ -80,15 +76,10 @@ var QuickStart = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("initial commit"),
 			).
 			// Try again, verify we fail because we're already rebasing
-			Press(keys.Commits.StartInteractiveRebase).
-			Tap(func() {
-				t.ExpectPopup().Alert().
-					Title(Equals("Error")).
-					Content(Contains("Can't perform this action during a rebase")).
-					Confirm()
+			Press(keys.Commits.StartInteractiveRebase)
 
-				t.Common().AbortRebase()
-			})
+		t.ExpectToast(Equals("Disabled: Can't perform this action during a rebase"))
+		t.Common().AbortRebase()
 
 		// Verify if a merge commit is present on the branch we start from there
 		t.Views().Branches().

--- a/pkg/integration/tests/interactive_rebase/squash_down_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/squash_down_first_commit.go
@@ -24,10 +24,7 @@ var SquashDownFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("commit 01")).
 			Press(keys.Commits.SquashDown).
 			Tap(func() {
-				t.ExpectPopup().Alert().
-					Title(Equals("Error")).
-					Content(Equals("There's no commit below to squash into")).
-					Confirm()
+				t.ExpectToast(Equals("Disabled: There's no commit below to squash into"))
 			}).
 			Lines(
 				Contains("commit 02"),

--- a/pkg/integration/tests/misc/copy_to_clipboard.go
+++ b/pkg/integration/tests/misc/copy_to_clipboard.go
@@ -27,6 +27,8 @@ var CopyToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			Press(keys.Universal.CopyToClipboard)
 
+		t.ExpectToast(Equals("'branch-a' Copied to clipboard"))
+
 		t.Views().Files().
 			Focus()
 

--- a/pkg/integration/tests/staging/diff_context_change.go
+++ b/pkg/integration/tests/staging/diff_context_change.go
@@ -62,6 +62,9 @@ var DiffContextChange = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains(` 6a`),
 			).
 			Press(keys.Universal.IncreaseContextInDiffView).
+			Tap(func() {
+				t.ExpectToast(Equals("Changed diff context size to 4"))
+			}).
 			SelectedLines(
 				Contains(`@@ -1,7 +1,7 @@`),
 				Contains(` 1a`),
@@ -74,6 +77,9 @@ var DiffContextChange = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains(` 7a`),
 			).
 			Press(keys.Universal.DecreaseContextInDiffView).
+			Tap(func() {
+				t.ExpectToast(Equals("Changed diff context size to 3"))
+			}).
 			SelectedLines(
 				Contains(`@@ -1,6 +1,6 @@`),
 				Contains(` 1a`),
@@ -85,6 +91,9 @@ var DiffContextChange = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains(` 6a`),
 			).
 			Press(keys.Universal.DecreaseContextInDiffView).
+			Tap(func() {
+				t.ExpectToast(Equals("Changed diff context size to 2"))
+			}).
 			SelectedLines(
 				Contains(`@@ -1,5 +1,5 @@`),
 				Contains(` 1a`),
@@ -95,6 +104,9 @@ var DiffContextChange = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains(` 5a`),
 			).
 			Press(keys.Universal.DecreaseContextInDiffView).
+			Tap(func() {
+				t.ExpectToast(Equals("Changed diff context size to 1"))
+			}).
 			SelectedLines(
 				Contains(`@@ -2,3 +2,3 @@`),
 				Contains(` 2a`),
@@ -116,6 +128,9 @@ var DiffContextChange = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains(` 4a`),
 			).
 			Press(keys.Universal.IncreaseContextInDiffView).
+			Tap(func() {
+				t.ExpectToast(Equals("Changed diff context size to 2"))
+			}).
 			SelectedLines(
 				Contains(`@@ -1,5 +1,5 @@`),
 				Contains(` 1a`),

--- a/pkg/integration/tests/tag/crud_annotated.go
+++ b/pkg/integration/tests/tag/crud_annotated.go
@@ -65,6 +65,7 @@ var CrudAnnotated = NewIntegrationTest(NewIntegrationTestArgs{
 					Title(Equals("Delete tag 'new-tag'?")).
 					Content(Equals("Are you sure you want to delete the remote tag 'new-tag' from 'origin'?")).
 					Confirm()
+				t.ExpectToast(Equals("Remote tag deleted"))
 			}).
 			Lines(
 				MatchesRegexp(`new-tag.*message`).IsSelected(),

--- a/pkg/integration/tests/tag/crud_lightweight.go
+++ b/pkg/integration/tests/tag/crud_lightweight.go
@@ -70,6 +70,7 @@ var CrudLightweight = NewIntegrationTest(NewIntegrationTestArgs{
 					Title(Equals("Delete tag 'new-tag'?")).
 					Content(Equals("Are you sure you want to delete the remote tag 'new-tag' from 'origin'?")).
 					Confirm()
+				t.ExpectToast(Equals("Remote tag deleted"))
 			}).
 			Lines(
 				MatchesRegexp(`new-tag.*initial commit`).IsSelected(),

--- a/pkg/integration/types/types.go
+++ b/pkg/integration/types/types.go
@@ -43,4 +43,6 @@ type GuiDriver interface {
 	View(viewName string) *gocui.View
 	SetCaption(caption string)
 	SetCaptionPrefix(prefix string)
+	// Pop the next toast that was displayed; returns nil if there was none
+	NextToast() *string
 }

--- a/pkg/integration/types/types.go
+++ b/pkg/integration/types/types.go
@@ -45,4 +45,5 @@ type GuiDriver interface {
 	SetCaptionPrefix(prefix string)
 	// Pop the next toast that was displayed; returns nil if there was none
 	NextToast() *string
+	CheckAllToastsAcknowledged()
 }


### PR DESCRIPTION
- **PR Description**

Addresses #3116.

I'm not 100% sure I like the behavior, but I put it out there so that others can test it and form an opinion. It not only affects keybindings, but also invoking menu items (either with enter or with their key binding): the menu now stays open in that case, which I think is actually better.

There's a horrible hack for keeping the integration tests working, I don't have a good idea how to fix that for real. Suggestions welcome.