### PR TITLE
Allow remote branch checkout-by-name without detaching

### DIFF
--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -433,7 +433,7 @@ func (self *BranchesController) forceCheckout() error {
 func (self *BranchesController) checkoutByName() error {
 	return self.c.Prompt(types.PromptOpts{
 		Title:               self.c.Tr.BranchName + ":",
-		FindSuggestionsFunc: self.c.Helpers().Suggestions.GetRefsSuggestionsFunc(),
+		FindSuggestionsFunc: self.c.Helpers().Suggestions.GetCheckoutBranchesSuggestionsFunc(),
 		HandleConfirm: func(response string) error {
 			self.c.LogAction("Checkout branch")
 			return self.c.Helpers().Refs.CheckoutRef(response, types.CheckoutRefOptions{

--- a/pkg/integration/components/shell.go
+++ b/pkg/integration/components/shell.go
@@ -148,6 +148,10 @@ func (self *Shell) Checkout(name string) *Shell {
 	return self.RunCommand([]string{"git", "checkout", name})
 }
 
+func (self *Shell) DeleteBranch(name string) *Shell {
+	return self.RunCommand([]string{"git", "branch", "-D", name})
+}
+
 func (self *Shell) Merge(name string) *Shell {
 	return self.RunCommand([]string{"git", "merge", "--commit", "--no-ff", name})
 }

--- a/pkg/integration/tests/branch/checkout_by_name_remote.go
+++ b/pkg/integration/tests/branch/checkout_by_name_remote.go
@@ -1,0 +1,66 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CheckoutByNameRemote = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Checkout a remote branch by name, both using the full name and the local name.",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("initial commit")
+		// create an origin/foo remote branch
+		shell.CloneIntoRemote("origin")
+		shell.NewBranch("foo")
+		shell.PushBranch("origin", "foo")
+		// delete the local version of the branch because we need to test checking it out from scratch
+		shell.Checkout("master")
+		shell.DeleteBranch("foo")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("master").IsSelected(),
+			).
+			// maximising window so that we can see the tracked branch
+			Press(keys.Universal.NextScreenMode).
+			Press(keys.Branches.CheckoutBranchByName).
+			Tap(func() {
+				t.ExpectPopup().Prompt().
+					Title(Equals("Branch name:")).
+					Type("foo").
+					SuggestionLines(
+						Contains("foo"),
+						Contains("origin/foo"),
+					).
+					ConfirmFirstSuggestion()
+			}).
+			Lines(
+				Contains("foo").
+					// we have not checked out origin/foo...
+					DoesNotContain("origin/foo").
+					// ... but we are tracking it (formatted as '<remote> <branch>')
+					Contains("origin foo"),
+				Contains("master"),
+			).
+			Press(keys.Branches.CheckoutBranchByName).
+			Tap(func() {
+				t.ExpectPopup().Prompt().
+					Title(Equals("Branch name:")).
+					Type("origin/foo").
+					SuggestionLines(
+						Contains("origin/foo"),
+					).
+					ConfirmFirstSuggestion()
+			}).
+			Lines(
+				Contains("HEAD detached at origin/foo"),
+				Contains("foo"),
+				Contains("master"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -37,6 +37,7 @@ var tests = []*components.IntegrationTest{
 	bisect.FromOtherBranch,
 	bisect.Skip,
 	branch.CheckoutByName,
+	branch.CheckoutByNameRemote,
 	branch.CreateTag,
 	branch.Delete,
 	branch.DeleteRemoteBranchWithCredentialPrompt,


### PR DESCRIPTION
Fixes https://github.com/jesseduffield/lazygit/issues/2312

The idea here is that in the git CLI you will often want to checkout a remote branch like origin/blah by doing `git checkout blah`. That will automatically create a local branch named blah that tracks origin/blah.

Previously in the suggestions view when checking out a branch by name, we would only show local branches and remote branches like origin/blah but wouldn't show blah as an option (assuming no local branch existed with that name). This meant users would checkout origin/blah and git would check out that branch as a detached head which is rarely what you actually want.

Now we give them both options. The alternative approach we could have taken is to still show the branch as origin/blah but then ask if the user wants to check out the branch as detached or as a local branch tracking the remote branch. That approach is certainly more versatile, but it's also something you can do already by going to the remote branch directly via the remotes view. Admittedly, my approach involves less work.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
