### PR TITLE
Clear cherry-picked commits after pasting

### DIFF
--- a/pkg/integration/tests/cherry_pick/cherry_pick.go
+++ b/pkg/integration/tests/cherry_pick/cherry_pick.go
@@ -60,10 +60,17 @@ var CherryPick = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			Press(keys.Commits.PasteCommits).
 			Tap(func() {
+				// cherry-picked commits will be deleted after confirmation
+				t.Views().Information().Content(Contains("2 commits copied"))
+			}).
+			Tap(func() {
 				t.ExpectPopup().Alert().
 					Title(Equals("Cherry-pick")).
 					Content(Contains("Are you sure you want to cherry-pick the copied commits onto this branch?")).
 					Confirm()
+			}).
+			Tap(func() {
+				t.Views().Information().Content(DoesNotContain("commits copied"))
 			}).
 			Lines(
 				Contains("four"),
@@ -71,14 +78,6 @@ var CherryPick = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("two"),
 				Contains("one"),
 				Contains("base"),
-			).
-			Tap(func() {
-				// we need to manually exit out of cherry pick mode
-				t.Views().Information().Content(Contains("2 commits copied"))
-			}).
-			PressEscape().
-			Tap(func() {
-				t.Views().Information().Content(DoesNotContain("commits copied"))
-			})
+			)
 	},
 })

--- a/pkg/integration/tests/cherry_pick/cherry_pick_conflicts.go
+++ b/pkg/integration/tests/cherry_pick/cherry_pick_conflicts.go
@@ -54,6 +54,10 @@ var CherryPickConflicts = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Common().AcknowledgeConflicts()
 
+		// cherry pick selection is not cleared when there are conflicts, so that the user
+		// is able to abort and try again without having to re-copy the commits
+		t.Views().Information().Content(Contains("2 commits copied"))
+
 		t.Views().Files().
 			IsFocused().
 			SelectedLine(Contains("file")).

--- a/pkg/integration/tests/cherry_pick/cherry_pick_during_rebase.go
+++ b/pkg/integration/tests/cherry_pick/cherry_pick_during_rebase.go
@@ -68,6 +68,9 @@ var CherryPickDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 					Content(Contains("Are you sure you want to cherry-pick the copied commits onto this branch?")).
 					Confirm()
 			}).
+			Tap(func() {
+				t.Views().Information().Content(DoesNotContain("commit copied"))
+			}).
 			Lines(
 				Contains("pick  CI two"),
 				Contains("pick  CI three"),

--- a/pkg/integration/tests/cherry_pick/cherry_pick_range.go
+++ b/pkg/integration/tests/cherry_pick/cherry_pick_range.go
@@ -66,20 +66,15 @@ var CherryPickRange = NewIntegrationTest(NewIntegrationTestArgs{
 					Content(Contains("Are you sure you want to cherry-pick the copied commits onto this branch?")).
 					Confirm()
 			}).
+			Tap(func() {
+				t.Views().Information().Content(DoesNotContain("commits copied"))
+			}).
 			Lines(
 				Contains("four"),
 				Contains("three"),
 				Contains("two"),
 				Contains("one"),
 				Contains("base"),
-			).
-			Tap(func() {
-				// we need to manually exit out of cherry pick mode
-				t.Views().Information().Content(Contains("2 commits copied"))
-			}).
-			PressEscape().
-			Tap(func() {
-				t.Views().Information().Content(DoesNotContain("commits copied"))
-			})
+			)
 	},
 })


### PR DESCRIPTION
- **PR Description**
 
It can be tedious after each cherry-pick opearation to clear the selection by pressing escape in order for lazygit to stop displaying info about copied commits. Also, it seems to be a rare case to cherry-pick commits to more than one destination.

The simplest solution to address this issue is to clear the selection upon paste, including merge conflict scenario.
Previously discussed in #3198.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
