### PR TITLE
Add support for Unspecified Author Colors

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -444,15 +444,17 @@ gui:
     'Alan Smithee': '#00ff00' # use green for Alan Smithee
 ```
 
-You can use wildcard to set a unified color in case your are lazy to customize the color for every author or you just want a single color for all/other authors:
+
+## Unspecified Author Color
+
+You can customize the set of random colors that lazygit picks from for authors who do not have an already specified author color
 
 ```yaml
 gui:
-  authorColors:
-    # use red for John Smith
-    'John Smith': 'red'
-    # use blue for other authors
-    '*': '#0000ff'
+  unspecifiedAuthorColors:
+    - 'red'
+    - '#00ff00'
+    - 'blue'
 ```
 
 ## Custom Branch Color

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -52,6 +52,8 @@ type RefresherConfig struct {
 type GuiConfig struct {
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-author-color
 	AuthorColors map[string]string `yaml:"authorColors"`
+	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#unspecified-author-color
+	UnspecifiedAuthorColors []string `yaml:"unspecifiedAuthorColors"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-branch-color
 	BranchColors map[string]string `yaml:"branchColors"`
 	// The number of lines you scroll by when scrolling the main window

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -544,6 +544,7 @@ func NewGui(
 	// TODO: reset these controllers upon changing repos due to state changing
 	gui.c = helperCommon
 
+	authors.SetUnspecifiedAuthorColors(gui.UserConfig.Gui.UnspecifiedAuthorColors)
 	authors.SetCustomAuthors(gui.UserConfig.Gui.AuthorColors)
 	if gui.UserConfig.Gui.NerdFontsVersion != "" {
 		icons.SetNerdFontsVersion(gui.UserConfig.Gui.NerdFontsVersion)

--- a/pkg/gui/presentation/authors/authors.go
+++ b/pkg/gui/presentation/authors/authors.go
@@ -14,12 +14,11 @@ import (
 // if these being global variables causes trouble we can wrap them in a struct
 // attached to the gui state.
 var (
-	authorInitialCache = make(map[string]string)
-	authorNameCache    = make(map[string]string)
-	authorStyleCache   = make(map[string]style.TextStyle)
+	authorInitialCache      = make(map[string]string)
+	authorNameCache         = make(map[string]string)
+	authorStyleCache        = make(map[string]style.TextStyle)
+	unspecifiedAuthorColors = make([]style.TextStyle, 0)
 )
-
-const authorNameWildcard = "*"
 
 func ShortAuthor(authorName string) string {
 	if value, ok := authorInitialCache[authorName]; ok {
@@ -55,16 +54,19 @@ func AuthorStyle(authorName string) style.TextStyle {
 		return value
 	}
 
-	// use the unified style whatever the author name is
-	if value, ok := authorStyleCache[authorNameWildcard]; ok {
-		return value
-	}
-
-	value := trueColorStyle(authorName)
+	value := getNewColorStyle(authorName)
 
 	authorStyleCache[authorName] = value
 
 	return value
+}
+
+func getNewColorStyle(authorName string) style.TextStyle {
+	if len(unspecifiedAuthorColors) > 0 {
+		return unspecifiedAuthorColors[randInt([]byte(authorName), len(unspecifiedAuthorColors))]
+	} else {
+		return trueColorStyle(authorName)
+	}
 }
 
 func trueColorStyle(str string) style.TextStyle {
@@ -115,4 +117,8 @@ func getFirstRune(str string) rune {
 
 func SetCustomAuthors(customAuthorColors map[string]string) {
 	authorStyleCache = utils.SetCustomColors(customAuthorColors)
+}
+
+func SetUnspecifiedAuthorColors(customAuthorColors []string) {
+	unspecifiedAuthorColors = utils.GetStylesFromColorStrings(customAuthorColors)
 }

--- a/pkg/gui/presentation/authors/authors_test.go
+++ b/pkg/gui/presentation/authors/authors_test.go
@@ -18,3 +18,13 @@ func TestGetInitials(t *testing.T) {
 		}
 	}
 }
+
+func TestSetUnspecifiedAuthorColors(t *testing.T) {
+	customAuthorColors := []string{"#FF0000", "red", "cyan"}
+
+	SetUnspecifiedAuthorColors(customAuthorColors)
+
+	if len(unspecifiedAuthorColors) != len(customAuthorColors) {
+		t.Errorf("Expected %d unspecified author colors, but got %d", len(customAuthorColors), len(unspecifiedAuthorColors))
+	}
+}

--- a/pkg/utils/color.go
+++ b/pkg/utils/color.go
@@ -57,9 +57,19 @@ func IsValidHexValue(v string) bool {
 
 func SetCustomColors(customColors map[string]string) map[string]style.TextStyle {
 	return lo.MapValues(customColors, func(c string, key string) style.TextStyle {
-		if s, ok := style.ColorMap[c]; ok {
-			return s.Foreground
-		}
-		return style.New().SetFg(style.NewRGBColor(color.HEX(c, false)))
+		return GetStyleFromColorString(c)
 	})
+}
+
+func GetStylesFromColorStrings(colorStrings []string) []style.TextStyle {
+	return lo.Map(colorStrings, func(c string, index int) style.TextStyle {
+		return GetStyleFromColorString(c)
+	})
+}
+
+func GetStyleFromColorString(colorString string) style.TextStyle {
+	if s, ok := style.ColorMap[colorString]; ok {
+		return s.Foreground
+	}
+	return style.New().SetFg(style.NewRGBColor(color.HEX(colorString, false)))
 }

--- a/schema/config.json
+++ b/schema/config.json
@@ -11,6 +11,13 @@
           "type": "object",
           "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-author-color"
         },
+        "unspecifiedAuthorColors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#unspecified-author-color"
+        },
         "branchColors": {
           "additionalProperties": {
             "type": "string"


### PR DESCRIPTION
- **PR Description**
Adds the support for the user to control the colors lazygit picks from when generating colors for unspecified authors

- **Notes**

There were some questions that came up w.r.t. how this plays with the wildcard `authorColors` syntax. Notably, how to handle the case when both are present. In this iteration of the pr I've just removed support for that syntax. I'm open to suggestions of a more elegant solution.

Additionally, It was difficult to write robust tests for these changes. Tests I couldn't find a way to implement include: 
* Unspecified author colors are preferred over random ones if available
* Setting unspecified author colors sets all of them
* Specified author colors are preferred over unspecified author colors

This is because of the lack of existing comparison functionality for `TextStyle`s. Implementing that seemed out of scope for this change. I would love input on how to either refactor this feature to make it more easily testable without having to introduce those changes.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->