### PR TITLE
Fix deleting update ref todos

### DIFF
--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -250,6 +250,36 @@ func (self *RebaseCommands) PrepareInteractiveRebaseCommand(opts PrepareInteract
 	return cmdObj
 }
 
+// GitRebaseEditTodo runs "git rebase --edit-todo", saving the given todosFileContent to the file
+func (self *RebaseCommands) GitRebaseEditTodo(todosFileContent []byte) error {
+	ex := oscommands.GetLazygitPath()
+
+	cmdArgs := NewGitCmd("rebase").
+		Arg("--edit-todo").
+		ToArgv()
+
+	debug := "FALSE"
+	if self.Debug {
+		debug = "TRUE"
+	}
+
+	self.Log.WithField("command", cmdArgs).Debug("RunCommand")
+
+	cmdObj := self.cmd.New(cmdArgs)
+
+	cmdObj.AddEnvVars(daemon.ToEnvVars(daemon.NewWriteRebaseTodoInstruction(todosFileContent))...)
+
+	cmdObj.AddEnvVars(
+		"DEBUG="+debug,
+		"LANG=en_US.UTF-8",   // Force using EN as language
+		"LC_ALL=en_US.UTF-8", // Force using EN as language
+		"GIT_EDITOR="+ex,
+		"GIT_SEQUENCE_EDITOR="+ex,
+	)
+
+	return cmdObj.Run()
+}
+
 // AmendTo amends the given commit with whatever files are staged
 func (self *RebaseCommands) AmendTo(commits []*models.Commit, commitIndex int) error {
 	commit := commits[commitIndex]
@@ -302,11 +332,16 @@ func (self *RebaseCommands) DeleteUpdateRefTodos(commits []*models.Commit) error
 		return todoFromCommit(commit)
 	})
 
-	return utils.DeleteTodos(
+	todosFileContent, err := utils.DeleteTodos(
 		filepath.Join(self.repoPaths.WorktreeGitDirPath(), "rebase-merge/git-rebase-todo"),
 		todosToDelete,
 		self.config.GetCoreCommentChar(),
 	)
+	if err != nil {
+		return err
+	}
+
+	return self.GitRebaseEditTodo(todosFileContent)
 }
 
 func (self *RebaseCommands) MoveTodosDown(commits []*models.Commit) error {

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -204,7 +204,7 @@ type PrepareInteractiveRebaseCommandOpts struct {
 
 // PrepareInteractiveRebaseCommand returns the cmd for an interactive rebase
 // we tell git to run lazygit to edit the todo list, and we pass the client
-// lazygit a todo string to write to the todo file
+// lazygit instructions what to do with the todo file
 func (self *RebaseCommands) PrepareInteractiveRebaseCommand(opts PrepareInteractiveRebaseCommandOpts) oscommands.ICmdObj {
 	ex := oscommands.GetLazygitPath()
 

--- a/pkg/integration/tests/interactive_rebase/delete_update_ref_todo.go
+++ b/pkg/integration/tests/interactive_rebase/delete_update_ref_todo.go
@@ -57,7 +57,7 @@ var DeleteUpdateRefTodo = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("CI ◯ commit 06"),
 				Contains("CI ◯ commit 05"),
 				Contains("CI ◯ commit 04"),
-				Contains("CI ◯ commit 03"), // No start on this commit, so there's no branch head here
+				Contains("CI ◯ commit 03"), // No star on this commit, so there's no branch head here
 				Contains("CI ◯ commit 02"),
 				Contains("CI ◯ commit 01"),
 			)

--- a/pkg/integration/tests/interactive_rebase/delete_update_ref_todo.go
+++ b/pkg/integration/tests/interactive_rebase/delete_update_ref_todo.go
@@ -50,6 +50,8 @@ var DeleteUpdateRefTodo = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("pick").Contains("CI commit 02"),
 				Contains("CI ◯ <-- YOU ARE HERE --- commit 01"),
 			).
+			NavigateToLine(Contains("commit 02")).
+			Press(keys.Universal.Remove).
 			Tap(func() {
 				t.Common().ContinueRebase()
 			}).
@@ -58,8 +60,15 @@ var DeleteUpdateRefTodo = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("CI ◯ commit 05"),
 				Contains("CI ◯ commit 04"),
 				Contains("CI ◯ commit 03"), // No star on this commit, so there's no branch head here
-				Contains("CI ◯ commit 02"),
 				Contains("CI ◯ commit 01"),
+			)
+
+		t.Views().Branches().
+			Lines(
+				Contains("branch2"),
+				/* branch1 was deleted, which is wrong:
+				Contains("branch1"),
+				*/
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/delete_update_ref_todo.go
+++ b/pkg/integration/tests/interactive_rebase/delete_update_ref_todo.go
@@ -66,9 +66,7 @@ var DeleteUpdateRefTodo = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Branches().
 			Lines(
 				Contains("branch2"),
-				/* branch1 was deleted, which is wrong:
 				Contains("branch1"),
-				*/
 			)
 	},
 })


### PR DESCRIPTION
- **PR Description**

Deleting an update-ref todo in an interactive rebase now behaves as expected (i.e. it leaves the branch referenced by the update-ref untouched). Previously it would have deleted the branch referenced by the update-ref todo when the rebase was continued. See #3418 for more details.

Fixes #3418.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
