### PR TITLE
Show "breaking changes" message at startup

### DIFF
--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -343,6 +343,7 @@ type AppState struct {
 	LastUpdateCheck     int64
 	RecentRepos         []string
 	StartupPopupVersion int
+	LastVersion         string // this is the last version the user was using, for the purpose of showing release notes
 
 	// these are for custom commands typed in directly, not for custom commands in the lazygit config
 	CustomCommandsHistory      []string
@@ -367,6 +368,7 @@ func getDefaultAppState() *AppState {
 		LastUpdateCheck:       0,
 		RecentRepos:           []string{},
 		StartupPopupVersion:   0,
+		LastVersion:           "",
 		DiffContextSize:       3,
 		LocalBranchSortOrder:  "recency",
 		RemoteBranchSortOrder: "alphabetical",

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -248,6 +248,16 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 			Handler:  self.scrollDownConfirmationPanel,
 		},
 		{
+			ViewName: "confirmation",
+			Key:      gocui.MouseWheelUp,
+			Handler:  self.scrollUpConfirmationPanel,
+		},
+		{
+			ViewName: "confirmation",
+			Key:      gocui.MouseWheelDown,
+			Handler:  self.scrollDownConfirmationPanel,
+		},
+		{
 			ViewName:          "submodules",
 			Key:               opts.GetKey(opts.Config.Universal.CopyToClipboard),
 			Handler:           self.handleCopySelectedSideContextItemToClipboard,

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -254,8 +254,13 @@ func (gui *Gui) onInitialViewsCreation() error {
 		storedPopupVersion := gui.c.GetAppState().StartupPopupVersion
 		if storedPopupVersion < StartupPopupVersion {
 			gui.showIntroPopupMessage()
+		} else {
+			gui.showBreakingChangesMessage()
 		}
 	}
+
+	gui.c.GetAppState().LastVersion = gui.Config.GetVersion()
+	gui.c.SaveAppStateAndLogError()
 
 	if gui.showRecentRepos {
 		if err := gui.helpers.Repos.CreateRecentReposMenu(); err != nil {

--- a/pkg/gui/types/version_number.go
+++ b/pkg/gui/types/version_number.go
@@ -1,0 +1,41 @@
+package types
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+)
+
+type VersionNumber struct {
+	Major, Minor, Patch int
+}
+
+func (v *VersionNumber) IsOlderThan(otherVersion *VersionNumber) bool {
+	this := v.Major*1000*1000 + v.Minor*1000 + v.Patch
+	other := otherVersion.Major*1000*1000 + otherVersion.Minor*1000 + otherVersion.Patch
+	return this < other
+}
+
+func ParseVersionNumber(versionStr string) (*VersionNumber, error) {
+	re := regexp.MustCompile(`^v?(\d+)\.(\d+)(?:\.(\d+))?$`)
+	matches := re.FindStringSubmatch(versionStr)
+	if matches == nil {
+		return nil, errors.New("unexpected version format: " + versionStr)
+	}
+
+	v := &VersionNumber{}
+	var err error
+
+	if v.Major, err = strconv.Atoi(matches[1]); err != nil {
+		return nil, err
+	}
+	if v.Minor, err = strconv.Atoi(matches[2]); err != nil {
+		return nil, err
+	}
+	if len(matches[3]) > 0 {
+		if v.Patch, err = strconv.Atoi(matches[3]); err != nil {
+			return nil, err
+		}
+	}
+	return v, nil
+}

--- a/pkg/gui/types/version_number_test.go
+++ b/pkg/gui/types/version_number_test.go
@@ -1,0 +1,81 @@
+package types
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseVersionNumber(t *testing.T) {
+	tests := []struct {
+		versionStr string
+		expected   *VersionNumber
+		err        error
+	}{
+		{
+			versionStr: "1.2.3",
+			expected: &VersionNumber{
+				Major: 1,
+				Minor: 2,
+				Patch: 3,
+			},
+			err: nil,
+		},
+		{
+			versionStr: "v1.2.3",
+			expected: &VersionNumber{
+				Major: 1,
+				Minor: 2,
+				Patch: 3,
+			},
+			err: nil,
+		},
+		{
+			versionStr: "12.34.56",
+			expected: &VersionNumber{
+				Major: 12,
+				Minor: 34,
+				Patch: 56,
+			},
+			err: nil,
+		},
+		{
+			versionStr: "1.2",
+			expected: &VersionNumber{
+				Major: 1,
+				Minor: 2,
+				Patch: 0,
+			},
+			err: nil,
+		},
+		{
+			versionStr: "1",
+			expected:   nil,
+			err:        errors.New("unexpected version format: 1"),
+		},
+		{
+			versionStr: "invalid",
+			expected:   nil,
+			err:        errors.New("unexpected version format: invalid"),
+		},
+		{
+			versionStr: "junk_before 1.2.3",
+			expected:   nil,
+			err:        errors.New("unexpected version format: junk_before 1.2.3"),
+		},
+		{
+			versionStr: "1.2.3 junk_after",
+			expected:   nil,
+			err:        errors.New("unexpected version format: 1.2.3 junk_after"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.versionStr, func(t *testing.T) {
+			actual, err := ParseVersionNumber(test.versionStr)
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.err, err)
+		})
+	}
+}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -773,6 +773,9 @@ type TranslationSet struct {
 	Actions                              Actions
 	Bisect                               Bisect
 	Log                                  Log
+	BreakingChangesTitle                 string
+	BreakingChangesMessage               string
+	BreakingChangesByVersion             map[string]string
 }
 
 type Bisect struct {
@@ -1865,6 +1868,32 @@ func EnglishTranslationSet() TranslationSet {
 			CreateFileWithContent:    "Creating file '{{.path}}'",
 			AppendingLineToFile:      "Appending '{{.line}}' to file '{{.filename}}'",
 			EditRebaseFromBaseCommit: "Beginning interactive rebase from '{{.baseCommit}}' onto '{{.targetBranchName}}",
+		},
+		BreakingChangesTitle: "Breaking Changes",
+		BreakingChangesMessage: `You are updating to a new version of lazygit which contains breaking changes. Please review the notes below and update your configuration if necessary.
+For more information, see the full release notes at <https://github.com/jesseduffield/lazygit/releases>.`,
+		BreakingChangesByVersion: map[string]string{
+			"0.41.0": `- When you press 'g' to bring up the git reset menu, the 'mixed' option is now the first and default, rather than 'soft'. This is because 'mixed' is the most commonly used option.
+- The commit message panel now automatically hard-wraps by default (i.e. it adds newline characters when you reach the margin). You can adjust the config like so:
+
+git:
+  commit:
+    autoWrapCommitMessage: true
+    autoWrapWidth: 72
+
+- The 'v' key was already being used in the staging view to start a range select, but now you can use it to start a range select in any view. Unfortunately this clashes with the 'v' keybinding for pasting commits (cherry-pick), so now pasting commits is done via 'shift+V' and for the sake of consistency, copying commits is now done via 'shift+C' instead of just 'c'. Note that the 'v' keybinding is only one way to start a range-select: you can use shift+up/down arrow instead. So, if you want to configure the cherry-pick keybindings to get the old behaviour, set the following in your config:
+
+keybinding:
+  universal:
+      toggleRangeSelect: <something other than v>
+    commits:
+      cherryPickCopy: 'c'
+      pasteCommits: 'v'
+
+- Squashing fixups using 'shift-S' now brings up a menu, with the default option being to squash all fixup commits in the branch. The original behaviour of only squashing fixup commits above the selected commit is still available as the second option in that menu.
+- Push/pull/fetch loading statuses are now shown against the branch rather than in a popup. This allows you to e.g. fetch multiple branches in parallel and see the status for each branch.
+- The git log graph in the commits view is now always shown by default (previously it was only shown when the view was maximised). If you find this too noisy, you can change it back via ctrl+L -> 'Show git graph' -> 'when maximised'
+	  `,
 		},
 	}
 }


### PR DESCRIPTION
- **PR Description**

Remember which version of lazygit the user was last running, and show a list of breaking changes since that version (if any) if the user upgraded to a newer version.

It's a little unobvious how to test this manually, because we don't show the popup for developer builds. You'll have to build with something like `go build -ldflags="-X 'main.version=0.41.0'"` in order to test it.

This is an extremely stripped down version of #3261.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc