### PR TITLE
Run integration tests on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ test/_results/**
 
 oryxBuildBinary
 __debug_bin
+__debug_bin.exe
 
 .worktrees
 demo/output/*

--- a/pkg/integration/components/runner.go
+++ b/pkg/integration/components/runner.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	lazycoreUtils "github.com/jesseduffield/lazycore/pkg/utils"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
@@ -254,11 +255,16 @@ func getLazygitCommand(
 }
 
 func tempLazygitPath() string {
-	return filepath.Join("/tmp", "lazygit", "test_lazygit")
+	filename := "test_lazygit"
+	if runtime.GOOS == "windows" {
+		filename = "test_lazygit.exe"
+	}
+
+	return filepath.Join(os.TempDir(), "lazygit", filename)
 }
 
 func raceDetectorLogsPath() string {
-	return filepath.Join("/tmp", "lazygit", "race_log")
+	return filepath.Join(os.TempDir(), "lazygit", "race_log")
 }
 
 func findOrCreateDir(path string) {

--- a/pkg/integration/components/test.go
+++ b/pkg/integration/components/test.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -223,7 +224,7 @@ func testNameFromCurrentFilePath() string {
 }
 
 func TestNameFromFilePath(path string) string {
-	name := strings.Split(path, "integration/tests/")[1]
+	name := strings.Split(filepath.ToSlash(path), "integration/tests/")[1]
 
 	return name[:len(name)-len(".go")]
 }

--- a/pkg/integration/tests/branch/delete_remote_branch_with_credential_prompt.go
+++ b/pkg/integration/tests/branch/delete_remote_branch_with_credential_prompt.go
@@ -1,6 +1,8 @@
 package branch
 
 import (
+	"runtime"
+
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
@@ -8,7 +10,7 @@ import (
 var DeleteRemoteBranchWithCredentialPrompt = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Delete a remote branch where credentials are required",
 	ExtraCmdArgs: []string{},
-	Skip:         false,
+	Skip:         runtime.GOOS == "windows",
 	SetupConfig: func(config *config.AppConfig) {
 	},
 	SetupRepo: func(shell *Shell) {

--- a/pkg/integration/tests/custom_commands/basic_cmd_at_runtime.go
+++ b/pkg/integration/tests/custom_commands/basic_cmd_at_runtime.go
@@ -1,6 +1,8 @@
 package custom_commands
 
 import (
+	"runtime"
+
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
@@ -14,6 +16,10 @@ var BasicCmdAtRuntime = NewIntegrationTest(NewIntegrationTestArgs{
 	},
 	SetupConfig: func(cfg *config.AppConfig) {},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		cmd := "touch file.txt"
+		if runtime.GOOS == "windows" {
+			cmd = "copy NUL file.txt"
+		}
 		t.Views().Files().
 			IsEmpty().
 			IsFocused().
@@ -21,7 +27,7 @@ var BasicCmdAtRuntime = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().Prompt().
 			Title(Equals("Custom command:")).
-			Type("touch file.txt").
+			Type(cmd).
 			Confirm()
 
 		t.GlobalPress(keys.Files.RefreshFiles)

--- a/pkg/integration/tests/custom_commands/basic_cmd_from_config.go
+++ b/pkg/integration/tests/custom_commands/basic_cmd_from_config.go
@@ -1,6 +1,8 @@
 package custom_commands
 
 import (
+	"runtime"
+
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
@@ -13,11 +15,15 @@ var BasicCmdFromConfig = NewIntegrationTest(NewIntegrationTestArgs{
 		shell.EmptyCommit("blah")
 	},
 	SetupConfig: func(cfg *config.AppConfig) {
+		cmd := "touch myfile"
+		if runtime.GOOS == "windows" {
+			cmd = "copy NUL myfile"
+		}
 		cfg.UserConfig.CustomCommands = []config.CustomCommand{
 			{
 				Key:     "a",
 				Context: "files",
-				Command: "touch myfile",
+				Command: cmd,
 			},
 		}
 	},

--- a/pkg/integration/tests/custom_commands/complex_cmd_at_runtime.go
+++ b/pkg/integration/tests/custom_commands/complex_cmd_at_runtime.go
@@ -1,6 +1,8 @@
 package custom_commands
 
 import (
+	"runtime"
+
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
@@ -8,7 +10,7 @@ import (
 var ComplexCmdAtRuntime = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Using a custom command provided at runtime to create a new file, via a shell command. We invoke custom commands through a shell already. This test proves that we can run a shell within a shell, which requires complex escaping.",
 	ExtraCmdArgs: []string{},
-	Skip:         false,
+	Skip:         runtime.GOOS == "windows",
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("blah")
 	},

--- a/pkg/integration/tests/custom_commands/form_prompts.go
+++ b/pkg/integration/tests/custom_commands/form_prompts.go
@@ -1,6 +1,8 @@
 package custom_commands
 
 import (
+	"runtime"
+
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
@@ -8,7 +10,7 @@ import (
 var FormPrompts = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Using a custom command reffering prompt responses by name",
 	ExtraCmdArgs: []string{},
-	Skip:         false,
+	Skip:         runtime.GOOS == "windows",
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("blah")
 	},

--- a/pkg/integration/tests/custom_commands/menu_from_command.go
+++ b/pkg/integration/tests/custom_commands/menu_from_command.go
@@ -1,6 +1,8 @@
 package custom_commands
 
 import (
+	"runtime"
+
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
@@ -10,7 +12,7 @@ import (
 var MenuFromCommand = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Using menuFromCommand prompt type",
 	ExtraCmdArgs: []string{},
-	Skip:         false,
+	Skip:         runtime.GOOS == "windows",
 	SetupRepo: func(shell *Shell) {
 		shell.
 			EmptyCommit("foo").

--- a/pkg/integration/tests/custom_commands/multiple_prompts.go
+++ b/pkg/integration/tests/custom_commands/multiple_prompts.go
@@ -1,6 +1,8 @@
 package custom_commands
 
 import (
+	"runtime"
+
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
@@ -8,7 +10,7 @@ import (
 var MultiplePrompts = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Using a custom command with multiple prompts",
 	ExtraCmdArgs: []string{},
-	Skip:         false,
+	Skip:         runtime.GOOS == "windows",
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("blah")
 	},

--- a/pkg/integration/tests/misc/copy_to_clipboard.go
+++ b/pkg/integration/tests/misc/copy_to_clipboard.go
@@ -1,6 +1,8 @@
 package misc
 
 import (
+	"runtime"
+
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
@@ -10,7 +12,7 @@ import (
 var CopyToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Copy a branch name to the clipboard using custom clipboard command template",
 	ExtraCmdArgs: []string{},
-	Skip:         false,
+	Skip:         runtime.GOOS == "windows",
 	SetupConfig: func(config *config.AppConfig) {
 		config.UserConfig.OS.CopyToClipboardCmd = "echo {{text}} > clipboard"
 	},

--- a/pkg/integration/tests/sync/push_with_credential_prompt.go
+++ b/pkg/integration/tests/sync/push_with_credential_prompt.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"runtime"
+
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
@@ -8,7 +10,7 @@ import (
 var PushWithCredentialPrompt = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Push a commit to a pre-configured upstream, where credentials are required",
 	ExtraCmdArgs: []string{},
-	Skip:         false,
+	Skip:         runtime.GOOS == "windows",
 	SetupConfig: func(config *config.AppConfig) {
 	},
 	SetupRepo: func(shell *Shell) {


### PR DESCRIPTION
Fix running integration tests on Windows

At least they now work when using 
  `go run cmd/integration_test/main.go cli` 
or 
  `go run cmd/integration_test/main.go tui`. 

I haven't been able to get them to run headless (i.e. using `go test pkg/integration/clients/*.go`), which prevents us from running them on CI.