### PR TITLE
Keep same selection range when quick-starting an interactive rebase

### DIFF
--- a/pkg/gui/context/traits/list_cursor.go
+++ b/pkg/gui/context/traits/list_cursor.go
@@ -128,7 +128,7 @@ func (self *ListCursor) AreMultipleItemsSelected() bool {
 
 func (self *ListCursor) GetSelectionRange() (int, int) {
 	if self.IsSelectingRange() {
-		return utils.MinMax(self.selectedIdx, self.rangeStartIdx)
+		return utils.SortRange(self.selectedIdx, self.rangeStartIdx)
 	}
 
 	return self.selectedIdx, self.selectedIdx

--- a/pkg/gui/context/traits/list_cursor.go
+++ b/pkg/gui/context/traits/list_cursor.go
@@ -64,6 +64,21 @@ func (self *ListCursor) SetSelection(value int) {
 	self.CancelRangeSelect()
 }
 
+func (self *ListCursor) SetSelectionRangeAndMode(selectedIdx, rangeStartIdx int, mode RangeSelectMode) {
+	self.selectedIdx = self.clampValue(selectedIdx)
+	self.rangeStartIdx = self.clampValue(rangeStartIdx)
+	self.rangeSelectMode = mode
+}
+
+// Returns the selectedIdx, the rangeStartIdx, and the mode of the current selection.
+func (self *ListCursor) GetSelectionRangeAndMode() (int, int, RangeSelectMode) {
+	if self.IsSelectingRange() {
+		return self.selectedIdx, self.rangeStartIdx, self.rangeSelectMode
+	} else {
+		return self.selectedIdx, self.selectedIdx, self.rangeSelectMode
+	}
+}
+
 func (self *ListCursor) clampValue(value int) int {
 	clampedValue := -1
 	if self.list.Len() > 0 {

--- a/pkg/integration/tests/interactive_rebase/quick_start_keep_selection.go
+++ b/pkg/integration/tests/interactive_rebase/quick_start_keep_selection.go
@@ -1,0 +1,51 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var QuickStartKeepSelection = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Starts an interactive rebase and checks that the same commit stays selected",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	GitVersion:   AtLeast("2.38.0"),
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Git.MainBranches = []string{"master"}
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			CreateNCommits(1).
+			NewBranch("branch1").
+			CreateNCommitsStartingAt(3, 2).
+			NewBranch("branch2").
+			CreateNCommitsStartingAt(3, 5)
+
+		shell.SetConfig("rebase.updateRefs", "true")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("CI commit 07").IsSelected(),
+				Contains("CI commit 06"),
+				Contains("CI commit 05"),
+				Contains("CI * commit 04"),
+				Contains("CI commit 03"),
+				Contains("CI commit 02"),
+				Contains("CI commit 01"),
+			).
+			NavigateToLine(Contains("commit 02")).
+			Press(keys.Commits.StartInteractiveRebase).
+			Lines(
+				Contains("pick").Contains("CI commit 07"),
+				Contains("pick").Contains("CI commit 06"),
+				Contains("pick").Contains("CI commit 05"),
+				Contains("update-ref").Contains("branch1"),
+				Contains("pick").Contains("CI * commit 04"),
+				Contains("pick").Contains("CI commit 03"),
+				Contains("CI commit 02").IsSelected(),
+				Contains("CI <-- YOU ARE HERE --- commit 01"),
+			)
+	},
+})

--- a/pkg/integration/tests/interactive_rebase/quick_start_keep_selection_range.go
+++ b/pkg/integration/tests/interactive_rebase/quick_start_keep_selection_range.go
@@ -46,10 +46,9 @@ var QuickStartKeepSelectionRange = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("CI commit 06"),
 				Contains("update-ref").Contains("branch2"),
 				Contains("CI * commit 05"),
-				// Only 01 remains selected, but we want 04 through 01 to stay selected:
-				Contains("CI commit 04"),
-				Contains("update-ref").Contains("branch1"),
-				Contains("CI * commit 03"),
+				Contains("CI commit 04").IsSelected(),
+				Contains("update-ref").Contains("branch1").IsSelected(),
+				Contains("CI * commit 03").IsSelected(),
 				Contains("CI commit 02").IsSelected(),
 				Contains("CI <-- YOU ARE HERE --- commit 01"),
 			)

--- a/pkg/integration/tests/interactive_rebase/quick_start_keep_selection_range.go
+++ b/pkg/integration/tests/interactive_rebase/quick_start_keep_selection_range.go
@@ -1,0 +1,57 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var QuickStartKeepSelectionRange = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Starts an interactive rebase and checks that the same commit range stays selected",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	GitVersion:   AtLeast("2.38.0"),
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Git.MainBranches = []string{"master"}
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			CreateNCommits(1).
+			NewBranch("branch1").
+			CreateNCommitsStartingAt(2, 2).
+			NewBranch("branch2").
+			CreateNCommitsStartingAt(2, 4).
+			NewBranch("branch3").
+			CreateNCommitsStartingAt(2, 6)
+
+		shell.SetConfig("rebase.updateRefs", "true")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			NavigateToLine(Contains("commit 04")).
+			Press(keys.Universal.RangeSelectDown).
+			Press(keys.Universal.RangeSelectDown).
+			Lines(
+				Contains("CI commit 07"),
+				Contains("CI commit 06"),
+				Contains("CI * commit 05"),
+				Contains("CI commit 04").IsSelected(),
+				Contains("CI * commit 03").IsSelected(),
+				Contains("CI commit 02").IsSelected(),
+				Contains("CI commit 01"),
+			).
+			Press(keys.Commits.StartInteractiveRebase).
+			Lines(
+				Contains("CI commit 07"),
+				Contains("CI commit 06"),
+				Contains("update-ref").Contains("branch2"),
+				Contains("CI * commit 05"),
+				// Only 01 remains selected, but we want 04 through 01 to stay selected:
+				Contains("CI commit 04"),
+				Contains("update-ref").Contains("branch1"),
+				Contains("CI * commit 03"),
+				Contains("CI commit 02").IsSelected(),
+				Contains("CI <-- YOU ARE HERE --- commit 01"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -172,6 +172,8 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.OutsideRebaseRangeSelect,
 	interactive_rebase.PickRescheduled,
 	interactive_rebase.QuickStart,
+	interactive_rebase.QuickStartKeepSelection,
+	interactive_rebase.QuickStartKeepSelectionRange,
 	interactive_rebase.Rebase,
 	interactive_rebase.RewordCommitWithEditorAndFail,
 	interactive_rebase.RewordFirstCommit,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -50,7 +50,7 @@ func Max(x, y int) int {
 	return y
 }
 
-func MinMax(x int, y int) (int, int) {
+func SortRange(x int, y int) (int, int) {
 	if x < y {
 		return x, y
 	}


### PR DESCRIPTION
- **PR Description**

This is useful if you want to move a range of commits, so you select them, and
then realize it's better to do it in an interactive rebase. Pressing 'i'
preserves the range now.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
