### PR TITLE
Fix schema link in Config.md

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -19,7 +19,7 @@ If you want to change the config directory:
 JSON schema is available for `config.yml` so that IntelliSense in Visual Studio Code (completion and error checking) is automatically enabled when the [YAML Red Hat][yaml] extension is installed. However, note that automatic schema detection only works if your config file is in one of the standard paths mentioned above. If you override the path to the file, you can still make IntelliSense work by adding
 
 ```yaml
-# yaml-language-server: $schema=https://json.schemastore.org/lazygit.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/jesseduffield/lazygit/master/schema/config.json
 ```
 
 to the top of your config file or via [Visual Studio Code settings.json config][settings].


### PR DESCRIPTION
The schema at https://json.schemastore.org/lazygit.json is broken and doesn't work. It should actually be removed.
