### PR TITLE
Fix cherrypick demo

### DIFF
--- a/pkg/integration/tests/demo/cherry_pick.go
+++ b/pkg/integration/tests/demo/cherry_pick.go
@@ -82,11 +82,6 @@ var CherryPick = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("Fix bug in timezone conversion."),
 			).
 			Tap(func() {
-				// we need to manually exit out of cherry pick mode
-				t.Views().Information().Content(Contains("2 commits copied"))
-			}).
-			PressEscape().
-			Tap(func() {
 				t.Views().Information().Content(DoesNotContain("commits copied"))
 			})
 	},


### PR DESCRIPTION
Cherrypick selections are now cleared after pasting (#3240), so the demo needs a tiny change to reflect that.

- **PR Description**
The cherry pick demo is failing after the changes in #3240. This is just a small update to that demo to reflect the new (and more convenient) behavior from #3240.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
