### PR TITLE
Add config setting to suppress showing file icons

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -79,6 +79,7 @@ gui:
   showCommandLog: true
   showIcons: false # deprecated: use nerdFontsVersion instead
   nerdFontsVersion: "" # nerd fonts version to use ("2" or "3"); empty means don't show nerd font icons
+  showFileIcons: true # for hiding file icons in the file views
   commandLogSize: 8
   splitDiff: 'auto' # one of 'auto' | 'always'
   skipRewordInEditorWarning: false # for skipping the confirmation before launching the reword editor

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -121,6 +121,8 @@ type GuiConfig struct {
 	// One of: '2' | '3' | empty string (default)
 	// If empty, do not show icons.
 	NerdFontsVersion string `yaml:"nerdFontsVersion" jsonschema:"enum=2,enum=3,enum="`
+	// If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.
+	ShowFileIcons bool `yaml:"showFileIcons"`
 	// If true, show commit hashes alongside branch names in the branches view.
 	ShowBranchCommitHash bool `yaml:"showBranchCommitHash"`
 	// Height of the command log view
@@ -635,6 +637,7 @@ func GetDefaultConfig() *UserConfig {
 			ShowRandomTip:             true,
 			ShowIcons:                 false,
 			NerdFontsVersion:          "",
+			ShowFileIcons:             true,
 			ShowBranchCommitHash:      false,
 			CommandLogSize:            8,
 			SplitDiff:                 "auto",

--- a/pkg/gui/context/commit_files_context.go
+++ b/pkg/gui/context/commit_files_context.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/filetree"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
+	"github.com/jesseduffield/lazygit/pkg/gui/presentation/icons"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/samber/lo"
@@ -33,7 +34,8 @@ func NewCommitFilesContext(c *ContextCommon) *CommitFilesContext {
 			return [][]string{{style.FgRed.Sprint("(none)")}}
 		}
 
-		lines := presentation.RenderCommitFileTree(viewModel, c.Git().Patch.PatchBuilder)
+		showFileIcons := icons.IsIconEnabled() && c.UserConfig.Gui.ShowFileIcons
+		lines := presentation.RenderCommitFileTree(viewModel, c.Git().Patch.PatchBuilder, showFileIcons)
 		return lo.Map(lines, func(line string, _ int) []string {
 			return []string{line}
 		})

--- a/pkg/gui/context/working_tree_context.go
+++ b/pkg/gui/context/working_tree_context.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/filetree"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
+	"github.com/jesseduffield/lazygit/pkg/gui/presentation/icons"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/samber/lo"
 )
@@ -24,7 +25,8 @@ func NewWorkingTreeContext(c *ContextCommon) *WorkingTreeContext {
 	)
 
 	getDisplayStrings := func(_ int, _ int) [][]string {
-		lines := presentation.RenderFileTree(viewModel, c.Model().Submodules)
+		showFileIcons := icons.IsIconEnabled() && c.UserConfig.Gui.ShowFileIcons
+		lines := presentation.RenderFileTree(viewModel, c.Model().Submodules, showFileIcons)
 		return lo.Map(lines, func(line string, _ int) []string {
 			return []string{line}
 		})

--- a/pkg/gui/presentation/files.go
+++ b/pkg/gui/presentation/files.go
@@ -21,24 +21,26 @@ const (
 func RenderFileTree(
 	tree filetree.IFileTree,
 	submoduleConfigs []*models.SubmoduleConfig,
+	showFileIcons bool,
 ) []string {
 	collapsedPaths := tree.CollapsedPaths()
 	return renderAux(tree.GetRoot().Raw(), collapsedPaths, -1, -1, func(node *filetree.Node[models.File], treeDepth int, visualDepth int, isCollapsed bool) string {
 		fileNode := filetree.NewFileNode(node)
 
-		return getFileLine(isCollapsed, fileNode.GetHasUnstagedChanges(), fileNode.GetHasStagedChanges(), treeDepth, visualDepth, submoduleConfigs, node)
+		return getFileLine(isCollapsed, fileNode.GetHasUnstagedChanges(), fileNode.GetHasStagedChanges(), treeDepth, visualDepth, showFileIcons, submoduleConfigs, node)
 	})
 }
 
 func RenderCommitFileTree(
 	tree *filetree.CommitFileTreeViewModel,
 	patchBuilder *patch.PatchBuilder,
+	showFileIcons bool,
 ) []string {
 	collapsedPaths := tree.CollapsedPaths()
 	return renderAux(tree.GetRoot().Raw(), collapsedPaths, -1, -1, func(node *filetree.Node[models.CommitFile], treeDepth int, visualDepth int, isCollapsed bool) string {
 		status := commitFilePatchStatus(node, tree, patchBuilder)
 
-		return getCommitFileLine(isCollapsed, treeDepth, visualDepth, node, status)
+		return getCommitFileLine(isCollapsed, treeDepth, visualDepth, node, status, showFileIcons)
 	})
 }
 
@@ -109,6 +111,7 @@ func getFileLine(
 	hasStagedChanges bool,
 	treeDepth int,
 	visualDepth int,
+	showFileIcons bool,
 	submoduleConfigs []*models.SubmoduleConfig,
 	node *filetree.Node[models.File],
 ) string {
@@ -150,7 +153,7 @@ func getFileLine(
 	isLinkedWorktree := file != nil && file.IsWorktree
 	isDirectory := file == nil
 
-	if icons.IsIconEnabled() {
+	if showFileIcons {
 		icon := icons.IconForFile(name, isSubmodule, isLinkedWorktree, isDirectory)
 		paint := color.C256(icon.Color, false)
 		output += paint.Sprint(icon.Icon) + nameColor.Sprint(" ")
@@ -189,6 +192,7 @@ func getCommitFileLine(
 	visualDepth int,
 	node *filetree.Node[models.CommitFile],
 	status patch.PatchStatus,
+	showFileIcons bool,
 ) string {
 	indentation := strings.Repeat("  ", visualDepth)
 	name := commitFileNameAtDepth(node, treeDepth)
@@ -236,7 +240,7 @@ func getCommitFileLine(
 	isSubmodule := false
 	isLinkedWorktree := false
 
-	if icons.IsIconEnabled() {
+	if showFileIcons {
 		icon := icons.IconForFile(name, isSubmodule, isLinkedWorktree, isDirectory)
 		paint := color.C256(icon.Color, false)
 		output += paint.Sprint(icon.Icon) + " "

--- a/pkg/gui/presentation/files_test.go
+++ b/pkg/gui/presentation/files_test.go
@@ -74,7 +74,7 @@ M  file1
 			for _, path := range s.collapsedPaths {
 				viewModel.ToggleCollapsed(path)
 			}
-			result := RenderFileTree(viewModel, nil)
+			result := RenderFileTree(viewModel, nil, false)
 			assert.EqualValues(t, s.expected, result)
 		})
 	}
@@ -141,7 +141,7 @@ M file1
 				},
 			)
 			patchBuilder.Start("from", "to", false, false)
-			result := RenderCommitFileTree(viewModel, patchBuilder)
+			result := RenderCommitFileTree(viewModel, patchBuilder, false)
 			assert.EqualValues(t, s.expected, result)
 		})
 	}

--- a/schema/config.json
+++ b/schema/config.json
@@ -304,6 +304,11 @@
           ],
           "description": "Nerd fonts version to use.\nOne of: '2' | '3' | empty string (default)\nIf empty, do not show icons."
         },
+        "showFileIcons": {
+          "type": "boolean",
+          "description": "If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.",
+          "default": true
+        },
         "showBranchCommitHash": {
           "type": "boolean",
           "description": "If true, show commit hashes alongside branch names in the branches view."


### PR DESCRIPTION
- **PR Description**

Add a config option `gui.showFileIcons` (default: true) which can be set to false to suppress showing file icons.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
