### PR TITLE
Add config options for length of commit hash displayed in commits view

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -80,6 +80,7 @@ gui:
   showIcons: false # deprecated: use nerdFontsVersion instead
   nerdFontsVersion: "" # nerd fonts version to use ("2" or "3"); empty means don't show nerd font icons
   showFileIcons: true # for hiding file icons in the file views
+  commitHashLength: 8 # length of commit hash in commits view. 0 shows '*' if NF icons aren't enabled
   commandLogSize: 8
   splitDiff: 'auto' # one of 'auto' | 'always'
   skipRewordInEditorWarning: false # for skipping the confirmation before launching the reword editor

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -123,6 +123,8 @@ type GuiConfig struct {
 	NerdFontsVersion string `yaml:"nerdFontsVersion" jsonschema:"enum=2,enum=3,enum="`
 	// If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.
 	ShowFileIcons bool `yaml:"showFileIcons"`
+	// Length of commit hash in commits view. 0 shows '*' if NF icons aren't on.
+	CommitHashLength int `yaml:"commitHashLength" jsonschema:"minimum=0"`
 	// If true, show commit hashes alongside branch names in the branches view.
 	ShowBranchCommitHash bool `yaml:"showBranchCommitHash"`
 	// Height of the command log view
@@ -675,6 +677,7 @@ func GetDefaultConfig() *UserConfig {
 			ShowIcons:                 false,
 			NerdFontsVersion:          "",
 			ShowFileIcons:             true,
+			CommitHashLength:          8,
 			ShowBranchCommitHash:      false,
 			CommandLogSize:            8,
 			SplitDiff:                 "auto",

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -325,6 +325,20 @@ func displayCommit(
 		hashString = hashColor.Sprint("*")
 	}
 
+	divergenceString := ""
+	if commit.Divergence != models.DivergenceNone {
+		divergenceString = hashColor.Sprint(lo.Ternary(commit.Divergence == models.DivergenceLeft, "↑", "↓"))
+	} else if icons.IsIconEnabled() {
+		divergenceString = hashColor.Sprint(icons.IconForCommit(commit))
+	}
+
+	descriptionString := ""
+	if fullDescription {
+		descriptionString = style.FgBlue.Sprint(
+			utils.UnixToDateSmart(now, commit.UnixTimestamp, timeFormat, shortTimeFormat),
+		)
+	}
+
 	actionString := ""
 	if commit.Action != models.ActionNone {
 		todoString := lo.Ternary(commit.Action == models.ActionConflict, "conflict", commit.Action.String())
@@ -378,20 +392,12 @@ func displayCommit(
 	}
 
 	cols := make([]string, 0, 7)
-	if commit.Divergence != models.DivergenceNone {
-		cols = append(cols, hashColor.Sprint(lo.Ternary(commit.Divergence == models.DivergenceLeft, "↑", "↓")))
-	} else if icons.IsIconEnabled() {
-		cols = append(cols, hashColor.Sprint(icons.IconForCommit(commit)))
-	}
-	cols = append(cols, hashString)
-	cols = append(cols, bisectString)
-	if fullDescription {
-		cols = append(cols, style.FgBlue.Sprint(
-			utils.UnixToDateSmart(now, commit.UnixTimestamp, timeFormat, shortTimeFormat),
-		))
-	}
 	cols = append(
 		cols,
+		divergenceString,
+		hashString,
+		bisectString,
+		descriptionString,
 		actionString,
 		authorFunc(commit.AuthorName),
 		graphLine+mark+tagString+theme.DefaultTextColor.Sprint(name),

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -312,8 +312,18 @@ func displayCommit(
 	bisectInfo *git_commands.BisectInfo,
 	isYouAreHereCommit bool,
 ) []string {
-	hashColor := getHashColor(commit, diffName, cherryPickedCommitHashSet, bisectStatus, bisectInfo)
 	bisectString := getBisectStatusText(bisectStatus, bisectInfo)
+
+	hashString := ""
+	hashColor := getHashColor(commit, diffName, cherryPickedCommitHashSet, bisectStatus, bisectInfo)
+	hashLength := common.UserConfig.Gui.CommitHashLength
+	if hashLength >= len(commit.Hash) {
+		hashString = hashColor.Sprint(commit.Hash)
+	} else if hashLength > 0 {
+		hashString = hashColor.Sprint(commit.Hash[:hashLength])
+	} else if !icons.IsIconEnabled() { // hashLength <= 0
+		hashString = hashColor.Sprint("*")
+	}
 
 	actionString := ""
 	if commit.Action != models.ActionNone {
@@ -373,7 +383,7 @@ func displayCommit(
 	} else if icons.IsIconEnabled() {
 		cols = append(cols, hashColor.Sprint(icons.IconForCommit(commit)))
 	}
-	cols = append(cols, hashColor.Sprint(commit.ShortHash()))
+	cols = append(cols, hashString)
 	cols = append(cols, bisectString)
 	if fullDescription {
 		cols = append(cols, style.FgBlue.Sprint(

--- a/schema/config.json
+++ b/schema/config.json
@@ -309,6 +309,12 @@
           "description": "If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.",
           "default": true
         },
+        "commitHashLength": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Length of commit hash in commits view. 0 shows '*' if NF icons aren't on.",
+          "default": 8
+        },
         "showBranchCommitHash": {
           "type": "boolean",
           "description": "If true, show commit hashes alongside branch names in the branches view."


### PR DESCRIPTION
- **PR Description**

Add a new config option `gui.commitHashLength` to change the length of the commit hash displayed in commits view.

default:
<img width="472" alt="image" src="https://github.com/jesseduffield/lazygit/assets/98684296/36dced1e-0c74-4dbd-8670-98e17a75d83a">

With config:
```yaml
gui:
  commitHashLength: 3
```
<img width="463" alt="image" src="https://github.com/jesseduffield/lazygit/assets/98684296/e8023cd8-f138-4af8-ae0e-3661f80206ca">


- Changes
  - Added the user config option to to `pkg/config/user_config.go` and `schema/config.json`
  - documented in `docs/Config.md`
  - Changed the code that displays the hash in `pkg/gui/presentation/commits.go`
  
---

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
