### PR TITLE
Correct Ubuntu installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ sudo eopkg install lazygit
 ```sh
 LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
 curl -Lo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz"
-tar xf lazygit.tar.gz lazygit
+tar -xf lazygit.tar.gz lazygit
 sudo install lazygit /usr/local/bin
 ```
 


### PR DESCRIPTION
- VERY small PR to correct the Readme.md file

missing hyphen in the tar command