### PR TITLE
Switch between multiple log views

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -306,7 +306,8 @@ git:
   # Command used when displaying the current branch git log in the main window
   branchLogCmd: git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --
 
-  # Command used to display git log of all branches in the main window
+  # Command used to display git log of all branches in the main window.
+  # Deprecated: User `allBranchesLogCmds` instead.
   allBranchesLogCmd: git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium
 
   # If true, do not spawn a separate process when using GPG

--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -309,7 +309,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` e `` | Edit config file | Open file in external editor. |
 | `` u `` | Check for update |  |
 | `` <enter> `` | Switch to a recent repo |  |
-| `` a `` | Show all branch logs |  |
+| `` a `` | Show/cycle all branch logs |  |
 
 ## Sub-commits
 

--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -7,10 +7,12 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/mgutz/str"
+	"github.com/samber/lo"
 )
 
 type BranchCommands struct {
 	*GitCommon
+	allBranchesLogCmdIndex uint8 // keeps track of current all branches log command
 }
 
 func NewBranchCommands(gitCommon *GitCommon) *BranchCommands {
@@ -244,5 +246,17 @@ func (self *BranchCommands) Merge(branchName string, opts MergeOpts) error {
 }
 
 func (self *BranchCommands) AllBranchesLogCmdObj() oscommands.ICmdObj {
-	return self.cmd.New(str.ToArgv(self.UserConfig.Git.AllBranchesLogCmd)).DontLog()
+	// Only choose between non-empty, non-identical commands
+	candidates := lo.Uniq(lo.WithoutEmpty(append([]string{
+		self.UserConfig.Git.AllBranchesLogCmd,
+	},
+		self.UserConfig.Git.AllBranchesLogCmds...,
+	)))
+
+	n := len(candidates)
+
+	i := self.allBranchesLogCmdIndex
+	self.allBranchesLogCmdIndex = uint8((int(i) + 1) % n)
+
+	return self.cmd.New(str.ToArgv(candidates[i])).DontLog()
 }

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -226,8 +226,11 @@ type GitConfig struct {
 	FetchAll bool `yaml:"fetchAll"`
 	// Command used when displaying the current branch git log in the main window
 	BranchLogCmd string `yaml:"branchLogCmd"`
-	// Command used to display git log of all branches in the main window
+	// Command used to display git log of all branches in the main window.
+	// Deprecated: User `allBranchesLogCmds` instead.
 	AllBranchesLogCmd string `yaml:"allBranchesLogCmd"`
+	// Commands used to display git log of all branches in the main window, they will be cycled in order of appearance
+	AllBranchesLogCmds []string `yaml:"allBranchesLogCmds"`
 	// If true, do not spawn a separate process when using GPG
 	OverrideGpg bool `yaml:"overrideGpg"`
 	// If true, do not allow force pushes

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1208,7 +1208,7 @@ func EnglishTranslationSet() *TranslationSet {
 		MergeBranchTooltip:                   "View options for merging the selected item into the current branch (regular merge, squash merge)",
 		ConfirmQuit:                          `Are you sure you want to quit?`,
 		SwitchRepo:                           `Switch to a recent repo`,
-		AllBranchesLogGraph:                  `Show all branch logs`,
+		AllBranchesLogGraph:                  `Show/cycle all branch logs`,
 		UnsupportedGitService:                `Unsupported git service`,
 		CreatePullRequest:                    `Create pull request`,
 		CopyPullRequestURL:                   `Copy pull request URL to clipboard`,

--- a/pkg/integration/tests/status/log_cmd.go
+++ b/pkg/integration/tests/status/log_cmd.go
@@ -1,0 +1,33 @@
+package status
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var LogCmd = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Cycle between two different log commands in the Status view",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.UserConfig.Git.AllBranchesLogCmd = `echo "view1"`
+		config.UserConfig.Git.AllBranchesLogCmds = []string{`echo "view2"`}
+	},
+	SetupRepo: func(shell *Shell) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Status().
+			Focus().
+			Press(keys.Status.AllBranchesLogGraph)
+		t.Views().Main().Content(Contains("view1"))
+
+		t.Views().Status().
+			Focus().
+			Press(keys.Status.AllBranchesLogGraph)
+		t.Views().Main().Content(Contains("view2").DoesNotContain("view1"))
+
+		t.Views().Status().
+			Focus().
+			Press(keys.Status.AllBranchesLogGraph)
+		t.Views().Main().Content(Contains("view1").DoesNotContain("view2"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -286,6 +286,7 @@ var tests = []*components.IntegrationTest{
 	status.ClickRepoNameToOpenReposMenu,
 	status.ClickToFocus,
 	status.ClickWorkingTreeStateToOpenRebaseOptionsMenu,
+	status.LogCmd,
 	status.ShowDivergenceFromBaseBranch,
 	submodule.Add,
 	submodule.Enter,

--- a/schema/config.json
+++ b/schema/config.json
@@ -580,8 +580,15 @@
         },
         "allBranchesLogCmd": {
           "type": "string",
-          "description": "Command used to display git log of all branches in the main window",
+          "description": "Command used to display git log of all branches in the main window.\nDeprecated: User `allBranchesLogCmds` instead.",
           "default": "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium"
+        },
+        "allBranchesLogCmds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Commands used to display git log of all branches in the main window, they will be cycled in order of appearance"
         },
         "overrideGpg": {
           "type": "boolean",


### PR DESCRIPTION
- **PR Description**

* Fixes jesseduffield/lazygit#1363
* Allow switching between up two three log views

Seeing as the last activity related to this issue was over a year ago, I decided to take a stab at this.
The implementation should be fully backwards compatible. Simply add `allBranchesLogCmdAlt1` and/or `allBranchesLogCmdAlt2` to your config file to use them when cycling between log commands using 'a'.
You can even use `allBranchesLogCmdAlt2` together with `allBranchesLogCmd` (skipping `allBranchesLogCmdAlt1`) if you want, it should not affect usability.

This is my first contribution to LazyGit, but I have experience with Go.

Changes:

- Introduced two new optional user config commands, allBranchesLogCmdAlt1+2
- When pressing 'a' in the Status view, cycle between non-empty, non-identical log commands
- There will always be at least one command to run, since allBranhesLogCmd has a default

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
