### PR TITLE
Fix crash when filtering the keybindings menu

### DIFF
--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -74,9 +74,6 @@ func (self *MenuViewModel) SetMenuItems(items []*types.MenuItem, columnAlignment
 // TODO: move into presentation package
 func (self *MenuViewModel) GetDisplayStrings(_ int, _ int) [][]string {
 	menuItems := self.FilteredListViewModel.GetItems()
-	showKeys := lo.SomeBy(menuItems, func(item *types.MenuItem) bool {
-		return item.Key != nil
-	})
 
 	return lo.Map(menuItems, func(item *types.MenuItem, _ int) []string {
 		displayStrings := item.LabelColumns
@@ -84,12 +81,12 @@ func (self *MenuViewModel) GetDisplayStrings(_ int, _ int) [][]string {
 			displayStrings[0] = style.FgDefault.SetStrikethrough().Sprint(displayStrings[0])
 		}
 
-		if !showKeys {
-			return displayStrings
+		keyLabel := ""
+		if item.Key != nil {
+			keyLabel = style.FgCyan.Sprint(keybindings.LabelFromKey(item.Key))
 		}
 
-		keyLabel := keybindings.LabelFromKey(item.Key)
-		displayStrings = utils.Prepend(displayStrings, style.FgCyan.Sprint(keyLabel))
+		displayStrings = utils.Prepend(displayStrings, keyLabel)
 		return displayStrings
 	})
 }

--- a/pkg/integration/tests/filter_and_search/filter_menu_with_no_keybindings.go
+++ b/pkg/integration/tests/filter_and_search/filter_menu_with_no_keybindings.go
@@ -1,0 +1,32 @@
+package filter_and_search
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var FilterMenuWithNoKeybindings = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Filtering the keybindings menu so that only entries without keybinding are left",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.UserConfig.Keybinding.Universal.ToggleWhitespaceInDiffView = "<disabled>"
+	},
+	SetupRepo: func(shell *Shell) {
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			IsFocused().
+			Press(keys.Universal.OptionMenu)
+
+		t.ExpectPopup().Menu().
+			Title(Equals("Keybindings")).
+			Filter("whitespace").
+			Lines(
+				// menu has filtered down to the one item that matches the
+				// filter, and it doesn't have a keybinding
+				Equals("--- Global ---"),
+				Equals("Toggle whitespace").IsSelected(),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -146,6 +146,7 @@ var tests = []*components.IntegrationTest{
 	filter_and_search.FilterFuzzy,
 	filter_and_search.FilterMenu,
 	filter_and_search.FilterMenuCancelFilterWithEscape,
+	filter_and_search.FilterMenuWithNoKeybindings,
 	filter_and_search.FilterRemoteBranches,
 	filter_and_search.FilterRemotes,
 	filter_and_search.FilterSearchHistory,


### PR DESCRIPTION
- **PR Description**

It would crash when some keybindings are set to null, and the filter string is such that only those keybindings remain visible.

Fixes #3449.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
