### PR TITLE
Fix excluding files in submodules or worktrees

### DIFF
--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -3,6 +3,7 @@ package git_commands
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/go-errors/errors"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
@@ -232,7 +233,8 @@ func (self *WorkingTreeCommands) Ignore(filename string) error {
 
 // Exclude adds a file to the .git/info/exclude for the repo
 func (self *WorkingTreeCommands) Exclude(filename string) error {
-	return self.os.AppendLineToFile(".git/info/exclude", filename)
+	excludeFile := path.Join(self.repoPaths.repoGitDirPath, "info", "exclude")
+	return self.os.AppendLineToFile(excludeFile, filename)
 }
 
 // WorktreeFileDiff returns the diff of a file

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -608,12 +608,7 @@ func (self *FilesController) ignore(node *filetree.FileNode) error {
 	if node.GetPath() == ".gitignore" {
 		return self.c.ErrorMsg(self.c.Tr.Actions.IgnoreFileErr)
 	}
-	err := self.ignoreOrExcludeFile(node, self.c.Tr.IgnoreTracked, self.c.Tr.IgnoreTrackedPrompt, self.c.Tr.Actions.IgnoreExcludeFile, self.c.Git().WorkingTree.Ignore)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return self.ignoreOrExcludeFile(node, self.c.Tr.IgnoreTracked, self.c.Tr.IgnoreTrackedPrompt, self.c.Tr.Actions.IgnoreExcludeFile, self.c.Git().WorkingTree.Ignore)
 }
 
 func (self *FilesController) exclude(node *filetree.FileNode) error {
@@ -621,11 +616,7 @@ func (self *FilesController) exclude(node *filetree.FileNode) error {
 		return self.c.ErrorMsg(self.c.Tr.Actions.ExcludeGitIgnoreErr)
 	}
 
-	err := self.ignoreOrExcludeFile(node, self.c.Tr.ExcludeTracked, self.c.Tr.ExcludeTrackedPrompt, self.c.Tr.Actions.ExcludeFile, self.c.Git().WorkingTree.Exclude)
-	if err != nil {
-		return err
-	}
-	return nil
+	return self.ignoreOrExcludeFile(node, self.c.Tr.ExcludeTracked, self.c.Tr.ExcludeTrackedPrompt, self.c.Tr.Actions.ExcludeFile, self.c.Git().WorkingTree.Exclude)
 }
 
 func (self *FilesController) ignoreOrExcludeMenu(node *filetree.FileNode) error {

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -617,10 +617,6 @@ func (self *FilesController) ignore(node *filetree.FileNode) error {
 }
 
 func (self *FilesController) exclude(node *filetree.FileNode) error {
-	if node.GetPath() == ".git/info/exclude" {
-		return self.c.ErrorMsg(self.c.Tr.Actions.ExcludeFileErr)
-	}
-
 	if node.GetPath() == ".gitignore" {
 		return self.c.ErrorMsg(self.c.Tr.Actions.ExcludeGitIgnoreErr)
 	}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -873,7 +873,6 @@ type Actions struct {
 	IgnoreExcludeFile                 string
 	IgnoreFileErr                     string
 	ExcludeFile                       string
-	ExcludeFileErr                    string
 	ExcludeGitIgnoreErr               string
 	Commit                            string
 	EditFile                          string
@@ -1796,7 +1795,6 @@ func EnglishTranslationSet() TranslationSet {
 			IgnoreExcludeFile:               "Ignore or exclude file",
 			IgnoreFileErr:                   "Cannot ignore .gitignore",
 			ExcludeFile:                     "Exclude file",
-			ExcludeFileErr:                  "Cannot exclude .git/info/exclude",
 			ExcludeGitIgnoreErr:             "Cannot exclude .gitignore",
 			Commit:                          "Commit",
 			EditFile:                        "Edit file",

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -807,7 +807,6 @@ func polishTranslationSet() TranslationSet {
 			IgnoreExcludeFile:               "Ignoruj lub wyklucz plik",
 			IgnoreFileErr:                   "Nie można zignorować .gitignore",
 			ExcludeFile:                     "Wyklucz plik",
-			ExcludeFileErr:                  "Nie można wykluczyć .git/info/exclude",
 			ExcludeGitIgnoreErr:             "Nie można wykluczyć .gitignore",
 			Commit:                          "Commituj",
 			EditFile:                        "Edytuj plik",

--- a/pkg/i18n/russian.go
+++ b/pkg/i18n/russian.go
@@ -599,7 +599,6 @@ func RussianTranslationSet() TranslationSet {
 			IgnoreExcludeFile:                 "Игнорировать или исключить файл",
 			IgnoreFileErr:                     "Невозможно игнорировать .gitignore",
 			ExcludeFile:                       "Исключить файл",
-			ExcludeFileErr:                    "Невозможно исключить .git/info/exclude",
 			ExcludeGitIgnoreErr:               "Невозможно исключить .gitignore",
 			Commit:                            "Коммит",
 			EditFile:                          "Редактировать файл",

--- a/pkg/i18n/traditional_chinese.go
+++ b/pkg/i18n/traditional_chinese.go
@@ -667,7 +667,6 @@ func traditionalChineseTranslationSet() TranslationSet {
 			IgnoreExcludeFile:                 "忽略或排除檔案",
 			IgnoreFileErr:                     "無法忽略 .gitignore 檔案",
 			ExcludeFile:                       "排除檔案",
-			ExcludeFileErr:                    "無法排除 .git/info/exclude 檔案",
 			ExcludeGitIgnoreErr:               "無法排除 .gitignore 檔案",
 			Commit:                            "提交",
 			EditFile:                          "編輯檔案",

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -306,6 +306,7 @@ var tests = []*components.IntegrationTest{
 	worktree.DetachWorktreeFromBranch,
 	worktree.DotfileBareRepo,
 	worktree.DoubleNestedLinkedSubmodule,
+	worktree.ExcludeFileInWorktree,
 	worktree.FastForwardWorktreeBranch,
 	worktree.ForceRemoveWorktree,
 	worktree.RemoveWorktreeFromBranch,

--- a/pkg/integration/tests/worktree/exclude_file_in_worktree.go
+++ b/pkg/integration/tests/worktree/exclude_file_in_worktree.go
@@ -34,13 +34,8 @@ var ExcludeFileInWorktree = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Menu().Title(Equals("Ignore or exclude file")).Select(Contains("Add to .git/info/exclude")).Confirm()
 			}).
-			/* EXPECTED:
 			IsEmpty()
 
-			t.FileSystem().FileContent("../repo/.git/info/exclude", Contains("toExclude"))
-			ACTUAL: */
-			Tap(func() {
-				t.ExpectPopup().Alert().Title(Equals("Error")).Content(Contains("open .git/info/exclude: not a directory"))
-			})
+		t.FileSystem().FileContent("../repo/.git/info/exclude", Contains("toExclude"))
 	},
 })

--- a/pkg/integration/tests/worktree/exclude_file_in_worktree.go
+++ b/pkg/integration/tests/worktree/exclude_file_in_worktree.go
@@ -1,0 +1,46 @@
+package worktree
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ExcludeFileInWorktree = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Add a file to .git/info/exclude in a worktree",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("commit1")
+		shell.AddWorktree("HEAD", "../linked-worktree", "mybranch")
+		shell.CreateFile("../linked-worktree/toExclude", "")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Worktrees().
+			Focus().
+			Lines(
+				Contains("repo (main)").IsSelected(),
+				Contains("linked-worktree"),
+			).
+			SelectNextItem().
+			PressPrimaryAction()
+
+		t.Views().Files().
+			Focus().
+			Lines(
+				Contains("toExclude"),
+			).
+			Press(keys.Files.IgnoreFile).
+			Tap(func() {
+				t.ExpectPopup().Menu().Title(Equals("Ignore or exclude file")).Select(Contains("Add to .git/info/exclude")).Confirm()
+			}).
+			/* EXPECTED:
+			IsEmpty()
+
+			t.FileSystem().FileContent("../repo/.git/info/exclude", Contains("toExclude"))
+			ACTUAL: */
+			Tap(func() {
+				t.ExpectPopup().Alert().Title(Equals("Error")).Content(Contains("open .git/info/exclude: not a directory"))
+			})
+	},
+})


### PR DESCRIPTION
- **PR Description**

Make the "Add to .git/info/exclude" command work correctly in a worktree or in a submodule. Previously it would result in an error message.

Fixes #3427.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
