### PR TITLE
Fix enabling/disabling of ctrl-o in commit message panel

### DIFF
--- a/pkg/gui/context/commit_message_context.go
+++ b/pkg/gui/context/commit_message_context.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
-	"github.com/samber/lo"
 )
 
 type CommitMessageContext struct {
@@ -112,8 +111,7 @@ func (self *CommitMessageContext) SetPanelState(
 	self.GetView().Title = summaryTitle
 	self.c.Views().CommitDescription.Title = descriptionTitle
 
-	subtitleTemplate := lo.Ternary(onSwitchToEditor != nil, self.c.Tr.CommitDescriptionSubTitle, self.c.Tr.CommitDescriptionSubTitleNoSwitch)
-	self.c.Views().CommitDescription.Subtitle = utils.ResolvePlaceholderString(subtitleTemplate,
+	self.c.Views().CommitDescription.Subtitle = utils.ResolvePlaceholderString(self.c.Tr.CommitDescriptionSubTitle,
 		map[string]string{
 			"togglePanelKeyBinding": keybindings.Label(self.c.UserConfig.Keybinding.Universal.TogglePanel),
 			"commitMenuKeybinding":  keybindings.Label(self.c.UserConfig.Keybinding.CommitMessage.CommitMenu),

--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -91,10 +91,6 @@ func TryRemoveHardLineBreaks(message string, autoWrapWidth int) string {
 }
 
 func (self *CommitsHelper) SwitchToEditor() error {
-	if !self.c.Contexts().CommitMessage.CanSwitchToEditor() {
-		return nil
-	}
-
 	message := lo.Ternary(len(self.getCommitDescription()) == 0,
 		self.getCommitSummary(),
 		self.getCommitSummary()+"\n\n"+self.getCommitDescription())
@@ -218,13 +214,21 @@ func (self *CommitsHelper) commitMessageContexts() []types.Context {
 }
 
 func (self *CommitsHelper) OpenCommitMenu(suggestionFunc func(string) []*types.Suggestion) error {
+	var disabledReasonForOpenInEditor *types.DisabledReason
+	if !self.c.Contexts().CommitMessage.CanSwitchToEditor() {
+		disabledReasonForOpenInEditor = &types.DisabledReason{
+			Text: self.c.Tr.CommandDoesNotSupportOpeningInEditor,
+		}
+	}
+
 	menuItems := []*types.MenuItem{
 		{
 			Label: self.c.Tr.OpenInEditor,
 			OnPress: func() error {
 				return self.SwitchToEditor()
 			},
-			Key: 'e',
+			Key:            'e',
+			DisabledReason: disabledReasonForOpenInEditor,
 		},
 		{
 			Label: self.c.Tr.AddCoAuthor,

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -775,6 +775,7 @@ type TranslationSet struct {
 	SelectedItemDoesNotHaveFiles         string
 	RangeSelectNotSupportedForSubmodules string
 	OldCherryPickKeyWarning              string
+	CommandDoesNotSupportOpeningInEditor string
 	Actions                              Actions
 	Bisect                               Bisect
 	Log                                  Log
@@ -1731,6 +1732,7 @@ func EnglishTranslationSet() TranslationSet {
 		SelectedItemDoesNotHaveFiles:          "Selected item does not have files to view",
 		RangeSelectNotSupportedForSubmodules:  "Range select not supported for submodules",
 		OldCherryPickKeyWarning:               "The 'c' key is no longer the default key for copying commits to cherry pick. Please use `{{.copy}}` instead (and `{{.paste}}` to paste). The reason for this change is that the 'v' key for selecting a range of lines when staging is now also used for selecting a range of lines in any list view, meaning that we needed to find a new key for pasting commits, and if we're going to now use `{{.paste}}` for pasting commits, we may as well use `{{.copy}}` for copying them. If you want to configure the keybindings to get the old behaviour, set the following in your config:\n\nkeybinding:\n  universal:\n    toggleRangeSelect: <something other than v>\n  commits:\n    cherryPickCopy: 'c'\n    pasteCommits: 'v'",
+		CommandDoesNotSupportOpeningInEditor:  "This command doesn't support switching to the editor",
 
 		Actions: Actions{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -272,7 +272,6 @@ type TranslationSet struct {
 	CommitSummaryTitle                    string
 	CommitDescriptionTitle                string
 	CommitDescriptionSubTitle             string
-	CommitDescriptionSubTitleNoSwitch     string
 	LocalBranchesTitle                    string
 	SearchTitle                           string
 	TagsTitle                             string
@@ -1229,7 +1228,6 @@ func EnglishTranslationSet() TranslationSet {
 		CommitSummaryTitle:                  "Commit summary",
 		CommitDescriptionTitle:              "Commit description",
 		CommitDescriptionSubTitle:           "Press {{.togglePanelKeyBinding}} to toggle focus, {{.commitMenuKeybinding}} to open menu",
-		CommitDescriptionSubTitleNoSwitch:   "Press {{.togglePanelKeyBinding}} to toggle focus",
 		LocalBranchesTitle:                  "Local branches",
 		SearchTitle:                         "Search",
 		TagsTitle:                           "Tags",

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -256,7 +256,6 @@ func polishTranslationSet() TranslationSet {
 		CommitSummaryTitle:                  "Podsumowanie commita",
 		CommitDescriptionTitle:              "Opis commita",
 		CommitDescriptionSubTitle:           "Naciśnij {{.togglePanelKeyBinding}}, aby przełączyć fokus, {{.commitMenuKeybinding}}, aby otworzyć menu",
-		CommitDescriptionSubTitleNoSwitch:   "Naciśnij {{.togglePanelKeyBinding}}, aby przełączyć fokus",
 		LocalBranchesTitle:                  "Lokalne gałęzie",
 		SearchTitle:                         "Szukaj",
 		TagsTitle:                           "Tagi",


### PR DESCRIPTION
- **PR Description**

This fixes two minor regressions introduced in #3097 related to commands that open a commit message panel but don't set an onSwitchToEditor function (an example is the commit message panel that appears when moving a custom patch to a new commit):
- the "Press <c-o> to open menu" hint was hidden. That's wrong, it is still possible to open the menu in this case. (And it still worked, we just wouldn't show the hint.)
- invoking the "open in editor" menu item would silently do nothing. Now we set a DisabledReason for the item in this case.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
