### PR TITLE
Replace min/max helpers with built-in min/max

### DIFF
--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -457,9 +457,9 @@ func (self *LocalCommitsController) drop(selectedCommits []*models.Commit, start
 					}
 
 					if selectedIdx > rangeStartIdx {
-						selectedIdx = utils.Max(selectedIdx-len(updateRefTodos), rangeStartIdx)
+						selectedIdx = max(selectedIdx-len(updateRefTodos), rangeStartIdx)
 					} else {
-						rangeStartIdx = utils.Max(rangeStartIdx-len(updateRefTodos), selectedIdx)
+						rangeStartIdx = max(rangeStartIdx-len(updateRefTodos), selectedIdx)
 					}
 
 					self.context().SetSelectionRangeAndMode(selectedIdx, rangeStartIdx, rangeSelectMode)

--- a/pkg/gui/controllers/scroll_off_margin.go
+++ b/pkg/gui/controllers/scroll_off_margin.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
-	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 // To be called after pressing up-arrow; checks whether the cursor entered the
@@ -39,7 +38,7 @@ func calculateLinesToScrollUp(viewPortStart int, viewPortHeight int, scrollOffMa
 	// a very large value to keep the cursor always in the middle of the screen.
 	// Use +.5 so that if the height is even, the top margin is one line higher
 	// than the bottom margin.
-	scrollOffMargin = utils.Min(scrollOffMargin, int((float64(viewPortHeight)+.5)/2))
+	scrollOffMargin = min(scrollOffMargin, int((float64(viewPortHeight)+.5)/2))
 
 	// Scroll only if the "before" position was visible (this could be false if
 	// the scroll wheel was used to scroll the selected line out of view) ...
@@ -59,7 +58,7 @@ func calculateLinesToScrollDown(viewPortStart int, viewPortHeight int, scrollOff
 	// a very large value to keep the cursor always in the middle of the screen.
 	// Use -.5 so that if the height is even, the bottom margin is one line lower
 	// than the top margin.
-	scrollOffMargin = utils.Min(scrollOffMargin, int((float64(viewPortHeight)-.5)/2))
+	scrollOffMargin = min(scrollOffMargin, int((float64(viewPortHeight)-.5)/2))
 
 	// Scroll only if the "before" position was visible (this could be false if
 	// the scroll wheel was used to scroll the selected line out of view) ...

--- a/pkg/gui/filetree/file_tree.go
+++ b/pkg/gui/filetree/file_tree.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
-	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
@@ -140,7 +139,7 @@ func (self *FileTree) GetAllItems() []*FileNode {
 
 func (self *FileTree) Len() int {
 	// -1 because we're ignoring the root
-	return utils.Max(self.tree.Size(self.collapsedPaths)-1, 0)
+	return max(self.tree.Size(self.collapsedPaths)-1, 0)
 }
 
 func (self *FileTree) GetItem(index int) types.HasUrn {

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -145,7 +145,7 @@ func (gui *Gui) handleCopySelectedSideContextItemToClipboardWithTruncation(maxWi
 	}
 
 	if maxWidth > 0 {
-		itemId = itemId[:utils.Min(len(itemId), maxWidth)]
+		itemId = itemId[:min(len(itemId), maxWidth)]
 	}
 
 	gui.c.LogAction(gui.c.Tr.Actions.CopyToClipboard)

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/theme"
-	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 // note: items option is mutated by this function
@@ -31,7 +30,7 @@ func (gui *Gui) createMenu(opts types.CreateMenuOptions) error {
 			item.LabelColumns[0] = fmt.Sprintf("%s...", item.LabelColumns[0])
 		}
 
-		maxColumnSize = utils.Max(maxColumnSize, len(item.LabelColumns))
+		maxColumnSize = max(maxColumnSize, len(item.LabelColumns))
 	}
 
 	for _, item := range opts.Items {

--- a/pkg/gui/patch_exploring/focus.go
+++ b/pkg/gui/patch_exploring/focus.go
@@ -1,7 +1,5 @@
 package patch_exploring
 
-import "github.com/jesseduffield/lazygit/pkg/utils"
-
 func calculateOrigin(currentOrigin int, bufferHeight int, numLines int, firstLineIdx int, lastLineIdx int, selectedLineIdx int, mode selectMode) int {
 	needToSeeIdx, wantToSeeIdx := getNeedAndWantLineIdx(firstLineIdx, lastLineIdx, selectedLineIdx, mode)
 
@@ -14,7 +12,7 @@ func calculateOrigin(currentOrigin int, bufferHeight int, numLines int, firstLin
 func calculateNewOriginWithNeededAndWantedIdx(currentOrigin int, bufferHeight int, numLines int, needToSeeIdx int, wantToSeeIdx int) int {
 	origin := currentOrigin
 	if needToSeeIdx < currentOrigin || needToSeeIdx > currentOrigin+bufferHeight {
-		origin = utils.Max(utils.Min(needToSeeIdx-bufferHeight/2, numLines-bufferHeight-1), 0)
+		origin = max(min(needToSeeIdx-bufferHeight/2, numLines-bufferHeight-1), 0)
 	}
 
 	bottom := origin + bufferHeight
@@ -22,11 +20,11 @@ func calculateNewOriginWithNeededAndWantedIdx(currentOrigin int, bufferHeight in
 	if wantToSeeIdx < origin {
 		requiredChange := origin - wantToSeeIdx
 		allowedChange := bottom - needToSeeIdx
-		return origin - utils.Min(requiredChange, allowedChange)
+		return origin - min(requiredChange, allowedChange)
 	} else if wantToSeeIdx > origin+bufferHeight {
 		requiredChange := wantToSeeIdx - bottom
 		allowedChange := needToSeeIdx - origin
-		return origin + utils.Min(requiredChange, allowedChange)
+		return origin + min(requiredChange, allowedChange)
 	} else {
 		return origin
 	}

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -79,9 +79,9 @@ func getBranchDisplayStrings(
 	}
 
 	// Don't bother shortening branch names that are already 3 characters or less
-	if len(displayName) > utils.Max(availableWidth, 3) {
+	if len(displayName) > max(availableWidth, 3) {
 		// Never shorten the branch name to less then 3 characters
-		len := utils.Max(availableWidth, 4)
+		len := max(availableWidth, 4)
 		displayName = displayName[:len-1] + "…"
 	}
 	coloredName := nameTextStyle.Sprint(displayName)

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -69,7 +69,7 @@ func GetCommitListDisplayStrings(
 	}
 
 	// this is where my non-TODO commits begin
-	rebaseOffset := utils.Min(indexOfFirstNonTODOCommit(commits), endIdx)
+	rebaseOffset := min(indexOfFirstNonTODOCommit(commits), endIdx)
 
 	filteredCommits := commits[startIdx:endIdx]
 
@@ -80,11 +80,11 @@ func GetCommitListDisplayStrings(
 	if showGraph {
 		// this is where the graph begins (may be beyond the TODO commits depending on startIdx,
 		// but we'll never include TODO commits as part of the graph because it'll be messy)
-		graphOffset := utils.Max(startIdx, rebaseOffset)
+		graphOffset := max(startIdx, rebaseOffset)
 
 		pipeSets := loadPipesets(commits[rebaseOffset:])
-		pipeSetOffset := utils.Max(startIdx-rebaseOffset, 0)
-		graphPipeSets := pipeSets[pipeSetOffset:utils.Max(endIdx-rebaseOffset, 0)]
+		pipeSetOffset := max(startIdx-rebaseOffset, 0)
+		graphPipeSets := pipeSets[pipeSetOffset:max(endIdx-rebaseOffset, 0)]
 		graphCommits := commits[graphOffset:endIdx]
 		graphLines := graph.RenderAux(
 			graphPipeSets,

--- a/pkg/gui/presentation/graph/graph.go
+++ b/pkg/gui/presentation/graph/graph.go
@@ -42,11 +42,11 @@ func ContainsCommitSha(pipes []*Pipe, sha string) bool {
 }
 
 func (self Pipe) left() int {
-	return utils.Min(self.fromPos, self.toPos)
+	return min(self.fromPos, self.toPos)
 }
 
 func (self Pipe) right() int {
-	return utils.Max(self.fromPos, self.toPos)
+	return max(self.fromPos, self.toPos)
 }
 
 func RenderCommitGraph(commits []*models.Commit, selectedCommitSha string, getStyle func(c *models.Commit) style.TextStyle) []string {
@@ -390,7 +390,7 @@ func equalHashes(a, b string) bool {
 		return false
 	}
 
-	length := utils.Min(len(a), len(b))
+	length := min(len(a), len(b))
 	// parent hashes are only stored up to 20 characters for some reason so we'll truncate to that for comparison
 	return a[:length] == b[:length]
 }

--- a/pkg/integration/components/shell.go
+++ b/pkg/integration/components/shell.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"time"
-
-	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 // this is for running shell commands, mostly for the sake of setting up the repo
@@ -289,7 +287,7 @@ func (self *Shell) CreateRepoHistory() *Shell {
 
 		// Choose a random commit within the last 20 commits on the master branch
 		lastMasterCommit := totalCommits - 1
-		commitOffset := rand.Intn(utils.Min(lastMasterCommit, 5)) + 1
+		commitOffset := rand.Intn(min(lastMasterCommit, 5)) + 1
 
 		// Create the feature branch and checkout the chosen commit
 		self.NewBranchFrom(branchName, fmt.Sprintf("master~%d", commitOffset))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -32,21 +32,6 @@ func Loader(now time.Time, config config.SpinnerConfig) string {
 	return config.Frames[index]
 }
 
-// Min returns the minimum of two integers
-func Min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
-func Max(x, y int) int {
-	if x > y {
-		return x
-	}
-	return y
-}
-
 func SortRange(x int, y int) (int, int) {
 	if x < y {
 		return x, y

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -6,37 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestMin is a function.
-func TestMin(t *testing.T) {
-	type scenario struct {
-		a        int
-		b        int
-		expected int
-	}
-
-	scenarios := []scenario{
-		{
-			1,
-			1,
-			1,
-		},
-		{
-			1,
-			2,
-			1,
-		},
-		{
-			2,
-			1,
-			1,
-		},
-	}
-
-	for _, s := range scenarios {
-		assert.EqualValues(t, s.expected, Min(s.a, s.b))
-	}
-}
-
 func TestAsJson(t *testing.T) {
 	type myStruct struct {
 		a string


### PR DESCRIPTION
- **PR Description**

We upgraded our minimum Go version to 1.21 in commit 57ac9c2189458a7f0e63c2e9cac8334694a3d545. We can now replace our `utils.Min` and `utils.Max` functions with the built-in `min` and `max`.

Reference: https://go.dev/ref/spec#Min_and_max

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
