### PR TITLE
Always prompt to return from subprocess if there was an error

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -824,7 +824,7 @@ func (gui *Gui) runSubprocess(cmdObj oscommands.ICmdObj) error { //nolint:unpara
 	subprocess.Stderr = io.Discard
 	subprocess.Stdin = nil
 
-	if gui.Config.GetUserConfig().PromptToReturnFromSubprocess {
+	if gui.integrationTest == nil && (gui.Config.GetUserConfig().PromptToReturnFromSubprocess || err != nil) {
 		fmt.Fprintf(os.Stdout, "\n%s", style.FgGreen.Sprint(gui.Tr.PressEnterToReturn))
 
 		// scan to buffer to prevent run unintentional operations when TUI resumes.


### PR DESCRIPTION
- **PR Description**

When lazygit suspends itself to the background to run an external command, and the command returns a non-zero exit code, always show the prompt for pressing enter to return to lazygit, even if the `promptToReturnFromSubprocess` is set to `false`. The rationale is that if the process returned an error, it likely also printed some error message to the console that users will always want to read.

I was considering turning the `promptToReturnFromSubprocess` config into an enum with values `never`, `onlyOnError`, `always`, but then I felt that `onlyOnError` is really the only sensible choice for people who have it set to `false` now, so I just hard-coded that.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
