### PR TITLE
Allow setting a default name when creating new branches

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -323,6 +323,9 @@ git:
     # Replace directive. E.g. for 'feature/AB-123' to start the commit message with 'AB-123 ' use "[$1] "
     replace: ""
 
+  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-branch-name-prefix
+  branchPrefix: ""
+
   # If true, parse emoji strings in commit messages e.g. render :rocket: as 🚀
   # (This should really be under 'gui', not 'git')
   parseEmoji: false
@@ -883,6 +886,21 @@ git:
     my_project: # This is repository folder name
       pattern: "^\\w+\\/(\\w+-\\w+).*"
       replace: '[$1] '
+```
+
+## Predefined branch name prefix
+
+In situations where certain naming pattern is used for branches, this can be used to populate new branch creation with a static prefix.
+
+Example:
+
+Some branches:
+- jsmith/AB-123
+- cwilson/AB-125
+
+```yaml
+git:
+  branchPrefix: "firstlast/"
 ```
 
 ## Custom git log command

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -236,6 +236,8 @@ type GitConfig struct {
 	CommitPrefix *CommitPrefixConfig `yaml:"commitPrefix"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix
 	CommitPrefixes map[string]CommitPrefixConfig `yaml:"commitPrefixes"`
+	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-branch-name-prefix
+	BranchPrefix string `yaml:"branchPrefix"`
 	// If true, parse emoji strings in commit messages e.g. render :rocket: as 🚀
 	// (This should really be under 'gui', not 'git')
 	ParseEmoji bool `yaml:"parseEmoji"`
@@ -750,6 +752,7 @@ func GetDefaultConfig() *UserConfig {
 			AllBranchesLogCmd:            "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium",
 			DisableForcePushing:          false,
 			CommitPrefixes:               map[string]CommitPrefixConfig(nil),
+			BranchPrefix:                 "",
 			ParseEmoji:                   false,
 			TruncateCopiedCommitHashesTo: 12,
 		},

--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -274,6 +274,10 @@ func (self *RefsHelper) NewBranch(from string, fromFormattedName string, suggest
 		},
 	)
 
+	if suggestedBranchName == "" {
+		suggestedBranchName = self.c.UserConfig.Git.BranchPrefix
+	}
+
 	return self.c.Prompt(types.PromptOpts{
 		Title:          message,
 		InitialContent: suggestedBranchName,

--- a/pkg/integration/tests/commit/new_branch_with_prefix.go
+++ b/pkg/integration/tests/commit/new_branch_with_prefix.go
@@ -1,0 +1,33 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var NewBranchWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Creating a new branch from a commit with a default name",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.UserConfig.Git.BranchPrefix = "myprefix/"
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			EmptyCommit("commit 1")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("commit 1").IsSelected(),
+			).
+			SelectNextItem().
+			Press(keys.Universal.New).
+			Tap(func() {
+				branchName := "my-branch-name"
+				t.ExpectPopup().Prompt().Title(Contains("New branch name")).Type(branchName).Confirm()
+				t.Git().CurrentBranchName("myprefix/" + branchName)
+			})
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -92,6 +92,7 @@ var tests = []*components.IntegrationTest{
 	commit.History,
 	commit.HistoryComplex,
 	commit.NewBranch,
+	commit.NewBranchWithPrefix,
 	commit.PasteCommitMessage,
 	commit.PasteCommitMessageOverExisting,
 	commit.PreserveCommitMessage,

--- a/schema/config.json
+++ b/schema/config.json
@@ -638,6 +638,10 @@
           "type": "object",
           "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix"
         },
+        "branchPrefix": {
+          "type": "string",
+          "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-branch-name-prefix"
+        },
         "parseEmoji": {
           "type": "boolean",
           "description": "If true, parse emoji strings in commit messages e.g. render :rocket: as 🚀\n(This should really be under 'gui', not 'git')",


### PR DESCRIPTION
- **PR Description**

I commonly prefix my branch names with my first initial and last name, such as this one (`ecubit/branch-prefixes`). It can be a bit annoying to type out.

This PR adds a config option to set a default value for the name in the branch creation modal.

If there would have previously been a branch name autofilled (I do not know all such cases), this change has no effect.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
  - `CONTRIBUTING.md` says I may submit without doing localization (and I am unable)
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc