### PR TITLE
Keep the same commit selected when exiting filtering mode

### DIFF
--- a/pkg/gui/context/local_commits_context.go
+++ b/pkg/gui/context/local_commits_context.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/types/enums"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/samber/lo"
 )
 
 type LocalCommitsContext struct {
@@ -123,6 +124,29 @@ func (self *LocalCommitsContext) GetSelectedRef() types.Ref {
 		return nil
 	}
 	return commit
+}
+
+// Returns the commit hash of the selected commit, or an empty string if no
+// commit is selected
+func (self *LocalCommitsContext) GetSelectedCommitHash() string {
+	commit := self.GetSelected()
+	if commit == nil {
+		return ""
+	}
+	return commit.Sha
+}
+
+func (self *LocalCommitsContext) SelectCommitByHash(hash string) bool {
+	if hash == "" {
+		return false
+	}
+
+	if _, idx, found := lo.FindIndexOf(self.GetItems(), func(c *models.Commit) bool { return c.Sha == hash }); found {
+		self.SetSelection(idx)
+		return true
+	}
+
+	return false
 }
 
 func (self *LocalCommitsContext) GetDiffTerminals() []string {

--- a/pkg/gui/controllers/filtering_menu_action.go
+++ b/pkg/gui/controllers/filtering_menu_action.go
@@ -109,6 +109,8 @@ func (self *FilteringMenuAction) setFilteringAuthor(author string) error {
 }
 
 func (self *FilteringMenuAction) setFiltering() error {
+	self.c.Modes().Filtering.SetSelectedCommitHash(self.c.Contexts().LocalCommits.GetSelectedCommitHash())
+
 	repoState := self.c.State().GetRepoState()
 	if repoState.GetScreenMode() == types.SCREEN_NORMAL {
 		repoState.SetScreenMode(types.SCREEN_HALF)

--- a/pkg/gui/modes/filtering/filtering.go
+++ b/pkg/gui/modes/filtering/filtering.go
@@ -1,8 +1,9 @@
 package filtering
 
 type Filtering struct {
-	path   string // the filename that gets passed to git log
-	author string // the author that gets passed to git log
+	path               string // the filename that gets passed to git log
+	author             string // the author that gets passed to git log
+	selectedCommitHash string // the commit that was selected before we entered filtering mode
 }
 
 func New(path string, author string) Filtering {
@@ -32,4 +33,12 @@ func (m *Filtering) SetAuthor(author string) {
 
 func (m *Filtering) GetAuthor() string {
 	return m.author
+}
+
+func (m *Filtering) SetSelectedCommitHash(hash string) {
+	m.selectedCommitHash = hash
+}
+
+func (m *Filtering) GetSelectedCommitHash() string {
+	return m.selectedCommitHash
 }

--- a/pkg/integration/tests/filter_by_path/keep_same_commit_selected_on_exit.go
+++ b/pkg/integration/tests/filter_by_path/keep_same_commit_selected_on_exit.go
@@ -1,0 +1,51 @@
+package filter_by_path
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var KeepSameCommitSelectedOnExit = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "When exiting filtering mode, keep the same commit selected if possible",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+	},
+	SetupRepo: func(shell *Shell) {
+		commonSetup(shell)
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains(`none of the two`).IsSelected(),
+				Contains(`only filterFile`),
+				Contains(`only otherFile`),
+				Contains(`both files`),
+			).Press(keys.Universal.FilteringMenu).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Filtering")).
+					Select(Contains("Enter path to filter by")).
+					Confirm()
+
+				t.ExpectPopup().Prompt().
+					Title(Equals("Enter path:")).
+					Type("filterF").
+					SuggestionLines(Equals("filterFile")).
+					ConfirmFirstSuggestion()
+			}).
+			Lines(
+				Contains(`only filterFile`).IsSelected(),
+				Contains(`both files`),
+			).
+			SelectNextItem().
+			PressEscape().
+			Lines(
+				Contains(`none of the two`),
+				Contains(`only filterFile`),
+				Contains(`only otherFile`),
+				Contains(`both files`).IsSelected(),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -157,6 +157,7 @@ var tests = []*components.IntegrationTest{
 	filter_by_author.SelectAuthor,
 	filter_by_author.TypeAuthor,
 	filter_by_path.CliArg,
+	filter_by_path.KeepSameCommitSelectedOnExit,
 	filter_by_path.SelectFile,
 	filter_by_path.TypeFile,
 	interactive_rebase.AdvancedInteractiveRebase,


### PR DESCRIPTION
- **PR Description**

When exiting filtering mode, we currently keep the selection index the same in the commits panel. This doesn't make sense at all, since the index in the filtered view has no relation to the index in the unfiltered view.

I often use filtering mode (either by path or by author) to find a given commit faster than I would otherwise be able to. When exiting filtering mode, it's useful to keep the same commit selected, so that I can look at the surrounding commits, see which branch it was a part of, etc. So reselect the commit again after exiting filtering mode.

Sometimes this is not possible, most likely when the commit is so long ago that it's outside of the initial 300 range. In that case, at least select the commit again that was selected before I entered filtering; this is still better than arbitrarily keeping the same selection index.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
