### PR TITLE
Copy branch url to clipboard

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -157,7 +157,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` n `` | New branch |  |
 | `` o `` | Create pull request |  |
 | `` O `` | View create pull request options |  |
-| `` <c-y> `` | Copy pull request URL to clipboard |  |
+| `` y `` | Copy branch attribute to clipboard |  |
 | `` c `` | Checkout by name | Checkout by name. In the input box you can enter '-' to switch to the last branch. |
 | `` F `` | Force checkout | Force checkout selected branch. This will discard all local changes in your working directory before checking out the selected branch. |
 | `` d `` | Delete | View delete options for local/remote branch. |

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -227,7 +227,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` n `` | 新しいブランチを作成 |  |
 | `` o `` | Pull Requestを作成 |  |
 | `` O `` | View create pull request options |  |
-| `` <c-y> `` | Pull RequestのURLをクリップボードにコピー |  |
+| `` y `` | Copy branch attribute to clipboard |  |
 | `` c `` | Checkout by name | Checkout by name. In the input box you can enter '-' to switch to the last branch. |
 | `` F `` | Force checkout | Force checkout selected branch. This will discard all local changes in your working directory before checking out the selected branch. |
 | `` d `` | Delete | View delete options for local/remote branch. |

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -183,7 +183,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` n `` | 새 브랜치 생성 |  |
 | `` o `` | 풀 리퀘스트 생성 |  |
 | `` O `` | 풀 리퀘스트 생성 옵션 |  |
-| `` <c-y> `` | 풀 리퀘스트 URL을 클립보드에 복사 |  |
+| `` y `` | Copy branch attribute to clipboard |  |
 | `` c `` | 이름으로 체크아웃 | Checkout by name. In the input box you can enter '-' to switch to the last branch. |
 | `` F `` | 강제 체크아웃 | Force checkout selected branch. This will discard all local changes in your working directory before checking out the selected branch. |
 | `` d `` | Delete | View delete options for local/remote branch. |

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -96,7 +96,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` n `` | Nieuwe branch |  |
 | `` o `` | Maak een pull-request |  |
 | `` O `` | Bekijk opties voor pull-aanvraag |  |
-| `` <c-y> `` | Kopieer de URL van het pull-verzoek naar het klembord |  |
+| `` y `` | Copy branch attribute to clipboard |  |
 | `` c `` | Uitchecken bij naam | Checkout by name. In the input box you can enter '-' to switch to the last branch. |
 | `` F `` | Forceer checkout | Force checkout selected branch. This will discard all local changes in your working directory before checking out the selected branch. |
 | `` d `` | Delete | View delete options for local/remote branch. |

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -111,7 +111,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` n `` | Nowa gałąź |  |
 | `` o `` | Utwórz żądanie pobrania |  |
 | `` O `` | Utwórz opcje żądania ściągnięcia |  |
-| `` <c-y> `` | Skopiuj adres URL żądania pobrania do schowka |  |
+| `` y `` | Copy branch attribute to clipboard |  |
 | `` c `` | Przełącz używając nazwy | Checkout by name. In the input box you can enter '-' to switch to the last branch. |
 | `` F `` | Wymuś przełączenie | Force checkout selected branch. This will discard all local changes in your working directory before checking out the selected branch. |
 | `` d `` | Delete | View delete options for local/remote branch. |

--- a/docs/keybindings/Keybindings_ru.md
+++ b/docs/keybindings/Keybindings_ru.md
@@ -183,7 +183,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` n `` | Новая ветка |  |
 | `` o `` | Создать запрос на принятие изменений |  |
 | `` O `` | Создать параметры запроса принятие изменений |  |
-| `` <c-y> `` | Скопировать URL запроса на принятие изменений в буфер обмена |  |
+| `` y `` | Copy branch attribute to clipboard |  |
 | `` c `` | Переключить по названию | Checkout by name. In the input box you can enter '-' to switch to the last branch. |
 | `` F `` | Принудительное переключение | Force checkout selected branch. This will discard all local changes in your working directory before checking out the selected branch. |
 | `` d `` | Delete | View delete options for local/remote branch. |

--- a/docs/keybindings/Keybindings_zh-CN.md
+++ b/docs/keybindings/Keybindings_zh-CN.md
@@ -86,7 +86,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` n `` | 新分支 |  |
 | `` o `` | 创建抓取请求 |  |
 | `` O `` | 创建抓取请求选项 |  |
-| `` <c-y> `` | 将抓取请求 URL 复制到剪贴板 |  |
+| `` y `` | Copy branch attribute to clipboard |  |
 | `` c `` | 按名称检出 | Checkout by name. In the input box you can enter '-' to switch to the last branch. |
 | `` F `` | 强制检出 | Force checkout selected branch. This will discard all local changes in your working directory before checking out the selected branch. |
 | `` d `` | Delete | View delete options for local/remote branch. |

--- a/docs/keybindings/Keybindings_zh-TW.md
+++ b/docs/keybindings/Keybindings_zh-TW.md
@@ -258,7 +258,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` n `` | 新分支 |  |
 | `` o `` | 建立拉取請求 |  |
 | `` O `` | 建立拉取請求選項 |  |
-| `` <c-y> `` | 複製拉取請求的 URL 到剪貼板 |  |
+| `` y `` | Copy branch attribute to clipboard |  |
 | `` c `` | 根據名稱檢出 | Checkout by name. In the input box you can enter '-' to switch to the last branch. |
 | `` F `` | 強制檢出 | Force checkout selected branch. This will discard all local changes in your working directory before checking out the selected branch. |
 | `` d `` | Delete | View delete options for local/remote branch. |

--- a/pkg/commands/git_commands/remote.go
+++ b/pkg/commands/git_commands/remote.go
@@ -66,9 +66,13 @@ func (self *RemoteCommands) DeleteRemoteTag(task gocui.Task, remoteName string, 
 }
 
 // CheckRemoteBranchExists Returns remote branch
-func (self *RemoteCommands) CheckRemoteBranchExists(branchName string) bool {
+func (self *RemoteCommands) CheckRemoteBranchExists(branchName string, upstreamRemote string) bool {
+	if upstreamRemote == "" {
+		upstreamRemote = "origin"
+	}
+
 	cmdArgs := NewGitCmd("show-ref").
-		Arg("--verify", "--", fmt.Sprintf("refs/remotes/origin/%s", branchName)).
+		Arg("--verify", "--", fmt.Sprintf("refs/remotes/%s/%s", upstreamRemote, branchName)).
 		ToArgv()
 
 	_, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()

--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -15,6 +15,7 @@ var githubServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/compare/{{.From}}?expand=1",
 	pullRequestURLIntoTargetBranch:  "/compare/{{.To}}...{{.From}}?expand=1",
 	commitURL:                       "/commit/{{.CommitSha}}",
+	branchURL:                       "/tree/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }
@@ -24,6 +25,7 @@ var bitbucketServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pull-requests/new?source={{.From}}&t=1",
 	pullRequestURLIntoTargetBranch:  "/pull-requests/new?source={{.From}}&dest={{.To}}&t=1",
 	commitURL:                       "/commits/{{.CommitSha}}",
+	branchURL:                       "/src/{{.BranchName}}",
 	regexStrings: []string{
 		`^(?:https?|ssh)://.*/(?P<owner>.*)/(?P<repo>.*?)(?:\.git)?$`,
 		`^.*@.*:(?P<owner>.*)/(?P<repo>.*?)(?:\.git)?$`,
@@ -36,6 +38,7 @@ var gitLabServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/-/merge_requests/new?merge_request[source_branch]={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/-/merge_requests/new?merge_request[source_branch]={{.From}}&merge_request[target_branch]={{.To}}",
 	commitURL:                       "/-/commit/{{.CommitSha}}",
+	branchURL:                       "/-/tree/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }
@@ -45,6 +48,7 @@ var azdoServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pullrequestcreate?sourceRef={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/pullrequestcreate?sourceRef={{.From}}&targetRef={{.To}}",
 	commitURL:                       "/commit/{{.CommitSha}}",
+	branchURL:                       "?version=GB{{.BranchName}}",
 	regexStrings: []string{
 		`^git@ssh.dev.azure.com.*/(?P<org>.*)/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
 		`^https://.*@dev.azure.com/(?P<org>.*?)/(?P<project>.*?)/_git/(?P<repo>.*?)(?:\.git)?$`,
@@ -57,6 +61,7 @@ var bitbucketServerServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pull-requests?create&sourceBranch={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/pull-requests?create&targetBranch={{.To}}&sourceBranch={{.From}}",
 	commitURL:                       "/commits/{{.CommitSha}}",
+	branchURL:                       "/browse?at=refs/heads/{{.BranchName}}",
 	regexStrings: []string{
 		`^ssh://git@.*/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
 		`^https://.*/scm/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
@@ -69,6 +74,7 @@ var giteaServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/compare/{{.From}}",
 	pullRequestURLIntoTargetBranch:  "/compare/{{.To}}...{{.From}}",
 	commitURL:                       "/commit/{{.CommitSha}}",
+	branchURL:                       "/src/branch/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }

--- a/pkg/commands/hosting_service/hosting_service.go
+++ b/pkg/commands/hosting_service/hosting_service.go
@@ -142,6 +142,7 @@ type ServiceDefinition struct {
 	pullRequestURLIntoDefaultBranch string
 	pullRequestURLIntoTargetBranch  string
 	commitURL                       string
+	branchURL                       string
 	regexStrings                    []string
 
 	// can expect 'webdomain' to be passed in. Otherwise, you get to pick what we match in the regex

--- a/pkg/commands/hosting_service/hosting_service.go
+++ b/pkg/commands/hosting_service/hosting_service.go
@@ -62,6 +62,17 @@ func (self *HostingServiceMgr) GetCommitURL(commitSha string) (string, error) {
 	return pullRequestURL, nil
 }
 
+func (self *HostingServiceMgr) GetBranchURL(branchName string) (string, error) {
+	gitService, err := self.getService()
+	if err != nil {
+		return "", err
+	}
+
+	branchURL := gitService.getBranchURL(branchName)
+
+	return branchURL, nil
+}
+
 func (self *HostingServiceMgr) getService() (*Service, error) {
 	serviceDomain, err := self.getServiceDomain(self.remoteURL)
 	if err != nil {
@@ -177,6 +188,10 @@ func (self *Service) getPullRequestURLIntoTargetBranch(from string, to string) s
 
 func (self *Service) getCommitURL(commitSha string) string {
 	return self.resolveUrl(self.commitURL, map[string]string{"CommitSha": commitSha})
+}
+
+func (self *Service) getBranchURL(branch string) string {
+	return self.resolveUrl(self.branchURL, map[string]string{"BranchName": branch})
 }
 
 func (self *Service) resolveUrl(templateString string, args map[string]string) string {

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -388,21 +388,21 @@ type KeybindingFilesConfig struct {
 }
 
 type KeybindingBranchesConfig struct {
-	CreatePullRequest      string `yaml:"createPullRequest"`
-	ViewPullRequestOptions string `yaml:"viewPullRequestOptions"`
-	CopyPullRequestURL     string `yaml:"copyPullRequestURL"`
-	CheckoutBranchByName   string `yaml:"checkoutBranchByName"`
-	ForceCheckoutBranch    string `yaml:"forceCheckoutBranch"`
-	RebaseBranch           string `yaml:"rebaseBranch"`
-	RenameBranch           string `yaml:"renameBranch"`
-	MergeIntoCurrentBranch string `yaml:"mergeIntoCurrentBranch"`
-	ViewGitFlowOptions     string `yaml:"viewGitFlowOptions"`
-	FastForward            string `yaml:"fastForward"`
-	CreateTag              string `yaml:"createTag"`
-	PushTag                string `yaml:"pushTag"`
-	SetUpstream            string `yaml:"setUpstream"`
-	FetchRemote            string `yaml:"fetchRemote"`
-	SortOrder              string `yaml:"sortOrder"`
+	CreatePullRequest              string `yaml:"createPullRequest"`
+	ViewPullRequestOptions         string `yaml:"viewPullRequestOptions"`
+	CopyBranchAttributeToClipboard string `yaml: "copyToClipboard"`
+	CheckoutBranchByName           string `yaml:"checkoutBranchByName"`
+	ForceCheckoutBranch            string `yaml:"forceCheckoutBranch"`
+	RebaseBranch                   string `yaml:"rebaseBranch"`
+	RenameBranch                   string `yaml:"renameBranch"`
+	MergeIntoCurrentBranch         string `yaml:"mergeIntoCurrentBranch"`
+	ViewGitFlowOptions             string `yaml:"viewGitFlowOptions"`
+	FastForward                    string `yaml:"fastForward"`
+	CreateTag                      string `yaml:"createTag"`
+	PushTag                        string `yaml:"pushTag"`
+	SetUpstream                    string `yaml:"setUpstream"`
+	FetchRemote                    string `yaml:"fetchRemote"`
+	SortOrder                      string `yaml:"sortOrder"`
 }
 
 type KeybindingWorktreesConfig struct {
@@ -785,21 +785,21 @@ func GetDefaultConfig() *UserConfig {
 				CopyFileInfoToClipboard:  "y",
 			},
 			Branches: KeybindingBranchesConfig{
-				CopyPullRequestURL:     "<c-y>",
-				CreatePullRequest:      "o",
-				ViewPullRequestOptions: "O",
-				CheckoutBranchByName:   "c",
-				ForceCheckoutBranch:    "F",
-				RebaseBranch:           "r",
-				RenameBranch:           "R",
-				MergeIntoCurrentBranch: "M",
-				ViewGitFlowOptions:     "i",
-				FastForward:            "f",
-				CreateTag:              "T",
-				PushTag:                "P",
-				SetUpstream:            "u",
-				FetchRemote:            "f",
-				SortOrder:              "s",
+				CopyBranchAttributeToClipboard: "y",
+				CreatePullRequest:              "o",
+				ViewPullRequestOptions:         "O",
+				CheckoutBranchByName:           "c",
+				ForceCheckoutBranch:            "F",
+				RebaseBranch:                   "r",
+				RenameBranch:                   "R",
+				MergeIntoCurrentBranch:         "M",
+				ViewGitFlowOptions:             "i",
+				FastForward:                    "f",
+				CreateTag:                      "T",
+				PushTag:                        "P",
+				SetUpstream:                    "u",
+				FetchRemote:                    "f",
+				SortOrder:                      "s",
 			},
 			Worktrees: KeybindingWorktreesConfig{
 				ViewWorktreeOptions: "w",

--- a/pkg/gui/controllers/helpers/host_helper.go
+++ b/pkg/gui/controllers/helpers/host_helper.go
@@ -9,6 +9,7 @@ import (
 type IHostHelper interface {
 	GetPullRequestURL(from string, to string) (string, error)
 	GetCommitURL(commitSha string) (string, error)
+	GetBranchURL(branchName string) (string, error)
 }
 
 type HostHelper struct {
@@ -37,6 +38,14 @@ func (self *HostHelper) GetCommitURL(commitSha string) (string, error) {
 		return "", err
 	}
 	return mgr.GetCommitURL(commitSha)
+}
+
+func (self *HostHelper) GetBranchURL(branchName string) (string, error) {
+	mgr, err := self.getHostingServiceMgr()
+	if err != nil {
+		return "", err
+	}
+	return mgr.GetBranchURL(branchName)
 }
 
 // getting this on every request rather than storing it in state in case our remoteURL changes

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -97,6 +97,8 @@ type TranslationSet struct {
 	SureForceCheckout                     string
 	ForceCheckoutBranch                   string
 	BranchName                            string
+	BranchURL                             string
+	PullRequestURL                        string
 	NewBranchNameBranchOff                string
 	CantDeleteCheckOutBranch              string
 	DeleteBranchTitle                     string
@@ -567,6 +569,7 @@ type TranslationSet struct {
 	CopyCommitAttributeToClipboard        string
 	CopyCommitAttributeToClipboardTooltip string
 	CopyBranchNameToClipboard             string
+	CopyBranchAttributeToClipboard        string
 	CopyPathToClipboard                   string
 	CommitPrefixPatternError              string
 	CopySelectedTextToClipboard           string
@@ -620,6 +623,8 @@ type TranslationSet struct {
 	ExtrasTitle                          string
 	PushingTagStatus                     string
 	PullRequestURLCopiedToClipboard      string
+	BranchNameCopiedToClipboard          string
+	BranchURLCopiedToClipboard           string
 	CommitDiffCopiedToClipboard          string
 	CommitSHACopiedToClipboard           string
 	CommitURLCopiedToClipboard           string
@@ -909,6 +914,9 @@ type Actions struct {
 	Undo                              string
 	Redo                              string
 	CopyPullRequestURL                string
+	CopyBranchName                    string
+	CopyBranchURL                     string
+	CopyBranchAttributeToClipboard    string
 	OpenDiffTool                      string
 	OpenMergeTool                     string
 	OpenCommitInBrowser               string
@@ -1041,6 +1049,8 @@ func EnglishTranslationSet() TranslationSet {
 		SureForceCheckout:                   "Are you sure you want force checkout? You will lose all local changes",
 		ForceCheckoutBranch:                 "Force checkout branch",
 		BranchName:                          "Branch name",
+		BranchURL:                           "Branch URL",
+		PullRequestURL:                      "Pull request URL",
 		NewBranchNameBranchOff:              "New branch name (branch is off of '{{.branchName}}')",
 		CantDeleteCheckOutBranch:            "You cannot delete the checked out branch!",
 		DeleteBranchTitle:                   "Delete branch '{{.selectedBranchName}}'?",
@@ -1514,6 +1524,7 @@ func EnglishTranslationSet() TranslationSet {
 		CopyCommitAttributeToClipboard:        "Copy commit attribute to clipboard",
 		CopyCommitAttributeToClipboardTooltip: "Copy commit attribute to clipboard (e.g. hash, URL, diff, message, author).",
 		CopyBranchNameToClipboard:             "Copy branch name to clipboard",
+		CopyBranchAttributeToClipboard:        "Copy branch attribute to clipboard",
 		CopyPathToClipboard:                   "Copy path to clipboard",
 		CopySelectedTextToClipboard:           "Copy selected text to clipboard",
 		CommitPrefixPatternError:              "Error in commitPrefix pattern",
@@ -1566,6 +1577,8 @@ func EnglishTranslationSet() TranslationSet {
 		ExtrasTitle:                           "Command log",
 		PushingTagStatus:                      "Pushing tag",
 		PullRequestURLCopiedToClipboard:       "Pull request URL copied to clipboard",
+		BranchNameCopiedToClipboard:           "Branch name copied to clipboard",
+		BranchURLCopiedToClipboard:            "Branch URL copied to clipboard",
 		CommitDiffCopiedToClipboard:           "Commit diff copied to clipboard",
 		CommitSHACopiedToClipboard:            "Commit SHA copied to clipboard",
 		CommitURLCopiedToClipboard:            "Commit URL copied to clipboard",
@@ -1746,6 +1759,9 @@ func EnglishTranslationSet() TranslationSet {
 			CopyCommitURLToClipboard:       "Copy commit URL to clipboard",
 			CopyCommitAuthorToClipboard:    "Copy commit author to clipboard",
 			CopyCommitAttributeToClipboard: "Copy to clipboard",
+			CopyBranchAttributeToClipboard: "Copy to clipboard",
+			CopyBranchName:                 "Copy branch name",
+			CopyBranchURL:                  "Copy branch URL",
 			CopyPatchToClipboard:           "Copy patch to clipboard",
 			MoveCommitUp:                   "Move commit up",
 			MoveCommitDown:                 "Move commit down",

--- a/schema/config.json
+++ b/schema/config.json
@@ -985,9 +985,9 @@
               "type": "string",
               "default": "O"
             },
-            "copyPullRequestURL": {
+            "CopyBranchAttributeToClipboard": {
               "type": "string",
-              "default": "\u003cc-y\u003e"
+              "default": "y"
             },
             "checkoutBranchByName": {
               "type": "string",


### PR DESCRIPTION
- **PR Description**
This change allows copying branch URL to clipboard in the branches view. The existing copy X items are moved to a Copy to Clipboard menu with the following copy options:
* Branch name
* Branch URL (key: u)
* Pull request URL (key: p)

Fixes #1959

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
