### PR TITLE
Adjust selection after squashing fixups

### DIFF
--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -847,11 +847,7 @@ func (self *LocalCommitsController) squashFixupCommits() error {
 }
 
 func (self *LocalCommitsController) squashAllFixupsAboveSelectedCommit(commit *models.Commit) error {
-	return self.c.WithWaitingStatus(self.c.Tr.SquashingStatus, func(gocui.Task) error {
-		self.c.LogAction(self.c.Tr.Actions.SquashAllAboveFixupCommits)
-		err := self.c.Git().Rebase.SquashAllAboveFixupCommits(commit)
-		return self.c.Helpers().MergeAndRebase.CheckMergeOrRebase(err)
-	})
+	return self.squashFixupsImpl(commit)
 }
 
 func (self *LocalCommitsController) squashAllFixupsInCurrentBranch() error {
@@ -860,6 +856,10 @@ func (self *LocalCommitsController) squashAllFixupsInCurrentBranch() error {
 		return self.c.Error(err)
 	}
 
+	return self.squashFixupsImpl(commit)
+}
+
+func (self *LocalCommitsController) squashFixupsImpl(commit *models.Commit) error {
 	return self.c.WithWaitingStatus(self.c.Tr.SquashingStatus, func(gocui.Task) error {
 		self.c.LogAction(self.c.Tr.Actions.SquashAllAboveFixupCommits)
 		err := self.c.Git().Rebase.SquashAllAboveFixupCommits(commit)

--- a/pkg/gui/controllers/local_commits_controller_test.go
+++ b/pkg/gui/controllers/local_commits_controller_test.go
@@ -1,0 +1,141 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_countSquashableCommitsAbove(t *testing.T) {
+	scenarios := []struct {
+		name           string
+		commits        []*models.Commit
+		selectedIdx    int
+		rebaseStartIdx int
+		expectedResult int
+	}{
+		{
+			name: "no squashable commits",
+			commits: []*models.Commit{
+				{Name: "abc"},
+				{Name: "def"},
+				{Name: "ghi"},
+			},
+			selectedIdx:    2,
+			rebaseStartIdx: 2,
+			expectedResult: 0,
+		},
+		{
+			name: "some squashable commits, including for the selected commit",
+			commits: []*models.Commit{
+				{Name: "fixup! def"},
+				{Name: "fixup! ghi"},
+				{Name: "abc"},
+				{Name: "def"},
+				{Name: "ghi"},
+			},
+			selectedIdx:    4,
+			rebaseStartIdx: 4,
+			expectedResult: 2,
+		},
+		{
+			name: "base commit is below rebase start",
+			commits: []*models.Commit{
+				{Name: "fixup! def"},
+				{Name: "abc"},
+				{Name: "def"},
+			},
+			selectedIdx:    1,
+			rebaseStartIdx: 1,
+			expectedResult: 0,
+		},
+		{
+			name: "base commit does not exist at all",
+			commits: []*models.Commit{
+				{Name: "fixup! xyz"},
+				{Name: "abc"},
+				{Name: "def"},
+			},
+			selectedIdx:    2,
+			rebaseStartIdx: 2,
+			expectedResult: 0,
+		},
+		{
+			name: "selected commit is in the middle of fixups",
+			commits: []*models.Commit{
+				{Name: "fixup! def"},
+				{Name: "abc"},
+				{Name: "fixup! ghi"},
+				{Name: "def"},
+				{Name: "ghi"},
+			},
+			selectedIdx:    1,
+			rebaseStartIdx: 4,
+			expectedResult: 1,
+		},
+		{
+			name: "selected commit is after rebase start",
+			commits: []*models.Commit{
+				{Name: "fixup! def"},
+				{Name: "abc"},
+				{Name: "def"},
+				{Name: "ghi"},
+			},
+			selectedIdx:    3,
+			rebaseStartIdx: 2,
+			expectedResult: 1,
+		},
+	}
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			assert.Equal(t, s.expectedResult, countSquashableCommitsAbove(s.commits, s.selectedIdx, s.rebaseStartIdx))
+		})
+	}
+}
+
+func Test_isFixupCommit(t *testing.T) {
+	scenarios := []struct {
+		subject                string
+		expectedTrimmedSubject string
+		expectedIsFixup        bool
+	}{
+		{
+			subject:                "Bla",
+			expectedTrimmedSubject: "Bla",
+			expectedIsFixup:        false,
+		},
+		{
+			subject:                "fixup Bla",
+			expectedTrimmedSubject: "fixup Bla",
+			expectedIsFixup:        false,
+		},
+		{
+			subject:                "fixup! Bla",
+			expectedTrimmedSubject: "Bla",
+			expectedIsFixup:        true,
+		},
+		{
+			subject:                "fixup! fixup! Bla",
+			expectedTrimmedSubject: "Bla",
+			expectedIsFixup:        true,
+		},
+		{
+			subject:                "amend! squash! Bla",
+			expectedTrimmedSubject: "Bla",
+			expectedIsFixup:        true,
+		},
+		{
+			subject:                "fixup!",
+			expectedTrimmedSubject: "fixup!",
+			expectedIsFixup:        false,
+		},
+	}
+	for _, s := range scenarios {
+		t.Run(s.subject, func(t *testing.T) {
+			trimmedSubject, isFixupCommit := isFixupCommit(s.subject)
+			assert.Equal(t, s.expectedTrimmedSubject, trimmedSubject)
+			assert.Equal(t, s.expectedIsFixup, isFixupCommit)
+		})
+	}
+}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -341,6 +341,7 @@ type TranslationSet struct {
 	CheckingOutStatus                     string
 	CommittingStatus                      string
 	RevertingStatus                       string
+	CreatingFixupCommitStatus             string
 	CommitFiles                           string
 	SubCommitsDynamicTitle                string
 	CommitFilesDynamicTitle               string
@@ -1289,6 +1290,7 @@ func EnglishTranslationSet() TranslationSet {
 		CheckingOutStatus:                   "Checking out",
 		CommittingStatus:                    "Committing",
 		RevertingStatus:                     "Reverting",
+		CreatingFixupCommitStatus:           "Creating fixup commit",
 		CommitFiles:                         "Commit files",
 		SubCommitsDynamicTitle:              "Commits (%s)",
 		CommitFilesDynamicTitle:             "Diff files (%s)",

--- a/pkg/integration/tests/interactive_rebase/squash_fixups_above.go
+++ b/pkg/integration/tests/interactive_rebase/squash_fixups_above.go
@@ -46,10 +46,9 @@ var SquashFixupsAbove = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Lines(
 				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01").IsSelected(), // wrong, we want the previous line
-			).
-			SelectPreviousItem()
+				Contains("commit 02").IsSelected(),
+				Contains("commit 01"),
+			)
 
 		t.Views().Main().
 			Content(Contains("fixup content"))

--- a/pkg/integration/tests/interactive_rebase/squash_fixups_above.go
+++ b/pkg/integration/tests/interactive_rebase/squash_fixups_above.go
@@ -33,11 +33,10 @@ var SquashFixupsAbove = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Lines(
 				Contains("fixup! commit 02"),
-				Contains("commit 03").IsSelected(), // wrong, we want the next line
-				Contains("commit 02"),
+				Contains("commit 03"),
+				Contains("commit 02").IsSelected(),
 				Contains("commit 01"),
 			).
-			SelectNextItem().
 			Press(keys.Commits.SquashAboveCommits).
 			Tap(func() {
 				t.ExpectPopup().Menu().

--- a/pkg/integration/tests/interactive_rebase/squash_fixups_above.go
+++ b/pkg/integration/tests/interactive_rebase/squash_fixups_above.go
@@ -1,0 +1,58 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var SquashFixupsAbove = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Squashes all fixups above a commit and checks that the selected line stays correct.",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			CreateNCommits(3).
+			CreateFileAndAdd("fixup-file", "fixup content")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("commit 03"),
+				Contains("commit 02"),
+				Contains("commit 01"),
+			).
+			NavigateToLine(Contains("commit 02")).
+			Press(keys.Commits.CreateFixupCommit).
+			Tap(func() {
+				t.ExpectPopup().Confirmation().
+					Title(Equals("Create fixup commit")).
+					Content(Contains("Are you sure you want to create a fixup! commit for commit")).
+					Confirm()
+			}).
+			Lines(
+				Contains("fixup! commit 02"),
+				Contains("commit 03").IsSelected(), // wrong, we want the next line
+				Contains("commit 02"),
+				Contains("commit 01"),
+			).
+			SelectNextItem().
+			Press(keys.Commits.SquashAboveCommits).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Apply fixup commits")).
+					Select(Contains("Above the selected commit")).
+					Confirm()
+			}).
+			Lines(
+				Contains("commit 03"),
+				Contains("commit 02"),
+				Contains("commit 01").IsSelected(), // wrong, we want the previous line
+			).
+			SelectPreviousItem()
+
+		t.Views().Main().
+			Content(Contains("fixup content"))
+	},
+})

--- a/pkg/integration/tests/interactive_rebase/squash_fixups_in_current_branch.go
+++ b/pkg/integration/tests/interactive_rebase/squash_fixups_in_current_branch.go
@@ -27,10 +27,12 @@ var SquashFixupsInCurrentBranch = NewIntegrationTest(NewIntegrationTestArgs{
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().
 			Focus().
+			SelectNextItem().
+			SelectNextItem().
 			Lines(
 				Contains("fixup! commit 01"),
 				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit 01").IsSelected(),
 				Contains("fixup! master commit"),
 				Contains("master commit"),
 			).
@@ -44,7 +46,7 @@ var SquashFixupsInCurrentBranch = NewIntegrationTest(NewIntegrationTestArgs{
 			Lines(
 				Contains("commit 02"),
 				Contains("commit 01"),
-				Contains("fixup! master commit"),
+				Contains("fixup! master commit").IsSelected(), // wrong, we want the previous line
 				Contains("master commit"),
 			).
 			NavigateToLine(Contains("commit 01"))

--- a/pkg/integration/tests/interactive_rebase/squash_fixups_in_current_branch.go
+++ b/pkg/integration/tests/interactive_rebase/squash_fixups_in_current_branch.go
@@ -45,11 +45,10 @@ var SquashFixupsInCurrentBranch = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Lines(
 				Contains("commit 02"),
-				Contains("commit 01"),
-				Contains("fixup! master commit").IsSelected(), // wrong, we want the previous line
+				Contains("commit 01").IsSelected(),
+				Contains("fixup! master commit"),
 				Contains("master commit"),
-			).
-			NavigateToLine(Contains("commit 01"))
+			)
 
 		t.Views().Main().
 			Content(Contains("fixup content"))

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -188,6 +188,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.RewordYouAreHereCommitWithEditor,
 	interactive_rebase.SquashDownFirstCommit,
 	interactive_rebase.SquashDownSecondCommit,
+	interactive_rebase.SquashFixupsAbove,
 	interactive_rebase.SquashFixupsAboveFirstCommit,
 	interactive_rebase.SquashFixupsInCurrentBranch,
 	interactive_rebase.SwapInRebaseWithConflict,


### PR DESCRIPTION
- **PR Description**

Keep the same commit selected after squashing fixup commits, and after creating fixup commits.

Edge case: it is now possible to have a range of commits selected when squashing fixups (by using the "in current branch" version of the command), and in that case we don't bother preserving the range. It would be possible, but would require more code, and I don't think it's worth it, so I'm simply collapsing the range in that case.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
