### PR TITLE
Fix order of custom commands history

### DIFF
--- a/pkg/gui/controllers/custom_command_action.go
+++ b/pkg/gui/controllers/custom_command_action.go
@@ -25,10 +25,7 @@ func (self *CustomCommandAction) Call() error {
 				)
 			}
 
-			err := self.c.SaveAppState()
-			if err != nil {
-				self.c.Log.Error(err)
-			}
+			self.c.SaveAppStateAndLogError()
 
 			self.c.LogAction(self.c.Tr.Actions.CustomCommand)
 			return self.c.RunSubprocessAndRefresh(

--- a/pkg/gui/controllers/custom_command_action.go
+++ b/pkg/gui/controllers/custom_command_action.go
@@ -20,7 +20,7 @@ func (self *CustomCommandAction) Call() error {
 		HandleConfirm: func(command string) error {
 			if self.shouldSaveCommand(command) {
 				self.c.GetAppState().CustomCommandsHistory = utils.Limit(
-					lo.Uniq(append(self.c.GetAppState().CustomCommandsHistory, command)),
+					lo.Uniq(append([]string{command}, self.c.GetAppState().CustomCommandsHistory...)),
 					1000,
 				)
 			}
@@ -36,8 +36,7 @@ func (self *CustomCommandAction) Call() error {
 }
 
 func (self *CustomCommandAction) GetCustomCommandsHistorySuggestionsFunc() func(string) []*types.Suggestion {
-	// reversing so that we display the latest command first
-	history := lo.Reverse(self.c.GetAppState().CustomCommandsHistory)
+	history := self.c.GetAppState().CustomCommandsHistory
 
 	return helpers.FuzzySearchFunc(history)
 }

--- a/pkg/integration/tests/custom_commands/history.go
+++ b/pkg/integration/tests/custom_commands/history.go
@@ -1,0 +1,60 @@
+package custom_commands
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var History = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Test that the custom commands history is saved correctly",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo:    func(shell *Shell) {},
+	SetupConfig:  func(cfg *config.AppConfig) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.ExpectPopup().Prompt().
+			Title(Equals("Custom command:")).
+			Type("echo 1").
+			Confirm()
+
+		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.ExpectPopup().Prompt().
+			Title(Equals("Custom command:")).
+			SuggestionLines(Contains("1")).
+			Type("echo 2").
+			Confirm()
+
+		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.ExpectPopup().Prompt().
+			Title(Equals("Custom command:")).
+			SuggestionLines(
+				// "echo 2" was typed last, so it should come first
+				Contains("2"),
+				Contains("1"),
+			).
+			Type("echo 3").
+			Confirm()
+
+		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.ExpectPopup().Prompt().
+			Title(Equals("Custom command:")).
+			SuggestionLines(
+				Contains("3"),
+				Contains("2"),
+				Contains("1"),
+			).
+			Type("echo 1").
+			Confirm()
+
+		// Executing a command again should move it to the front:
+		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.ExpectPopup().Prompt().
+			Title(Equals("Custom command:")).
+			SuggestionLines(
+				Contains("1"),
+				Contains("3"),
+				Contains("2"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -98,6 +98,7 @@ var tests = []*components.IntegrationTest{
 	custom_commands.CheckForConflicts,
 	custom_commands.ComplexCmdAtRuntime,
 	custom_commands.FormPrompts,
+	custom_commands.History,
 	custom_commands.MenuFromCommand,
 	custom_commands.MenuFromCommandsOutput,
 	custom_commands.MultiplePrompts,


### PR DESCRIPTION
- **PR Description**

Fix order problems when saving custom commands history

This fixes two problems:
- each time the custom commands panel was opened, the history of commands would
  be shown in reversed order compared to last time. (The reason is that
  lo.Reverse modifies the slice in place rather than just returning a new,
  reversed slice.)
- when executing a previous command again (either by typing it in again, or by
  picking it from the history), it should move to the beginning of the history,
  but didn't.

We fix this by storing the history in reversed order (as the user sees it in
the panel), this makes the logic simpler. We just have to prepend rather
than append newly added commands now.

While this is theoretically a breaking change, it's not worth bothering because
the order was wrong for existing users in 50% of the cases anyway.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
