### PR TITLE
Allow multiple fetch commands (or fetch and pull) to run concurrently

### DIFF
--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -221,9 +221,9 @@ func (self *RebaseCommands) PrepareInteractiveRebaseCommand(opts PrepareInteract
 		Arg("--interactive").
 		Arg("--autostash").
 		Arg("--keep-empty").
-		ArgIf(opts.keepCommitsThatBecomeEmpty && !self.version.IsOlderThan(2, 26, 0), "--empty=keep").
+		ArgIf(opts.keepCommitsThatBecomeEmpty && self.version.IsAtLeast(2, 26, 0), "--empty=keep").
 		Arg("--no-autosquash").
-		ArgIf(!self.version.IsOlderThan(2, 22, 0), "--rebase-merges").
+		ArgIf(self.version.IsAtLeast(2, 22, 0), "--rebase-merges").
 		ArgIf(opts.onto != "", "--onto", opts.onto).
 		Arg(opts.baseShaOrRoot).
 		ToArgv()

--- a/pkg/commands/git_commands/sync.go
+++ b/pkg/commands/git_commands/sync.go
@@ -49,10 +49,13 @@ func (self *SyncCommands) Push(task gocui.Task, opts PushOpts) error {
 	return cmdObj.Run()
 }
 
+func (self *SyncCommands) fetchCommandBuilder(fetchAll bool) *GitCommandBuilder {
+	return NewGitCmd("fetch").
+		ArgIf(fetchAll, "--all")
+}
+
 func (self *SyncCommands) FetchCmdObj(task gocui.Task) oscommands.ICmdObj {
-	cmdArgs := NewGitCmd("fetch").
-		ArgIf(self.UserConfig.Git.FetchAll, "--all").
-		ToArgv()
+	cmdArgs := self.fetchCommandBuilder(self.UserConfig.Git.FetchAll).ToArgv()
 
 	cmdObj := self.cmd.New(cmdArgs)
 	cmdObj.PromptOnCredentialRequest(task)
@@ -64,9 +67,7 @@ func (self *SyncCommands) Fetch(task gocui.Task) error {
 }
 
 func (self *SyncCommands) FetchBackgroundCmdObj() oscommands.ICmdObj {
-	cmdArgs := NewGitCmd("fetch").
-		ArgIf(self.UserConfig.Git.FetchAll, "--all").
-		ToArgv()
+	cmdArgs := self.fetchCommandBuilder(self.UserConfig.Git.FetchAll).ToArgv()
 
 	cmdObj := self.cmd.New(cmdArgs)
 	cmdObj.DontLog().FailOnCredentialRequest()
@@ -104,7 +105,7 @@ func (self *SyncCommands) FastForward(
 	remoteName string,
 	remoteBranchName string,
 ) error {
-	cmdArgs := NewGitCmd("fetch").
+	cmdArgs := self.fetchCommandBuilder(false).
 		Arg(remoteName).
 		Arg(remoteBranchName + ":" + branchName).
 		ToArgv()
@@ -113,7 +114,7 @@ func (self *SyncCommands) FastForward(
 }
 
 func (self *SyncCommands) FetchRemote(task gocui.Task, remoteName string) error {
-	cmdArgs := NewGitCmd("fetch").
+	cmdArgs := self.fetchCommandBuilder(false).
 		Arg(remoteName).
 		ToArgv()
 

--- a/pkg/commands/git_commands/sync.go
+++ b/pkg/commands/git_commands/sync.go
@@ -51,7 +51,10 @@ func (self *SyncCommands) Push(task gocui.Task, opts PushOpts) error {
 
 func (self *SyncCommands) fetchCommandBuilder(fetchAll bool) *GitCommandBuilder {
 	return NewGitCmd("fetch").
-		ArgIf(fetchAll, "--all")
+		ArgIf(fetchAll, "--all").
+		// avoid writing to .git/FETCH_HEAD; this allows running a pull
+		// concurrently without getting errors
+		ArgIf(self.version.IsAtLeast(2, 29, 0), "--no-write-fetch-head")
 }
 
 func (self *SyncCommands) FetchCmdObj(task gocui.Task) oscommands.ICmdObj {

--- a/pkg/commands/git_commands/version.go
+++ b/pkg/commands/git_commands/version.go
@@ -69,3 +69,11 @@ func (v *GitVersion) IsOlderThan(major, minor, patch int) bool {
 func (v *GitVersion) IsOlderThanVersion(version *GitVersion) bool {
 	return v.IsOlderThan(version.Major, version.Minor, version.Patch)
 }
+
+func (v *GitVersion) IsAtLeast(major, minor, patch int) bool {
+	return !v.IsOlderThan(major, minor, patch)
+}
+
+func (v *GitVersion) IsAtLeastVersion(version *GitVersion) bool {
+	return v.IsAtLeast(version.Major, version.Minor, version.Patch)
+}

--- a/pkg/commands/git_commands/version_test.go
+++ b/pkg/commands/git_commands/version_test.go
@@ -45,3 +45,12 @@ func TestGitVersionIsOlderThan(t *testing.T) {
 	assert.True(t, (&GitVersion{2, 0, 1, ""}).IsOlderThan(2, 1, 0))
 	assert.True(t, (&GitVersion{2, 0, 1, ""}).IsOlderThan(3, 0, 0))
 }
+
+func TestGitVersionIsAtLeast(t *testing.T) {
+	assert.True(t, (&GitVersion{2, 0, 0, ""}).IsAtLeast(1, 99, 99))
+	assert.True(t, (&GitVersion{2, 0, 0, ""}).IsAtLeast(2, 0, 0))
+	assert.True(t, (&GitVersion{2, 1, 0, ""}).IsAtLeast(2, 0, 9))
+
+	assert.False(t, (&GitVersion{2, 0, 1, ""}).IsAtLeast(2, 1, 0))
+	assert.False(t, (&GitVersion{2, 0, 1, ""}).IsAtLeast(3, 0, 0))
+}

--- a/pkg/integration/components/test.go
+++ b/pkg/integration/components/test.go
@@ -100,7 +100,7 @@ func (self GitVersionRestriction) shouldRunOnVersion(version *git_commands.GitVe
 		if err != nil {
 			panic("Invalid git version string: " + self.from)
 		}
-		return !version.IsOlderThanVersion(from)
+		return version.IsAtLeastVersion(from)
 	}
 	if self.before != "" {
 		before, err := git_commands.ParseGitVersion(self.before)


### PR DESCRIPTION
Git [has a bug](https://public-inbox.org/git/xmqqy1daffk8.fsf@gitster.g/) whereby running multiple fetch commands at the same time causes all of them to append their information to the `.git/FETCH_HEAD` file, causing the next git pull that wants to use the information to become confused, and show an error like "Cannot rebase onto multiple branches". This error would occur when pressing "f" and "p" in quick succession in the files panel, but also when pressing "p" while a background fetch happens to be running. One likely situation for this is pressing "p" right after startup.

Since lazygit never uses the information written to `.git/FETCH_HEAD`, it's best to avoid writing to it, which fixes the scenarios described above.

However, it doesn't fix the problem of repeatedly pressing "f" quickly on the checked-out branch; since we call "git pull" in that case, the above fix doesn't help there. We'll address this separately in another PR.