### PR TITLE
Add config to truncate commit hashes when copying them to the clipboard

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -126,6 +126,7 @@ git:
   overrideGpg: false # prevents lazygit from spawning a separate process when using GPG
   disableForcePushing: false
   parseEmoji: false
+  truncateCopiedCommitHashesTo: 12 # When copying commit hashes to the clipboard, truncate them to this length. Set to 40 to disable truncation.
 os:
   copyToClipboardCmd: '' # See 'Custom Command for Copying to Clipboard' section
   editPreset: '' # see 'Configuring File Editing' section

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -214,6 +214,9 @@ type GitConfig struct {
 	ParseEmoji bool `yaml:"parseEmoji"`
 	// Config for showing the log in the commits view
 	Log LogConfig `yaml:"log"`
+	// When copying commit hashes to the clipboard, truncate them to this
+	// length. Set to 40 to disable truncation.
+	TruncateCopiedCommitHashesTo int `yaml:"truncateCopiedCommitHashesTo"`
 }
 
 type PagerType string
@@ -690,16 +693,17 @@ func GetDefaultConfig() *UserConfig {
 				ShowGraph:      "always",
 				ShowWholeGraph: false,
 			},
-			SkipHookPrefix:      "WIP",
-			MainBranches:        []string{"master", "main"},
-			AutoFetch:           true,
-			AutoRefresh:         true,
-			FetchAll:            true,
-			BranchLogCmd:        "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",
-			AllBranchesLogCmd:   "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium",
-			DisableForcePushing: false,
-			CommitPrefixes:      map[string]CommitPrefixConfig(nil),
-			ParseEmoji:          false,
+			SkipHookPrefix:               "WIP",
+			MainBranches:                 []string{"master", "main"},
+			AutoFetch:                    true,
+			AutoRefresh:                  true,
+			FetchAll:                     true,
+			BranchLogCmd:                 "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",
+			AllBranchesLogCmd:            "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium",
+			DisableForcePushing:          false,
+			CommitPrefixes:               map[string]CommitPrefixConfig(nil),
+			ParseEmoji:                   false,
+			TruncateCopiedCommitHashesTo: 12,
 		},
 		Refresher: RefresherConfig{
 			RefreshInterval: 10,

--- a/pkg/gui/controllers/basic_commits_controller.go
+++ b/pkg/gui/controllers/basic_commits_controller.go
@@ -175,7 +175,7 @@ func (self *BasicCommitsController) copyCommitSHAToClipboard(commit *models.Comm
 		return self.c.Error(err)
 	}
 
-	self.c.Toast(self.c.Tr.CommitSHACopiedToClipboard)
+	self.c.Toast(fmt.Sprintf("'%s' %s", commit.Sha, self.c.Tr.CopiedToClipboard))
 	return nil
 }
 

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -110,6 +110,15 @@ func (gui *Gui) scrollDownConfirmationPanel() error {
 }
 
 func (gui *Gui) handleCopySelectedSideContextItemToClipboard() error {
+	return gui.handleCopySelectedSideContextItemToClipboardWithTruncation(-1)
+}
+
+func (gui *Gui) handleCopySelectedSideContextItemCommitHashToClipboard() error {
+	return gui.handleCopySelectedSideContextItemToClipboardWithTruncation(
+		gui.UserConfig.Git.TruncateCopiedCommitHashesTo)
+}
+
+func (gui *Gui) handleCopySelectedSideContextItemToClipboardWithTruncation(maxWidth int) error {
 	// important to note that this assumes we've selected an item in a side context
 	currentSideContext := gui.c.CurrentSideContext()
 	if currentSideContext == nil {
@@ -125,6 +134,10 @@ func (gui *Gui) handleCopySelectedSideContextItemToClipboard() error {
 
 	if itemId == "" {
 		return nil
+	}
+
+	if maxWidth > 0 {
+		itemId = itemId[:utils.Min(len(itemId), maxWidth)]
 	}
 
 	gui.c.LogAction(gui.c.Tr.Actions.CopyToClipboard)

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -146,7 +146,7 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 		{
 			ViewName:          "commits",
 			Key:               opts.GetKey(opts.Config.Universal.CopyToClipboard),
-			Handler:           self.handleCopySelectedSideContextItemToClipboard,
+			Handler:           self.handleCopySelectedSideContextItemCommitHashToClipboard,
 			GetDisabledReason: self.getCopySelectedSideContextItemToClipboardDisabledReason,
 			Description:       self.c.Tr.CopyCommitShaToClipboard,
 		},
@@ -166,7 +166,7 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 		{
 			ViewName:          "subCommits",
 			Key:               opts.GetKey(opts.Config.Universal.CopyToClipboard),
-			Handler:           self.handleCopySelectedSideContextItemToClipboard,
+			Handler:           self.handleCopySelectedSideContextItemCommitHashToClipboard,
 			GetDisabledReason: self.getCopySelectedSideContextItemToClipboardDisabledReason,
 			Description:       self.c.Tr.CopyCommitShaToClipboard,
 		},

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -319,7 +319,7 @@ func dutchTranslationSet() TranslationSet {
 		BranchNotFoundPrompt:            "Branch niet gevonden. Creëer een nieuwe branch genaamd",
 		PullRequestURLCopiedToClipboard: "Pull-aanvraag-URL gekopieerd naar klembord",
 		CommitMessageCopiedToClipboard:  "Commit message gekopieerd naar klembord",
-		CopiedToClipboard:               "Gekopieerd naar klembord",
+		CopiedToClipboard:               "gekopieerd naar klembord",
 		NavigationTitle:                 "Lijstpaneel navigatie",
 		ViewCommits:                     "Bekijk commits",
 		ToggleTreeView:                  "Toggle bestandsboom weergave",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1775,7 +1775,7 @@ func EnglishTranslationSet() TranslationSet {
 			CopyCommitMessageToClipboard:   "Copy commit message to clipboard",
 			CopyCommitSubjectToClipboard:   "Copy commit subject to clipboard",
 			CopyCommitDiffToClipboard:      "Copy commit diff to clipboard",
-			CopyCommitSHAToClipboard:       "Copy commit SHA to clipboard",
+			CopyCommitSHAToClipboard:       "Copy full commit SHA to clipboard",
 			CopyCommitURLToClipboard:       "Copy commit URL to clipboard",
 			CopyCommitAuthorToClipboard:    "Copy commit author to clipboard",
 			CopyCommitAttributeToClipboard: "Copy to clipboard",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1603,7 +1603,7 @@ func EnglishTranslationSet() TranslationSet {
 		CommitSubjectCopiedToClipboard:        "Commit subject copied to clipboard",
 		CommitAuthorCopiedToClipboard:         "Commit author copied to clipboard",
 		PatchCopiedToClipboard:                "Patch copied to clipboard",
-		CopiedToClipboard:                     "Copied to clipboard",
+		CopiedToClipboard:                     "copied to clipboard",
 		ErrCannotEditDirectory:                "Cannot edit directories: you can only edit individual files",
 		ErrStageDirWithInlineMergeConflicts:   "Cannot stage/unstage directory containing files with inline merge conflicts. Please fix up the merge conflicts first",
 		ErrRepositoryMovedOrDeleted:           "Cannot find repo. It might have been moved or deleted ¯\\_(ツ)_/¯",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -635,7 +635,6 @@ type TranslationSet struct {
 	PushingTagStatus                     string
 	PullRequestURLCopiedToClipboard      string
 	CommitDiffCopiedToClipboard          string
-	CommitSHACopiedToClipboard           string
 	CommitURLCopiedToClipboard           string
 	CommitMessageCopiedToClipboard       string
 	CommitSubjectCopiedToClipboard       string
@@ -1599,7 +1598,6 @@ func EnglishTranslationSet() TranslationSet {
 		PushingTagStatus:                      "Pushing tag",
 		PullRequestURLCopiedToClipboard:       "Pull request URL copied to clipboard",
 		CommitDiffCopiedToClipboard:           "Commit diff copied to clipboard",
-		CommitSHACopiedToClipboard:            "Commit SHA copied to clipboard",
 		CommitURLCopiedToClipboard:            "Commit URL copied to clipboard",
 		CommitMessageCopiedToClipboard:        "Commit message copied to clipboard",
 		CommitSubjectCopiedToClipboard:        "Commit subject copied to clipboard",

--- a/pkg/i18n/japanese.go
+++ b/pkg/i18n/japanese.go
@@ -423,7 +423,6 @@ func japaneseTranslationSet() TranslationSet {
 		// PushingTagStatus:                    "Pushing tag",
 		PullRequestURLCopiedToClipboard:     "Pull requestのURLがクリップボードにコピーされました",
 		CommitDiffCopiedToClipboard:         "コミットの差分がクリップボードにコピーされました",
-		CommitSHACopiedToClipboard:          "コミットのSHAがクリップボードにコピーされました",
 		CommitURLCopiedToClipboard:          "コミットのURLがクリップボードにコピーされました",
 		CommitMessageCopiedToClipboard:      "コミットメッセージがクリップボードにコピーされました",
 		CommitAuthorCopiedToClipboard:       "コミットの作成者名がクリップボードにコピーされました",

--- a/pkg/i18n/korean.go
+++ b/pkg/i18n/korean.go
@@ -417,7 +417,6 @@ func koreanTranslationSet() TranslationSet {
 		PushingTagStatus:                    "Pushing tag",
 		PullRequestURLCopiedToClipboard:     "풀 리퀘스트의 URL을 클립보드에 복사했습니다.",
 		CommitDiffCopiedToClipboard:         "커밋의 Diff를 클립보드에 복사했습니다.",
-		CommitSHACopiedToClipboard:          "커밋의 SHA를 클립보드에 복사했습니다.",
 		CommitURLCopiedToClipboard:          "커밋의 URL를 클립보드에 복사했습니다.",
 		CommitMessageCopiedToClipboard:      "커밋 메시지를 클립보드에 복사했습니다.",
 		CommitAuthorCopiedToClipboard:       "커밋 작성자를 클립보드에 복사했습니다.",

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -611,7 +611,6 @@ func polishTranslationSet() TranslationSet {
 		PushingTagStatus:                      "Wysyłanie tagu",
 		PullRequestURLCopiedToClipboard:       "URL żądania ściągnięcia skopiowany do schowka",
 		CommitDiffCopiedToClipboard:           "Różnice commita skopiowane do schowka",
-		CommitSHACopiedToClipboard:            "SHA commita skopiowany do schowka",
 		CommitURLCopiedToClipboard:            "URL commita skopiowany do schowka",
 		CommitMessageCopiedToClipboard:        "Wiadomość commita skopiowana do schowka",
 		CommitSubjectCopiedToClipboard:        "Temat commita skopiowany do schowka",

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -616,7 +616,7 @@ func polishTranslationSet() TranslationSet {
 		CommitSubjectCopiedToClipboard:        "Temat commita skopiowany do schowka",
 		CommitAuthorCopiedToClipboard:         "Autor commita skopiowany do schowka",
 		PatchCopiedToClipboard:                "Łatka skopiowana do schowka",
-		CopiedToClipboard:                     "Skopiowane do schowka",
+		CopiedToClipboard:                     "skopiowane do schowka",
 		ErrCannotEditDirectory:                "Nie można edytować katalogu: można edytować tylko pojedyncze pliki",
 		ErrStageDirWithInlineMergeConflicts:   "Nie można przygotować/odprzygotować katalogu zawierającego pliki z konfliktami scalania w linii. Proszę najpierw rozwiązać konflikty scalania",
 		ErrRepositoryMovedOrDeleted:           "Nie można znaleźć repozytorium. Mogło zostać przeniesione lub usunięte ¯\\_(ツ)_/¯",

--- a/pkg/i18n/russian.go
+++ b/pkg/i18n/russian.go
@@ -480,7 +480,6 @@ func RussianTranslationSet() TranslationSet {
 		PushingTagStatus:                    "Отправка тега",
 		PullRequestURLCopiedToClipboard:     "URL запроса на принятие изменений скопирован в буфер обмена",
 		CommitDiffCopiedToClipboard:         "Сравнения коммита скопированы в буфер обмена",
-		CommitSHACopiedToClipboard:          "SHA коммита скопировано в буфер обмена",
 		CommitURLCopiedToClipboard:          "URL коммита скопирован в буфер обмена",
 		CommitMessageCopiedToClipboard:      "Сообщение коммита скопировано в буфер обмена",
 		CommitSubjectCopiedToClipboard:      "Тема коммита скопирована в буфер обмена",

--- a/pkg/i18n/traditional_chinese.go
+++ b/pkg/i18n/traditional_chinese.go
@@ -511,7 +511,6 @@ func traditionalChineseTranslationSet() TranslationSet {
 		PushingTagStatus:                    "正在推送標籤",
 		PullRequestURLCopiedToClipboard:     "複製拉取請求 URL 至剪貼簿",
 		CommitDiffCopiedToClipboard:         "已複製提交差異至剪貼簿",
-		CommitSHACopiedToClipboard:          "已複製提交 SHA 至剪貼簿",
 		CommitURLCopiedToClipboard:          "已複製提交 URL 至剪貼簿",
 		CommitMessageCopiedToClipboard:      "已複製提交訊息至剪貼簿",
 		CommitAuthorCopiedToClipboard:       "已複製提交者至剪貼簿",

--- a/pkg/integration/tests/misc/copy_to_clipboard.go
+++ b/pkg/integration/tests/misc/copy_to_clipboard.go
@@ -27,7 +27,7 @@ var CopyToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			Press(keys.Universal.CopyToClipboard)
 
-		t.ExpectToast(Equals("'branch-a' Copied to clipboard"))
+		t.ExpectToast(Equals("'branch-a' copied to clipboard"))
 
 		t.Views().Files().
 			Focus()

--- a/schema/config.json
+++ b/schema/config.json
@@ -559,6 +559,11 @@
           "additionalProperties": false,
           "type": "object",
           "description": "Config for showing the log in the commits view"
+        },
+        "truncateCopiedCommitHashesTo": {
+          "type": "integer",
+          "description": "When copying commit hashes to the clipboard, truncate them to this\nlength. Set to 40 to disable truncation.",
+          "default": 12
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
- **PR Description**

I often copy hashes in the commits panel in order to paste them into Github comments (or other places), and I can't stand it when they have the full length.

I picked a default of 12 for this; I find this to be a good middle ground between being reliable in large repos (12 still works in the linux kernel repo today, but it might not be enough in really huge repos) and not being too ugly (many smaller repos can probably get away with less).

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
