### PR TITLE
Set working directory in lazygit test command

### DIFF
--- a/pkg/integration/README.md
+++ b/pkg/integration/README.md
@@ -24,6 +24,8 @@ Each test has two important steps: the setup step and the run step.
 
 In the setup step, we prepare a repo with shell commands, for example, creating a merge conflict that will need to be resolved upon opening lazygit. This is all done via the `shell` argument.
 
+When the test runs, lazygit will open in the same working directory that the shell ends up in (so if you want to start lazygit somewhere other than the default location, you can use `shell.Chdir()` at the end of the setup step to set that working directory.
+
 ### Run step
 
 The run step has two arguments passed in:

--- a/pkg/integration/clients/cli.go
+++ b/pkg/integration/clients/cli.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/jesseduffield/lazycore/pkg/utils"
 	"github.com/jesseduffield/lazygit/pkg/integration/components"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests"
 	"github.com/samber/lo"
@@ -53,7 +54,7 @@ func runAndPrintFatalError(test *components.IntegrationTest, f func() error) {
 }
 
 func getTestsToRun(testNames []string) []*components.IntegrationTest {
-	allIntegrationTests := tests.GetTests()
+	allIntegrationTests := tests.GetTests(utils.GetLazyRootDirectory())
 	var testsToRun []*components.IntegrationTest
 
 	if len(testNames) == 0 {

--- a/pkg/integration/clients/go_test.go
+++ b/pkg/integration/clients/go_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/creack/pty"
+	"github.com/jesseduffield/lazycore/pkg/utils"
 	"github.com/jesseduffield/lazygit/pkg/integration/components"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests"
 	"github.com/stretchr/testify/assert"
@@ -35,7 +36,7 @@ func TestIntegration(t *testing.T) {
 	testNumber := 0
 
 	err := components.RunTests(components.RunTestArgs{
-		Tests:  tests.GetTests(),
+		Tests:  tests.GetTests(utils.GetLazyRootDirectory()),
 		Logf:   t.Logf,
 		RunCmd: runCmdHeadless,
 		TestWrapper: func(test *components.IntegrationTest, f func() error) {

--- a/pkg/integration/clients/injector/main.go
+++ b/pkg/integration/clients/injector/main.go
@@ -58,7 +58,8 @@ func getIntegrationTest() integrationTypes.IntegrationTest {
 		))
 	}
 
-	allTests := tests.GetTests()
+	lazygitRootDir := os.Getenv(components.LAZYGIT_ROOT_DIR)
+	allTests := tests.GetTests(lazygitRootDir)
 	for _, candidateTest := range allTests {
 		if candidateTest.Name() == integrationTestName {
 			return candidateTest

--- a/pkg/integration/clients/tui.go
+++ b/pkg/integration/clients/tui.go
@@ -233,7 +233,7 @@ type app struct {
 }
 
 func newApp(testDir string) *app {
-	return &app{testDir: testDir, allTests: tests.GetTests()}
+	return &app{testDir: testDir, allTests: tests.GetTests(utils.GetLazyRootDirectory())}
 }
 
 func (self *app) getCurrentTest() *components.IntegrationTest {

--- a/pkg/integration/components/test.go
+++ b/pkg/integration/components/test.go
@@ -35,11 +35,10 @@ type IntegrationTest struct {
 		testDriver *TestDriver,
 		keys config.KeybindingConfig,
 	)
-	gitVersion    GitVersionRestriction
-	width         int
-	height        int
-	isDemo        bool
-	useCustomPath bool
+	gitVersion GitVersionRestriction
+	width      int
+	height     int
+	isDemo     bool
 }
 
 var _ integrationTypes.IntegrationTest = &IntegrationTest{}
@@ -55,9 +54,9 @@ type NewIntegrationTestArgs struct {
 	Run func(t *TestDriver, keys config.KeybindingConfig)
 	// additional args passed to lazygit
 	ExtraCmdArgs []string
-	// for when a test is flakey
 	ExtraEnvVars map[string]string
-	Skip         bool
+	// for when a test is flakey
+	Skip bool
 	// to run a test only on certain git versions
 	GitVersion GitVersionRestriction
 	// width and height when running in headless mode, for testing
@@ -67,10 +66,6 @@ type NewIntegrationTestArgs struct {
 	Height int
 	// If true, this is not a test but a demo to be added to our docs
 	IsDemo bool
-	// If true, the test won't invoke lazygit with the --path arg.
-	// Useful for when we're passing --git-dir and --work-tree (because --path is
-	// incompatible with those args)
-	UseCustomPath bool
 }
 
 type GitVersionRestriction struct {
@@ -130,19 +125,18 @@ func NewIntegrationTest(args NewIntegrationTestArgs) *IntegrationTest {
 	}
 
 	return &IntegrationTest{
-		name:          name,
-		description:   args.Description,
-		extraCmdArgs:  args.ExtraCmdArgs,
-		extraEnvVars:  args.ExtraEnvVars,
-		skip:          args.Skip,
-		setupRepo:     args.SetupRepo,
-		setupConfig:   args.SetupConfig,
-		run:           args.Run,
-		gitVersion:    args.GitVersion,
-		width:         args.Width,
-		height:        args.Height,
-		isDemo:        args.IsDemo,
-		useCustomPath: args.UseCustomPath,
+		name:         name,
+		description:  args.Description,
+		extraCmdArgs: args.ExtraCmdArgs,
+		extraEnvVars: args.ExtraEnvVars,
+		skip:         args.Skip,
+		setupRepo:    args.SetupRepo,
+		setupConfig:  args.SetupConfig,
+		run:          args.Run,
+		gitVersion:   args.GitVersion,
+		width:        args.Width,
+		height:       args.Height,
+		isDemo:       args.IsDemo,
 	}
 }
 

--- a/pkg/integration/tests/filter_by_path/cli_arg.go
+++ b/pkg/integration/tests/filter_by_path/cli_arg.go
@@ -7,7 +7,7 @@ import (
 
 var CliArg = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Filter commits by file path, using CLI arg",
-	ExtraCmdArgs: []string{"-f", "filterFile"},
+	ExtraCmdArgs: []string{"-f=filterFile"},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 	},

--- a/pkg/integration/tests/tests.go
+++ b/pkg/integration/tests/tests.go
@@ -9,12 +9,11 @@ import (
 	"strings"
 
 	"github.com/jesseduffield/generics/set"
-	"github.com/jesseduffield/lazycore/pkg/utils"
 	"github.com/jesseduffield/lazygit/pkg/integration/components"
 	"github.com/samber/lo"
 )
 
-func GetTests() []*components.IntegrationTest {
+func GetTests(lazygitRootDir string) []*components.IntegrationTest {
 	// first we ensure that each test in this directory has actually been added to the above list.
 	testCount := 0
 
@@ -27,7 +26,7 @@ func GetTests() []*components.IntegrationTest {
 
 	missingTestNames := []string{}
 
-	if err := filepath.Walk(filepath.Join(utils.GetLazyRootDirectory(), "pkg/integration/tests"), func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(filepath.Join(lazygitRootDir, "pkg/integration/tests"), func(path string, info os.FileInfo, err error) error {
 		if !info.IsDir() && strings.HasSuffix(path, ".go") {
 			// ignoring non-test files
 			if filepath.Base(path) == "tests.go" || filepath.Base(path) == "test_list.go" || filepath.Base(path) == "test_list_generator.go" {

--- a/pkg/integration/tests/worktree/bare_repo.go
+++ b/pkg/integration/tests/worktree/bare_repo.go
@@ -38,6 +38,8 @@ var BareRepo = NewIntegrationTest(NewIntegrationTestArgs{
 
 		shell.RunCommand([]string{"git", "--git-dir", ".bare", "worktree", "add", "-b", "repo", "repo", "mybranch"})
 		shell.RunCommand([]string{"git", "--git-dir", ".bare", "worktree", "add", "-b", "worktree2", "worktree2", "mybranch"})
+
+		shell.Chdir("repo")
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Branches().

--- a/pkg/integration/tests/worktree/dotfile_bare_repo.go
+++ b/pkg/integration/tests/worktree/dotfile_bare_repo.go
@@ -12,9 +12,7 @@ var DotfileBareRepo = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Open lazygit in the worktree of a dotfile bare repo and add a file and commit",
 	ExtraCmdArgs: []string{"--git-dir={{.actualPath}}/.bare", "--work-tree={{.actualPath}}/repo"},
 	Skip:         false,
-	// passing this because we're explicitly passing --git-dir and --work-tree args
-	UseCustomPath: true,
-	SetupConfig:   func(config *config.AppConfig) {},
+	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
 		// we're going to have a directory structure like this:
 		// project


### PR DESCRIPTION
We need to fetch our list of tests both outside of our test binary and within. We need to get the list from within so that we can run the code that drives the test and runs assertions. To get the list of tests we need to know where the root of the lazygit repo is, given that the tests live in files under that root.

So far, we've used this GetLazyRootDirectory() function for that, but it assumes that we're not in a test directory (it just looks for the first .git dir it can find). Because we didn't want to properly fix this before, we've been setting the working directory of the test command to the lazygit root, and using the --path CLI arg to override it when the test itself ran. This was a terrible hack.

Now, we're passing the lazygit root directory as an env var to the integration test, so that we can set the working directory to the actual path of the test repo; removing the need to use the --path arg.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
