### PR TITLE
Change "git reset" default to --mixed

### DIFF
--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -169,8 +169,8 @@ func (self *RefsHelper) CreateGitResetMenu(ref string) error {
 	}
 	strengths := []strengthWithKey{
 		// not i18'ing because it's git terminology
-		{strength: "soft", label: "Soft reset", key: 's'},
 		{strength: "mixed", label: "Mixed reset", key: 'm'},
+		{strength: "soft", label: "Soft reset", key: 's'},
 		{strength: "hard", label: "Hard reset", key: 'h'},
 	}
 

--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -166,12 +166,13 @@ func (self *RefsHelper) CreateGitResetMenu(ref string) error {
 		strength string
 		label    string
 		key      types.Key
+		tooltip  string
 	}
 	strengths := []strengthWithKey{
 		// not i18'ing because it's git terminology
-		{strength: "mixed", label: "Mixed reset", key: 'm'},
-		{strength: "soft", label: "Soft reset", key: 's'},
-		{strength: "hard", label: "Hard reset", key: 'h'},
+		{strength: "mixed", label: "Mixed reset", key: 'm', tooltip: self.c.Tr.ResetMixedTooltip},
+		{strength: "soft", label: "Soft reset", key: 's', tooltip: self.c.Tr.ResetSoftTooltip},
+		{strength: "hard", label: "Hard reset", key: 'h', tooltip: self.c.Tr.ResetHardTooltip},
 	}
 
 	menuItems := lo.Map(strengths, func(row strengthWithKey, _ int) *types.MenuItem {
@@ -184,7 +185,8 @@ func (self *RefsHelper) CreateGitResetMenu(ref string) error {
 				self.c.LogAction("Reset")
 				return self.ResetToRef(ref, row.strength, []string{})
 			},
-			Key: row.key,
+			Key:     row.key,
+			Tooltip: row.tooltip,
 		}
 	})
 

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -398,6 +398,9 @@ type TranslationSet struct {
 	CommitChangesWithoutHook              string
 	SkipHookPrefixNotConfigured           string
 	ResetTo                               string
+	ResetSoftTooltip                      string
+	ResetMixedTooltip                     string
+	ResetHardTooltip                      string
 	PressEnterToReturn                    string
 	ViewStashOptions                      string
 	ViewStashOptionsTooltip               string
@@ -1320,6 +1323,9 @@ func EnglishTranslationSet() TranslationSet {
 		Delete:                              "Delete",
 		Reset:                               "Reset",
 		ResetTooltip:                        "View reset options (soft/mixed/hard) for resetting onto selected item.",
+		ResetSoftTooltip:                    "Reset HEAD to the chosen commit, and keep the changes between the current and chosen commit as staged changes.",
+		ResetMixedTooltip:                   "Reset HEAD to the chosen commit, and keep the changes between the current and chosen commit as unstaged changes.",
+		ResetHardTooltip:                    "Reset HEAD to the chosen commit, and discard all changes between the current and chosen commit, as well as all current modifications in the working tree.",
 		ViewResetOptions:                    `Reset`,
 		FileResetOptionsTooltip:             "View reset options for working tree (e.g. nuking the working tree).",
 		FixupTooltip:                        "Meld the selected commit into the commit below it. Similar to fixup, but the selected commit's message will be discarded.",


### PR DESCRIPTION
Calling "git reset" on the command line (without further arguments) defaults to --mixed, which is reason enough to make it the default for us, too.

But I also find myself using --mixed more often than --soft. The main use case for me is that I made a bunch of WIP commits, and want to turn them into real commits when I'm done hacking. I select the last commit before the WIP commits and reset to it, leaving all changes of all those commits in the working directory. Since I want to start staging things from there, I prefer those modifications to be unstaged at that point, which is what --mixed does.