### PR TITLE
Do not include keybindings from another view in keybindings menu

### DIFF
--- a/pkg/gui/controllers/options_menu_action.go
+++ b/pkg/gui/controllers/options_menu_action.go
@@ -69,10 +69,12 @@ func (self *OptionsMenuAction) getBindings(context types.Context) ([]*types.Bind
 		if keybindings.LabelFromKey(binding.Key) != "" && binding.Description != "" {
 			if binding.ViewName == "" {
 				bindingsGlobal = append(bindingsGlobal, binding)
-			} else if binding.Tag == "navigation" {
-				bindingsNavigation = append(bindingsNavigation, binding)
 			} else if binding.ViewName == context.GetViewName() {
-				bindingsPanel = append(bindingsPanel, binding)
+				if binding.Tag == "navigation" {
+					bindingsNavigation = append(bindingsNavigation, binding)
+				} else {
+					bindingsPanel = append(bindingsPanel, binding)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Previously we included all navigation keybindings from all views in the keybindings menu, meaning if you pressed enter on 'next page' in the commits view, you'd end up triggering the action in the sub-commits view.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
