### PR TITLE
Allow configuration of windowSize when passing a git arg

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -33,6 +33,8 @@ to the top of your config file or via [Visual Studio Code settings.json config][
 gui:
   # stuff relating to the UI
   windowSize: 'normal' # one of 'normal' | 'half' | 'full' default is 'normal'
+  panelWindowSize:
+    log : 'full' # one of 'normal' | 'half' | 'full' default is 'full'
   scrollHeight: 2 # how many lines you scroll by
   scrollPastBottom: true # enable scrolling past the bottom
   scrollOffMargin: 2 # how many lines to keep before/after the cursor when it reaches the top/bottom of the view; see 'Scroll-off Margin' section below

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -131,7 +131,8 @@ type GuiConfig struct {
 	SplitDiff string `yaml:"splitDiff" jsonschema:"enum=auto,enum=always"`
 	// Default size for focused window. Window size can be changed from within Lazygit with '+' and '_' (but this won't change the default).
 	// One of: 'normal' (default) | 'half' | 'full'
-	WindowSize string `yaml:"windowSize" jsonschema:"enum=normal,enum=half,enum=full"`
+	WindowSize      string            `yaml:"windowSize" jsonschema:"enum=normal,enum=half,enum=full"`
+	PanelWindowSize map[string]string `yaml:"panelWindowSize"`
 	// Window border style.
 	// One of 'rounded' (default) | 'single' | 'double' | 'hidden'
 	Border string `yaml:"border" jsonschema:"enum=single,enum=double,enum=rounded,enum=hidden"`
@@ -140,6 +141,15 @@ type GuiConfig struct {
 	// Whether to stack UI components on top of each other.
 	// One of 'auto' (default) | 'always' | 'never'
 	PortraitMode string `yaml:"portraitMode"`
+}
+
+func (GuiConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
+	windowSize, _ := schema.Properties.Get("windowSize")
+	panelWindowSize, _ := schema.Properties.Get("panelWindowSize")
+	panelWindowSize.PatternProperties = map[string]*jsonschema.Schema{
+		"^(main|status|branch|log|stash)$": windowSize,
+	}
+	panelWindowSize.AdditionalProperties = jsonschema.FalseSchema
 }
 
 type ThemeConfig struct {

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -415,19 +415,25 @@ func initialWindowViewNameMap(contextTree *context.ContextTree) *utils.ThreadSaf
 }
 
 func initialScreenMode(startArgs appTypes.StartArgs, config config.AppConfigurer) types.WindowMaximisation {
-	if startArgs.FilterPath != "" || startArgs.GitArg != appTypes.GitArgNone {
-		return types.SCREEN_FULL
-	} else {
-		defaultWindowSize := config.GetUserConfig().Gui.WindowSize
-
-		switch defaultWindowSize {
-		case "half":
-			return types.SCREEN_HALF
-		case "full":
+	panelName := string(startArgs.GitArg)
+	if startArgs.GitArg == appTypes.GitArgNone {
+		panelName = "main"
+	}
+	defaultWindowSize, ok := config.GetUserConfig().Gui.PanelWindowSize[panelName]
+	if !ok {
+		if startArgs.GitArg != appTypes.GitArgNone {
 			return types.SCREEN_FULL
-		default:
-			return types.SCREEN_NORMAL
+		} else {
+			defaultWindowSize = config.GetUserConfig().Gui.WindowSize
 		}
+	}
+	switch defaultWindowSize {
+	case "half":
+		return types.SCREEN_HALF
+	case "full":
+		return types.SCREEN_FULL
+	default:
+		return types.SCREEN_NORMAL
 	}
 }
 

--- a/schema/config.json
+++ b/schema/config.json
@@ -344,6 +344,21 @@
           ],
           "description": "Default size for focused window. Window size can be changed from within Lazygit with '+' and '_' (but this won't change the default).\nOne of: 'normal' (default) | 'half' | 'full'"
         },
+        "panelWindowSize": {
+          "patternProperties": {
+            "^(main|status|branch|log|stash)$": {
+              "type": "string",
+              "enum": [
+                "normal",
+                "half",
+                "full"
+              ],
+              "description": "Default size for focused window. Window size can be changed from within Lazygit with '+' and '_' (but this won't change the default).\nOne of: 'normal' (default) | 'half' | 'full'"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        },
         "border": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
- **PR Description**

Previously, lazygit status, log, or branch always opened in a full
window size regardless of the gui.windowSize value. Now,
gui.panelWindowSize configures the window size per arg (and no arg can
be configured as "main") regardless of requested filter path.

Closes #3042

Happy for feedback:

+ Tests not added
  + I tried in `pkg/integration/tests/branch/set_upstream.go` but `SetupConfig` didn't have an effect. Should this work or is `SetupConfig` too late for this?
+ `panelWindowSize.PatternProperties` is hardcoded
  + Same as `windowSize`
  + I tried to move `permittedValues `from `entry_point.go` to `types.go` to use from `user_config.go` but there were circular imports on `integrationTypes`.


- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [X] Docs (specifically `docs/Config.md`) have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
