### PR TITLE
Fix two problems related to update-ref rebase todo items

### DIFF
--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -274,7 +274,7 @@ func (self *RefreshHelper) refreshCommitsAndCommitFiles() {
 		// or perhaps we could just pop that context off the stack whenever cycling windows.
 		// For now the awkwardness remains.
 		commit := self.c.Contexts().LocalCommits.GetSelected()
-		if commit != nil {
+		if commit != nil && commit.RefName() != "" {
 			self.c.Contexts().CommitFiles.SetRef(commit)
 			self.c.Contexts().CommitFiles.SetTitleRef(commit.RefName())
 			_ = self.refreshCommitFilesContext()

--- a/pkg/gui/controllers/switch_to_diff_files_controller.go
+++ b/pkg/gui/controllers/switch_to_diff_files_controller.go
@@ -51,7 +51,7 @@ func (self *SwitchToDiffFilesController) GetKeybindings(opts types.KeybindingsOp
 		{
 			Key:               opts.GetKey(opts.Config.Universal.GoInto),
 			Handler:           self.withItem(self.enter),
-			GetDisabledReason: self.require(self.singleItemSelected()),
+			GetDisabledReason: self.require(self.singleItemSelected(self.itemRepresentsCommit)),
 			Description:       self.c.Tr.ViewItemFiles,
 		},
 	}
@@ -90,4 +90,12 @@ func (self *SwitchToDiffFilesController) viewFiles(opts SwitchToCommitFilesConte
 	}
 
 	return self.c.PushContext(diffFilesContext)
+}
+
+func (self *SwitchToDiffFilesController) itemRepresentsCommit(ref types.Ref) *types.DisabledReason {
+	if ref.RefName() == "" {
+		return &types.DisabledReason{Text: self.c.Tr.SelectedItemDoesNotHaveFiles}
+	}
+
+	return nil
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -756,6 +756,7 @@ type TranslationSet struct {
 	RangeSelectNotSupported              string
 	NoItemSelected                       string
 	SelectedItemIsNotABranch             string
+	SelectedItemDoesNotHaveFiles         string
 	RangeSelectNotSupportedForSubmodules string
 	OldCherryPickKeyWarning              string
 	Actions                              Actions
@@ -1693,6 +1694,7 @@ func EnglishTranslationSet() TranslationSet {
 		RangeSelectNotSupported:               "Action does not support range selection, please select a single item",
 		NoItemSelected:                        "No item selected",
 		SelectedItemIsNotABranch:              "Selected item is not a branch",
+		SelectedItemDoesNotHaveFiles:          "Selected item does not have files to view",
 		RangeSelectNotSupportedForSubmodules:  "Range select not supported for submodules",
 		OldCherryPickKeyWarning:               "The 'c' key is no longer the default key for copying commits to cherry pick. Please use `{{.copy}}` instead (and `{{.paste}}` to paste). The reason for this change is that the 'v' key for selecting a range of lines when staging is now also used for selecting a range of lines in any list view, meaning that we needed to find a new key for pasting commits, and if we're going to now use `{{.paste}}` for pasting commits, we may as well use `{{.copy}}` for copying them. If you want to configure the keybindings to get the old behaviour, set the following in your config:\n\nkeybinding:\n  universal:\n    toggleRangeSelect: <something other than v>\n  commits:\n    cherryPickCopy: 'c'\n    pasteCommits: 'v'",
 

--- a/pkg/integration/tests/interactive_rebase/view_files_of_todo_entries.go
+++ b/pkg/integration/tests/interactive_rebase/view_files_of_todo_entries.go
@@ -1,0 +1,52 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ViewFilesOfTodoEntries = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Check that files of a pick todo can be viewed, but files of an update-ref todo can't",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	GitVersion:   AtLeast("2.38.0"),
+	SetupConfig: func(config *config.AppConfig) {
+		config.UserConfig.Git.Log.ShowGraph = "never"
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			CreateNCommits(1).
+			NewBranch("branch1").
+			CreateNCommitsStartingAt(1, 2).
+			NewBranch("branch2").
+			CreateNCommitsStartingAt(1, 3)
+
+		shell.SetConfig("rebase.updateRefs", "true")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Press(keys.Commits.StartInteractiveRebase).
+			Lines(
+				Contains("pick").Contains("CI commit 03").IsSelected(),
+				Contains("update-ref").Contains("branch1"),
+				Contains("pick").Contains("CI * commit 02"),
+				Contains("CI <-- YOU ARE HERE --- commit 01"),
+			).
+			Press(keys.Universal.GoInto)
+
+		t.Views().CommitFiles().
+			IsFocused().
+			Lines(
+				Contains("file03.txt"),
+			).
+			PressEscape()
+
+		t.Views().Commits().
+			IsFocused().
+			NavigateToLine(Contains("update-ref")).
+			Press(keys.Universal.GoInto)
+
+		t.ExpectToast(Equals("Disabled: Selected item does not have files to view"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -187,6 +187,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.SwapInRebaseWithConflict,
 	interactive_rebase.SwapInRebaseWithConflictAndEdit,
 	interactive_rebase.SwapWithConflict,
+	interactive_rebase.ViewFilesOfTodoEntries,
 	misc.ConfirmOnQuit,
 	misc.CopyToClipboard,
 	misc.DisabledKeybindings,


### PR DESCRIPTION
- **PR Description**

This fixes two loosely related problems with `update-ref` todos:
1. Panic when hitting enter on an `update-ref` item
2. When selecting an `update-ref` item and then triggering a refresh, there was a bogus error message `fatal: ambiguous argument '': unknown revision or path not in the working tree.`

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc