### PR TITLE
Make ctrl-f available in staging view

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -230,6 +230,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` c `` | Commit | Commit staged changes. |
 | `` w `` | Commit changes without pre-commit hook |  |
 | `` C `` | Commit changes using git editor |  |
+| `` <c-f> `` | Find base commit for fixup | Find the commit that your current changes are building upon, for the sake of amending/fixing up the commit. This spares you from having to look through your branch's commits one-by-one to see which commit should be amended/fixed up. See docs: <https://github.com/jesseduffield/lazygit/tree/master/docs/Fixup_Commits.md> |
 | `` / `` | Search the current view by text |  |
 
 ## Menu

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -300,6 +300,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` c `` | 変更をコミット | Commit staged changes. |
 | `` w `` | pre-commitフックを実行せずに変更をコミット |  |
 | `` C `` | gitエディタを使用して変更をコミット |  |
+| `` <c-f> `` | Find base commit for fixup | Find the commit that your current changes are building upon, for the sake of amending/fixing up the commit. This spares you from having to look through your branch's commits one-by-one to see which commit should be amended/fixed up. See docs: <https://github.com/jesseduffield/lazygit/tree/master/docs/Fixup_Commits.md> |
 | `` / `` | 検索を開始 |  |
 
 ## メニュー

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -171,6 +171,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` c `` | 커밋 변경내용 | Commit staged changes. |
 | `` w `` | Commit changes without pre-commit hook |  |
 | `` C `` | Git 편집기를 사용하여 변경 내용을 커밋합니다. |  |
+| `` <c-f> `` | Find base commit for fixup | Find the commit that your current changes are building upon, for the sake of amending/fixing up the commit. This spares you from having to look through your branch's commits one-by-one to see which commit should be amended/fixed up. See docs: <https://github.com/jesseduffield/lazygit/tree/master/docs/Fixup_Commits.md> |
 | `` / `` | 검색 시작 |  |
 
 ## 브랜치

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -283,6 +283,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` c `` | Commit veranderingen | Commit staged changes. |
 | `` w `` | Commit veranderingen zonder pre-commit hook |  |
 | `` C `` | Commit veranderingen met de git editor |  |
+| `` <c-f> `` | Find base commit for fixup | Find the commit that your current changes are building upon, for the sake of amending/fixing up the commit. This spares you from having to look through your branch's commits one-by-one to see which commit should be amended/fixed up. See docs: <https://github.com/jesseduffield/lazygit/tree/master/docs/Fixup_Commits.md> |
 | `` / `` | Start met zoeken |  |
 
 ## Stash

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -215,6 +215,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` c `` | Zatwierdź zmiany | Commit staged changes. |
 | `` w `` | Zatwierdź zmiany bez skryptu pre-commit |  |
 | `` C `` | Zatwierdź zmiany używając edytora |  |
+| `` <c-f> `` | Find base commit for fixup | Find the commit that your current changes are building upon, for the sake of amending/fixing up the commit. This spares you from having to look through your branch's commits one-by-one to see which commit should be amended/fixed up. See docs: <https://github.com/jesseduffield/lazygit/tree/master/docs/Fixup_Commits.md> |
 | `` / `` | Search the current view by text |  |
 
 ## Reflog

--- a/docs/keybindings/Keybindings_ru.md
+++ b/docs/keybindings/Keybindings_ru.md
@@ -78,6 +78,7 @@ _Связки клавиш_
 | `` c `` | Сохранить изменения | Commit staged changes. |
 | `` w `` | Закоммитить изменения без предварительного хука коммита |  |
 | `` C `` | Сохранить изменения с помощью редактора git |  |
+| `` <c-f> `` | Find base commit for fixup | Find the commit that your current changes are building upon, for the sake of amending/fixing up the commit. This spares you from having to look through your branch's commits one-by-one to see which commit should be amended/fixed up. See docs: <https://github.com/jesseduffield/lazygit/tree/master/docs/Fixup_Commits.md> |
 | `` / `` | Найти |  |
 
 ## Главная панель (Обычный)

--- a/docs/keybindings/Keybindings_zh-CN.md
+++ b/docs/keybindings/Keybindings_zh-CN.md
@@ -287,6 +287,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` c `` | 提交更改 | Commit staged changes. |
 | `` w `` | 提交更改而无需预先提交钩子 |  |
 | `` C `` | 提交更改（使用编辑器编辑提交信息） |  |
+| `` <c-f> `` | Find base commit for fixup | Find the commit that your current changes are building upon, for the sake of amending/fixing up the commit. This spares you from having to look through your branch's commits one-by-one to see which commit should be amended/fixed up. See docs: <https://github.com/jesseduffield/lazygit/tree/master/docs/Fixup_Commits.md> |
 | `` / `` | 开始搜索 |  |
 
 ## 正常

--- a/docs/keybindings/Keybindings_zh-TW.md
+++ b/docs/keybindings/Keybindings_zh-TW.md
@@ -118,6 +118,7 @@ _說明：`<c-b>` 表示 Ctrl+B、`<a-b>` 表示 Alt+B，`B`表示 Shift+B_
 | `` c `` | 提交變更 | Commit staged changes. |
 | `` w `` | 沒有預提交 hook 就提交更改 |  |
 | `` C `` | 使用 git 編輯器提交變更 |  |
+| `` <c-f> `` | Find base commit for fixup | Find the commit that your current changes are building upon, for the sake of amending/fixing up the commit. This spares you from having to look through your branch's commits one-by-one to see which commit should be amended/fixed up. See docs: <https://github.com/jesseduffield/lazygit/tree/master/docs/Fixup_Commits.md> |
 | `` / `` | 開始搜尋 |  |
 
 ## 主面板 (補丁生成)

--- a/pkg/gui/controllers/staging_controller.go
+++ b/pkg/gui/controllers/staging_controller.go
@@ -99,6 +99,12 @@ func (self *StagingController) GetKeybindings(opts types.KeybindingsOpts) []*typ
 			Handler:     self.c.Helpers().WorkingTree.HandleCommitEditorPress,
 			Description: self.c.Tr.CommitChangesWithEditor,
 		},
+		{
+			Key:         opts.GetKey(opts.Config.Files.FindBaseCommitForFixup),
+			Handler:     self.c.Helpers().FixupHelper.HandleFindBaseCommitForFixupPress,
+			Description: self.c.Tr.FindBaseCommitForFixup,
+			Tooltip:     self.c.Tr.FindBaseCommitForFixupTooltip,
+		},
 	}
 }
 


### PR DESCRIPTION
- **PR Description**

A common workflow for me is to create a fixup commit from only some of my current changes; to do that, I enter a file, stage a few hunks, and then want to invoke ctrl-f to find the base commit for these changes. Currently I need to esc back to the files panel in order to do that; it's more convenient to be able to do this right from the staging panel.

Labelled as "ignore-for-release" because the ctrl-f feature has only been added after the last release, so no release notes needed for this change.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
