### PR TITLE
Add NixOs installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,20 @@ sudo zypper ar https://download.opensuse.org/repositories/devel:/languages:/go/$
 sudo zypper ref && sudo zypper in lazygit
 ```
 
+### NixOs
+
+On NixOs lazygit is packaged with nix and distributed via nixpkgs.
+You can try the lazygit without installing it with:
+
+```sh
+nix-shell -p lazygit
+# or with flakes enabled
+nix run nixpkgs#lazygit
+```
+
+Or you can add lazygit to you configuration.nix in the environment.systemPackages section.
+More details can be found via NixOs search [page](https://search.nixos.org/).
+
 ### FreeBSD
 
 ```sh


### PR DESCRIPTION
Extend README.md with instructions on how to try and install the lazygit on NixOs.

- **PR Description**
Just README.md update, no code changes.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
