### PR TITLE
Keep sort order when filtering lists sorted by date

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 
 env:
-  GO_VERSION: 1.20
+  GO_VERSION: 1.21
 
 on:
   push:
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Test code
         # we're passing -short so that we skip the integration tests, which will be run in parallel below
         run: |
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Print git version
         run: git --version
       - name: Test code
@@ -115,7 +115,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Build linux binary
         run: |
           GOOS=linux go build
@@ -142,7 +142,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Check Vendor Directory
         # ensure our vendor directory matches up with our go modules
         run: |
@@ -168,7 +168,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,5 +30,5 @@ linters-settings:
     max-func-lines: 0
 
 run:
-  go: '1.20'
+  go: '1.21'
   timeout: 10m

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # docker build -t lazygit .
 # docker run -it lazygit:latest /bin/sh
 
-FROM golang:1.20 as build
+FROM golang:1.21 as build
 WORKDIR /go/src/github.com/jesseduffield/lazygit/
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jesseduffield/lazygit
 
-go 1.20
+go 1.21
 
 require (
 	github.com/OpenPeeDeeP/xdg v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,7 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
+github.com/thoas/go-funk v0.9.1/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/urfave/cli v1.20.1-0.20180226030253-8e01ec4cd3e2/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=

--- a/pkg/gui/context/branches_context.go
+++ b/pkg/gui/context/branches_context.go
@@ -22,6 +22,7 @@ func NewBranchesContext(c *ContextCommon) *BranchesContext {
 		func(branch *models.Branch) []string {
 			return []string{branch.Name}
 		},
+		func() bool { return c.AppState.LocalBranchSortOrder != "alphabetical" },
 	)
 
 	getDisplayStrings := func(_ int, _ int) [][]string {

--- a/pkg/gui/context/filtered_list_view_model.go
+++ b/pkg/gui/context/filtered_list_view_model.go
@@ -6,8 +6,8 @@ type FilteredListViewModel[T HasID] struct {
 	*SearchHistory
 }
 
-func NewFilteredListViewModel[T HasID](getList func() []T, getFilterFields func(T) []string) *FilteredListViewModel[T] {
-	filteredList := NewFilteredList(getList, getFilterFields)
+func NewFilteredListViewModel[T HasID](getList func() []T, getFilterFields func(T) []string, shouldRetainSortOrder func() bool) *FilteredListViewModel[T] {
+	filteredList := NewFilteredList(getList, getFilterFields, shouldRetainSortOrder)
 
 	self := &FilteredListViewModel[T]{
 		FilteredList:  filteredList,

--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -61,6 +61,10 @@ func NewMenuViewModel(c *ContextCommon) *MenuViewModel {
 	self.FilteredListViewModel = NewFilteredListViewModel(
 		func() []*types.MenuItem { return self.menuItems },
 		func(item *types.MenuItem) []string { return item.LabelColumns },
+		// The only menu that the user is likely to filter in is the keybindings
+		// menu; retain the sort order in that one because this allows us to
+		// keep the section headers while filtering:
+		func() bool { return true },
 	)
 
 	return self

--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -112,13 +112,6 @@ func (self *MenuViewModel) GetDisplayStrings(_ int, _ int) [][]string {
 }
 
 func (self *MenuViewModel) GetNonModelItems() []*NonModelItem {
-	// Don't display section headers when we are filtering. The reason is that
-	// filtering changes the order of the items (they are sorted by best match),
-	// so all the sections would be messed up.
-	if self.FilteredListViewModel.IsFiltering() {
-		return []*NonModelItem{}
-	}
-
 	result := []*NonModelItem{}
 	menuItems := self.FilteredListViewModel.GetItems()
 	var prevSection *types.MenuSection = nil

--- a/pkg/gui/context/reflog_commits_context.go
+++ b/pkg/gui/context/reflog_commits_context.go
@@ -24,6 +24,7 @@ func NewReflogCommitsContext(c *ContextCommon) *ReflogCommitsContext {
 		func(commit *models.Commit) []string {
 			return []string{commit.ShortSha(), commit.Name}
 		},
+		func() bool { return true },
 	)
 
 	getDisplayStrings := func(_ int, _ int) [][]string {

--- a/pkg/gui/context/remote_branches_context.go
+++ b/pkg/gui/context/remote_branches_context.go
@@ -26,6 +26,7 @@ func NewRemoteBranchesContext(
 		func(remoteBranch *models.RemoteBranch) []string {
 			return []string{remoteBranch.Name}
 		},
+		func() bool { return c.AppState.RemoteBranchSortOrder != "alphabetical" },
 	)
 
 	getDisplayStrings := func(_ int, _ int) [][]string {

--- a/pkg/gui/context/remotes_context.go
+++ b/pkg/gui/context/remotes_context.go
@@ -22,6 +22,7 @@ func NewRemotesContext(c *ContextCommon) *RemotesContext {
 		func(remote *models.Remote) []string {
 			return []string{remote.Name}
 		},
+		nil,
 	)
 
 	getDisplayStrings := func(_ int, _ int) [][]string {

--- a/pkg/gui/context/stash_context.go
+++ b/pkg/gui/context/stash_context.go
@@ -24,6 +24,7 @@ func NewStashContext(
 		func(stashEntry *models.StashEntry) []string {
 			return []string{stashEntry.Name}
 		},
+		func() bool { return true },
 	)
 
 	getDisplayStrings := func(_ int, _ int) [][]string {

--- a/pkg/gui/context/submodules_context.go
+++ b/pkg/gui/context/submodules_context.go
@@ -19,6 +19,7 @@ func NewSubmodulesContext(c *ContextCommon) *SubmodulesContext {
 		func(submodule *models.SubmoduleConfig) []string {
 			return []string{submodule.Name}
 		},
+		nil,
 	)
 
 	getDisplayStrings := func(_ int, _ int) [][]string {

--- a/pkg/gui/context/tags_context.go
+++ b/pkg/gui/context/tags_context.go
@@ -24,6 +24,7 @@ func NewTagsContext(
 		func(tag *models.Tag) []string {
 			return []string{tag.Name, tag.Message}
 		},
+		nil,
 	)
 
 	getDisplayStrings := func(_ int, _ int) [][]string {

--- a/pkg/gui/context/worktrees_context.go
+++ b/pkg/gui/context/worktrees_context.go
@@ -19,6 +19,7 @@ func NewWorktreesContext(c *ContextCommon) *WorktreesContext {
 		func(Worktree *models.Worktree) []string {
 			return []string{Worktree.Name}
 		},
+		nil,
 	)
 
 	getDisplayStrings := func(_ int, _ int) [][]string {

--- a/pkg/integration/tests/filter_and_search/filter_menu.go
+++ b/pkg/integration/tests/filter_and_search/filter_menu.go
@@ -26,6 +26,7 @@ var FilterMenu = NewIntegrationTest(NewIntegrationTestArgs{
 					Filter("Ignore").
 					Lines(
 						// menu has filtered down to the one item that matches the filter
+						Contains(`--- Local ---`),
 						Contains(`Ignore`).IsSelected(),
 					).
 					Confirm()

--- a/pkg/integration/tests/filter_and_search/filter_menu_cancel_filter_with_escape.go
+++ b/pkg/integration/tests/filter_and_search/filter_menu_cancel_filter_with_escape.go
@@ -20,6 +20,7 @@ var FilterMenuCancelFilterWithEscape = NewIntegrationTest(NewIntegrationTestArgs
 			Filter("Ignore").
 			Lines(
 				// menu has filtered down to the one item that matches the filter
+				Contains(`--- Local ---`),
 				Contains(`Ignore`).IsSelected(),
 			)
 

--- a/pkg/integration/tests/filter_and_search/filter_updates_when_model_changes.go
+++ b/pkg/integration/tests/filter_and_search/filter_updates_when_model_changes.go
@@ -27,9 +27,10 @@ var FilterUpdatesWhenModelChanges = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			FilterOrSearch("branch").
 			Lines(
-				Contains("branch-to-delete").IsSelected(),
-				Contains("checked-out-branch"),
+				Contains("checked-out-branch").IsSelected(),
+				Contains("branch-to-delete"),
 			).
+			SelectNextItem().
 			Press(keys.Universal.Remove).
 			Tap(func() {
 				t.ExpectPopup().


### PR DESCRIPTION
- **PR Description**

Keep the sort order stable when filtering lists of things sorted by date (branches, stashes, reflog entries).

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
