### PR TITLE
Add commitPrefix for defining a prefix for any project

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -551,6 +551,15 @@ Example:
 
 ```yaml
 git:
+  commitPrefix:
+    pattern: "^\\w+\\/(\\w+-\\w+).*"
+    replace: '[$1] '
+```
+
+If you want repository-specific prefixes, you can map them with `commitPrefixes`. If you have both `commitPrefixes` defined and an entry in `commitPrefixes` for the current repo, the `commitPrefixes` entry is given higher precedence. Repository folder names must be an exact match.
+
+```yaml
+git:
   commitPrefixes:
     my_project: # This is repository folder name
       pattern: "^\\w+\\/(\\w+-\\w+).*"

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -222,6 +222,8 @@ type GitConfig struct {
 	// If true, do not allow force pushes
 	DisableForcePushing bool `yaml:"disableForcePushing"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix
+	CommitPrefix *CommitPrefixConfig `yaml:"commitPrefix"`
+	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix
 	CommitPrefixes map[string]CommitPrefixConfig `yaml:"commitPrefixes"`
 	// If true, parse emoji strings in commit messages e.g. render :rocket: as 🚀
 	// (This should really be under 'gui', not 'git')

--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -220,9 +220,9 @@ func (self *WorkingTreeHelper) prepareFilesForCommit() error {
 
 func (self *WorkingTreeHelper) commitPrefixConfigForRepo() *config.CommitPrefixConfig {
 	cfg, ok := self.c.UserConfig.Git.CommitPrefixes[self.c.Git().RepoPaths.RepoName()]
-	if !ok {
-		return nil
+	if ok {
+		return &cfg
 	}
 
-	return &cfg
+	return self.c.UserConfig.Git.CommitPrefix
 }

--- a/pkg/integration/tests/commit/commit_with_global_prefix.go
+++ b/pkg/integration/tests/commit/commit_with_global_prefix.go
@@ -5,12 +5,12 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
-var CommitWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Commit with defined config commitPrefixes",
+var CommitWithGlobalPrefix = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Commit with defined config commitPrefix",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(testConfig *config.AppConfig) {
-		testConfig.UserConfig.Git.CommitPrefixes = map[string]config.CommitPrefixConfig{"repo": {Pattern: "^\\w+\\/(\\w+-\\w+).*", Replace: "[$1]: "}}
+		testConfig.UserConfig.Git.CommitPrefix = &config.CommitPrefixConfig{Pattern: "^\\w+\\/(\\w+-\\w+).*", Replace: "[$1]: "}
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.NewBranch("feature/TEST-001")

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -72,6 +72,7 @@ var tests = []*components.IntegrationTest{
 	commit.CommitMultiline,
 	commit.CommitSwitchToEditor,
 	commit.CommitWipWithPrefix,
+	commit.CommitWithGlobalPrefix,
 	commit.CommitWithPrefix,
 	commit.CreateAmendCommit,
 	commit.CreateTag,

--- a/schema/config.json
+++ b/schema/config.json
@@ -539,6 +539,29 @@
           "type": "boolean",
           "description": "If true, do not allow force pushes"
         },
+        "commitPrefix": {
+          "properties": {
+            "pattern": {
+              "type": "string",
+              "minLength": 1,
+              "description": "pattern to match on. E.g. for 'feature/AB-123' to match on the AB-123 use \"^\\\\w+\\\\/(\\\\w+-\\\\w+).*\"",
+              "examples": [
+                "^\\w+\\/(\\w+-\\w+).*"
+              ]
+            },
+            "replace": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Replace directive. E.g. for 'feature/AB-123' to start the commit message with 'AB-123 ' use \"[$1] \"",
+              "examples": [
+                "[$1] "
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix"
+        },
         "commitPrefixes": {
           "additionalProperties": {
             "properties": {


### PR DESCRIPTION
- **PR Description**

Adds a new option `git.comitPrefix` to act similarly to `git.commitPrefixes`, except, if defined, it applies to any repo that doesn't have an entry in `git.commitPrefixes`.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
