### PR TITLE
Allow more than one argument in git.merging.args config

### DIFF
--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -210,7 +210,7 @@ type MergeOpts struct {
 func (self *BranchCommands) Merge(branchName string, opts MergeOpts) error {
 	cmdArgs := NewGitCmd("merge").
 		Arg("--no-edit").
-		ArgIf(self.UserConfig.Git.Merging.Args != "", self.UserConfig.Git.Merging.Args).
+		Arg(strings.Fields(self.UserConfig.Git.Merging.Args)...).
 		ArgIf(opts.FastForwardOnly, "--ff-only").
 		Arg(branchName).
 		ToArgv()

--- a/pkg/commands/git_commands/branch_test.go
+++ b/pkg/commands/git_commands/branch_test.go
@@ -128,6 +128,20 @@ func TestBranchMerge(t *testing.T) {
 			expected:   []string{"merge", "--no-edit", "--merging-args", "mybranch"},
 		},
 		{
+			testName: "multiple merging args",
+			userConfig: &config.UserConfig{
+				Git: config.GitConfig{
+					Merging: config.MergingConfig{
+						Args: "--arg1 --arg2", // it's up to the user what they put here
+					},
+				},
+			},
+			opts:       MergeOpts{},
+			branchName: "mybranch",
+			expected:   []string{"merge", "--no-edit", "--arg1 --arg2", "mybranch"},
+			// This is wrong, we want separate arguments for "--arg1" and "--arg2"
+		},
+		{
 			testName:   "fast forward only",
 			userConfig: &config.UserConfig{},
 			opts:       MergeOpts{FastForwardOnly: true},

--- a/pkg/commands/git_commands/branch_test.go
+++ b/pkg/commands/git_commands/branch_test.go
@@ -138,8 +138,7 @@ func TestBranchMerge(t *testing.T) {
 			},
 			opts:       MergeOpts{},
 			branchName: "mybranch",
-			expected:   []string{"merge", "--no-edit", "--arg1 --arg2", "mybranch"},
-			// This is wrong, we want separate arguments for "--arg1" and "--arg2"
+			expected:   []string{"merge", "--no-edit", "--arg1", "--arg2", "mybranch"},
 		},
 		{
 			testName:   "fast forward only",


### PR DESCRIPTION
- **PR Description**

Fix a bug where merging would fail with an error message when you try to put more than one argument in the `git.merging.args` config. This broke with 25f8b0337e.

Fixes #3334.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
