### PR TITLE
Fix initial scroll bar size again

### DIFF
--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -32,7 +32,7 @@ func (gui *Gui) linesToReadFromCmdTask(v *gocui.View) tasks.LinesToRead {
 	// We want to read as many lines initially as necessary to let the
 	// scrollbar go to its minimum height, so that the scrollbar thumb doesn't
 	// change size as you scroll down.
-	minScrollbarHeight := 2
+	minScrollbarHeight := 1
 	linesToReadForAccurateScrollbar := height*(height-1)/minScrollbarHeight + oy
 
 	// However, cap it at some arbitrary max limit, so that we don't get


### PR DESCRIPTION
After #3283 we need to read more lines initially so that the scrollbar goes to its minimal height of 1 for long diffs. Without this, it would start with a height of 2 and then become smaller after you scroll down half the window height.

It does mean that we need to read twice the number of lines initially (up to the limit of 5000). I think it's worth it, I find the incorrect initial size confusing.