### PR TITLE
Migrate git.log.showGraph and git.log.order to app state

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -101,9 +101,13 @@ git:
     # one of date-order, author-date-order, topo-order or default.
     # topo-order makes it easier to read the git log graph, but commits may not
     # appear chronologically. See https://git-scm.com/docs/git-log#_commit_ordering
+    #
+    # Deprecated: Configure this with `Log menu -> Commit sort order` (<c-l> in the commits window by default).
     order: 'topo-order'
     # one of always, never, when-maximised
     # this determines whether the git graph is rendered in the commits panel
+    #
+    # Deprecated: Configure this with `Log menu -> Show git graph` (<c-l> in the commits window by default).
     showGraph: 'always'
     # displays the whole git graph by default in the commits panel (equivalent to passing the `--all` argument to `git log`)
     showWholeGraph: false

--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -650,7 +650,7 @@ func (self *CommitLoader) getFirstPushedCommit(refName string) (string, error) {
 
 // getLog gets the git log.
 func (self *CommitLoader) getLogCmd(opts GetCommitsOptions) oscommands.ICmdObj {
-	config := self.UserConfig.Git.Log
+	gitLogOrder := self.AppState.GitLogOrder
 
 	refSpec := opts.RefName
 	if opts.RefToShowDivergenceFrom != "" {
@@ -659,7 +659,7 @@ func (self *CommitLoader) getLogCmd(opts GetCommitsOptions) oscommands.ICmdObj {
 
 	cmdArgs := NewGitCmd("log").
 		Arg(refSpec).
-		ArgIf(config.Order != "default", "--"+config.Order).
+		ArgIf(gitLogOrder != "default", "--"+gitLogOrder).
 		ArgIf(opts.All, "--all").
 		Arg("--oneline").
 		Arg(prettyFormat).

--- a/pkg/commands/git_commands/commit_loader_test.go
+++ b/pkg/commands/git_commands/commit_loader_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 	"github.com/jesseduffield/lazygit/pkg/commands/types/enums"
+	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -305,7 +306,8 @@ func TestGetCommits(t *testing.T) {
 		scenario := scenario
 		t.Run(scenario.testName, func(t *testing.T) {
 			common := utils.NewDummyCommon()
-			common.UserConfig.Git.Log.Order = scenario.logOrder
+			common.AppState = &config.AppState{}
+			common.AppState.GitLogOrder = scenario.logOrder
 
 			builder := &CommitLoader{
 				Common:        common,

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -80,6 +80,17 @@ func NewAppConfig(
 		return nil, err
 	}
 
+	// Temporary: the defaults for these are set to empty strings in
+	// getDefaultAppState so that we can migrate them from userConfig (which is
+	// now deprecated). Once we remove the user configs, we can remove this code
+	// and set the proper defaults in getDefaultAppState.
+	if appState.GitLogOrder == "" {
+		appState.GitLogOrder = userConfig.Git.Log.Order
+	}
+	if appState.GitLogShowGraph == "" {
+		appState.GitLogShowGraph = userConfig.Git.Log.ShowGraph
+	}
+
 	appConfig := &AppConfig{
 		Name:            name,
 		Version:         version,
@@ -325,6 +336,15 @@ type AppState struct {
 	DiffContextSize            int
 	LocalBranchSortOrder       string
 	RemoteBranchSortOrder      string
+
+	// One of: 'date-order' | 'author-date-order' | 'topo-order' | 'default'
+	// 'topo-order' makes it easier to read the git log graph, but commits may not
+	// appear chronologically. See https://git-scm.com/docs/
+	GitLogOrder string
+
+	// This determines whether the git graph is rendered in the commits panel
+	// One of 'always' | 'never' | 'when-maximised'
+	GitLogShowGraph string
 }
 
 func getDefaultAppState() *AppState {
@@ -335,6 +355,8 @@ func getDefaultAppState() *AppState {
 		DiffContextSize:       3,
 		LocalBranchSortOrder:  "recency",
 		RemoteBranchSortOrder: "alphabetical",
+		GitLogOrder:           "", // should be "topo-order" eventually
+		GitLogShowGraph:       "", // should be "always" eventually
 	}
 }
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -247,13 +247,17 @@ type MergingConfig struct {
 }
 
 type LogConfig struct {
-	// One of: 'date-order' | 'author-date-order' | 'topo-order | default'
+	// One of: 'date-order' | 'author-date-order' | 'topo-order' | 'default'
 	// 'topo-order' makes it easier to read the git log graph, but commits may not
 	// appear chronologically. See https://git-scm.com/docs/
-	Order string `yaml:"order" jsonschema:"enum=date-order,enum=author-date-order,enum=topo-order,enum=default"`
+	//
+	// Deprecated: Configure this with `Log menu -> Commit sort order` (<c-l> in the commits window by default).
+	Order string `yaml:"order" jsonschema:"deprecated,enum=date-order,enum=author-date-order,enum=topo-order,enum=default,deprecated"`
 	// This determines whether the git graph is rendered in the commits panel
 	// One of 'always' | 'never' | 'when-maximised'
-	ShowGraph string `yaml:"showGraph" jsonschema:"enum=always,enum=never,enum=when-maximised"`
+	//
+	// Deprecated: Configure this with `Log menu -> Show git graph` (<c-l> in the commits window by default).
+	ShowGraph string `yaml:"showGraph" jsonschema:"deprecated,enum=always,enum=never,enum=when-maximised"`
 	// displays the whole git graph by default in the commits view (equivalent to passing the `--all` argument to `git log`)
 	ShowWholeGraph bool `yaml:"showWholeGraph"`
 }

--- a/pkg/gui/context/local_commits_context.go
+++ b/pkg/gui/context/local_commits_context.go
@@ -156,7 +156,8 @@ func shouldShowGraph(c *ContextCommon) bool {
 		return false
 	}
 
-	value := c.UserConfig.Git.Log.ShowGraph
+	value := c.GetAppState().GitLogShowGraph
+
 	switch value {
 	case "always":
 		return true

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -928,7 +928,8 @@ func (self *LocalCommitsController) handleOpenLogMenu() error {
 				OnPress: func() error {
 					onPress := func(value string) func() error {
 						return func() error {
-							self.c.UserConfig.Git.Log.ShowGraph = value
+							self.c.GetAppState().GitLogShowGraph = value
+							self.c.SaveAppStateAndLogError()
 							return nil
 						}
 					}
@@ -957,7 +958,8 @@ func (self *LocalCommitsController) handleOpenLogMenu() error {
 				OnPress: func() error {
 					onPress := func(value string) func() error {
 						return func() error {
-							self.c.UserConfig.Git.Log.Order = value
+							self.c.GetAppState().GitLogOrder = value
+							self.c.SaveAppStateAndLogError()
 							return self.c.WithWaitingStatus(self.c.Tr.LoadingCommits, func(gocui.Task) error {
 								return self.c.Refresh(
 									types.RefreshOptions{

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -930,7 +930,10 @@ func (self *LocalCommitsController) handleOpenLogMenu() error {
 						return func() error {
 							self.c.GetAppState().GitLogShowGraph = value
 							self.c.SaveAppStateAndLogError()
-							return nil
+							if err := self.c.PostRefreshUpdate(self.c.Contexts().LocalCommits); err != nil {
+								return err
+							}
+							return self.c.PostRefreshUpdate(self.c.Contexts().SubCommits)
 						}
 					}
 					return self.c.Menu(types.CreateMenuOptions{

--- a/pkg/integration/tests/bisect/basic.go
+++ b/pkg/integration/tests/bisect/basic.go
@@ -15,7 +15,7 @@ var Basic = NewIntegrationTest(NewIntegrationTestArgs{
 			CreateNCommits(10)
 	},
 	SetupConfig: func(cfg *config.AppConfig) {
-		cfg.UserConfig.Git.Log.ShowGraph = "never"
+		cfg.AppState.GitLogShowGraph = "never"
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		markCommitAsBad := func() {

--- a/pkg/integration/tests/bisect/choose_terms.go
+++ b/pkg/integration/tests/bisect/choose_terms.go
@@ -15,7 +15,7 @@ var ChooseTerms = NewIntegrationTest(NewIntegrationTestArgs{
 			CreateNCommits(10)
 	},
 	SetupConfig: func(cfg *config.AppConfig) {
-		cfg.UserConfig.Git.Log.ShowGraph = "never"
+		cfg.AppState.GitLogShowGraph = "never"
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		markCommitAsFixed := func() {

--- a/pkg/integration/tests/bisect/skip.go
+++ b/pkg/integration/tests/bisect/skip.go
@@ -14,7 +14,7 @@ var Skip = NewIntegrationTest(NewIntegrationTestArgs{
 			CreateNCommits(10)
 	},
 	SetupConfig: func(cfg *config.AppConfig) {
-		cfg.UserConfig.Git.Log.ShowGraph = "never"
+		cfg.AppState.GitLogShowGraph = "never"
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().

--- a/pkg/integration/tests/cherry_pick/cherry_pick_during_rebase.go
+++ b/pkg/integration/tests/cherry_pick/cherry_pick_during_rebase.go
@@ -10,7 +10,7 @@ var CherryPickDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
-		config.UserConfig.Git.Log.ShowGraph = "never"
+		config.AppState.GitLogShowGraph = "never"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/commit/highlight.go
+++ b/pkg/integration/tests/commit/highlight.go
@@ -10,7 +10,7 @@ var Highlight = NewIntegrationTest(NewIntegrationTestArgs{
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
-		config.GetUserConfig().Git.Log.ShowGraph = "always"
+		config.AppState.GitLogShowGraph = "always"
 		config.GetUserConfig().Gui.AuthorColors = map[string]string{
 			"CI": "red",
 		}

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
@@ -12,7 +12,7 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {
 		config.GetUserConfig().Git.MainBranches = []string{"master"}
-		config.UserConfig.Git.Log.ShowGraph = "never"
+		config.AppState.GitLogShowGraph = "never"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/interactive_rebase/quick_start_keep_selection.go
+++ b/pkg/integration/tests/interactive_rebase/quick_start_keep_selection.go
@@ -12,7 +12,7 @@ var QuickStartKeepSelection = NewIntegrationTest(NewIntegrationTestArgs{
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {
 		config.GetUserConfig().Git.MainBranches = []string{"master"}
-		config.UserConfig.Git.Log.ShowGraph = "never"
+		config.AppState.GitLogShowGraph = "never"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/interactive_rebase/quick_start_keep_selection_range.go
+++ b/pkg/integration/tests/interactive_rebase/quick_start_keep_selection_range.go
@@ -12,7 +12,7 @@ var QuickStartKeepSelectionRange = NewIntegrationTest(NewIntegrationTestArgs{
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {
 		config.GetUserConfig().Git.MainBranches = []string{"master"}
-		config.UserConfig.Git.Log.ShowGraph = "never"
+		config.AppState.GitLogShowGraph = "never"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/interactive_rebase/view_files_of_todo_entries.go
+++ b/pkg/integration/tests/interactive_rebase/view_files_of_todo_entries.go
@@ -11,7 +11,7 @@ var ViewFilesOfTodoEntries = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {
-		config.UserConfig.Git.Log.ShowGraph = "never"
+		config.AppState.GitLogShowGraph = "never"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/reflog/do_not_show_branch_markers_in_reflog_subcommits.go
+++ b/pkg/integration/tests/reflog/do_not_show_branch_markers_in_reflog_subcommits.go
@@ -10,7 +10,7 @@ var DoNotShowBranchMarkersInReflogSubcommits = NewIntegrationTest(NewIntegration
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
-		config.UserConfig.Git.Log.ShowGraph = "never"
+		config.AppState.GitLogShowGraph = "never"
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.NewBranch("branch1")

--- a/schema/config.json
+++ b/schema/config.json
@@ -519,7 +519,7 @@
                 "topo-order",
                 "default"
               ],
-              "description": "One of: 'date-order' | 'author-date-order' | 'topo-order | default'\n'topo-order' makes it easier to read the git log graph, but commits may not\nappear chronologically. See https://git-scm.com/docs/",
+              "description": "One of: 'date-order' | 'author-date-order' | 'topo-order' | 'default'\n'topo-order' makes it easier to read the git log graph, but commits may not\nappear chronologically. See https://git-scm.com/docs/\n\nDeprecated: Configure this with `Log menu -\u003e Commit sort order` (\u003cc-l\u003e in the commits window by default).",
               "default": "topo-order"
             },
             "showGraph": {
@@ -529,7 +529,7 @@
                 "never",
                 "when-maximised"
               ],
-              "description": "This determines whether the git graph is rendered in the commits panel\nOne of 'always' | 'never' | 'when-maximised'",
+              "description": "This determines whether the git graph is rendered in the commits panel\nOne of 'always' | 'never' | 'when-maximised'\n\nDeprecated: Configure this with `Log menu -\u003e Show git graph` (\u003cc-l\u003e in the commits window by default).",
               "default": "always"
             },
             "showWholeGraph": {


### PR DESCRIPTION
- **PR Description**

Fixes https://github.com/jesseduffield/lazygit/issues/3166. Loading the config.yml and state.yml were combined into one function with migrations taking the parsed AppState. Yaml nodes are then removed from the config.yml and their valued preserved in state.yml before being removed from the config. The rest of the changes are trivial. I've added tests to `yaml_util_test.go` for the new `RemoveYamlNode` function.

I am a bit unsure about this part in the `app_config.go`, as it runs even if no migrations were made:
```golang
	// app state could have been affected by migrations and needs to be saved
	if err := appConfig.SaveAppState(); err != nil {
		return nil, err
	}
```

Perhaps the `migrateUserConfig` should take in the yaml bytes for app state and only save it when necessary. Any feedback/criticism is welcome.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
