### PR TITLE
Update keybinding names to match labels in menu

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -207,18 +207,18 @@ keybinding:
     checkForUpdate: 'u'
     recentRepos: '<enter>'
   files:
-    commitChanges: 'c'
-    commitChangesWithoutHook: 'w' # commit changes without pre-commit hook
+    commit: 'c'
+    commitWithoutHook: 'w' # commit changes without pre-commit hook
     amendLastCommit: 'A'
     commitChangesWithEditor: 'C'
     findBaseCommitForFixup: '<c-f>'
     confirmDiscard: 'x'
     ignoreFile: 'i'
     refreshFiles: 'r'
-    stashAllChanges: 's'
+    stash: 's'
     viewStashOptions: 'S'
     toggleStagedAll: 'a' # stage/unstage all
-    viewResetOptions: 'D'
+    reset: 'D'
     fetch: 'f'
     toggleTreeView: '`'
     openMergeTool: 'M'
@@ -230,30 +230,31 @@ keybinding:
     forceCheckoutBranch: 'F'
     rebaseBranch: 'r'
     renameBranch: 'R'
-    mergeIntoCurrentBranch: 'M'
+    merge: 'M'
     viewGitFlowOptions: 'i'
     fastForward: 'f' # fast-forward this branch from its upstream
-    createTag: 'T'
+    newTag: 'T'
     pushTag: 'P'
     setUpstream: 'u' # set as upstream of checked-out branch
-    fetchRemote: 'f'
+    fetch: 'f'
   commits:
-    squashDown: 's'
-    renameCommit: 'r'
-    renameCommitWithEditor: 'R'
+    squash: 's'
+    reword: 'r'
+    rewordWithEditor: 'R'
     viewResetOptions: 'g'
-    markCommitAsFixup: 'f'
+    fixup: 'f'
     createFixupCommit: 'F' # create fixup commit for this commit
-    squashAboveCommits: 'S'
+    applyFixupCommits: 'S'
     moveDownCommit: '<c-j>' # move commit down one
     moveUpCommit: '<c-k>' # move commit up one
-    amendToCommit: 'A'
-    pickCommit: 'p' # pick commit (when mid-rebase)
-    revertCommit: 't'
+    amend: 'A'
+    amendCommitAttribute: 'a'
+    pick: 'p' # pick commit (when mid-rebase)
+    revert: 't'
     cherryPickCopy: 'C'
     pasteCommits: 'V'
     tagCommit: 'T'
-    checkoutCommit: '<space>'
+    checkout: '<space>'
     resetCherryPick: '<c-R>'
     copyCommitMessageToClipboard: '<c-y>'
     openLogMenu: '<c-l>'
@@ -262,7 +263,7 @@ keybinding:
     popStash: 'g'
     renameStash: 'r'
   commitFiles:
-    checkoutCommitFile: 'c'
+    checkout: 'c'
   main:
     toggleSelectHunk: 'a'
     pickBothHunks: 'b'

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -364,23 +364,23 @@ type KeybindingStatusConfig struct {
 }
 
 type KeybindingFilesConfig struct {
-	CommitChanges            string `yaml:"commitChanges"`
-	CommitChangesWithoutHook string `yaml:"commitChangesWithoutHook"`
-	AmendLastCommit          string `yaml:"amendLastCommit"`
-	CommitChangesWithEditor  string `yaml:"commitChangesWithEditor"`
-	FindBaseCommitForFixup   string `yaml:"findBaseCommitForFixup"`
-	ConfirmDiscard           string `yaml:"confirmDiscard"`
-	IgnoreFile               string `yaml:"ignoreFile"`
-	RefreshFiles             string `yaml:"refreshFiles"`
-	StashAllChanges          string `yaml:"stashAllChanges"`
-	ViewStashOptions         string `yaml:"viewStashOptions"`
-	ToggleStagedAll          string `yaml:"toggleStagedAll"`
-	ViewResetOptions         string `yaml:"viewResetOptions"`
-	Fetch                    string `yaml:"fetch"`
-	ToggleTreeView           string `yaml:"toggleTreeView"`
-	OpenMergeTool            string `yaml:"openMergeTool"`
-	OpenStatusFilter         string `yaml:"openStatusFilter"`
-	CopyFileInfoToClipboard  string `yaml:"copyFileInfoToClipboard"`
+	Commit                  string `yaml:"commit"`
+	CommitWithoutHook       string `yaml:"commitWithoutHook"`
+	AmendLastCommit         string `yaml:"amendLastCommit"`
+	CommitChangesWithEditor string `yaml:"commitChangesWithEditor"`
+	FindBaseCommitForFixup  string `yaml:"findBaseCommitForFixup"`
+	ConfirmDiscard          string `yaml:"confirmDiscard"`
+	IgnoreFile              string `yaml:"ignoreFile"`
+	RefreshFiles            string `yaml:"refreshFiles"`
+	Stash                   string `yaml:"stash"`
+	ViewStashOptions        string `yaml:"viewStashOptions"`
+	ToggleStagedAll         string `yaml:"toggleStagedAll"`
+	Reset                   string `yaml:"reset"`
+	Fetch                   string `yaml:"fetch"`
+	ToggleTreeView          string `yaml:"toggleTreeView"`
+	OpenMergeTool           string `yaml:"openMergeTool"`
+	OpenStatusFilter        string `yaml:"openStatusFilter"`
+	CopyFileInfoToClipboard string `yaml:"copyFileInfoToClipboard"`
 }
 
 type KeybindingBranchesConfig struct {
@@ -391,13 +391,13 @@ type KeybindingBranchesConfig struct {
 	ForceCheckoutBranch    string `yaml:"forceCheckoutBranch"`
 	RebaseBranch           string `yaml:"rebaseBranch"`
 	RenameBranch           string `yaml:"renameBranch"`
-	MergeIntoCurrentBranch string `yaml:"mergeIntoCurrentBranch"`
+	Merge                  string `yaml:"merge"`
 	ViewGitFlowOptions     string `yaml:"viewGitFlowOptions"`
 	FastForward            string `yaml:"fastForward"`
-	CreateTag              string `yaml:"createTag"`
+	NewTag                 string `yaml:"newTag"`
 	PushTag                string `yaml:"pushTag"`
 	SetUpstream            string `yaml:"setUpstream"`
-	FetchRemote            string `yaml:"fetchRemote"`
+	Fetch                  string `yaml:"fetch"`
 	SortOrder              string `yaml:"sortOrder"`
 }
 
@@ -406,24 +406,24 @@ type KeybindingWorktreesConfig struct {
 }
 
 type KeybindingCommitsConfig struct {
-	SquashDown                     string `yaml:"squashDown"`
-	RenameCommit                   string `yaml:"renameCommit"`
-	RenameCommitWithEditor         string `yaml:"renameCommitWithEditor"`
+	Squash                         string `yaml:"squash"`
+	Reword                         string `yaml:"reword"`
+	RewordWithEditor               string `yaml:"rewordWithEditor"`
 	ViewResetOptions               string `yaml:"viewResetOptions"`
-	MarkCommitAsFixup              string `yaml:"markCommitAsFixup"`
+	Fixup                          string `yaml:"fixup"`
 	CreateFixupCommit              string `yaml:"createFixupCommit"`
-	SquashAboveCommits             string `yaml:"squashAboveCommits"`
+	ApplyFixupCommits              string `yaml:"applyFixupCommits"`
 	MoveDownCommit                 string `yaml:"moveDownCommit"`
 	MoveUpCommit                   string `yaml:"moveUpCommit"`
-	AmendToCommit                  string `yaml:"amendToCommit"`
-	ResetCommitAuthor              string `yaml:"resetCommitAuthor"`
-	PickCommit                     string `yaml:"pickCommit"`
-	RevertCommit                   string `yaml:"revertCommit"`
+	Amend                          string `yaml:"amend"`
+	AmendCommitAttribute           string `yaml:"amendCommitAttribute"`
+	Pick                           string `yaml:"pick"`
+	Revert                         string `yaml:"revert"`
 	CherryPickCopy                 string `yaml:"cherryPickCopy"`
 	PasteCommits                   string `yaml:"pasteCommits"`
 	MarkCommitAsBaseForRebase      string `yaml:"markCommitAsBaseForRebase"`
 	CreateTag                      string `yaml:"tagCommit"`
-	CheckoutCommit                 string `yaml:"checkoutCommit"`
+	Checkout                       string `yaml:"checkout"`
 	ResetCherryPick                string `yaml:"resetCherryPick"`
 	CopyCommitAttributeToClipboard string `yaml:"copyCommitAttributeToClipboard"`
 	OpenLogMenu                    string `yaml:"openLogMenu"`
@@ -438,7 +438,7 @@ type KeybindingStashConfig struct {
 }
 
 type KeybindingCommitFilesConfig struct {
-	CheckoutCommitFile string `yaml:"checkoutCommitFile"`
+	Checkout string `yaml:"checkout"`
 }
 
 type KeybindingMainConfig struct {
@@ -762,23 +762,23 @@ func GetDefaultConfig() *UserConfig {
 				AllBranchesLogGraph: "a",
 			},
 			Files: KeybindingFilesConfig{
-				CommitChanges:            "c",
-				CommitChangesWithoutHook: "w",
-				AmendLastCommit:          "A",
-				CommitChangesWithEditor:  "C",
-				FindBaseCommitForFixup:   "<c-f>",
-				IgnoreFile:               "i",
-				RefreshFiles:             "r",
-				StashAllChanges:          "s",
-				ViewStashOptions:         "S",
-				ToggleStagedAll:          "a",
-				ViewResetOptions:         "D",
-				Fetch:                    "f",
-				ToggleTreeView:           "`",
-				OpenMergeTool:            "M",
-				OpenStatusFilter:         "<c-b>",
-				ConfirmDiscard:           "x",
-				CopyFileInfoToClipboard:  "y",
+				Commit:                  "c",
+				CommitWithoutHook:       "w",
+				AmendLastCommit:         "A",
+				CommitChangesWithEditor: "C",
+				FindBaseCommitForFixup:  "<c-f>",
+				IgnoreFile:              "i",
+				RefreshFiles:            "r",
+				Stash:                   "s",
+				ViewStashOptions:        "S",
+				ToggleStagedAll:         "a",
+				Reset:                   "D",
+				Fetch:                   "f",
+				ToggleTreeView:          "`",
+				OpenMergeTool:           "M",
+				OpenStatusFilter:        "<c-b>",
+				ConfirmDiscard:          "x",
+				CopyFileInfoToClipboard: "y",
 			},
 			Branches: KeybindingBranchesConfig{
 				CopyPullRequestURL:     "<c-y>",
@@ -788,37 +788,37 @@ func GetDefaultConfig() *UserConfig {
 				ForceCheckoutBranch:    "F",
 				RebaseBranch:           "r",
 				RenameBranch:           "R",
-				MergeIntoCurrentBranch: "M",
+				Merge:                  "M",
 				ViewGitFlowOptions:     "i",
 				FastForward:            "f",
-				CreateTag:              "T",
+				NewTag:                 "T",
 				PushTag:                "P",
 				SetUpstream:            "u",
-				FetchRemote:            "f",
+				Fetch:                  "f",
 				SortOrder:              "s",
 			},
 			Worktrees: KeybindingWorktreesConfig{
 				ViewWorktreeOptions: "w",
 			},
 			Commits: KeybindingCommitsConfig{
-				SquashDown:                     "s",
-				RenameCommit:                   "r",
-				RenameCommitWithEditor:         "R",
+				Squash:                         "s",
+				Reword:                         "r",
+				RewordWithEditor:               "R",
 				ViewResetOptions:               "g",
-				MarkCommitAsFixup:              "f",
+				Fixup:                          "f",
 				CreateFixupCommit:              "F",
-				SquashAboveCommits:             "S",
+				ApplyFixupCommits:              "S",
 				MoveDownCommit:                 "<c-j>",
 				MoveUpCommit:                   "<c-k>",
-				AmendToCommit:                  "A",
-				ResetCommitAuthor:              "a",
-				PickCommit:                     "p",
-				RevertCommit:                   "t",
+				Amend:                          "A",
+				AmendCommitAttribute:           "a",
+				Pick:                           "p",
+				Revert:                         "t",
 				CherryPickCopy:                 "C",
 				PasteCommits:                   "V",
 				MarkCommitAsBaseForRebase:      "B",
 				CreateTag:                      "T",
-				CheckoutCommit:                 "<space>",
+				Checkout:                       "<space>",
 				ResetCherryPick:                "<c-R>",
 				CopyCommitAttributeToClipboard: "y",
 				OpenLogMenu:                    "<c-l>",
@@ -831,7 +831,7 @@ func GetDefaultConfig() *UserConfig {
 				RenameStash: "r",
 			},
 			CommitFiles: KeybindingCommitFilesConfig{
-				CheckoutCommitFile: "c",
+				Checkout: "c",
 			},
 			Main: KeybindingMainConfig{
 				ToggleSelectHunk: "a",

--- a/pkg/gui/command_log_panel.go
+++ b/pkg/gui/command_log_panel.go
@@ -129,7 +129,7 @@ func (gui *Gui) getRandomTip() string {
 		),
 		fmt.Sprintf(
 			"To revert a commit, press '%s' on that commit",
-			formattedKey(config.Commits.RevertCommit),
+			formattedKey(config.Commits.Revert),
 		),
 		fmt.Sprintf(
 			"To escape a mode, for example cherry-picking, patch-building, diffing, or filtering mode, you can just spam the '%s' button. Unless of course you have `quitOnTopLevelReturn` enabled in your config",
@@ -151,7 +151,7 @@ func (gui *Gui) getRandomTip() string {
 		),
 		fmt.Sprintf(
 			"You can append your staged changes to an older commit by pressing '%s' on that commit",
-			formattedKey(config.Commits.AmendToCommit),
+			formattedKey(config.Commits.Amend),
 		),
 		fmt.Sprintf(
 			"You can amend the last commit with your new file changes by pressing '%s' in the files panel",

--- a/pkg/gui/controllers/basic_commits_controller.go
+++ b/pkg/gui/controllers/basic_commits_controller.go
@@ -47,7 +47,7 @@ func NewBasicCommitsController(c *ControllerCommon, context ContainsCommits) *Ba
 func (self *BasicCommitsController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
 	bindings := []*types.Binding{
 		{
-			Key:               opts.GetKey(opts.Config.Commits.CheckoutCommit),
+			Key:               opts.GetKey(opts.Config.Commits.Checkout),
 			Handler:           self.withItem(self.checkout),
 			GetDisabledReason: self.require(self.singleItemSelected()),
 			Description:       self.c.Tr.Checkout,

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -110,7 +110,7 @@ func (self *BranchesController) GetKeybindings(opts types.KeybindingsOpts) []*ty
 			DisplayOnScreen: true,
 		},
 		{
-			Key:               opts.GetKey(opts.Config.Branches.MergeIntoCurrentBranch),
+			Key:               opts.GetKey(opts.Config.Branches.Merge),
 			Handler:           opts.Guards.OutsideFilterMode(self.merge),
 			GetDisabledReason: self.require(self.singleItemSelected()),
 			Description:       self.c.Tr.Merge,
@@ -125,7 +125,7 @@ func (self *BranchesController) GetKeybindings(opts types.KeybindingsOpts) []*ty
 			Tooltip:           self.c.Tr.FastForwardTooltip,
 		},
 		{
-			Key:               opts.GetKey(opts.Config.Branches.CreateTag),
+			Key:               opts.GetKey(opts.Config.Branches.NewTag),
 			Handler:           self.withItem(self.createTag),
 			GetDisabledReason: self.require(self.singleItemSelected()),
 			Description:       self.c.Tr.NewTag,

--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -41,7 +41,7 @@ func NewCommitFilesController(
 func (self *CommitFilesController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
 	bindings := []*types.Binding{
 		{
-			Key:               opts.GetKey(opts.Config.CommitFiles.CheckoutCommitFile),
+			Key:               opts.GetKey(opts.Config.CommitFiles.Checkout),
 			Handler:           self.withItem(self.checkout),
 			GetDisabledReason: self.require(self.singleItemSelected()),
 			Description:       self.c.Tr.Checkout,

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -57,14 +57,14 @@ func (self *FilesController) GetKeybindings(opts types.KeybindingsOpts) []*types
 			OpensMenu:   true,
 		},
 		{
-			Key:             opts.GetKey(opts.Config.Files.CommitChanges),
+			Key:             opts.GetKey(opts.Config.Files.Commit),
 			Handler:         self.c.Helpers().WorkingTree.HandleCommitPress,
 			Description:     self.c.Tr.Commit,
 			Tooltip:         self.c.Tr.CommitTooltip,
 			DisplayOnScreen: true,
 		},
 		{
-			Key:         opts.GetKey(opts.Config.Files.CommitChangesWithoutHook),
+			Key:         opts.GetKey(opts.Config.Files.CommitWithoutHook),
 			Handler:     self.c.Helpers().WorkingTree.HandleWIPCommitPress,
 			Description: self.c.Tr.CommitChangesWithoutHook,
 		},
@@ -112,7 +112,7 @@ func (self *FilesController) GetKeybindings(opts types.KeybindingsOpts) []*types
 			Description: self.c.Tr.RefreshFiles,
 		},
 		{
-			Key:             opts.GetKey(opts.Config.Files.StashAllChanges),
+			Key:             opts.GetKey(opts.Config.Files.Stash),
 			Handler:         self.stash,
 			Description:     self.c.Tr.Stash,
 			Tooltip:         self.c.Tr.StashTooltip,
@@ -154,7 +154,7 @@ func (self *FilesController) GetKeybindings(opts types.KeybindingsOpts) []*types
 			OpensMenu:   true,
 		},
 		{
-			Key:             opts.GetKey(opts.Config.Files.ViewResetOptions),
+			Key:             opts.GetKey(opts.Config.Files.Reset),
 			Handler:         self.createResetMenu,
 			Description:     self.c.Tr.Reset,
 			Tooltip:         self.c.Tr.FileResetOptionsTooltip,

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -56,7 +56,7 @@ func (self *LocalCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 
 	outsideFilterModeBindings := []*types.Binding{
 		{
-			Key:     opts.GetKey(opts.Config.Commits.SquashDown),
+			Key:     opts.GetKey(opts.Config.Commits.Squash),
 			Handler: self.withItemsRange(self.squashDown),
 			GetDisabledReason: self.require(
 				self.itemRangeSelected(
@@ -69,7 +69,7 @@ func (self *LocalCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 			DisplayOnScreen: true,
 		},
 		{
-			Key:     opts.GetKey(opts.Config.Commits.MarkCommitAsFixup),
+			Key:     opts.GetKey(opts.Config.Commits.Fixup),
 			Handler: self.withItemsRange(self.fixup),
 			GetDisabledReason: self.require(
 				self.itemRangeSelected(
@@ -82,7 +82,7 @@ func (self *LocalCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 			DisplayOnScreen: true,
 		},
 		{
-			Key:     opts.GetKey(opts.Config.Commits.RenameCommit),
+			Key:     opts.GetKey(opts.Config.Commits.Reword),
 			Handler: self.withItem(self.reword),
 			GetDisabledReason: self.require(
 				self.singleItemSelected(self.rewordEnabled),
@@ -93,7 +93,7 @@ func (self *LocalCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 			OpensMenu:       true,
 		},
 		{
-			Key:     opts.GetKey(opts.Config.Commits.RenameCommitWithEditor),
+			Key:     opts.GetKey(opts.Config.Commits.RewordWithEditor),
 			Handler: self.withItem(self.rewordEditor),
 			GetDisabledReason: self.require(
 				self.singleItemSelected(self.rewordEnabled),
@@ -137,7 +137,7 @@ func (self *LocalCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 			}),
 		},
 		{
-			Key:     opts.GetKey(opts.Config.Commits.PickCommit),
+			Key:     opts.GetKey(opts.Config.Commits.Pick),
 			Handler: self.withItems(self.pick),
 			GetDisabledReason: self.require(
 				self.itemRangeSelected(self.pickEnabled),
@@ -161,12 +161,12 @@ func (self *LocalCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 			Tooltip: utils.ResolvePlaceholderString(
 				self.c.Tr.CreateFixupCommitTooltip,
 				map[string]string{
-					"squashAbove": keybindings.Label(opts.Config.Commits.SquashAboveCommits),
+					"squashAbove": keybindings.Label(opts.Config.Commits.ApplyFixupCommits),
 				},
 			),
 		},
 		{
-			Key:     opts.GetKey(opts.Config.Commits.SquashAboveCommits),
+			Key:     opts.GetKey(opts.Config.Commits.ApplyFixupCommits),
 			Handler: self.squashFixupCommits,
 			GetDisabledReason: self.require(
 				self.notMidRebase(self.c.Tr.AlreadyRebasing),
@@ -229,7 +229,7 @@ func (self *LocalCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 
 	bindings := append(outsideFilterModeBindings, []*types.Binding{
 		{
-			Key:               opts.GetKey(opts.Config.Commits.AmendToCommit),
+			Key:               opts.GetKey(opts.Config.Commits.Amend),
 			Handler:           self.withItem(self.amendTo),
 			GetDisabledReason: self.require(self.singleItemSelected(self.canAmend)),
 			Description:       self.c.Tr.Amend,
@@ -237,7 +237,7 @@ func (self *LocalCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 			DisplayOnScreen:   true,
 		},
 		{
-			Key:               opts.GetKey(opts.Config.Commits.ResetCommitAuthor),
+			Key:               opts.GetKey(opts.Config.Commits.AmendCommitAttribute),
 			Handler:           self.withItem(self.amendAttribute),
 			GetDisabledReason: self.require(self.singleItemSelected(self.canAmend)),
 			Description:       self.c.Tr.AmendCommitAttribute,
@@ -245,7 +245,7 @@ func (self *LocalCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 			OpensMenu:         true,
 		},
 		{
-			Key:               opts.GetKey(opts.Config.Commits.RevertCommit),
+			Key:               opts.GetKey(opts.Config.Commits.Revert),
 			Handler:           self.withItem(self.revert),
 			GetDisabledReason: self.require(self.singleItemSelected()),
 			Description:       self.c.Tr.Revert,

--- a/pkg/gui/controllers/remote_branches_controller.go
+++ b/pkg/gui/controllers/remote_branches_controller.go
@@ -50,7 +50,7 @@ func (self *RemoteBranchesController) GetKeybindings(opts types.KeybindingsOpts)
 			Description:       self.c.Tr.NewBranch,
 		},
 		{
-			Key:               opts.GetKey(opts.Config.Branches.MergeIntoCurrentBranch),
+			Key:               opts.GetKey(opts.Config.Branches.Merge),
 			Handler:           opts.Guards.OutsideFilterMode(self.withItem(self.merge)),
 			GetDisabledReason: self.require(self.singleItemSelected()),
 			Description:       self.c.Tr.Merge,

--- a/pkg/gui/controllers/remotes_controller.go
+++ b/pkg/gui/controllers/remotes_controller.go
@@ -71,7 +71,7 @@ func (self *RemotesController) GetKeybindings(opts types.KeybindingsOpts) []*typ
 			DisplayOnScreen:   true,
 		},
 		{
-			Key:               opts.GetKey(opts.Config.Branches.FetchRemote),
+			Key:               opts.GetKey(opts.Config.Branches.Fetch),
 			Handler:           self.withItem(self.fetch),
 			GetDisabledReason: self.require(self.singleItemSelected()),
 			Description:       self.c.Tr.Fetch,

--- a/pkg/gui/controllers/staging_controller.go
+++ b/pkg/gui/controllers/staging_controller.go
@@ -84,13 +84,13 @@ func (self *StagingController) GetKeybindings(opts types.KeybindingsOpts) []*typ
 			Tooltip:     self.c.Tr.EditHunkTooltip,
 		},
 		{
-			Key:         opts.GetKey(opts.Config.Files.CommitChanges),
+			Key:         opts.GetKey(opts.Config.Files.Commit),
 			Handler:     self.c.Helpers().WorkingTree.HandleCommitPress,
 			Description: self.c.Tr.Commit,
 			Tooltip:     self.c.Tr.CommitTooltip,
 		},
 		{
-			Key:         opts.GetKey(opts.Config.Files.CommitChangesWithoutHook),
+			Key:         opts.GetKey(opts.Config.Files.CommitWithoutHook),
 			Handler:     self.c.Helpers().WorkingTree.HandleWIPCommitPress,
 			Description: self.c.Tr.CommitChangesWithoutHook,
 		},

--- a/pkg/integration/tests/branch/create_tag.go
+++ b/pkg/integration/tests/branch/create_tag.go
@@ -24,7 +24,7 @@ var CreateTag = NewIntegrationTest(NewIntegrationTestArgs{
 				MatchesRegexp(`master`),
 			).
 			SelectNextItem().
-			Press(keys.Branches.CreateTag)
+			Press(keys.Branches.NewTag)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Tag name")).

--- a/pkg/integration/tests/commit/add_co_author.go
+++ b/pkg/integration/tests/commit/add_co_author.go
@@ -19,7 +19,7 @@ var AddCoAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 			Lines(
 				Contains("initial commit").IsSelected(),
 			).
-			Press(keys.Commits.ResetCommitAuthor).
+			Press(keys.Commits.AmendCommitAttribute).
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Amend commit attribute")).

--- a/pkg/integration/tests/commit/amend.go
+++ b/pkg/integration/tests/commit/amend.go
@@ -23,7 +23,7 @@ var Amend = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Files().
 			Focus().
-			Press(keys.Commits.AmendToCommit)
+			Press(keys.Commits.Amend)
 
 		t.ExpectPopup().Confirmation().Title(
 			Equals("Amend last commit")).

--- a/pkg/integration/tests/commit/commit.go
+++ b/pkg/integration/tests/commit/commit.go
@@ -35,7 +35,7 @@ var Commit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("A  myfile"),
 				Contains("A  myfile2").IsSelected(),
 			).
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		commitMessage := "my commit message"
 

--- a/pkg/integration/tests/commit/commit_multiline.go
+++ b/pkg/integration/tests/commit/commit_multiline.go
@@ -20,7 +20,7 @@ var CommitMultiline = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().
 			IsFocused().
 			PressPrimaryAction().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Type("first line").

--- a/pkg/integration/tests/commit/commit_switch_to_editor.go
+++ b/pkg/integration/tests/commit/commit_switch_to_editor.go
@@ -26,7 +26,7 @@ var CommitSwitchToEditor = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().
 			IsFocused().
 			PressPrimaryAction(). // stage one of the files
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Type("first line").
@@ -46,7 +46,7 @@ var CommitSwitchToEditor = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().
 			Focus().
 			PressPrimaryAction(). // stage the other file
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			InitialText(Equals(""))

--- a/pkg/integration/tests/commit/commit_wip_with_prefix.go
+++ b/pkg/integration/tests/commit/commit_wip_with_prefix.go
@@ -23,7 +23,7 @@ var CommitWipWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().
 			IsFocused().
 			PressPrimaryAction().
-			Press(keys.Files.CommitChangesWithoutHook)
+			Press(keys.Files.CommitWithoutHook)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).
@@ -33,7 +33,7 @@ var CommitWipWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Files().
 			IsFocused().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).
@@ -43,7 +43,7 @@ var CommitWipWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Files().
 			IsFocused().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).

--- a/pkg/integration/tests/commit/commit_with_prefix.go
+++ b/pkg/integration/tests/commit/commit_with_prefix.go
@@ -23,7 +23,7 @@ var CommitWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().
 			IsFocused().
 			PressPrimaryAction().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).
@@ -33,7 +33,7 @@ var CommitWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Files().
 			IsFocused().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).

--- a/pkg/integration/tests/commit/find_base_commit_for_fixup.go
+++ b/pkg/integration/tests/commit/find_base_commit_for_fixup.go
@@ -56,7 +56,7 @@ var FindBaseCommitForFixup = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("2nd commit").IsSelected(),
 				Contains("1st commit"),
 			).
-			Press(keys.Commits.AmendToCommit)
+			Press(keys.Commits.Amend)
 
 		t.ExpectPopup().Confirmation().
 			Title(Equals("Amend commit")).

--- a/pkg/integration/tests/commit/history.go
+++ b/pkg/integration/tests/commit/history.go
@@ -21,7 +21,7 @@ var History = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().
 			IsFocused().
 			PressPrimaryAction(). // stage file
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			InitialText(Equals("")).

--- a/pkg/integration/tests/commit/history_complex.go
+++ b/pkg/integration/tests/commit/history_complex.go
@@ -26,7 +26,7 @@ var HistoryComplex = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Files().
 			IsFocused().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			InitialText(Equals("")).
@@ -36,7 +36,7 @@ var HistoryComplex = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			SelectedLine(Contains("commit 3")).
-			Press(keys.Commits.RenameCommit)
+			Press(keys.Commits.Reword)
 
 		t.ExpectPopup().CommitMessagePanel().
 			InitialText(Equals("commit 3")).
@@ -51,7 +51,7 @@ var HistoryComplex = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Files().
 			Focus().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			InitialText(Equals("my commit message"))

--- a/pkg/integration/tests/commit/preserve_commit_message.go
+++ b/pkg/integration/tests/commit/preserve_commit_message.go
@@ -16,7 +16,7 @@ var PreserveCommitMessage = NewIntegrationTest(NewIntegrationTestArgs{
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Files().
 			IsFocused().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			InitialText(Equals("")).
@@ -30,7 +30,7 @@ var PreserveCommitMessage = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Files().
 			IsFocused().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Content(Equals("my commit message")).

--- a/pkg/integration/tests/commit/reset_author.go
+++ b/pkg/integration/tests/commit/reset_author.go
@@ -25,7 +25,7 @@ var ResetAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 			Lines(
 				Contains("BS").Contains("one").IsSelected(),
 			).
-			Press(keys.Commits.ResetCommitAuthor).
+			Press(keys.Commits.AmendCommitAttribute).
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Amend commit attribute")).

--- a/pkg/integration/tests/commit/revert.go
+++ b/pkg/integration/tests/commit/revert.go
@@ -21,7 +21,7 @@ var Revert = NewIntegrationTest(NewIntegrationTestArgs{
 			Lines(
 				Contains("first commit"),
 			).
-			Press(keys.Commits.RevertCommit).
+			Press(keys.Commits.Revert).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Revert commit")).

--- a/pkg/integration/tests/commit/revert_merge.go
+++ b/pkg/integration/tests/commit/revert_merge.go
@@ -19,7 +19,7 @@ var RevertMerge = NewIntegrationTest(NewIntegrationTestArgs{
 			TopLines(
 				Contains("Merge branch 'second-change-branch' into first-change-branch").IsSelected(),
 			).
-			Press(keys.Commits.RevertCommit)
+			Press(keys.Commits.Revert)
 
 		t.ExpectPopup().Menu().
 			Title(Equals("Select parent commit for merge")).

--- a/pkg/integration/tests/commit/reword.go
+++ b/pkg/integration/tests/commit/reword.go
@@ -21,7 +21,7 @@ var Reword = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().
 			IsFocused().
 			PressPrimaryAction().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		commitMessage := "my commit message"
 
@@ -34,7 +34,7 @@ var Reword = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().
 			IsFocused().
 			PressPrimaryAction().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		wipCommitMessage := "my commit message wip"
 
@@ -43,7 +43,7 @@ var Reword = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().Focus().
 			Lines(
 				Contains(commitMessage),
-			).Press(keys.Commits.RenameCommit)
+			).Press(keys.Commits.Reword)
 
 		t.ExpectPopup().CommitMessagePanel().
 			SwitchToDescription().
@@ -55,7 +55,7 @@ var Reword = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Files().
 			Focus().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().Confirm()
 		t.Views().Commits().

--- a/pkg/integration/tests/commit/set_author.go
+++ b/pkg/integration/tests/commit/set_author.go
@@ -57,7 +57,7 @@ var SetAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Commits().
 			Focus().
-			Press(keys.Commits.ResetCommitAuthor).
+			Press(keys.Commits.AmendCommitAttribute).
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Amend commit attribute")).

--- a/pkg/integration/tests/commit/staged.go
+++ b/pkg/integration/tests/commit/staged.go
@@ -43,7 +43,7 @@ var Staged = NewIntegrationTest(NewIntegrationTestArgs{
 				t.Views().Staging().Content(Contains("+myfile content"))
 				t.Views().Staging().Content(DoesNotContain("+with a second line"))
 			}).
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		commitMessage := "my commit message"
 		t.ExpectPopup().CommitMessagePanel().Type(commitMessage).Confirm()

--- a/pkg/integration/tests/commit/staged_without_hooks.go
+++ b/pkg/integration/tests/commit/staged_without_hooks.go
@@ -43,7 +43,7 @@ var StagedWithoutHooks = NewIntegrationTest(NewIntegrationTestArgs{
 				t.Views().Staging().Content(Contains("+myfile content").DoesNotContain("+with a second line"))
 			}).
 			Content(DoesNotContain("+myfile content").Contains("+with a second line")).
-			Press(keys.Files.CommitChangesWithoutHook)
+			Press(keys.Files.CommitWithoutHook)
 
 		commitMessage := ": my commit message"
 		t.ExpectPopup().CommitMessagePanel().InitialText(Contains("WIP")).Type(commitMessage).Confirm()

--- a/pkg/integration/tests/commit/unstaged.go
+++ b/pkg/integration/tests/commit/unstaged.go
@@ -37,7 +37,7 @@ var Unstaged = NewIntegrationTest(NewIntegrationTestArgs{
 					SelectedLine(Equals("+with a second line"))
 				t.Views().StagingSecondary().Content(Contains("+myfile content"))
 			}).
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		commitMessage := "my commit message"
 		t.ExpectPopup().CommitMessagePanel().Type(commitMessage).Confirm()

--- a/pkg/integration/tests/demo/amend_old_commit.go
+++ b/pkg/integration/tests/demo/amend_old_commit.go
@@ -38,7 +38,7 @@ var AmendOldCommit = NewIntegrationTest(NewIntegrationTestArgs{
 			Focus().
 			NavigateToLine(Contains("Improve accessibility of site navigation")).
 			Wait(500).
-			Press(keys.Commits.AmendToCommit).
+			Press(keys.Commits.Amend).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Amend commit")).

--- a/pkg/integration/tests/demo/commit_and_push.go
+++ b/pkg/integration/tests/demo/commit_and_push.go
@@ -32,7 +32,7 @@ var CommitAndPush = NewIntegrationTest(NewIntegrationTestArgs{
 			IsFocused().
 			PressPrimaryAction().
 			SetCaptionPrefix("Commit our changes").
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Type("my commit summary").

--- a/pkg/integration/tests/demo/interactive_rebase.go
+++ b/pkg/integration/tests/demo/interactive_rebase.go
@@ -35,9 +35,9 @@ var InteractiveRebase = NewIntegrationTest(NewIntegrationTestArgs{
 			SelectPreviousItem().
 			Press(keys.Universal.Remove).
 			SelectPreviousItem().
-			Press(keys.Commits.SquashDown).
+			Press(keys.Commits.Squash).
 			SelectPreviousItem().
-			Press(keys.Commits.MarkCommitAsFixup).
+			Press(keys.Commits.Fixup).
 			Press(keys.Universal.CreateRebaseOptionsMenu).
 			Tap(func() {
 				t.ExpectPopup().Menu().

--- a/pkg/integration/tests/demo/nuke_working_tree.go
+++ b/pkg/integration/tests/demo/nuke_working_tree.go
@@ -31,7 +31,7 @@ var NukeWorkingTree = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().
 			IsFocused().
 			Wait(1000).
-			Press(keys.Files.ViewResetOptions).
+			Press(keys.Files.Reset).
 			Tap(func() {
 				t.Wait(1000)
 

--- a/pkg/integration/tests/demo/stage_lines.go
+++ b/pkg/integration/tests/demo/stage_lines.go
@@ -70,7 +70,7 @@ var StageLines = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Files().
 			IsFocused().
-			Press(keys.Files.CommitChanges).
+			Press(keys.Files.Commit).
 			Tap(func() {
 				t.ExpectPopup().CommitMessagePanel().
 					Type("Update tagline").

--- a/pkg/integration/tests/file/discard_staged_changes.go
+++ b/pkg/integration/tests/file/discard_staged_changes.go
@@ -35,7 +35,7 @@ var DiscardStagedChanges = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains(`?? file3`),
 				Contains(`M  fileToRemove`).IsSelected(),
 			).
-			Press(keys.Files.ViewResetOptions)
+			Press(keys.Files.Reset)
 
 		t.ExpectPopup().Menu().Title(Equals("")).Select(Contains("Discard staged changes")).Confirm()
 

--- a/pkg/integration/tests/file/remember_commit_message_after_fail.go
+++ b/pkg/integration/tests/file/remember_commit_message_after_fail.go
@@ -34,7 +34,7 @@ var RememberCommitMessageAfterFail = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("bad"),
 				Contains("one"),
 			).
-			Press(keys.Files.CommitChanges).
+			Press(keys.Files.Commit).
 			Tap(func() {
 				t.ExpectPopup().CommitMessagePanel().Type("my message").Confirm()
 
@@ -50,7 +50,7 @@ var RememberCommitMessageAfterFail = NewIntegrationTest(NewIntegrationTestArgs{
 			Lines(
 				Contains("one"),
 			).
-			Press(keys.Files.CommitChanges).
+			Press(keys.Files.Commit).
 			Tap(func() {
 				t.ExpectPopup().CommitMessagePanel().
 					InitialText(Equals("my message")). // it remembered the commit message

--- a/pkg/integration/tests/interactive_rebase/amend_commit_with_conflict.go
+++ b/pkg/integration/tests/interactive_rebase/amend_commit_with_conflict.go
@@ -25,7 +25,7 @@ var AmendCommitWithConflict = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("one"),
 			).
 			NavigateToLine(Contains("two")).
-			Press(keys.Commits.AmendToCommit).
+			Press(keys.Commits.Amend).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Amend commit")).

--- a/pkg/integration/tests/interactive_rebase/amend_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/amend_first_commit.go
@@ -23,7 +23,7 @@ var AmendFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit 01"),
 			).
 			NavigateToLine(Contains("commit 01")).
-			Press(keys.Commits.AmendToCommit).
+			Press(keys.Commits.Amend).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Amend commit")).

--- a/pkg/integration/tests/interactive_rebase/amend_fixup_commit.go
+++ b/pkg/integration/tests/interactive_rebase/amend_fixup_commit.go
@@ -29,7 +29,7 @@ var AmendFixupCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit 01"),
 			).
 			NavigateToLine(Contains("fixup! commit 01")).
-			Press(keys.Commits.AmendToCommit).
+			Press(keys.Commits.Amend).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Amend commit")).

--- a/pkg/integration/tests/interactive_rebase/amend_head_commit_during_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/amend_head_commit_during_rebase.go
@@ -40,7 +40,7 @@ var AmendHeadCommitDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Commits().
 			Focus().
-			Press(keys.Commits.AmendToCommit).
+			Press(keys.Commits.Amend).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Amend commit")).

--- a/pkg/integration/tests/interactive_rebase/amend_merge.go
+++ b/pkg/integration/tests/interactive_rebase/amend_merge.go
@@ -39,7 +39,7 @@ var AmendMerge = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Commits().
 			Focus().
-			Press(keys.Commits.AmendToCommit)
+			Press(keys.Commits.Amend)
 
 		t.ExpectPopup().Confirmation().
 			Title(Equals("Amend commit")).

--- a/pkg/integration/tests/interactive_rebase/amend_non_head_commit_during_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/amend_non_head_commit_during_rebase.go
@@ -32,7 +32,7 @@ var AmendNonHeadCommitDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 		for _, commit := range []string{"commit 01", "commit 03"} {
 			t.Views().Commits().
 				NavigateToLine(Contains(commit)).
-				Press(keys.Commits.AmendToCommit)
+				Press(keys.Commits.Amend)
 
 			t.ExpectToast(Contains("Can't perform this action during a rebase"))
 		}

--- a/pkg/integration/tests/interactive_rebase/edit_the_confl_commit.go
+++ b/pkg/integration/tests/interactive_rebase/edit_the_confl_commit.go
@@ -37,7 +37,7 @@ var EditTheConflCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit one"),
 			).
 			NavigateToLine(Contains("<-- YOU ARE HERE --- commit three")).
-			Press(keys.Commits.RenameCommit)
+			Press(keys.Commits.Reword)
 
 		t.ExpectToast(Contains("Disabled: Rewording commits while interactively rebasing is not currently supported"))
 	},

--- a/pkg/integration/tests/interactive_rebase/fixup_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/fixup_first_commit.go
@@ -22,7 +22,7 @@ var FixupFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit 01"),
 			).
 			NavigateToLine(Contains("commit 01")).
-			Press(keys.Commits.MarkCommitAsFixup).
+			Press(keys.Commits.Fixup).
 			Tap(func() {
 				t.ExpectToast(Equals("Disabled: There's no commit below to squash into"))
 			}).

--- a/pkg/integration/tests/interactive_rebase/fixup_second_commit.go
+++ b/pkg/integration/tests/interactive_rebase/fixup_second_commit.go
@@ -25,7 +25,7 @@ var FixupSecondCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("First Commit"),
 			).
 			NavigateToLine(Contains("Fixup Commit Message")).
-			Press(keys.Commits.MarkCommitAsFixup).
+			Press(keys.Commits.Fixup).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Fixup")).

--- a/pkg/integration/tests/interactive_rebase/mid_rebase_range_select.go
+++ b/pkg/integration/tests/interactive_rebase/mid_rebase_range_select.go
@@ -65,7 +65,7 @@ var MidRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("<-- YOU ARE HERE --- commit 05"),
 				Contains("commit 04"),
 			).
-			Press(keys.Commits.MarkCommitAsFixup).
+			Press(keys.Commits.Fixup).
 			TopLines(
 				Contains("pick").Contains("commit 10"),
 				Contains("pick").Contains("commit 09"),
@@ -75,7 +75,7 @@ var MidRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("<-- YOU ARE HERE --- commit 05"),
 				Contains("commit 04"),
 			).
-			Press(keys.Commits.PickCommit).
+			Press(keys.Commits.Pick).
 			TopLines(
 				Contains("pick").Contains("commit 10"),
 				Contains("pick").Contains("commit 09"),
@@ -95,7 +95,7 @@ var MidRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("<-- YOU ARE HERE --- commit 05"),
 				Contains("commit 04"),
 			).
-			Press(keys.Commits.SquashDown).
+			Press(keys.Commits.Squash).
 			TopLines(
 				Contains("pick").Contains("commit 10"),
 				Contains("pick").Contains("commit 09"),
@@ -174,7 +174,7 @@ var MidRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("<-- YOU ARE HERE --- commit 05").IsSelected(),
 				Contains("commit 04"),
 			).
-			Press(keys.Commits.MarkCommitAsFixup).
+			Press(keys.Commits.Fixup).
 			Tap(func() {
 				t.ExpectToast(Contains("Disabled: When rebasing, this action only works on a selection of TODO commits."))
 			}).

--- a/pkg/integration/tests/interactive_rebase/outside_rebase_range_select.go
+++ b/pkg/integration/tests/interactive_rebase/outside_rebase_range_select.go
@@ -45,7 +45,7 @@ var OutsideRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit 06"),
 			).
 			// Squash commits
-			Press(keys.Commits.SquashDown).
+			Press(keys.Commits.Squash).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Squash")).
@@ -75,7 +75,7 @@ var OutsideRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit 05").IsSelected(),
 				Contains("commit 04"),
 			).
-			Press(keys.Commits.MarkCommitAsFixup).
+			Press(keys.Commits.Fixup).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Fixup")).

--- a/pkg/integration/tests/interactive_rebase/rebase.go
+++ b/pkg/integration/tests/interactive_rebase/rebase.go
@@ -42,7 +42,7 @@ var Rebase = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("initial commit"),
 			).
 			SelectPreviousItem().
-			Press(keys.Commits.SquashDown).
+			Press(keys.Commits.Squash).
 			Lines(
 				MatchesRegexp("pick.*commit to fixup"),
 				MatchesRegexp("pick.*commit to drop"),
@@ -72,7 +72,7 @@ var Rebase = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("initial commit"),
 			).
 			SelectPreviousItem().
-			Press(keys.Commits.MarkCommitAsFixup).
+			Press(keys.Commits.Fixup).
 			Lines(
 				MatchesRegexp("fixup.*commit to fixup").IsSelected(),
 				MatchesRegexp("drop.*commit to drop"),

--- a/pkg/integration/tests/interactive_rebase/reword_commit_with_editor_and_fail.go
+++ b/pkg/integration/tests/interactive_rebase/reword_commit_with_editor_and_fail.go
@@ -25,7 +25,7 @@ var RewordCommitWithEditorAndFail = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit 01"),
 			).
 			NavigateToLine(Contains("commit 02")).
-			Press(keys.Commits.RenameCommitWithEditor).
+			Press(keys.Commits.RewordWithEditor).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Reword in editor")).

--- a/pkg/integration/tests/interactive_rebase/reword_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/reword_first_commit.go
@@ -25,7 +25,7 @@ var RewordFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit 01"),
 			).
 			NavigateToLine(Contains("commit 01")).
-			Press(keys.Commits.RenameCommit).
+			Press(keys.Commits.Reword).
 			Tap(func() {
 				t.ExpectPopup().CommitMessagePanel().
 					Title(Equals("Reword commit")).

--- a/pkg/integration/tests/interactive_rebase/reword_last_commit.go
+++ b/pkg/integration/tests/interactive_rebase/reword_last_commit.go
@@ -21,7 +21,7 @@ var RewordLastCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit 02").IsSelected(),
 				Contains("commit 01"),
 			).
-			Press(keys.Commits.RenameCommit).
+			Press(keys.Commits.Reword).
 			Tap(func() {
 				t.ExpectPopup().CommitMessagePanel().
 					Title(Equals("Reword commit")).

--- a/pkg/integration/tests/interactive_rebase/reword_you_are_here_commit.go
+++ b/pkg/integration/tests/interactive_rebase/reword_you_are_here_commit.go
@@ -29,7 +29,7 @@ var RewordYouAreHereCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("<-- YOU ARE HERE --- commit 02").IsSelected(),
 				Contains("commit 01"),
 			).
-			Press(keys.Commits.RenameCommit).
+			Press(keys.Commits.Reword).
 			Tap(func() {
 				t.ExpectPopup().CommitMessagePanel().
 					Title(Equals("Reword commit")).

--- a/pkg/integration/tests/interactive_rebase/reword_you_are_here_commit_with_editor.go
+++ b/pkg/integration/tests/interactive_rebase/reword_you_are_here_commit_with_editor.go
@@ -31,7 +31,7 @@ var RewordYouAreHereCommitWithEditor = NewIntegrationTest(NewIntegrationTestArgs
 				Contains("<-- YOU ARE HERE --- commit 02").IsSelected(),
 				Contains("commit 01"),
 			).
-			Press(keys.Commits.RenameCommitWithEditor).
+			Press(keys.Commits.RewordWithEditor).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Reword in editor")).

--- a/pkg/integration/tests/interactive_rebase/squash_down_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/squash_down_first_commit.go
@@ -22,7 +22,7 @@ var SquashDownFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit 01"),
 			).
 			NavigateToLine(Contains("commit 01")).
-			Press(keys.Commits.SquashDown).
+			Press(keys.Commits.Squash).
 			Tap(func() {
 				t.ExpectToast(Equals("Disabled: There's no commit below to squash into"))
 			}).

--- a/pkg/integration/tests/interactive_rebase/squash_down_second_commit.go
+++ b/pkg/integration/tests/interactive_rebase/squash_down_second_commit.go
@@ -23,7 +23,7 @@ var SquashDownSecondCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit 01"),
 			).
 			NavigateToLine(Contains("commit 02")).
-			Press(keys.Commits.SquashDown).
+			Press(keys.Commits.Squash).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Squash")).

--- a/pkg/integration/tests/interactive_rebase/squash_fixups_above_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/squash_fixups_above_first_commit.go
@@ -31,7 +31,7 @@ var SquashFixupsAboveFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			NavigateToLine(Contains("commit 01").DoesNotContain("fixup!")).
-			Press(keys.Commits.SquashAboveCommits).
+			Press(keys.Commits.ApplyFixupCommits).
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Apply fixup commits")).

--- a/pkg/integration/tests/interactive_rebase/squash_fixups_in_current_branch.go
+++ b/pkg/integration/tests/interactive_rebase/squash_fixups_in_current_branch.go
@@ -34,7 +34,7 @@ var SquashFixupsInCurrentBranch = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("fixup! master commit"),
 				Contains("master commit"),
 			).
-			Press(keys.Commits.SquashAboveCommits).
+			Press(keys.Commits.ApplyFixupCommits).
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Apply fixup commits")).

--- a/pkg/integration/tests/stash/stash.go
+++ b/pkg/integration/tests/stash/stash.go
@@ -23,7 +23,7 @@ var Stash = NewIntegrationTest(NewIntegrationTestArgs{
 			Lines(
 				Contains("file"),
 			).
-			Press(keys.Files.StashAllChanges)
+			Press(keys.Files.Stash)
 
 		t.ExpectPopup().Prompt().Title(Equals("Stash changes")).Type("my stashed file").Confirm()
 

--- a/pkg/integration/tests/submodule/enter.go
+++ b/pkg/integration/tests/submodule/enter.go
@@ -67,7 +67,7 @@ var Enter = NewIntegrationTest(NewIntegrationTestArgs{
 				t.Views().Main().Content(Contains("> empty commit"))
 			}).
 			PressPrimaryAction().
-			Press(keys.Files.CommitChanges).
+			Press(keys.Files.Commit).
 			Tap(func() {
 				t.ExpectPopup().CommitMessagePanel().Type("submodule change").Confirm()
 			}).

--- a/pkg/integration/tests/sync/fetch_when_sorted_by_date.go
+++ b/pkg/integration/tests/sync/fetch_when_sorted_by_date.go
@@ -39,7 +39,7 @@ var FetchWhenSortedByDate = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("master ↓1"),
 			).
 			NavigateToLine(Contains("master")).
-			Press(keys.Branches.FetchRemote).
+			Press(keys.Branches.Fetch).
 			Lines(
 				Contains("* branch1"),
 				Contains("master").IsSelected(),

--- a/pkg/integration/tests/tag/create_while_committing.go
+++ b/pkg/integration/tests/tag/create_while_committing.go
@@ -16,7 +16,7 @@ var CreateWhileCommitting = NewIntegrationTest(NewIntegrationTestArgs{
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Files().
-			Press(keys.Files.CommitChanges).
+			Press(keys.Files.Commit).
 			Tap(func() {
 				t.ExpectPopup().CommitMessagePanel().
 					Title(Equals("Commit summary")).

--- a/pkg/integration/tests/ui/mode_specific_keybinding_suggestions.go
+++ b/pkg/integration/tests/ui/mode_specific_keybinding_suggestions.go
@@ -99,7 +99,7 @@ var ModeSpecificKeybindingSuggestions = NewIntegrationTest(NewIntegrationTestArg
 			NavigateToLine(Contains("first-change-branch")).
 			Press(keys.Universal.Select).
 			NavigateToLine(Contains("second-change-branch")).
-			Press(keys.Branches.MergeIntoCurrentBranch).
+			Press(keys.Branches.Merge).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
 					Title(Equals("Merge")).

--- a/pkg/integration/tests/worktree/bare_repo_worktree_config.go
+++ b/pkg/integration/tests/worktree/bare_repo_worktree_config.go
@@ -72,7 +72,7 @@ var BareRepoWorktreeConfig = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains(" M a/b/c/blah"), // shows as modified
 			).
 			PressPrimaryAction().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).

--- a/pkg/integration/tests/worktree/dotfile_bare_repo.go
+++ b/pkg/integration/tests/worktree/dotfile_bare_repo.go
@@ -53,7 +53,7 @@ var DotfileBareRepo = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains(" M blah"), // shows as modified
 			).
 			PressPrimaryAction().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).

--- a/pkg/integration/tests/worktree/double_nested_linked_submodule.go
+++ b/pkg/integration/tests/worktree/double_nested_linked_submodule.go
@@ -74,7 +74,7 @@ var DoubleNestedLinkedSubmodule = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains(" M a/b/c/blah"), // shows as modified
 			).
 			PressPrimaryAction().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).

--- a/pkg/integration/tests/worktree/symlink_into_repo_subdir.go
+++ b/pkg/integration/tests/worktree/symlink_into_repo_subdir.go
@@ -44,7 +44,7 @@ var SymlinkIntoRepoSubdir = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains(" M a/b/c/blah"), // shows as modified
 			).
 			PressPrimaryAction().
-			Press(keys.Files.CommitChanges)
+			Press(keys.Files.Commit)
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).

--- a/schema/config.json
+++ b/schema/config.json
@@ -903,11 +903,11 @@
         },
         "files": {
           "properties": {
-            "commitChanges": {
+            "commit": {
               "type": "string",
               "default": "c"
             },
-            "commitChangesWithoutHook": {
+            "commitWithoutHook": {
               "type": "string",
               "default": "w"
             },
@@ -935,7 +935,7 @@
               "type": "string",
               "default": "r"
             },
-            "stashAllChanges": {
+            "stash": {
               "type": "string",
               "default": "s"
             },
@@ -947,7 +947,7 @@
               "type": "string",
               "default": "a"
             },
-            "viewResetOptions": {
+            "reset": {
               "type": "string",
               "default": "D"
             },
@@ -1005,7 +1005,7 @@
               "type": "string",
               "default": "R"
             },
-            "mergeIntoCurrentBranch": {
+            "merge": {
               "type": "string",
               "default": "M"
             },
@@ -1017,7 +1017,7 @@
               "type": "string",
               "default": "f"
             },
-            "createTag": {
+            "newTag": {
               "type": "string",
               "default": "T"
             },
@@ -1029,7 +1029,7 @@
               "type": "string",
               "default": "u"
             },
-            "fetchRemote": {
+            "fetch": {
               "type": "string",
               "default": "f"
             },
@@ -1053,15 +1053,15 @@
         },
         "commits": {
           "properties": {
-            "squashDown": {
+            "squash": {
               "type": "string",
               "default": "s"
             },
-            "renameCommit": {
+            "reword": {
               "type": "string",
               "default": "r"
             },
-            "renameCommitWithEditor": {
+            "rewordWithEditor": {
               "type": "string",
               "default": "R"
             },
@@ -1069,7 +1069,7 @@
               "type": "string",
               "default": "g"
             },
-            "markCommitAsFixup": {
+            "fixup": {
               "type": "string",
               "default": "f"
             },
@@ -1077,7 +1077,7 @@
               "type": "string",
               "default": "F"
             },
-            "squashAboveCommits": {
+            "applyFixupCommits": {
               "type": "string",
               "default": "S"
             },
@@ -1089,19 +1089,19 @@
               "type": "string",
               "default": "\u003cc-k\u003e"
             },
-            "amendToCommit": {
+            "amend": {
               "type": "string",
               "default": "A"
             },
-            "resetCommitAuthor": {
+            "amendCommitAttribute": {
               "type": "string",
               "default": "a"
             },
-            "pickCommit": {
+            "pick": {
               "type": "string",
               "default": "p"
             },
-            "revertCommit": {
+            "revert": {
               "type": "string",
               "default": "t"
             },
@@ -1121,7 +1121,7 @@
               "type": "string",
               "default": "T"
             },
-            "checkoutCommit": {
+            "checkout": {
               "type": "string",
               "default": "\u003cspace\u003e"
             },
@@ -1169,7 +1169,7 @@
         },
         "commitFiles": {
           "properties": {
-            "checkoutCommitFile": {
+            "checkout": {
               "type": "string",
               "default": "c"
             }


### PR DESCRIPTION
- **PR Description**

After many of the keybinding labels were changed in 7bddf532235c, update the keybinding config names to match, to reduce confusion.

Of course this is a breaking change for those who remapped the keys for one of these; we _could_ automatically migrate these configs, but I'm not sure it's worth it. It would probably increase the time it takes to load the config (I haven't measured by how much), and my hunch is that only few people remap key bindings.

If we want to do this, we should merge it soon, because it has a high potential of conflicting with other PRs.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
