### PR TITLE
Make range selections created with the mouse non-sticky

### DIFF
--- a/pkg/gui/controllers/patch_explorer_controller.go
+++ b/pkg/gui/controllers/patch_explorer_controller.go
@@ -274,7 +274,7 @@ func (self *PatchExplorerController) HandleMouseDown() error {
 }
 
 func (self *PatchExplorerController) HandleMouseDrag() error {
-	self.context.GetState().SelectLine(self.context.GetViewTrait().SelectedLineIdx())
+	self.context.GetState().DragSelectLine(self.context.GetViewTrait().SelectedLineIdx())
 
 	return nil
 }

--- a/pkg/gui/patch_exploring/state.go
+++ b/pkg/gui/patch_exploring/state.go
@@ -49,12 +49,10 @@ func NewState(diff string, selectedLineIdx int, oldState *State, log *logrus.Ent
 	}
 
 	selectMode := LINE
-	rangeIsSticky := false
 	// if we have clicked from the outside to focus the main view we'll pass in a non-negative line index so that we can instantly select that line
 	if selectedLineIdx >= 0 {
 		selectMode = RANGE
 		rangeStartLineIdx = selectedLineIdx
-		rangeIsSticky = true
 	} else if oldState != nil {
 		// if we previously had a selectMode of RANGE, we want that to now be line again
 		if oldState.selectMode == HUNK {
@@ -70,7 +68,7 @@ func NewState(diff string, selectedLineIdx int, oldState *State, log *logrus.Ent
 		selectedLineIdx:   selectedLineIdx,
 		selectMode:        selectMode,
 		rangeStartLineIdx: rangeStartLineIdx,
-		rangeIsSticky:     rangeIsSticky,
+		rangeIsSticky:     false,
 		diff:              diff,
 	}
 }
@@ -150,7 +148,12 @@ func (s *State) SelectNewLineForRange(newSelectedLineIdx int) {
 	s.rangeStartLineIdx = newSelectedLineIdx
 
 	s.selectMode = RANGE
-	s.rangeIsSticky = true
+
+	s.selectLineWithoutRangeCheck(newSelectedLineIdx)
+}
+
+func (s *State) DragSelectLine(newSelectedLineIdx int) {
+	s.selectMode = RANGE
 
 	s.selectLineWithoutRangeCheck(newSelectedLineIdx)
 }


### PR DESCRIPTION
- **PR Description**

I prefer this because I almost never use sticky range selections, but I'm not sure everybody agrees. Also, this fixes the issue that just clicking a line in a diff (without dragging) already creates a range selection. It still does, technically, but it's no longer a problem because a non-sticky one-line range selection behaves the same as a non-range selection.

See #3233.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
