### PR TITLE
Fix support for old style non-interactive rebase

### DIFF
--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -316,7 +316,7 @@ func (self *CommitLoader) getHydratedRebasingCommits(rebaseMode enums.RebaseMode
 // getRebasingCommits obtains the commits that we're in the process of rebasing
 func (self *CommitLoader) getRebasingCommits(rebaseMode enums.RebaseMode) ([]*models.Commit, error) {
 	switch rebaseMode {
-	case enums.REBASE_MODE_MERGING:
+	case enums.REBASE_MODE_NORMAL:
 		return self.getNormalRebasingCommits()
 	case enums.REBASE_MODE_INTERACTIVE:
 		return self.getInteractiveRebasingCommits()

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -69,7 +69,7 @@ func GetCommitListDisplayStrings(
 	}
 
 	// this is where my non-TODO commits begin
-	rebaseOffset := utils.Min(indexOfFirstNonTODOCommit(commits), endIdx)
+	rebaseOffset := utils.Min(indexOfFirstNonRebasingCommit(commits), endIdx)
 
 	filteredCommits := commits[startIdx:endIdx]
 
@@ -187,9 +187,9 @@ func getbisectBounds(commits []*models.Commit, bisectInfo *git_commands.BisectIn
 }
 
 // precondition: slice is not empty
-func indexOfFirstNonTODOCommit(commits []*models.Commit) int {
+func indexOfFirstNonRebasingCommit(commits []*models.Commit) int {
 	for i, commit := range commits {
-		if !commit.IsTODO() {
+		if commit.Status != models.StatusRebasing {
 			return i
 		}
 	}

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -68,7 +68,7 @@ func GetCommitListDisplayStrings(
 		return nil
 	}
 
-	// this is where my non-TODO commits begin
+	// this is where my "normal" commits begin (the non-rebasing ones)
 	rebaseOffset := utils.Min(indexOfFirstNonRebasingCommit(commits), endIdx)
 
 	filteredCommits := commits[startIdx:endIdx]

--- a/pkg/gui/presentation/commits_test.go
+++ b/pkg/gui/presentation/commits_test.go
@@ -216,8 +216,8 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 		{
 			testName: "showing graph, including rebase commits",
 			commits: []*models.Commit{
-				{Name: "commit1", Sha: "sha1", Parents: []string{"sha2", "sha3"}, Action: todo.Pick},
-				{Name: "commit2", Sha: "sha2", Parents: []string{"sha3"}, Action: todo.Pick},
+				{Name: "commit1", Sha: "sha1", Parents: []string{"sha2", "sha3"}, Action: todo.Pick, Status: models.StatusRebasing},
+				{Name: "commit2", Sha: "sha2", Parents: []string{"sha3"}, Action: todo.Pick, Status: models.StatusRebasing},
 				{Name: "commit3", Sha: "sha3", Parents: []string{"sha4"}},
 				{Name: "commit4", Sha: "sha4", Parents: []string{"sha5"}},
 				{Name: "commit5", Sha: "sha5", Parents: []string{"sha7"}},
@@ -240,8 +240,8 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 		{
 			testName: "showing graph, including rebase commits, with offset",
 			commits: []*models.Commit{
-				{Name: "commit1", Sha: "sha1", Parents: []string{"sha2", "sha3"}, Action: todo.Pick},
-				{Name: "commit2", Sha: "sha2", Parents: []string{"sha3"}, Action: todo.Pick},
+				{Name: "commit1", Sha: "sha1", Parents: []string{"sha2", "sha3"}, Action: todo.Pick, Status: models.StatusRebasing},
+				{Name: "commit2", Sha: "sha2", Parents: []string{"sha3"}, Action: todo.Pick, Status: models.StatusRebasing},
 				{Name: "commit3", Sha: "sha3", Parents: []string{"sha4"}},
 				{Name: "commit4", Sha: "sha4", Parents: []string{"sha5"}},
 				{Name: "commit5", Sha: "sha5", Parents: []string{"sha7"}},
@@ -263,8 +263,8 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 		{
 			testName: "startIdx is past TODO commits",
 			commits: []*models.Commit{
-				{Name: "commit1", Sha: "sha1", Parents: []string{"sha2", "sha3"}, Action: todo.Pick},
-				{Name: "commit2", Sha: "sha2", Parents: []string{"sha3"}, Action: todo.Pick},
+				{Name: "commit1", Sha: "sha1", Parents: []string{"sha2", "sha3"}, Action: todo.Pick, Status: models.StatusRebasing},
+				{Name: "commit2", Sha: "sha2", Parents: []string{"sha3"}, Action: todo.Pick, Status: models.StatusRebasing},
 				{Name: "commit3", Sha: "sha3", Parents: []string{"sha4"}},
 				{Name: "commit4", Sha: "sha4", Parents: []string{"sha5"}},
 				{Name: "commit5", Sha: "sha5", Parents: []string{"sha7"}},
@@ -284,8 +284,8 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 		{
 			testName: "only showing TODO commits",
 			commits: []*models.Commit{
-				{Name: "commit1", Sha: "sha1", Parents: []string{"sha2", "sha3"}, Action: todo.Pick},
-				{Name: "commit2", Sha: "sha2", Parents: []string{"sha3"}, Action: todo.Pick},
+				{Name: "commit1", Sha: "sha1", Parents: []string{"sha2", "sha3"}, Action: todo.Pick, Status: models.StatusRebasing},
+				{Name: "commit2", Sha: "sha2", Parents: []string{"sha3"}, Action: todo.Pick, Status: models.StatusRebasing},
 				{Name: "commit3", Sha: "sha3", Parents: []string{"sha4"}},
 				{Name: "commit4", Sha: "sha4", Parents: []string{"sha5"}},
 				{Name: "commit5", Sha: "sha5", Parents: []string{"sha7"}},
@@ -325,10 +325,10 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 		{
 			testName: "only TODO commits except last",
 			commits: []*models.Commit{
-				{Name: "commit1", Sha: "sha1", Parents: []string{"sha2", "sha3"}, Action: todo.Pick},
-				{Name: "commit2", Sha: "sha2", Parents: []string{"sha3"}, Action: todo.Pick},
-				{Name: "commit3", Sha: "sha3", Parents: []string{"sha4"}, Action: todo.Pick},
-				{Name: "commit4", Sha: "sha4", Parents: []string{"sha5"}, Action: todo.Pick},
+				{Name: "commit1", Sha: "sha1", Parents: []string{"sha2", "sha3"}, Action: todo.Pick, Status: models.StatusRebasing},
+				{Name: "commit2", Sha: "sha2", Parents: []string{"sha3"}, Action: todo.Pick, Status: models.StatusRebasing},
+				{Name: "commit3", Sha: "sha3", Parents: []string{"sha4"}, Action: todo.Pick, Status: models.StatusRebasing},
+				{Name: "commit4", Sha: "sha4", Parents: []string{"sha5"}, Action: todo.Pick, Status: models.StatusRebasing},
 				{Name: "commit5", Sha: "sha5", Parents: []string{"sha7"}},
 			},
 			startIdx:                 0,
@@ -346,7 +346,7 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 		{
 			testName: "don't show YOU ARE HERE label when not asked for (e.g. in branches panel)",
 			commits: []*models.Commit{
-				{Name: "commit1", Sha: "sha1", Parents: []string{"sha2"}, Action: todo.Pick},
+				{Name: "commit1", Sha: "sha1", Parents: []string{"sha2"}, Action: todo.Pick, Status: models.StatusRebasing},
 				{Name: "commit2", Sha: "sha2", Parents: []string{"sha3"}},
 				{Name: "commit3", Sha: "sha3", Parents: []string{"sha4"}},
 			},


### PR DESCRIPTION
- **PR Description**

When doing a non-interactive rebase using a version of git earlier than 2.26, or by explicitly calling `git -c rebase.backend=apply rebase`, lazygit can display the pending todos by parsing the numbered patch files in `.git/rebase-apply/`. Unfortunately, support for this has been broken for more than three years because of the change in 682db77401e (the string literal "normal" should have been changed to `REBASE_MODE_NORMAL` instead of `REBASE_MODE_MERGING`).

Also, the position of the YOU ARE HERE marker was wrong for these old-style rebases.

It's not an important bug since you can only get into this situation by doing a rebase outside of lazygit, and then only with a pretty old git version. So instead of fixing the bug we might consider removing this code.