### PR TITLE
Respect Git config that are set via `GIT_CONFIG_{KEY,VALUE}_*` method

### DIFF
--- a/pkg/commands/git_config/get_key.go
+++ b/pkg/commands/git_config/get_key.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -53,7 +54,9 @@ func runGitConfigCmd(cmd *exec.Cmd) (string, error) {
 
 func getGitConfigCmd(key string) *exec.Cmd {
 	gitArgs := []string{"config", "--get", "--null", key}
-	return exec.Command("git", gitArgs...)
+	cmd := exec.Command("git", gitArgs...)
+	cmd.Env = os.Environ()
+	return cmd
 }
 
 func getGitConfigGeneralCmd(args string) *exec.Cmd {

--- a/pkg/commands/git_config/get_key_test.go
+++ b/pkg/commands/git_config/get_key_test.go
@@ -23,6 +23,20 @@ func TestGitConfigCount(t *testing.T) {
 				"user.signingkey": "abc0123",
 			},
 		},
+		{
+			TestName: "2 configs",
+			Envs: map[string]string{
+				"GIT_CONFIG_COUNT":   "2",
+				"GIT_CONFIG_KEY_0":   "custom.foo",
+				"GIT_CONFIG_VALUE_0": "bob",
+				"GIT_CONFIG_KEY_1":   "custom.bar",
+				"GIT_CONFIG_VALUE_1": "alice",
+			},
+			ExpectedConfigValues: map[string]string{
+				"custom.foo": "bob",
+				"custom.bar": "alice",
+			},
+		},
 	}
 	for _, s := range scenarios {
 		t.Run(s.TestName, func(t *testing.T) {

--- a/pkg/commands/git_config/get_key_test.go
+++ b/pkg/commands/git_config/get_key_test.go
@@ -1,0 +1,44 @@
+package git_config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGitConfigCount(t *testing.T) {
+	type scenario struct {
+		TestName             string
+		Envs                 map[string]string
+		ExpectedConfigValues map[string]string
+	}
+	scenarios := []scenario{
+		{
+			TestName: "1 config",
+			Envs: map[string]string{
+				"GIT_CONFIG_COUNT":   "1",
+				"GIT_CONFIG_KEY_0":   "user.signingkey",
+				"GIT_CONFIG_VALUE_0": "abc0123",
+			},
+			ExpectedConfigValues: map[string]string{
+				"user.signingkey": "abc0123",
+			},
+		},
+	}
+	for _, s := range scenarios {
+		t.Run(s.TestName, func(t *testing.T) {
+			for k, v := range s.Envs {
+				os.Setenv(k, v)
+			}
+			for k, v := range s.ExpectedConfigValues {
+				cmd := getGitConfigCmd(k)
+				res, err := runGitConfigCmd(cmd)
+				if err != nil {
+					t.Error(err)
+				}
+				if v != res {
+					t.Errorf("expected: %s, got: %s", v, res)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- **PR Description**

Git allows setting configuration values via environment variables via the `GIT_CONFIG_COUNT` method e.g.

```sh
# Tells Git to look for 2 config key-val pairs
export GIT_CONFIG_COUNT=2 

# The key-value pairs, zero-indexed.
export GIT_CONFIG_KEY_0=gpg.format
export GIT_CONFIG_VALUE_0=openpgp
export GIT_CONFIG_KEY_1=user.signingkey
export GIT_CONFIG_VALUE_1=E21087ED...
```

^^^ this will yield:

```
gpg.format=openpgp
user.signingkey=E21087ED...
```

This PR ensures that logic in Lazygit that relies on config values pulled via the `git_config` package respects values set this way.

A concrete use-case I have is that I have a Mac Studio configured to use 1Password's SSH agent to sign commits: signing the commit involves unlocking 1Password via Touch ID, etc.

That doesn't work well when I'm not physically on my desk e.g. I'm SSHed while remote. I have a config block very much like the example above, conditional on `[[ -n $SSH_CONNECTION ]]`. Unfortunately, Lazygit doesn't respect it. This PR would address that & other use-cases folks probably have.


- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
