### PR TITLE
Fix amend to operation not working with non-HEAD merge commit

### DIFF
--- a/pkg/utils/rebase_todo.go
+++ b/pkg/utils/rebase_todo.go
@@ -235,7 +235,7 @@ func MoveFixupCommitDown(fileName string, originalHash string, fixupHash string,
 
 func moveFixupCommitDown(todos []todo.Todo, originalHash string, fixupHash string) ([]todo.Todo, error) {
 	isOriginal := func(t todo.Todo) bool {
-		return t.Command == todo.Pick && equalHash(t.Commit, originalHash)
+		return (t.Command == todo.Pick || t.Command == todo.Merge) && equalHash(t.Commit, originalHash)
 	}
 
 	isFixup := func(t todo.Todo) bool {

--- a/pkg/utils/rebase_todo_test.go
+++ b/pkg/utils/rebase_todo_test.go
@@ -284,7 +284,6 @@ func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			// TODO: is this something we actually want to support?
 			name: "fixup commit is separated from original commit",
 			todos: []todo.Todo{
 				{Command: todo.Pick, Commit: "original"},
@@ -295,6 +294,22 @@ func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
 			fixupHash:    "fixup",
 			expectedTodos: []todo.Todo{
 				{Command: todo.Pick, Commit: "original"},
+				{Command: todo.Fixup, Commit: "fixup"},
+				{Command: todo.Pick, Commit: "other"},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "fixup commit is separated from original merge commit",
+			todos: []todo.Todo{
+				{Command: todo.Merge, Commit: "original"},
+				{Command: todo.Pick, Commit: "other"},
+				{Command: todo.Pick, Commit: "fixup"},
+			},
+			originalHash: "original",
+			fixupHash:    "fixup",
+			expectedTodos: []todo.Todo{
+				{Command: todo.Merge, Commit: "original"},
 				{Command: todo.Fixup, Commit: "fixup"},
 				{Command: todo.Pick, Commit: "other"},
 			},


### PR DESCRIPTION
- **PR Description**

Resolves https://github.com/jesseduffield/lazygit/issues/3421

The error is "Expected exactly one original SHA, found 0" but the merge commit hash (`d6a7a04c626e40071133de26ebe8fdd225caa5c0`) is present in the rebase TODO file.

![image](https://github.com/jesseduffield/lazygit/assets/13722457/2e6d5fdb-af9f-4eae-9972-8e51a77ba614)
![image](https://github.com/jesseduffield/lazygit/assets/13722457/65dd4b1b-b080-47b0-9079-71c5e0d76cd2)

However, the commit is missed during search because the filter is only looking for pick commits: https://github.com/jesseduffield/lazygit/blob/580818e935e19a67f7fe1bbb148224a95781879c/pkg/utils/rebase_todo.go#L238

Checking for merge commits as well fixes the issue.

I believe only pick and merge should be valid here. If already in an interactive rebase, lazygit only allows amending to the current HEAD commit. When that happens, this whole interactive rebase logic is bypassed and lazygit just performs `git commit --amend`: https://github.com/jesseduffield/lazygit/blob/580818e935e19a67f7fe1bbb148224a95781879c/pkg/gui/controllers/local_commits_controller.go#L668

This is the reason why amending to a HEAD merge commit currently works whereas non-HEAD does not.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
