### PR TITLE
Warn users when attempting to cherry pick with old key

### DIFF
--- a/pkg/gui/controllers/basic_commits_controller.go
+++ b/pkg/gui/controllers/basic_commits_controller.go
@@ -106,6 +106,14 @@ func (self *BasicCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 			GetDisabledReason: self.require(self.singleItemSelected()),
 			Description:       self.c.Tr.OpenDiffTool,
 		},
+		// Putting this at the bottom of the list so that it has the lowest priority,
+		// meaning that if the user has configured another keybinding to the same key
+		// then that will take precedence.
+		{
+			// Hardcoding this key because it's not configurable
+			Key:     opts.GetKey("c"),
+			Handler: self.handleOldCherryPickKey,
+		},
 	}
 
 	return bindings
@@ -282,6 +290,16 @@ func (self *BasicCommitsController) checkout(commit *models.Commit) error {
 
 func (self *BasicCommitsController) copyRange(*models.Commit) error {
 	return self.c.Helpers().CherryPick.CopyRange(self.context.GetCommits(), self.context)
+}
+
+func (self *BasicCommitsController) handleOldCherryPickKey() error {
+	msg := utils.ResolvePlaceholderString(self.c.Tr.OldCherryPickKeyWarning,
+		map[string]string{
+			"copy":  keybindings.Label(self.c.UserConfig.Keybinding.Commits.CherryPickCopy),
+			"paste": keybindings.Label(self.c.UserConfig.Keybinding.Commits.PasteCommits),
+		})
+
+	return self.c.ErrorMsg(msg)
 }
 
 func (self *BasicCommitsController) openDiffTool(commit *models.Commit) error {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -753,6 +753,7 @@ type TranslationSet struct {
 	NoItemSelected                       string
 	SelectedItemIsNotABranch             string
 	RangeSelectNotSupportedForSubmodules string
+	OldCherryPickKeyWarning              string
 	Actions                              Actions
 	Bisect                               Bisect
 	Log                                  Log
@@ -1685,6 +1686,8 @@ func EnglishTranslationSet() TranslationSet {
 		NoItemSelected:                        "No item selected",
 		SelectedItemIsNotABranch:              "Selected item is not a branch",
 		RangeSelectNotSupportedForSubmodules:  "Range select not supported for submodules",
+		OldCherryPickKeyWarning:               "The 'c' key is no longer the default key for copying commits to cherry pick. Please use `{{.copy}}` instead (and `{{.paste}}` to paste). The reason for this change is that the 'v' key for selecting a range of lines when staging is now also used for selecting a range of lines in any list view, meaning that we needed to find a new key for pasting commits, and if we're going to now use `{{.paste}}` for pasting commits, we may as well use `{{.copy}}` for copying them. If you want to configure the keybindings to get the old behaviour, set the following in your config:\n\nkeybinding:\n  universal:\n    toggleRangeSelect: <something other than v>\n  commits:\n    cherryPickCopy: 'c'\n    pasteCommits: 'v'",
+
 		Actions: Actions{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)
 			CheckoutCommit:                 "Checkout commit",


### PR DESCRIPTION
I wrote this feature and even I sometimes use the wrong key so I want to make this very clear to users so that there's no confusion.

We can get rid of this once users have had time to adjust

![image](https://github.com/jesseduffield/lazygit/assets/8456633/8a453eaf-381d-468e-8280-58516eead43a)


- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
