### PR TITLE
Pass absolute file paths to all editor commands

### DIFF
--- a/pkg/gui/controllers/helpers/files_helper.go
+++ b/pkg/gui/controllers/helpers/files_helper.go
@@ -1,5 +1,9 @@
 package helpers
 
+import (
+	"path/filepath"
+)
+
 type IFilesHelper interface {
 	EditFile(filename string) error
 	EditFileAtLine(filename string, lineNumber int) error
@@ -19,17 +23,29 @@ func NewFilesHelper(c *HelperCommon) *FilesHelper {
 var _ IFilesHelper = &FilesHelper{}
 
 func (self *FilesHelper) EditFile(filename string) error {
-	cmdStr, suspend := self.c.Git().File.GetEditCmdStr(filename)
+	absPath, err := filepath.Abs(filename)
+	if err != nil {
+		return err
+	}
+	cmdStr, suspend := self.c.Git().File.GetEditCmdStr(absPath)
 	return self.callEditor(cmdStr, suspend)
 }
 
 func (self *FilesHelper) EditFileAtLine(filename string, lineNumber int) error {
-	cmdStr, suspend := self.c.Git().File.GetEditAtLineCmdStr(filename, lineNumber)
+	absPath, err := filepath.Abs(filename)
+	if err != nil {
+		return err
+	}
+	cmdStr, suspend := self.c.Git().File.GetEditAtLineCmdStr(absPath, lineNumber)
 	return self.callEditor(cmdStr, suspend)
 }
 
 func (self *FilesHelper) EditFileAtLineAndWait(filename string, lineNumber int) error {
-	cmdStr := self.c.Git().File.GetEditAtLineAndWaitCmdStr(filename, lineNumber)
+	absPath, err := filepath.Abs(filename)
+	if err != nil {
+		return err
+	}
+	cmdStr := self.c.Git().File.GetEditAtLineAndWaitCmdStr(absPath, lineNumber)
 
 	// Always suspend, regardless of the value of the suspend config,
 	// since we want to prevent interacting with the UI until the editor
@@ -38,7 +54,11 @@ func (self *FilesHelper) EditFileAtLineAndWait(filename string, lineNumber int) 
 }
 
 func (self *FilesHelper) OpenDirInEditor(path string) error {
-	cmdStr, suspend := self.c.Git().File.GetOpenDirInEditorCmdStr(path)
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	cmdStr, suspend := self.c.Git().File.GetOpenDirInEditorCmdStr(absPath)
 
 	return self.callEditor(cmdStr, suspend)
 }
@@ -54,8 +74,12 @@ func (self *FilesHelper) callEditor(cmdStr string, suspend bool) error {
 }
 
 func (self *FilesHelper) OpenFile(filename string) error {
+	absPath, err := filepath.Abs(filename)
+	if err != nil {
+		return err
+	}
 	self.c.LogAction(self.c.Tr.Actions.OpenFile)
-	if err := self.c.OS().OpenFile(filename); err != nil {
+	if err := self.c.OS().OpenFile(absPath); err != nil {
 		return self.c.Error(err)
 	}
 	return nil


### PR DESCRIPTION
- **PR Description**

This helps work around bugs in editors that may get confused about relative paths (like nvim-remote, see https://github.com/neovim/neovim/issues/18519), and shouldn't have any negative effect on others.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
