### PR TITLE
Add author filtering to commit view

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -23,7 +23,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` + `` | Next screen mode (normal/half/fullscreen) |  |
 | `` _ `` | Prev screen mode |  |
 | `` ? `` | Open keybindings menu |  |
-| `` <c-s> `` | View filter-by-path options | View options for filtering the commit log by a file path, so that only commits relating to that path are shown. |
+| `` <c-s> `` | View filter options | View options for filtering the commit log, so that only commits matching the filter are shown. |
 | `` W `` | View diffing options | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` <c-e> `` | View diffing options | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` q `` | Quit |  |

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -23,7 +23,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` + `` | 次のスクリーンモード (normal/half/fullscreen) |  |
 | `` _ `` | 前のスクリーンモード |  |
 | `` ? `` | メニューを開く |  |
-| `` <c-s> `` | View filter-by-path options | View options for filtering the commit log by a file path, so that only commits relating to that path are shown. |
+| `` <c-s> `` | View filter options | View options for filtering the commit log, so that only commits matching the filter are shown. |
 | `` W `` | 差分メニューを開く | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` <c-e> `` | 差分メニューを開く | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` q `` | 終了 |  |

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -23,7 +23,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` + `` | 다음 스크린 모드 (normal/half/fullscreen) |  |
 | `` _ `` | 이전 스크린 모드 |  |
 | `` ? `` | 매뉴 열기 |  |
-| `` <c-s> `` | View filter-by-path options | View options for filtering the commit log by a file path, so that only commits relating to that path are shown. |
+| `` <c-s> `` | View filter-by-path options | View options for filtering the commit log, so that only commits matching the filter are shown. |
 | `` W `` | Diff 메뉴 열기 | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` <c-e> `` | Diff 메뉴 열기 | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` q `` | 종료 |  |

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -23,7 +23,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` + `` | Volgende scherm modus (normaal/half/groot) |  |
 | `` _ `` | Vorige scherm modus |  |
 | `` ? `` | Open menu |  |
-| `` <c-s> `` | Bekijk scoping opties | View options for filtering the commit log by a file path, so that only commits relating to that path are shown. |
+| `` <c-s> `` | Bekijk scoping opties | View options for filtering the commit log, so that only commits matching the filter are shown. |
 | `` W `` | Open diff menu | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` <c-e> `` | Open diff menu | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` q `` | Quit |  |

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -23,7 +23,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` + `` | Next screen mode (normal/half/fullscreen) |  |
 | `` _ `` | Prev screen mode |  |
 | `` ? `` | Open keybindings menu |  |
-| `` <c-s> `` | View filter-by-path options | View options for filtering the commit log by a file path, so that only commits relating to that path are shown. |
+| `` <c-s> `` | View filter options | View options for filtering the commit log, so that only commits matching the filter are shown. |
 | `` W `` | View diffing options | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` <c-e> `` | View diffing options | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` q `` | Quit |  |

--- a/docs/keybindings/Keybindings_ru.md
+++ b/docs/keybindings/Keybindings_ru.md
@@ -23,7 +23,7 @@ _Связки клавиш_
 | `` + `` | Следующий режим экрана (нормальный/полуэкранный/полноэкранный) |  |
 | `` _ `` | Предыдущий режим экрана |  |
 | `` ? `` | Открыть меню |  |
-| `` <c-s> `` | Просмотреть параметры фильтрации по пути | View options for filtering the commit log by a file path, so that only commits relating to that path are shown. |
+| `` <c-s> `` | Просмотреть параметры фильтрации по пути | View options for filtering the commit log, so that only commits matching the filter are shown. |
 | `` W `` | Открыть меню сравнении | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` <c-e> `` | Открыть меню сравнении | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` q `` | Выйти |  |

--- a/docs/keybindings/Keybindings_zh-CN.md
+++ b/docs/keybindings/Keybindings_zh-CN.md
@@ -23,7 +23,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` + `` | 下一屏模式（正常/半屏/全屏） |  |
 | `` _ `` | 上一屏模式 |  |
 | `` ? `` | 打开菜单 |  |
-| `` <c-s> `` | 查看按路径过滤选项 | View options for filtering the commit log by a file path, so that only commits relating to that path are shown. |
+| `` <c-s> `` | 查看按路径过滤选项 | View options for filtering the commit log, so that only commits matching the filter are shown. |
 | `` W `` | 打开 diff 菜单 | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` <c-e> `` | 打开 diff 菜单 | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` q `` | 退出 |  |

--- a/docs/keybindings/Keybindings_zh-TW.md
+++ b/docs/keybindings/Keybindings_zh-TW.md
@@ -23,7 +23,7 @@ _說明：`<c-b>` 表示 Ctrl+B、`<a-b>` 表示 Alt+B，`B`表示 Shift+B_
 | `` + `` | 下一個螢幕模式（常規/半螢幕/全螢幕） |  |
 | `` _ `` | 上一個螢幕模式 |  |
 | `` ? `` | 開啟選單 |  |
-| `` <c-s> `` | 檢視篩選路徑選項 | View options for filtering the commit log by a file path, so that only commits relating to that path are shown. |
+| `` <c-s> `` | 檢視篩選路徑選項 | View options for filtering the commit log, so that only commits matching the filter are shown. |
 | `` W `` | 開啟差異比較選單 | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` <c-e> `` | 開啟差異比較選單 | View options relating to diffing two refs e.g. diffing against selected ref, entering ref to diff against, and reversing the diff direction. |
 | `` q `` | 結束 |  |

--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -64,6 +64,7 @@ func NewCommitLoader(
 type GetCommitsOptions struct {
 	Limit                bool
 	FilterPath           string
+	FilterAuthor         string
 	IncludeRebaseCommits bool
 	RefName              string // e.g. "HEAD" or "my_branch"
 	RefForPushedStatus   string // the ref to use for determining pushed/unpushed status
@@ -664,6 +665,7 @@ func (self *CommitLoader) getLogCmd(opts GetCommitsOptions) oscommands.ICmdObj {
 		Arg("--oneline").
 		Arg(prettyFormat).
 		Arg("--abbrev=40").
+		ArgIf(opts.FilterAuthor != "", "--author="+opts.FilterAuthor).
 		ArgIf(opts.Limit, "-300").
 		ArgIf(opts.FilterPath != "", "--follow").
 		Arg("--no-show-signature").

--- a/pkg/commands/git_commands/reflog_commit_loader.go
+++ b/pkg/commands/git_commands/reflog_commit_loader.go
@@ -23,7 +23,7 @@ func NewReflogCommitLoader(common *common.Common, cmd oscommands.ICmdObjBuilder)
 
 // GetReflogCommits only returns the new reflog commits since the given lastReflogCommit
 // if none is passed (i.e. it's value is nil) then we get all the reflog commits
-func (self *ReflogCommitLoader) GetReflogCommits(lastReflogCommit *models.Commit, filterPath string) ([]*models.Commit, bool, error) {
+func (self *ReflogCommitLoader) GetReflogCommits(lastReflogCommit *models.Commit, filterPath string, filterAuthor string) ([]*models.Commit, bool, error) {
 	commits := make([]*models.Commit, 0)
 
 	cmdArgs := NewGitCmd("log").
@@ -31,6 +31,7 @@ func (self *ReflogCommitLoader) GetReflogCommits(lastReflogCommit *models.Commit
 		Arg("-g").
 		Arg("--abbrev=40").
 		Arg("--format=%h%x00%ct%x00%gs%x00%p").
+		ArgIf(filterAuthor != "", "--author="+filterAuthor).
 		ArgIf(filterPath != "", "--follow", "--", filterPath).
 		ToArgv()
 

--- a/pkg/gui/controllers/helpers/mode_helper.go
+++ b/pkg/gui/controllers/helpers/mode_helper.go
@@ -72,11 +72,12 @@ func (self *ModeHelper) Statuses() []ModeStatus {
 		{
 			IsActive: self.c.Modes().Filtering.Active,
 			Description: func() string {
+				filterContent := lo.Ternary(self.c.Modes().Filtering.GetPath() != "", self.c.Modes().Filtering.GetPath(), self.c.Modes().Filtering.GetAuthor())
 				return self.withResetButton(
 					fmt.Sprintf(
 						"%s '%s'",
 						self.c.Tr.FilteringBy,
-						self.c.Modes().Filtering.GetPath(),
+						filterContent,
 					),
 					style.FgRed,
 				)

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -317,6 +317,7 @@ func (self *RefreshHelper) refreshCommitsWithLimit() error {
 		git_commands.GetCommitsOptions{
 			Limit:                self.c.Contexts().LocalCommits.GetLimitCommits(),
 			FilterPath:           self.c.Modes().Filtering.GetPath(),
+			FilterAuthor:         self.c.Modes().Filtering.GetAuthor(),
 			IncludeRebaseCommits: true,
 			RefName:              self.refForLog(),
 			RefForPushedStatus:   checkedOutBranchName,
@@ -342,6 +343,7 @@ func (self *RefreshHelper) refreshSubCommitsWithLimit() error {
 		git_commands.GetCommitsOptions{
 			Limit:                   self.c.Contexts().SubCommits.GetLimitCommits(),
 			FilterPath:              self.c.Modes().Filtering.GetPath(),
+			FilterAuthor:            self.c.Modes().Filtering.GetAuthor(),
 			IncludeRebaseCommits:    false,
 			RefName:                 self.c.Contexts().SubCommits.GetRef().FullRefName(),
 			RefToShowDivergenceFrom: self.c.Contexts().SubCommits.GetRefToShowDivergenceFrom(),
@@ -438,7 +440,7 @@ func (self *RefreshHelper) refreshBranches(refreshWorktrees bool, keepBranchSele
 		// which allows us to order them correctly. So if we're filtering we'll just
 		// manually load all the reflog commits here
 		var err error
-		reflogCommits, _, err = self.c.Git().Loaders.ReflogCommitLoader.GetReflogCommits(nil, "")
+		reflogCommits, _, err = self.c.Git().Loaders.ReflogCommitLoader.GetReflogCommits(nil, "", "")
 		if err != nil {
 			self.c.Log.Error(err)
 		}
@@ -597,9 +599,9 @@ func (self *RefreshHelper) refreshReflogCommits() error {
 		lastReflogCommit = model.ReflogCommits[0]
 	}
 
-	refresh := func(stateCommits *[]*models.Commit, filterPath string) error {
+	refresh := func(stateCommits *[]*models.Commit, filterPath string, filterAuthor string) error {
 		commits, onlyObtainedNewReflogCommits, err := self.c.Git().Loaders.ReflogCommitLoader.
-			GetReflogCommits(lastReflogCommit, filterPath)
+			GetReflogCommits(lastReflogCommit, filterPath, filterAuthor)
 		if err != nil {
 			return self.c.Error(err)
 		}
@@ -612,12 +614,12 @@ func (self *RefreshHelper) refreshReflogCommits() error {
 		return nil
 	}
 
-	if err := refresh(&model.ReflogCommits, ""); err != nil {
+	if err := refresh(&model.ReflogCommits, "", ""); err != nil {
 		return err
 	}
 
 	if self.c.Modes().Filtering.Active() {
-		if err := refresh(&model.FilteredReflogCommits, self.c.Modes().Filtering.GetPath()); err != nil {
+		if err := refresh(&model.FilteredReflogCommits, self.c.Modes().Filtering.GetPath(), self.c.Modes().Filtering.GetAuthor()); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/gui/controllers/helpers/sub_commits_helper.go
+++ b/pkg/gui/controllers/helpers/sub_commits_helper.go
@@ -39,6 +39,7 @@ func (self *SubCommitsHelper) ViewSubCommits(opts ViewSubCommitsOpts) error {
 		git_commands.GetCommitsOptions{
 			Limit:                   true,
 			FilterPath:              self.c.Modes().Filtering.GetPath(),
+			FilterAuthor:            self.c.Modes().Filtering.GetAuthor(),
 			IncludeRebaseCommits:    false,
 			RefName:                 opts.Ref.FullRefName(),
 			RefForPushedStatus:      opts.Ref.FullRefName(),

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -386,7 +386,7 @@ func (gui *Gui) resetState(startArgs appTypes.StartArgs) types.Context {
 			Authors:               map[string]*models.Author{},
 		},
 		Modes: &types.Modes{
-			Filtering:        filtering.New(startArgs.FilterPath),
+			Filtering:        filtering.New(startArgs.FilterPath, ""),
 			CherryPicking:    cherrypicking.New(),
 			Diffing:          diffing.New(),
 			MarkedBaseCommit: marked_base_commit.New(),

--- a/pkg/gui/modes/filtering/filtering.go
+++ b/pkg/gui/modes/filtering/filtering.go
@@ -1,19 +1,21 @@
 package filtering
 
 type Filtering struct {
-	path string // the filename that gets passed to git log
+	path   string // the filename that gets passed to git log
+	author string // the author that gets passed to git log
 }
 
-func New(path string) Filtering {
-	return Filtering{path: path}
+func New(path string, author string) Filtering {
+	return Filtering{path: path, author: author}
 }
 
 func (m *Filtering) Active() bool {
-	return m.path != ""
+	return m.path != "" || m.author != ""
 }
 
 func (m *Filtering) Reset() {
 	m.path = ""
+	m.author = ""
 }
 
 func (m *Filtering) SetPath(path string) {
@@ -22,4 +24,12 @@ func (m *Filtering) SetPath(path string) {
 
 func (m *Filtering) GetPath() string {
 	return m.path
+}
+
+func (m *Filtering) SetAuthor(author string) {
+	m.author = author
+}
+
+func (m *Filtering) GetAuthor() string {
+	return m.author
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -536,9 +536,13 @@ type TranslationSet struct {
 	OpenFilteringMenuTooltip              string
 	FilterBy                              string
 	ExitFilterMode                        string
+	ExitFilterModeAuthor                  string
 	FilterPathOption                      string
+	FilterAuthorOption                    string
 	EnterFileName                         string
+	EnterAuthor                           string
 	FilteringMenuTitle                    string
+	WillCancelExistingFilterTooltip       string
 	MustExitFilterModeTitle               string
 	MustExitFilterModePrompt              string
 	Diff                                  string
@@ -1475,13 +1479,16 @@ func EnglishTranslationSet() TranslationSet {
 		GotoBottom:                       "Scroll to bottom",
 		FilteringBy:                      "Filtering by",
 		ResetInParentheses:               "(Reset)",
-		OpenFilteringMenu:                "View filter-by-path options",
-		OpenFilteringMenuTooltip:         "View options for filtering the commit log by a file path, so that only commits relating to that path are shown.",
+		OpenFilteringMenu:                "View filter options",
+		OpenFilteringMenuTooltip:         "View options for filtering the commit log, so that only commits matching the filter are shown.",
 		FilterBy:                         "Filter by",
-		ExitFilterMode:                   "Stop filtering by path",
+		ExitFilterMode:                   "Stop filtering",
 		FilterPathOption:                 "Enter path to filter by",
+		FilterAuthorOption:               "Enter author to filter by",
 		EnterFileName:                    "Enter path:",
+		EnterAuthor:                      "Enter author:",
 		FilteringMenuTitle:               "Filtering",
+		WillCancelExistingFilterTooltip:  "Note: this will cancel the existing filter",
 		MustExitFilterModeTitle:          "Command not available",
 		MustExitFilterModePrompt:         "Command not available in filter-by-path mode. Exit filter-by-path mode?",
 		Diff:                             "Diff",

--- a/pkg/integration/tests/filter_by_author/select_author.go
+++ b/pkg/integration/tests/filter_by_author/select_author.go
@@ -1,0 +1,70 @@
+package filter_by_author
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var SelectAuthor = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Filter commits using the currently highlighted commit's author when the commit view is active",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.AppState.GitLogShowGraph = "never"
+	},
+	SetupRepo: func(shell *Shell) {
+		commonSetup(shell)
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			SelectedLineIdx(0).
+			Press(keys.Universal.FilteringMenu)
+
+		t.ExpectPopup().Menu().
+			Title(Equals("Filtering")).
+			Select(Contains("Filter by 'Paul Oberstein <paul.oberstein@email.com>'")).
+			Confirm()
+
+		t.Views().Commits().
+			IsFocused().
+			Lines(
+				Contains("commit 7"),
+				Contains("commit 6"),
+				Contains("commit 5"),
+				Contains("commit 4"),
+				Contains("commit 3"),
+				Contains("commit 2"),
+				Contains("commit 1"),
+				Contains("commit 0"),
+			)
+
+		t.Views().Information().Content(Contains("Filtering by 'Paul Oberstein <paul.oberstein@email.com>'"))
+
+		t.Views().Commits().
+			Press(keys.Universal.FilteringMenu)
+
+		t.ExpectPopup().Menu().
+			Title(Equals("Filtering")).
+			Select(Contains("Stop filtering")).
+			Confirm()
+
+		t.Views().Commits().
+			IsFocused().
+			NavigateToLine(Contains("SK commit 0")).
+			Press(keys.Universal.FilteringMenu)
+
+		t.ExpectPopup().Menu().
+			Title(Equals("Filtering")).
+			Select(Contains("Filter by 'Siegfried Kircheis <siegfried.kircheis@email.com>'")).
+			Confirm()
+
+		t.Views().Commits().
+			IsFocused().
+			Lines(
+				Contains("commit 0"),
+			)
+
+		t.Views().Information().Content(Contains("Filtering by 'Siegfried Kircheis <siegfried.kircheis@email.com>'"))
+	},
+})

--- a/pkg/integration/tests/filter_by_author/shared.go
+++ b/pkg/integration/tests/filter_by_author/shared.go
@@ -1,0 +1,30 @@
+package filter_by_author
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+type AuthorInfo struct {
+	name            string
+	numberOfCommits int
+}
+
+func commonSetup(shell *Shell) {
+	authors := []AuthorInfo{{"Yang Wen-li", 3}, {"Siegfried Kircheis", 1}, {"Paul Oberstein", 8}}
+	totalCommits := 0
+	repoStartDaysAgo := 100
+
+	for _, authorInfo := range authors {
+		for i := 0; i < authorInfo.numberOfCommits; i++ {
+			authorEmail := strings.ToLower(strings.ReplaceAll(authorInfo.name, " ", ".")) + "@email.com"
+			commitMessage := fmt.Sprintf("commit %d", i)
+
+			shell.SetAuthor(authorInfo.name, authorEmail)
+			shell.EmptyCommitDaysAgo(commitMessage, repoStartDaysAgo-totalCommits)
+			totalCommits++
+		}
+	}
+}

--- a/pkg/integration/tests/filter_by_author/type_author.go
+++ b/pkg/integration/tests/filter_by_author/type_author.go
@@ -1,0 +1,66 @@
+package filter_by_author
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var TypeAuthor = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Filter commits by author using the typed in author",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+	},
+	SetupRepo: func(shell *Shell) {
+		commonSetup(shell)
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Status().
+			Focus().
+			Press(keys.Universal.FilteringMenu)
+
+		t.ExpectPopup().Menu().
+			Title(Equals("Filtering")).
+			Select(Contains("Enter author to filter by")).
+			Confirm()
+
+		t.ExpectPopup().Prompt().
+			Title(Equals("Enter author:")).
+			Type("Yang").
+			SuggestionLines(Equals("Yang Wen-li <yang.wen-li@email.com>")).
+			ConfirmFirstSuggestion()
+
+		t.Views().Commits().
+			IsFocused().
+			Lines(
+				Contains("commit 2"),
+				Contains("commit 1"),
+				Contains("commit 0"),
+			)
+
+		t.Views().Information().Content(Contains("Filtering by 'Yang Wen-li <yang.wen-li@email.com>'"))
+
+		t.Views().Status().
+			Focus().
+			Press(keys.Universal.FilteringMenu)
+
+		t.ExpectPopup().Menu().
+			Title(Equals("Filtering")).
+			Select(Contains("Enter author to filter by")).
+			Confirm()
+
+		t.ExpectPopup().Prompt().
+			Title(Equals("Enter author:")).
+			Type("Siegfried").
+			SuggestionLines(Equals("Siegfried Kircheis <siegfried.kircheis@email.com>")).
+			ConfirmFirstSuggestion()
+
+		t.Views().Commits().
+			IsFocused().
+			Lines(
+				Contains("commit 0"),
+			)
+
+		t.Views().Information().Content(Contains("Filtering by 'Siegfried Kircheis <siegfried.kircheis@email.com>'"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/diff"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/file"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/filter_and_search"
+	"github.com/jesseduffield/lazygit/pkg/integration/tests/filter_by_author"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/filter_by_path"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/interactive_rebase"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/misc"
@@ -149,6 +150,8 @@ var tests = []*components.IntegrationTest{
 	filter_and_search.NestedFilter,
 	filter_and_search.NestedFilterTransient,
 	filter_and_search.NewSearch,
+	filter_by_author.SelectAuthor,
+	filter_by_author.TypeAuthor,
 	filter_by_path.CliArg,
 	filter_by_path.SelectFile,
 	filter_by_path.TypeFile,


### PR DESCRIPTION
- **PR Description**

This PR introduces a new feature to the commit view, allowing users to filter commits based on the author's name or email address. Similar to the existing path filtering functionality, accessible through `<c-s>`, this feature allows users to filter the commit history by the currently selected commit's author if the commit view is focused, or by typing in the author's name or email address.

This feature adds an entry to the filtering menu, to provide users with a familiar and intuitive experience

![filter-by-author](https://github.com/jesseduffield/lazygit/assets/3098462/5b00a716-e432-4204-8568-0e93b1411bc7)

- **Please check if the PR fulfils these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc