### PR TITLE
Support setting a range of commits to "edit" outside of a rebase

### DIFF
--- a/pkg/integration/tests/interactive_rebase/edit_range_select_outside_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/edit_range_select_outside_rebase.go
@@ -1,0 +1,51 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+	"github.com/jesseduffield/lazygit/pkg/integration/tests/shared"
+)
+
+var EditRangeSelectOutsideRebase = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Select a range of commits to edit outside of a rebase",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	GitVersion:   AtLeast("2.22.0"), // first version that supports the --rebase-merges option
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shared.CreateMergeCommit(shell)
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			TopLines(
+				Contains("Merge branch 'second-change-branch' into first-change-branch").IsSelected(),
+			).
+			Press(keys.Universal.RangeSelectDown).
+			Press(keys.Universal.RangeSelectDown).
+			Press(keys.Universal.RangeSelectDown).
+			Press(keys.Universal.RangeSelectDown).
+			Press(keys.Universal.RangeSelectDown).
+			Lines(
+				Contains("CI ⏣─╮ Merge branch 'second-change-branch' into first-change-branch").IsSelected(),
+				Contains("CI │ ◯ * second-change-branch unrelated change").IsSelected(),
+				Contains("CI │ ◯ second change").IsSelected(),
+				Contains("CI ◯ │ first change").IsSelected(),
+				Contains("CI ◯─╯ * original").IsSelected(),
+				Contains("CI ◯ three").IsSelected(),
+				Contains("CI ◯ two"),
+				Contains("CI ◯ one"),
+			).
+			Press(keys.Universal.Edit).
+			Lines(
+				Contains("merge  CI Merge branch 'second-change-branch' into first-change-branch").IsSelected(),
+				Contains("edit   CI first change").IsSelected(),
+				Contains("edit   CI * second-change-branch unrelated change").IsSelected(),
+				Contains("edit   CI second change").IsSelected(),
+				Contains("edit   CI * original").IsSelected(),
+				Contains("       CI ◯ <-- YOU ARE HERE --- three").IsSelected(),
+				Contains("       CI ◯ two"),
+				Contains("       CI ◯ one"),
+			)
+	},
+})

--- a/pkg/integration/tests/interactive_rebase/mid_rebase_range_select.go
+++ b/pkg/integration/tests/interactive_rebase/mid_rebase_range_select.go
@@ -20,27 +20,6 @@ var MidRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 			TopLines(
 				Contains("commit 10").IsSelected(),
 			).
-			NavigateToLine(Contains("commit 07")).
-			Press(keys.Universal.RangeSelectDown).
-			TopLines(
-				Contains("commit 10"),
-				Contains("commit 09"),
-				Contains("commit 08"),
-				Contains("commit 07").IsSelected(),
-				Contains("commit 06").IsSelected(),
-				Contains("commit 05"),
-				Contains("commit 04"),
-			).
-			// Verify we can't perform an edit on multiple commits (it's not supported
-			// yet)
-			Press(keys.Universal.Edit).
-			Tap(func() {
-				// This ought to be a toast but I'm too lazy to implement that right now.
-				t.ExpectPopup().Alert().
-					Title(Equals("Error")).
-					Content(Contains("Action does not support range selection, please select a single item")).
-					Confirm()
-			}).
 			NavigateToLine(Contains("commit 05")).
 			// Start a rebase
 			Press(keys.Universal.Edit).

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -167,6 +167,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.DropWithCustomCommentChar,
 	interactive_rebase.EditFirstCommit,
 	interactive_rebase.EditNonTodoCommitDuringRebase,
+	interactive_rebase.EditRangeSelectOutsideRebase,
 	interactive_rebase.EditTheConflCommit,
 	interactive_rebase.FixupFirstCommit,
 	interactive_rebase.FixupSecondCommit,


### PR DESCRIPTION
- **PR Description**

It is now possible to select a range of commits (while not in a rebase), and hit "e" to edit them all. This starts a rebase on the bottom-most commit of the range, and sets all the selected commits to "edit" (skipping merge commits, because they can't be edited).

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
