### PR TITLE
Inline status for fetching remotes

### DIFF
--- a/pkg/commands/models/remote.go
+++ b/pkg/commands/models/remote.go
@@ -15,6 +15,10 @@ func (r *Remote) ID() string {
 	return r.RefName()
 }
 
+func (r *Remote) URN() string {
+	return "remote-" + r.ID()
+}
+
 func (r *Remote) Description() string {
 	return r.RefName()
 }

--- a/pkg/gui/context/remotes_context.go
+++ b/pkg/gui/context/remotes_context.go
@@ -25,7 +25,8 @@ func NewRemotesContext(c *ContextCommon) *RemotesContext {
 	)
 
 	getDisplayStrings := func(_ int, _ int) [][]string {
-		return presentation.GetRemoteListDisplayStrings(viewModel.GetItems(), c.Modes().Diffing.Ref)
+		return presentation.GetRemoteListDisplayStrings(
+			viewModel.GetItems(), c.Modes().Diffing.Ref, c.State().GetItemOperation, c.Tr)
 	}
 
 	return &RemotesContext{

--- a/pkg/gui/controllers/remotes_controller.go
+++ b/pkg/gui/controllers/remotes_controller.go
@@ -206,12 +206,15 @@ func (self *RemotesController) edit(remote *models.Remote) error {
 }
 
 func (self *RemotesController) fetch(remote *models.Remote) error {
-	return self.c.WithWaitingStatus(self.c.Tr.FetchingRemoteStatus, func(task gocui.Task) error {
+	return self.c.WithInlineStatus(remote, types.ItemOperationFetching, context.REMOTES_CONTEXT_KEY, func(task gocui.Task) error {
 		err := self.c.Git().Sync.FetchRemote(task, remote.Name)
 		if err != nil {
 			_ = self.c.Error(err)
 		}
 
-		return self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.BRANCHES, types.REMOTES}})
+		return self.c.Refresh(types.RefreshOptions{
+			Scope: []types.RefreshableView{types.BRANCHES, types.REMOTES},
+			Mode:  types.ASYNC,
+		})
 	})
 }

--- a/pkg/gui/presentation/item_operations.go
+++ b/pkg/gui/presentation/item_operations.go
@@ -17,6 +17,8 @@ func ItemOperationToString(itemOperation types.ItemOperation, tr *i18n.Translati
 		return tr.FastForwarding
 	case types.ItemOperationDeleting:
 		return tr.DeletingStatus
+	case types.ItemOperationFetching:
+		return tr.FetchingStatus
 	}
 
 	return ""

--- a/pkg/gui/presentation/remotes.go
+++ b/pkg/gui/presentation/remotes.go
@@ -1,22 +1,37 @@
 package presentation
 
 import (
+	"time"
+
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation/icons"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/i18n"
 	"github.com/jesseduffield/lazygit/pkg/theme"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
 )
 
-func GetRemoteListDisplayStrings(remotes []*models.Remote, diffName string) [][]string {
+func GetRemoteListDisplayStrings(
+	remotes []*models.Remote,
+	diffName string,
+	getItemOperation func(item types.HasUrn) types.ItemOperation,
+	tr *i18n.TranslationSet,
+) [][]string {
 	return lo.Map(remotes, func(remote *models.Remote, _ int) []string {
 		diffed := remote.Name == diffName
-		return getRemoteDisplayStrings(remote, diffed)
+		return getRemoteDisplayStrings(remote, diffed, getItemOperation(remote), tr)
 	})
 }
 
 // getRemoteDisplayStrings returns the display string of branch
-func getRemoteDisplayStrings(r *models.Remote, diffed bool) []string {
+func getRemoteDisplayStrings(
+	r *models.Remote,
+	diffed bool,
+	itemOperation types.ItemOperation,
+	tr *i18n.TranslationSet,
+) []string {
 	branchCount := len(r.Branches)
 
 	textStyle := theme.DefaultTextColor
@@ -28,6 +43,11 @@ func getRemoteDisplayStrings(r *models.Remote, diffed bool) []string {
 	if icons.IsIconEnabled() {
 		res = append(res, textStyle.Sprint(icons.IconForRemote(r)))
 	}
-	res = append(res, textStyle.Sprint(r.Name), style.FgBlue.Sprintf("%d branches", branchCount))
+	descriptionStr := style.FgBlue.Sprintf("%d branches", branchCount)
+	itemOperationStr := ItemOperationToString(itemOperation, tr)
+	if itemOperationStr != "" {
+		descriptionStr += " " + style.FgCyan.Sprint(itemOperationStr+" "+utils.Loader(time.Now()))
+	}
+	res = append(res, textStyle.Sprint(r.Name), descriptionStr)
 	return res
 }

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -308,6 +308,7 @@ const (
 	ItemOperationPulling
 	ItemOperationFastForwarding
 	ItemOperationDeleting
+	ItemOperationFetching
 )
 
 type HasUrn interface {

--- a/pkg/i18n/chinese.go
+++ b/pkg/i18n/chinese.go
@@ -310,7 +310,6 @@ func chineseTranslationSet() TranslationSet {
 		PushTag:                             "推送标签",
 		CreateTag:                           "创建标签",
 		FetchRemote:                         "抓取远程仓库",
-		FetchingRemoteStatus:                "抓取远程仓库中",
 		CheckoutCommit:                      "检出提交",
 		SureCheckoutThisCommit:              "您确定要检出此提交吗?",
 		GitFlowOptions:                      "显示 git-flow 选项",

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -265,7 +265,6 @@ func dutchTranslationSet() TranslationSet {
 		PushTag:                             "Push tag",
 		CreateTag:                           "Creëer tag",
 		FetchRemote:                         "Fetch remote",
-		FetchingRemoteStatus:                "Remote fetchen",
 		CheckoutCommit:                      "Checkout commit",
 		SureCheckoutThisCommit:              "Weet je zeker dat je deze commit wil uitchecken?",
 		GitFlowOptions:                      "Laat git-flow opties zien",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -409,7 +409,6 @@ type TranslationSet struct {
 	ForceTag                            string
 	ForceTagPrompt                      string
 	FetchRemote                         string
-	FetchingRemoteStatus                string
 	CheckoutCommit                      string
 	SureCheckoutThisCommit              string
 	GitFlowOptions                      string
@@ -1252,7 +1251,6 @@ func EnglishTranslationSet() TranslationSet {
 		ForceTag:                            "Force Tag",
 		ForceTagPrompt:                      "The tag '{{.tagName}}' exists already. Press {{.cancelKey}} to cancel, or {{.confirmKey}} to overwrite.",
 		FetchRemote:                         "Fetch remote",
-		FetchingRemoteStatus:                "Fetching remote",
 		CheckoutCommit:                      "Checkout commit",
 		SureCheckoutThisCommit:              "Are you sure you want to checkout this commit?",
 		GitFlowOptions:                      "Show git-flow options",

--- a/pkg/i18n/japanese.go
+++ b/pkg/i18n/japanese.go
@@ -319,7 +319,6 @@ func japaneseTranslationSet() TranslationSet {
 		PushTag:                "タグをpush",
 		CreateTag:              "タグを作成",
 		FetchRemote:            "リモートをfetch",
-		FetchingRemoteStatus:   "リモートをfetch",
 		CheckoutCommit:         "コミットをチェックアウト",
 		SureCheckoutThisCommit: "選択されたコミットをチェックアウトします。よろしいですか?",
 		// LcGitFlowOptions:                    "Show git-flow options",

--- a/pkg/i18n/korean.go
+++ b/pkg/i18n/korean.go
@@ -315,7 +315,6 @@ func koreanTranslationSet() TranslationSet {
 		PushTag:                    "태그를 push",
 		CreateTag:                  "태그를 생성",
 		FetchRemote:                "원격을 업데이트",
-		FetchingRemoteStatus:       "원격을 업데이트 중",
 		CheckoutCommit:             "커밋을 체크아웃",
 		SureCheckoutThisCommit:     "정말로 선택한 커밋을 체크아웃 하시겠습니까?",
 		GitFlowOptions:             "Git-flow 옵션 보기",

--- a/pkg/i18n/russian.go
+++ b/pkg/i18n/russian.go
@@ -377,7 +377,6 @@ func RussianTranslationSet() TranslationSet {
 		PushTag:                             "Отправить тег",
 		CreateTag:                           "Создать тег",
 		FetchRemote:                         "Получение изменения из удалённого репозитория",
-		FetchingRemoteStatus:                "Получение статуса удалённого репозитория",
 		CheckoutCommit:                      "Переключить коммит",
 		SureCheckoutThisCommit:              "Вы уверены, что хотите переключить коммит?",
 		GitFlowOptions:                      "Показать параметры git-flow",

--- a/pkg/i18n/traditional_chinese.go
+++ b/pkg/i18n/traditional_chinese.go
@@ -403,7 +403,6 @@ func traditionalChineseTranslationSet() TranslationSet {
 		PushTag:                             "推送標籤",
 		CreateTag:                           "建立標籤",
 		FetchRemote:                         "擷取遠端",
-		FetchingRemoteStatus:                "正在擷取遠端",
 		CheckoutCommit:                      "檢出提交",
 		SureCheckoutThisCommit:              "你確定要檢出這個提交嗎？",
 		GitFlowOptions:                      "顯示 git-flow 選項",


### PR DESCRIPTION
- **PR Description**

When fetching a remote in the remotes tab, show the status inline (i.e. in the list row of the remote), like we do when fast-forwarding a branch in the branches panel.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
