### PR TITLE
Fix CI erroneously marking failed tests as successful

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -18,6 +18,7 @@ if [ -n "$LAZYGIT_GOCOVERDIR" ]; then
   # arg, but if we do that then the GOCOVERDIR env var (which you typically pass to the test binary) will be overwritten by the test runner. So we're passing LAZYGIT_COCOVERDIR instead
   # and then internally passing that to the test binary as GOCOVERDIR.
   go test -cover -coverpkg=github.com/jesseduffield/lazygit/pkg/... pkg/integration/clients/*.go -args -test.gocoverdir="/tmp/code_coverage"
+  EXITCODE=$?
 
   # We're merging the coverage data for the sake of having fewer artefacts to upload.
   # We can't merge inline so we're merging to a tmp dir then moving back to the original.
@@ -27,9 +28,8 @@ if [ -n "$LAZYGIT_GOCOVERDIR" ]; then
   mv /tmp/code_coverage_merged /tmp/code_coverage
 else
   go test pkg/integration/clients/*.go
+  EXITCODE=$?
 fi
-
-EXITCODE=$?
 
 if test -f ~/.gitconfig.lazygit.bak; then
   mv ~/.gitconfig.lazygit.bak ~/.gitconfig


### PR DESCRIPTION
CI is erroneously saying that our integration tests are passing.

As @stefanhaller says in a comment:
> It broke with this commit: https://github.com/jesseduffield/lazygit/commit/aaecd6cc40d8ffe07eb3c2cdbed5bf908787bc8b. Since that change, the run_integration_tests.sh script will exit with the exit status of the the last mv command, not the test run. Should be pretty easy to fix.

Thanks to Stefan for fixing this

(The reason I'm saying this all here in the PR description is that PR descriptions now get included in merge commits)