### PR TITLE
Support editing multiple files at once using range selection

### DIFF
--- a/pkg/commands/git_commands/file_test.go
+++ b/pkg/commands/git_commands/file_test.go
@@ -177,9 +177,9 @@ func TestEditFileCmdStrLegacy(t *testing.T) {
 	}
 }
 
-func TestEditFileCmd(t *testing.T) {
+func TestEditFilesCmd(t *testing.T) {
 	type scenario struct {
-		filename       string
+		filenames      []string
 		osConfig       config.OSConfig
 		expectedCmdStr string
 		suspend        bool
@@ -187,13 +187,13 @@ func TestEditFileCmd(t *testing.T) {
 
 	scenarios := []scenario{
 		{
-			filename:       "test",
+			filenames:      []string{"test"},
 			osConfig:       config.OSConfig{},
 			expectedCmdStr: `vim -- "test"`,
 			suspend:        true,
 		},
 		{
-			filename: "test",
+			filenames: []string{"test"},
 			osConfig: config.OSConfig{
 				Edit: "nano {{filename}}",
 			},
@@ -201,11 +201,19 @@ func TestEditFileCmd(t *testing.T) {
 			suspend:        true,
 		},
 		{
-			filename: "file/with space",
+			filenames: []string{"file/with space"},
 			osConfig: config.OSConfig{
 				EditPreset: "sublime",
 			},
 			expectedCmdStr: `subl -- "file/with space"`,
+			suspend:        false,
+		},
+		{
+			filenames: []string{"multiple", "files"},
+			osConfig: config.OSConfig{
+				EditPreset: "sublime",
+			},
+			expectedCmdStr: `subl -- "multiple" "files"`,
 			suspend:        false,
 		},
 	}
@@ -218,7 +226,7 @@ func TestEditFileCmd(t *testing.T) {
 			userConfig: userConfig,
 		})
 
-		cmdStr, suspend := instance.GetEditCmdStr(s.filename)
+		cmdStr, suspend := instance.GetEditCmdStr(s.filenames)
 		assert.Equal(t, s.expectedCmdStr, cmdStr)
 		assert.Equal(t, s.suspend, suspend)
 	}

--- a/pkg/gui/controllers/helpers/files_helper.go
+++ b/pkg/gui/controllers/helpers/files_helper.go
@@ -2,10 +2,12 @@ package helpers
 
 import (
 	"path/filepath"
+
+	"github.com/samber/lo"
 )
 
 type IFilesHelper interface {
-	EditFile(filename string) error
+	EditFiles(filenames []string) error
 	EditFileAtLine(filename string, lineNumber int) error
 	OpenFile(filename string) error
 }
@@ -22,12 +24,15 @@ func NewFilesHelper(c *HelperCommon) *FilesHelper {
 
 var _ IFilesHelper = &FilesHelper{}
 
-func (self *FilesHelper) EditFile(filename string) error {
-	absPath, err := filepath.Abs(filename)
-	if err != nil {
-		return err
-	}
-	cmdStr, suspend := self.c.Git().File.GetEditCmdStr(absPath)
+func (self *FilesHelper) EditFiles(filenames []string) error {
+	absPaths := lo.Map(filenames, func(filename string, _ int) string {
+		absPath, err := filepath.Abs(filename)
+		if err != nil {
+			return filename
+		}
+		return absPath
+	})
+	cmdStr, suspend := self.c.Git().File.GetEditCmdStr(absPaths)
 	return self.callEditor(cmdStr, suspend)
 }
 

--- a/pkg/gui/controllers/status_controller.go
+++ b/pkg/gui/controllers/status_controller.go
@@ -217,7 +217,9 @@ func (self *StatusController) openConfig() error {
 }
 
 func (self *StatusController) editConfig() error {
-	return self.askForConfigFile(self.c.Helpers().Files.EditFile)
+	return self.askForConfigFile(func(file string) error {
+		return self.c.Helpers().Files.EditFiles([]string{file})
+	})
 }
 
 func (self *StatusController) showAllBranchLogs() error {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1596,7 +1596,7 @@ func EnglishTranslationSet() TranslationSet {
 		CommitAuthorCopiedToClipboard:         "Commit author copied to clipboard",
 		PatchCopiedToClipboard:                "Patch copied to clipboard",
 		CopiedToClipboard:                     "Copied to clipboard",
-		ErrCannotEditDirectory:                "Cannot edit directory: you can only edit individual files",
+		ErrCannotEditDirectory:                "Cannot edit directories: you can only edit individual files",
 		ErrStageDirWithInlineMergeConflicts:   "Cannot stage/unstage directory containing files with inline merge conflicts. Please fix up the merge conflicts first",
 		ErrRepositoryMovedOrDeleted:           "Cannot find repo. It might have been moved or deleted ¯\\_(ツ)_/¯",
 		CommandLog:                            "Command log",


### PR DESCRIPTION
- **PR Description**

This makes it possible to select a range of files (either in the files panel, or in the commit-files panel), and hit `e` to open them all at once in the editor.

We pass all of them to a single editor command, hoping that the editor will be able to handle multiple files (VS Code and vim do).

We ignore directories that happen to be in the selection range; this makes it easier to edit multiple files in different folders in tree view. We show an error if only directories are selected, though.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
