### PR TITLE
Fix rewording signed commits when the log.showsignature git config is true

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -158,6 +158,7 @@ func (self *CommitCommands) signoffFlag() string {
 func (self *CommitCommands) GetCommitMessage(commitSha string) (string, error) {
 	cmdArgs := NewGitCmd("log").
 		Arg("--format=%B", "--max-count=1", commitSha).
+		Config("log.showsignature=false").
 		ToArgv()
 
 	message, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
@@ -167,6 +168,7 @@ func (self *CommitCommands) GetCommitMessage(commitSha string) (string, error) {
 func (self *CommitCommands) GetCommitSubject(commitSha string) (string, error) {
 	cmdArgs := NewGitCmd("log").
 		Arg("--format=%s", "--max-count=1", commitSha).
+		Config("log.showsignature=false").
 		ToArgv()
 
 	subject, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()

--- a/pkg/commands/git_commands/commit_test.go
+++ b/pkg/commands/git_commands/commit_test.go
@@ -337,7 +337,7 @@ func TestGetCommitMsg(t *testing.T) {
 		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildCommitCommands(commonDeps{
-				runner: oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"log", "--format=%B", "--max-count=1", "deadbeef"}, s.input, nil),
+				runner: oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"-c", "log.showsignature=false", "log", "--format=%B", "--max-count=1", "deadbeef"}, s.input, nil),
 			})
 
 			output, err := instance.GetCommitMessage("deadbeef")
@@ -358,14 +358,14 @@ func TestGetCommitMessageFromHistory(t *testing.T) {
 	scenarios := []scenario{
 		{
 			"Empty message",
-			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"log", "-1", "--skip=2", "--pretty=%H"}, "", nil).ExpectGitArgs([]string{"log", "--format=%B", "--max-count=1"}, "", nil),
+			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"log", "-1", "--skip=2", "--pretty=%H"}, "", nil).ExpectGitArgs([]string{"-c", "log.showsignature=false", "log", "--format=%B", "--max-count=1"}, "", nil),
 			func(output string, err error) {
 				assert.Error(t, err)
 			},
 		},
 		{
 			"Default case to retrieve a commit in history",
-			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"log", "-1", "--skip=2", "--pretty=%H"}, "sha3 \n", nil).ExpectGitArgs([]string{"log", "--format=%B", "--max-count=1", "sha3"}, `use generics to DRY up context code`, nil),
+			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"log", "-1", "--skip=2", "--pretty=%H"}, "sha3 \n", nil).ExpectGitArgs([]string{"-c", "log.showsignature=false", "log", "--format=%B", "--max-count=1", "sha3"}, `use generics to DRY up context code`, nil),
 			func(output string, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, "use generics to DRY up context code", output)


### PR DESCRIPTION
- **PR Description**

For people who have the log.showsignature git config set to true, trying to reword a signed commit would put the signature verification into the subject field and the commit subject into the description field of the commit message panel. Amending commits, adding co-authors to a commit, and copying a commit message to the clipboard would all be broken in a similar way.

Slightly related is #1911, but back then it was more about performance than wrong behavior, it seems.

Fixes #3425.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
