### PR TITLE
Fix crash with short branch names

### DIFF
--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -78,7 +78,8 @@ func getBranchDisplayStrings(
 		nameTextStyle = theme.DiffTerminalColor
 	}
 
-	if len(displayName) > availableWidth {
+	// Don't bother shortening branch names that are already 3 characters or less
+	if len(displayName) > utils.Max(availableWidth, 3) {
 		// Never shorten the branch name to less then 3 characters
 		len := utils.Max(availableWidth, 4)
 		displayName = displayName[:len-1] + "…"

--- a/pkg/gui/presentation/branches_test.go
+++ b/pkg/gui/presentation/branches_test.go
@@ -177,6 +177,33 @@ func Test_getBranchDisplayStrings(t *testing.T) {
 			expected:             []string{"1m", "branc… Pushing |"},
 		},
 		{
+			branch:               &models.Branch{Name: "abc", Recency: "1m"},
+			itemOperation:        types.ItemOperationPushing,
+			fullDescription:      false,
+			viewWidth:            -1,
+			useIcons:             false,
+			checkedOutByWorktree: false,
+			expected:             []string{"1m", "abc Pushing |"},
+		},
+		{
+			branch:               &models.Branch{Name: "ab", Recency: "1m"},
+			itemOperation:        types.ItemOperationPushing,
+			fullDescription:      false,
+			viewWidth:            -1,
+			useIcons:             false,
+			checkedOutByWorktree: false,
+			expected:             []string{"1m", "ab Pushing |"},
+		},
+		{
+			branch:               &models.Branch{Name: "a", Recency: "1m"},
+			itemOperation:        types.ItemOperationPushing,
+			fullDescription:      false,
+			viewWidth:            -1,
+			useIcons:             false,
+			checkedOutByWorktree: false,
+			expected:             []string{"1m", "a Pushing |"},
+		},
+		{
 			branch: &models.Branch{
 				Name:           "branch_name",
 				Recency:        "1m",


### PR DESCRIPTION
This fixes a potential crash when the available width in the branches panel is very small and the branch name is one to three characters long.
