### PR TITLE
Fix linter warnings

### DIFF
--- a/pkg/gui/controllers/helpers/patch_building_helper.go
+++ b/pkg/gui/controllers/helpers/patch_building_helper.go
@@ -79,9 +79,6 @@ func (self *PatchBuildingHelper) RefreshPatchBuildingPanel(opts types.OnFocusOpt
 	}
 
 	secondaryDiff := self.c.Git().Patch.PatchBuilder.RenderPatchForFile(path, false, false)
-	if err != nil {
-		return err
-	}
 
 	context := self.c.Contexts().CustomPatchBuilder
 

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -99,7 +99,7 @@ func GetCommitListDisplayStrings(
 			}
 		}
 	} else {
-		getGraphLine = func(idx int) string { return "" }
+		getGraphLine = func(int) string { return "" }
 	}
 
 	// Determine the hashes of the local branches for which we want to show a


### PR DESCRIPTION
These started to pop up in my editor after I installed an update of gopls, I think.