### PR TITLE
Allow moving and deleting update-ref todos

### DIFF
--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -348,7 +348,7 @@ func (self *CommitLoader) getRebasingCommits(rebaseMode enums.RebaseMode) []*mod
 
 	for _, t := range todos {
 		if t.Command == todo.UpdateRef {
-			t.Msg = strings.TrimPrefix(t.Ref, "refs/heads/")
+			t.Msg = t.Ref
 		} else if t.Commit == "" {
 			// Command does not have a commit associated, skip
 			continue

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -297,6 +297,18 @@ func (self *RebaseCommands) EditRebaseTodo(commits []*models.Commit, action todo
 	)
 }
 
+func (self *RebaseCommands) DeleteUpdateRefTodos(commits []*models.Commit) error {
+	todosToDelete := lo.Map(commits, func(commit *models.Commit, _ int) utils.Todo {
+		return todoFromCommit(commit)
+	})
+
+	return utils.DeleteTodos(
+		filepath.Join(self.repoPaths.WorktreeGitDirPath(), "rebase-merge/git-rebase-todo"),
+		todosToDelete,
+		self.config.GetCoreCommentChar(),
+	)
+}
+
 func (self *RebaseCommands) MoveTodosDown(commits []*models.Commit) error {
 	fileName := filepath.Join(self.repoPaths.WorktreeGitDirPath(), "rebase-merge/git-rebase-todo")
 	todosToMove := lo.Map(commits, func(commit *models.Commit, _ int) utils.Todo {

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -272,6 +272,14 @@ func (self *RebaseCommands) AmendTo(commits []*models.Commit, commitIndex int) e
 	}).Run()
 }
 
+func todoFromCommit(commit *models.Commit) utils.Todo {
+	if commit.Action == todo.UpdateRef {
+		return utils.Todo{Ref: commit.Name, Action: commit.Action}
+	} else {
+		return utils.Todo{Sha: commit.Sha, Action: commit.Action}
+	}
+}
+
 // Sets the action for the given commits in the git-rebase-todo file
 func (self *RebaseCommands) EditRebaseTodo(commits []*models.Commit, action todo.TodoCommand) error {
 	commitsWithAction := lo.Map(commits, func(commit *models.Commit, _ int) utils.TodoChange {
@@ -292,10 +300,7 @@ func (self *RebaseCommands) EditRebaseTodo(commits []*models.Commit, action todo
 func (self *RebaseCommands) MoveTodosDown(commits []*models.Commit) error {
 	fileName := filepath.Join(self.repoPaths.WorktreeGitDirPath(), "rebase-merge/git-rebase-todo")
 	todosToMove := lo.Map(commits, func(commit *models.Commit, _ int) utils.Todo {
-		return utils.Todo{
-			Sha:    commit.Sha,
-			Action: commit.Action,
-		}
+		return todoFromCommit(commit)
 	})
 
 	return utils.MoveTodosDown(fileName, todosToMove, self.config.GetCoreCommentChar())
@@ -304,10 +309,7 @@ func (self *RebaseCommands) MoveTodosDown(commits []*models.Commit) error {
 func (self *RebaseCommands) MoveTodosUp(commits []*models.Commit) error {
 	fileName := filepath.Join(self.repoPaths.WorktreeGitDirPath(), "rebase-merge/git-rebase-todo")
 	todosToMove := lo.Map(commits, func(commit *models.Commit, _ int) utils.Todo {
-		return utils.Todo{
-			Sha:    commit.Sha,
-			Action: commit.Action,
-		}
+		return todoFromCommit(commit)
 	})
 
 	return utils.MoveTodosUp(fileName, todosToMove, self.config.GetCoreCommentChar())

--- a/pkg/gui/context/traits/list_cursor.go
+++ b/pkg/gui/context/traits/list_cursor.go
@@ -65,7 +65,11 @@ func (self *ListCursor) SetSelection(value int) {
 func (self *ListCursor) SetSelectionRangeAndMode(selectedIdx, rangeStartIdx int, mode RangeSelectMode) {
 	self.selectedIdx = self.clampValue(selectedIdx)
 	self.rangeStartIdx = self.clampValue(rangeStartIdx)
-	self.rangeSelectMode = mode
+	if mode == RangeSelectModeNonSticky && selectedIdx == rangeStartIdx {
+		self.rangeSelectMode = RangeSelectModeNone
+	} else {
+		self.rangeSelectMode = mode
+	}
 }
 
 // Returns the selectedIdx, the rangeStartIdx, and the mode of the current selection.

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -282,7 +282,7 @@ func (self *LocalCommitsController) GetOnRenderToMain() func() error {
 					utils.ResolvePlaceholderString(
 						self.c.Tr.UpdateRefHere,
 						map[string]string{
-							"ref": commit.Name,
+							"ref": strings.TrimPrefix(commit.Name, "refs/heads/"),
 						}))
 			} else {
 				cmdObj := self.c.Git().Commit.ShowCmdObj(commit.Sha, self.c.Modes().Filtering.GetPath())

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -342,6 +342,9 @@ func displayCommit(
 	}
 
 	name := commit.Name
+	if commit.Action == todo.UpdateRef {
+		name = strings.TrimPrefix(name, "refs/heads/")
+	}
 	if parseEmoji {
 		name = emoji.Sprint(name)
 	}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -325,6 +325,7 @@ type TranslationSet struct {
 	AmendCommitPrompt                     string
 	DropCommitTitle                       string
 	DropCommitPrompt                      string
+	DropUpdateRefPrompt                   string
 	PullingStatus                         string
 	PushingStatus                         string
 	FetchingStatus                        string
@@ -1280,6 +1281,7 @@ func EnglishTranslationSet() TranslationSet {
 		AmendCommitPrompt:                   "Are you sure you want to amend this commit with your staged files?",
 		DropCommitTitle:                     "Drop commit",
 		DropCommitPrompt:                    "Are you sure you want to drop the selected commit(s)?",
+		DropUpdateRefPrompt:                 "Are you sure you want to delete the selected update-ref todo(s)? This is irreversible except by aborting the rebase.",
 		PullingStatus:                       "Pulling",
 		PushingStatus:                       "Pushing",
 		FetchingStatus:                      "Fetching",

--- a/pkg/integration/tests/interactive_rebase/delete_update_ref_todo.go
+++ b/pkg/integration/tests/interactive_rebase/delete_update_ref_todo.go
@@ -1,0 +1,65 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var DeleteUpdateRefTodo = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Delete an update-ref item from the rebase todo list",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	GitVersion:   AtLeast("2.38.0"),
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			NewBranch("branch1").
+			CreateNCommits(3).
+			NewBranch("branch2").
+			CreateNCommitsStartingAt(3, 4)
+
+		shell.SetConfig("rebase.updateRefs", "true")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			NavigateToLine(Contains("commit 01")).
+			Press(keys.Universal.Edit).
+			Lines(
+				Contains("pick").Contains("CI commit 06"),
+				Contains("pick").Contains("CI commit 05"),
+				Contains("pick").Contains("CI commit 04"),
+				Contains("update-ref").Contains("branch1"),
+				Contains("pick").Contains("CI commit 03"),
+				Contains("pick").Contains("CI commit 02"),
+				Contains("CI ◯ <-- YOU ARE HERE --- commit 01"),
+			).
+			NavigateToLine(Contains("update-ref")).
+			Press(keys.Universal.Remove).
+			Tap(func() {
+				t.ExpectPopup().Confirmation().
+					Title(Equals("Drop commit")).
+					Content(Contains("Are you sure you want to delete the selected update-ref todo(s)?")).
+					Confirm()
+			}).
+			Lines(
+				Contains("pick").Contains("CI commit 06"),
+				Contains("pick").Contains("CI commit 05"),
+				Contains("pick").Contains("CI commit 04"),
+				Contains("pick").Contains("CI commit 03").IsSelected(),
+				Contains("pick").Contains("CI commit 02"),
+				Contains("CI ◯ <-- YOU ARE HERE --- commit 01"),
+			).
+			Tap(func() {
+				t.Common().ContinueRebase()
+			}).
+			Lines(
+				Contains("CI ◯ commit 06"),
+				Contains("CI ◯ commit 05"),
+				Contains("CI ◯ commit 04"),
+				Contains("CI ◯ commit 03"), // No start on this commit, so there's no branch head here
+				Contains("CI ◯ commit 02"),
+				Contains("CI ◯ commit 01"),
+			)
+	},
+})

--- a/pkg/integration/tests/interactive_rebase/move_update_ref_todo.go
+++ b/pkg/integration/tests/interactive_rebase/move_update_ref_todo.go
@@ -1,0 +1,61 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var MoveUpdateRefTodo = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Move an update-ref item in the rebase todo list",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	GitVersion:   AtLeast("2.38.0"),
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			NewBranch("branch1").
+			CreateNCommits(3).
+			NewBranch("branch2").
+			CreateNCommitsStartingAt(3, 4)
+
+		shell.SetConfig("rebase.updateRefs", "true")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			NavigateToLine(Contains("commit 01")).
+			Press(keys.Universal.Edit).
+			Lines(
+				Contains("pick").Contains("CI commit 06"),
+				Contains("pick").Contains("CI commit 05"),
+				Contains("pick").Contains("CI commit 04"),
+				Contains("update-ref").Contains("branch1"),
+				Contains("pick").Contains("CI commit 03"),
+				Contains("pick").Contains("CI commit 02"),
+				Contains("CI ◯ <-- YOU ARE HERE --- commit 01"),
+			).
+			NavigateToLine(Contains("update-ref")).
+			Press(keys.Commits.MoveUpCommit).
+			Press(keys.Commits.MoveUpCommit).
+			Lines(
+				Contains("pick").Contains("CI commit 06"),
+				Contains("update-ref").Contains("branch1"),
+				Contains("pick").Contains("CI commit 05"),
+				Contains("pick").Contains("CI commit 04"),
+				Contains("pick").Contains("CI commit 03"),
+				Contains("pick").Contains("CI commit 02"),
+				Contains("CI ◯ <-- YOU ARE HERE --- commit 01"),
+			).
+			Tap(func() {
+				t.Common().ContinueRebase()
+			}).
+			Lines(
+				Contains("CI ◯ commit 06"),
+				Contains("CI ◯ * commit 05"),
+				Contains("CI ◯ commit 04"),
+				Contains("CI ◯ commit 03"),
+				Contains("CI ◯ commit 02"),
+				Contains("CI ◯ commit 01"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -164,6 +164,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.AmendHeadCommitDuringRebase,
 	interactive_rebase.AmendMerge,
 	interactive_rebase.AmendNonHeadCommitDuringRebase,
+	interactive_rebase.DeleteUpdateRefTodo,
 	interactive_rebase.DontShowBranchHeadsForTodoItems,
 	interactive_rebase.DropTodoCommitWithUpdateRef,
 	interactive_rebase.DropWithCustomCommentChar,

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -176,6 +176,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.MidRebaseRangeSelect,
 	interactive_rebase.Move,
 	interactive_rebase.MoveInRebase,
+	interactive_rebase.MoveUpdateRefTodo,
 	interactive_rebase.MoveWithCustomCommentChar,
 	interactive_rebase.OutsideRebaseRangeSelect,
 	interactive_rebase.PickRescheduled,

--- a/pkg/utils/rebase_todo.go
+++ b/pkg/utils/rebase_todo.go
@@ -10,7 +10,8 @@ import (
 )
 
 type Todo struct {
-	Sha    string
+	Sha    string // for todos that have one, e.g. pick, drop, fixup, etc.
+	Ref    string // for update-ref todos
 	Action todo.TodoCommand
 }
 
@@ -130,8 +131,11 @@ func moveTodoUp(todos []todo.Todo, todoToMove Todo) ([]todo.Todo, error) {
 	_, sourceIdx, ok := lo.FindIndexOf(todos, func(t todo.Todo) bool {
 		// Comparing just the sha is not enough; we need to compare both the
 		// action and the sha, as the sha could appear multiple times (e.g. in a
-		// pick and later in a merge)
-		return t.Command == todoToMove.Action && equalShas(t.Commit, todoToMove.Sha)
+		// pick and later in a merge). For update-ref todos we also must compare
+		// the Ref.
+		return t.Command == todoToMove.Action &&
+			equalShas(t.Commit, todoToMove.Sha) &&
+			t.Ref == todoToMove.Ref
 	})
 
 	if !ok {

--- a/pkg/utils/rebase_todo.go
+++ b/pkg/utils/rebase_todo.go
@@ -116,8 +116,8 @@ func MoveTodosUp(fileName string, todosToMove []Todo, commentChar byte) error {
 	return WriteRebaseTodoFile(fileName, rearrangedTodos, commentChar)
 }
 
-func moveTodoDown(todos []todo.Todo, sha string, action todo.TodoCommand) ([]todo.Todo, error) {
-	rearrangedTodos, err := moveTodoUp(lo.Reverse(todos), sha, action)
+func moveTodoDown(todos []todo.Todo, todoToMove Todo) ([]todo.Todo, error) {
+	rearrangedTodos, err := moveTodoUp(lo.Reverse(todos), todoToMove)
 	return lo.Reverse(rearrangedTodos), err
 }
 
@@ -126,17 +126,17 @@ func moveTodosDown(todos []todo.Todo, todosToMove []Todo) ([]todo.Todo, error) {
 	return lo.Reverse(rearrangedTodos), err
 }
 
-func moveTodoUp(todos []todo.Todo, sha string, action todo.TodoCommand) ([]todo.Todo, error) {
+func moveTodoUp(todos []todo.Todo, todoToMove Todo) ([]todo.Todo, error) {
 	_, sourceIdx, ok := lo.FindIndexOf(todos, func(t todo.Todo) bool {
 		// Comparing just the sha is not enough; we need to compare both the
 		// action and the sha, as the sha could appear multiple times (e.g. in a
 		// pick and later in a merge)
-		return t.Command == action && equalShas(t.Commit, sha)
+		return t.Command == todoToMove.Action && equalShas(t.Commit, todoToMove.Sha)
 	})
 
 	if !ok {
 		// Should never happen
-		return []todo.Todo{}, fmt.Errorf("Todo %s not found in git-rebase-todo", sha)
+		return []todo.Todo{}, fmt.Errorf("Todo %s not found in git-rebase-todo", todoToMove.Sha)
 	}
 
 	// The todos are ordered backwards compared to our model commits, so
@@ -161,7 +161,7 @@ func moveTodoUp(todos []todo.Todo, sha string, action todo.TodoCommand) ([]todo.
 func moveTodosUp(todos []todo.Todo, todosToMove []Todo) ([]todo.Todo, error) {
 	for _, todoToMove := range todosToMove {
 		var newTodos []todo.Todo
-		newTodos, err := moveTodoUp(todos, todoToMove.Sha, todoToMove.Action)
+		newTodos, err := moveTodoUp(todos, todoToMove)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/utils/rebase_todo.go
+++ b/pkg/utils/rebase_todo.go
@@ -106,6 +106,33 @@ func PrependStrToTodoFile(filePath string, linesToPrepend []byte) error {
 	return os.WriteFile(filePath, linesToPrepend, 0o644)
 }
 
+func DeleteTodos(fileName string, todosToDelete []Todo, commentChar byte) error {
+	todos, err := ReadRebaseTodoFile(fileName, commentChar)
+	if err != nil {
+		return err
+	}
+	rearrangedTodos, err := deleteTodos(todos, todosToDelete)
+	if err != nil {
+		return err
+	}
+	return WriteRebaseTodoFile(fileName, rearrangedTodos, commentChar)
+}
+
+func deleteTodos(todos []todo.Todo, todosToDelete []Todo) ([]todo.Todo, error) {
+	for _, todoToDelete := range todosToDelete {
+		idx, ok := findTodo(todos, todoToDelete)
+
+		if !ok {
+			// Should never happen
+			return []todo.Todo{}, fmt.Errorf("Todo %s not found in git-rebase-todo", todoToDelete.Sha)
+		}
+
+		todos = Remove(todos, idx)
+	}
+
+	return todos, nil
+}
+
 func MoveTodosDown(fileName string, todosToMove []Todo, commentChar byte) error {
 	todos, err := ReadRebaseTodoFile(fileName, commentChar)
 	if err != nil {

--- a/pkg/utils/rebase_todo_test.go
+++ b/pkg/utils/rebase_todo_test.go
@@ -49,6 +49,21 @@ func TestRebaseCommands_moveTodoDown(t *testing.T) {
 			},
 		},
 		{
+			testName: "move update-ref todo",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.Pick, Commit: "5678"},
+				{Command: todo.UpdateRef, Ref: "refs/heads/some_branch"},
+			},
+			todoToMoveDown: Todo{Ref: "refs/heads/some_branch", Action: todo.UpdateRef},
+			expectedErr:    "",
+			expectedTodos: []todo.Todo{
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.UpdateRef, Ref: "refs/heads/some_branch"},
+				{Command: todo.Pick, Commit: "5678"},
+			},
+		},
+		{
 			testName: "skip an invisible todo",
 			todos: []todo.Todo{
 				{Command: todo.Pick, Commit: "1234"},
@@ -157,6 +172,21 @@ func TestRebaseCommands_moveTodoUp(t *testing.T) {
 				{Command: todo.Pick, Commit: "5678"},
 				{Command: todo.Pick, Commit: "1234"},
 				{Command: todo.Pick, Commit: "abcd"},
+			},
+		},
+		{
+			testName: "move update-ref todo",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.UpdateRef, Ref: "refs/heads/some_branch"},
+				{Command: todo.Pick, Commit: "5678"},
+			},
+			todoToMoveUp: Todo{Ref: "refs/heads/some_branch", Action: todo.UpdateRef},
+			expectedErr:  "",
+			expectedTodos: []todo.Todo{
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.Pick, Commit: "5678"},
+				{Command: todo.UpdateRef, Ref: "refs/heads/some_branch"},
 			},
 		},
 		{


### PR DESCRIPTION
- **PR Description**

Previously it wasn't possible to move an update-ref entry up or down using ctrl-j and ctrl-k, or to delete an update-ref entry. For moving, a work-around was to move the surrounding commits instead, but it's still nice to be able to do it directly. Deleting is very much necessary though, since there are situations where git adds the update-ref entries but they are not wanted; one example is if you want to make a copy of a branch and rebase to a different place, without the original branch following it. (There's a long discussion about this [here](https://public-inbox.org/git/adb7f680-5bfa-6fa5-6d8a-61323fee7f53@haller-berlin.de/).)

Update-ref todos can't be set to "drop" like other todos, because they have no sha associated with them, so we need to delete them immediately. We show a confirmation before doing that, because you'd have to abort the rebase if you do it accidentally.

We allow range selecting normal todos and update-ref todos at the same time; in that case, we delete all the update-ref todos and set all the other ones to "drop". Not that this is an absolutely necessary feature, but it wasn't hard to do.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
