### PR TITLE
Keep same branch selected when fetching a branch while sorted by date

### DIFF
--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -447,7 +447,7 @@ func (self *BranchesController) createNewBranchWithName(newBranchName string) er
 	}
 
 	self.context().SetSelection(0)
-	return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})
+	return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, KeepBranchSelectionIndex: true})
 }
 
 func (self *BranchesController) checkedOutByOtherWorktree(branch *models.Branch) bool {

--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -51,6 +51,8 @@ func (self *RefsHelper) CheckoutRef(ref string, options types.CheckoutRefOptions
 		self.c.Contexts().LocalCommits.SetLimitCommits(true)
 	}
 
+	refreshOptions := types.RefreshOptions{Mode: types.BLOCK_UI, KeepBranchSelectionIndex: true}
+
 	return self.c.WithWaitingStatus(waitingStatus, func(gocui.Task) error {
 		if err := self.c.Git().Branch.Checkout(ref, cmdOptions); err != nil {
 			// note, this will only work for english-language git commands. If we force git to use english, and the error isn't this one, then the user will receive an english command they may not understand. I'm not sure what the best solution to this is. Running the command once in english and a second time in the native language is one option
@@ -74,12 +76,12 @@ func (self *RefsHelper) CheckoutRef(ref string, options types.CheckoutRefOptions
 
 						onSuccess()
 						if err := self.c.Git().Stash.Pop(0); err != nil {
-							if err := self.c.Refresh(types.RefreshOptions{Mode: types.BLOCK_UI}); err != nil {
+							if err := self.c.Refresh(refreshOptions); err != nil {
 								return err
 							}
 							return self.c.Error(err)
 						}
-						return self.c.Refresh(types.RefreshOptions{Mode: types.BLOCK_UI})
+						return self.c.Refresh(refreshOptions)
 					},
 				})
 			}
@@ -90,7 +92,7 @@ func (self *RefsHelper) CheckoutRef(ref string, options types.CheckoutRefOptions
 		}
 		onSuccess()
 
-		return self.c.Refresh(types.RefreshOptions{Mode: types.BLOCK_UI})
+		return self.c.Refresh(refreshOptions)
 	})
 }
 
@@ -218,7 +220,7 @@ func (self *RefsHelper) NewBranch(from string, fromFormattedName string, suggest
 			self.c.Contexts().LocalCommits.SetSelection(0)
 			self.c.Contexts().Branches.SetSelection(0)
 
-			return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})
+			return self.c.Refresh(types.RefreshOptions{Mode: types.BLOCK_UI, KeepBranchSelectionIndex: true})
 		},
 	})
 }

--- a/pkg/gui/types/refresh.go
+++ b/pkg/gui/types/refresh.go
@@ -36,4 +36,11 @@ type RefreshOptions struct {
 	Then  func()
 	Scope []RefreshableView // e.g. []RefreshableView{COMMITS, BRANCHES}. Leave empty to refresh everything
 	Mode  RefreshMode       // one of SYNC (default), ASYNC, and BLOCK_UI
+
+	// Normally a refresh of the branches tries to keep the same branch selected
+	// (by name); this is usually important in case the order of branches
+	// changes. Passing true for KeepBranchSelectionIndex suppresses this and
+	// keeps the selection index the same. Useful after checking out a detached
+	// head, and selecting index 0.
+	KeepBranchSelectionIndex bool
 }

--- a/pkg/integration/tests/custom_commands/suggestions_command.go
+++ b/pkg/integration/tests/custom_commands/suggestions_command.go
@@ -57,8 +57,8 @@ var SuggestionsCommand = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Branches().
 			Lines(
-				Contains("branch-three").IsSelected(),
-				Contains("branch-four"),
+				Contains("branch-three"),
+				Contains("branch-four").IsSelected(),
 				Contains("branch-two"),
 				Contains("branch-one"),
 			)

--- a/pkg/integration/tests/custom_commands/suggestions_preset.go
+++ b/pkg/integration/tests/custom_commands/suggestions_preset.go
@@ -57,8 +57,8 @@ var SuggestionsPreset = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Branches().
 			Lines(
-				Contains("branch-three").IsSelected(),
-				Contains("branch-four"),
+				Contains("branch-three"),
+				Contains("branch-four").IsSelected(),
 				Contains("branch-two"),
 				Contains("branch-one"),
 			)

--- a/pkg/integration/tests/sync/fetch_when_sorted_by_date.go
+++ b/pkg/integration/tests/sync/fetch_when_sorted_by_date.go
@@ -1,0 +1,54 @@
+package sync
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var FetchWhenSortedByDate = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Fetch a branch while sort order is by date; verify that branch stays selected",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			EmptyCommitWithDate("commit", "2023-04-07 10:00:00"). // first master commit, older than branch2
+			EmptyCommitWithDate("commit", "2023-04-07 12:00:00"). // second master commit, newer than branch2
+			NewBranch("branch1").                                 // branch1 will be checked out, so its date doesn't matter
+			EmptyCommitWithDate("commit", "2023-04-07 11:00:00"). // branch2 commit, date is between the two master commits
+			NewBranch("branch2").
+			Checkout("master").
+			CloneIntoRemote("origin").
+			SetBranchUpstream("master", "origin/master"). // upstream points to second master commit
+			HardReset("HEAD^").                           // rewind to first master commit
+			Checkout("branch1")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Press(keys.Branches.SortOrder)
+
+		t.ExpectPopup().Menu().Title(Equals("Sort order")).
+			Select(Contains("-committerdate")).
+			Confirm()
+
+		t.Views().Branches().
+			Lines(
+				Contains("* branch1").IsSelected(),
+				Contains("branch2"),
+				Contains("master ↓1"),
+			).
+			NavigateToLine(Contains("master")).
+			Press(keys.Branches.FetchRemote).
+			Lines(
+				/* EXPECTED:
+				Contains("* branch1"),
+				Contains("master").IsSelected(),
+				Contains("branch2"),
+				ACTUAL: */
+				Contains("* branch1"),
+				Contains("master"),
+				Contains("branch2").IsSelected(),
+			)
+	},
+})

--- a/pkg/integration/tests/sync/fetch_when_sorted_by_date.go
+++ b/pkg/integration/tests/sync/fetch_when_sorted_by_date.go
@@ -41,14 +41,9 @@ var FetchWhenSortedByDate = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("master")).
 			Press(keys.Branches.FetchRemote).
 			Lines(
-				/* EXPECTED:
 				Contains("* branch1"),
 				Contains("master").IsSelected(),
 				Contains("branch2"),
-				ACTUAL: */
-				Contains("* branch1"),
-				Contains("master"),
-				Contains("branch2").IsSelected(),
 			)
 	},
 })

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -230,6 +230,7 @@ var tests = []*components.IntegrationTest{
 	submodule.Remove,
 	submodule.Reset,
 	sync.FetchPrune,
+	sync.FetchWhenSortedByDate,
 	sync.ForcePush,
 	sync.ForcePushMultipleMatching,
 	sync.ForcePushMultipleUpstream,


### PR DESCRIPTION
- **PR Description**

Now that branches can be sorted by date, there's a new situation that we didn't have before: when fetching a branch, its committer date can change, so it will move up in the list; we need to update the selection index to follow. This is important for the case that master is behind its upstream and you want to rebase your checked-out branch onto master: in that case you would select master, press "f" to fetch, and then press "r" to rebase onto it. It's very bad if master doesn't stay selected after fetching.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
