### PR TITLE
Fix container detection

### DIFF
--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -12,16 +12,9 @@ func isWSL() bool {
 
 func isContainer() bool {
 	data, err := os.ReadFile("/proc/1/cgroup")
-
-	if strings.Contains(string(data), "docker") ||
+	return err == nil && (strings.Contains(string(data), "docker") ||
 		strings.Contains(string(data), "/lxc/") ||
-		[]string{string(data)}[0] != "systemd" &&
-			[]string{string(data)}[0] != "init" ||
-		os.Getenv("container") != "" {
-		return err == nil && true
-	}
-
-	return err == nil && false
+		os.Getenv("CONTAINER") != "")
 }
 
 // GetPlatformDefaultConfig gets the defaults for the platform


### PR DESCRIPTION
- **PR Description**

Running WSL without a container would be treated as native linux, causing problems at it would then attempt to use `xdg-open`. This was caused by `isContainer()` always returning true due to some dubious conditionals. These have been removed.

The env-var check seems to not be used by lazygit, nor any common containers, and therefore appears to only exist to manually tell lazygit to behave as if it were inside of a container. This functionality has been kept, but the env-var has been changed to be all uppercaps as to comply with the POSIX standard.

Fixes #2757
Bug introduced in 4d78d76

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
