### PR TITLE
Change field name of CommitFile

### DIFF
--- a/pkg/commands/git_commands/commit_file_loader.go
+++ b/pkg/commands/git_commands/commit_file_loader.go
@@ -55,7 +55,7 @@ func getCommitFilesFromFilenames(filenames string) []*models.CommitFile {
 	return lo.Map(lo.Chunk(lines, 2), func(chunk []string, _ int) *models.CommitFile {
 		return &models.CommitFile{
 			ChangeStatus: chunk[0],
-			Name:         chunk[1],
+			Path:         chunk[1],
 		}
 	})
 }

--- a/pkg/commands/git_commands/commit_file_loader_test.go
+++ b/pkg/commands/git_commands/commit_file_loader_test.go
@@ -23,7 +23,7 @@ func TestGetCommitFilesFromFilenames(t *testing.T) {
 			input:    "MM\x00Myfile\x00",
 			output: []*models.CommitFile{
 				{
-					Name:         "Myfile",
+					Path:         "Myfile",
 					ChangeStatus: "MM",
 				},
 			},
@@ -33,11 +33,11 @@ func TestGetCommitFilesFromFilenames(t *testing.T) {
 			input:    "MM\x00Myfile\x00M \x00MyOtherFile\x00",
 			output: []*models.CommitFile{
 				{
-					Name:         "Myfile",
+					Path:         "Myfile",
 					ChangeStatus: "MM",
 				},
 				{
-					Name:         "MyOtherFile",
+					Path:         "MyOtherFile",
 					ChangeStatus: "M ",
 				},
 			},
@@ -47,15 +47,15 @@ func TestGetCommitFilesFromFilenames(t *testing.T) {
 			input:    "MM\x00Myfile\x00M \x00MyOtherFile\x00 M\x00YetAnother\x00",
 			output: []*models.CommitFile{
 				{
-					Name:         "Myfile",
+					Path:         "Myfile",
 					ChangeStatus: "MM",
 				},
 				{
-					Name:         "MyOtherFile",
+					Path:         "MyOtherFile",
 					ChangeStatus: "M ",
 				},
 				{
-					Name:         "YetAnother",
+					Path:         "YetAnother",
 					ChangeStatus: " M",
 				},
 			},

--- a/pkg/commands/models/commit_file.go
+++ b/pkg/commands/models/commit_file.go
@@ -2,18 +2,17 @@ package models
 
 // CommitFile : A git commit file
 type CommitFile struct {
-	// TODO: rename this to Path
-	Name string
+	Path string // e.g. '/path/to/mydir'
 
 	ChangeStatus string // e.g. 'A' for added or 'M' for modified. This is based on the result from git diff --name-status
 }
 
 func (f *CommitFile) ID() string {
-	return f.Name
+	return f.Path
 }
 
 func (f *CommitFile) Description() string {
-	return f.Name
+	return f.Path
 }
 
 func (f *CommitFile) Added() bool {
@@ -25,5 +24,5 @@ func (f *CommitFile) Deleted() bool {
 }
 
 func (f *CommitFile) GetPath() string {
-	return f.Name
+	return f.Path
 }

--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -279,7 +279,7 @@ func (self *CommitFilesController) toggleForPatch(selectedNodes []*filetree.Comm
 			// Find if any file in the selection is unselected or partially added
 			adding := lo.SomeBy(selectedNodes, func(node *filetree.CommitFileNode) bool {
 				return node.SomeFile(func(file *models.CommitFile) bool {
-					fileStatus := self.c.Git().Patch.PatchBuilder.GetFileStatus(file.Name, self.context().GetRef().RefName())
+					fileStatus := self.c.Git().Patch.PatchBuilder.GetFileStatus(file.Path, self.context().GetRef().RefName())
 					return fileStatus == patch.PART || fileStatus == patch.UNSELECTED
 				})
 			})
@@ -292,7 +292,7 @@ func (self *CommitFilesController) toggleForPatch(selectedNodes []*filetree.Comm
 
 			for _, node := range selectedNodes {
 				err := node.ForEachFile(func(file *models.CommitFile) error {
-					return patchOperationFunction(file.Name)
+					return patchOperationFunction(file.Path)
 				})
 				if err != nil {
 					return err

--- a/pkg/gui/filetree/build_tree.go
+++ b/pkg/gui/filetree/build_tree.go
@@ -58,7 +58,7 @@ func BuildTreeFromCommitFiles(files []*models.CommitFile) *Node[models.CommitFil
 
 	var curr *Node[models.CommitFile]
 	for _, file := range files {
-		splitPath := split(file.Name)
+		splitPath := split(file.Path)
 		curr = root
 	outer:
 		for i := range splitPath {

--- a/pkg/gui/filetree/build_tree_test.go
+++ b/pkg/gui/filetree/build_tree_test.go
@@ -332,10 +332,10 @@ func TestBuildTreeFromCommitFiles(t *testing.T) {
 			name: "files in same directory",
 			files: []*models.CommitFile{
 				{
-					Name: "dir1/a",
+					Path: "dir1/a",
 				},
 				{
-					Name: "dir1/b",
+					Path: "dir1/b",
 				},
 			},
 			expected: &Node[models.CommitFile]{
@@ -345,11 +345,11 @@ func TestBuildTreeFromCommitFiles(t *testing.T) {
 						Path: "dir1",
 						Children: []*Node[models.CommitFile]{
 							{
-								File: &models.CommitFile{Name: "dir1/a"},
+								File: &models.CommitFile{Path: "dir1/a"},
 								Path: "dir1/a",
 							},
 							{
-								File: &models.CommitFile{Name: "dir1/b"},
+								File: &models.CommitFile{Path: "dir1/b"},
 								Path: "dir1/b",
 							},
 						},
@@ -361,10 +361,10 @@ func TestBuildTreeFromCommitFiles(t *testing.T) {
 			name: "paths that can be compressed",
 			files: []*models.CommitFile{
 				{
-					Name: "dir1/dir3/a",
+					Path: "dir1/dir3/a",
 				},
 				{
-					Name: "dir2/dir4/b",
+					Path: "dir2/dir4/b",
 				},
 			},
 			expected: &Node[models.CommitFile]{
@@ -374,7 +374,7 @@ func TestBuildTreeFromCommitFiles(t *testing.T) {
 						Path: "dir1/dir3",
 						Children: []*Node[models.CommitFile]{
 							{
-								File: &models.CommitFile{Name: "dir1/dir3/a"},
+								File: &models.CommitFile{Path: "dir1/dir3/a"},
 								Path: "dir1/dir3/a",
 							},
 						},
@@ -384,7 +384,7 @@ func TestBuildTreeFromCommitFiles(t *testing.T) {
 						Path: "dir2/dir4",
 						Children: []*Node[models.CommitFile]{
 							{
-								File: &models.CommitFile{Name: "dir2/dir4/b"},
+								File: &models.CommitFile{Path: "dir2/dir4/b"},
 								Path: "dir2/dir4/b",
 							},
 						},
@@ -397,21 +397,21 @@ func TestBuildTreeFromCommitFiles(t *testing.T) {
 			name: "paths that can be sorted",
 			files: []*models.CommitFile{
 				{
-					Name: "b",
+					Path: "b",
 				},
 				{
-					Name: "a",
+					Path: "a",
 				},
 			},
 			expected: &Node[models.CommitFile]{
 				Path: "",
 				Children: []*Node[models.CommitFile]{
 					{
-						File: &models.CommitFile{Name: "a"},
+						File: &models.CommitFile{Path: "a"},
 						Path: "a",
 					},
 					{
-						File: &models.CommitFile{Name: "b"},
+						File: &models.CommitFile{Path: "b"},
 						Path: "b",
 					},
 				},
@@ -446,22 +446,22 @@ func TestBuildFlatTreeFromCommitFiles(t *testing.T) {
 			name: "files in same directory",
 			files: []*models.CommitFile{
 				{
-					Name: "dir1/a",
+					Path: "dir1/a",
 				},
 				{
-					Name: "dir1/b",
+					Path: "dir1/b",
 				},
 			},
 			expected: &Node[models.CommitFile]{
 				Path: "",
 				Children: []*Node[models.CommitFile]{
 					{
-						File:             &models.CommitFile{Name: "dir1/a"},
+						File:             &models.CommitFile{Path: "dir1/a"},
 						Path:             "dir1/a",
 						CompressionLevel: 0,
 					},
 					{
-						File:             &models.CommitFile{Name: "dir1/b"},
+						File:             &models.CommitFile{Path: "dir1/b"},
 						Path:             "dir1/b",
 						CompressionLevel: 0,
 					},
@@ -472,22 +472,22 @@ func TestBuildFlatTreeFromCommitFiles(t *testing.T) {
 			name: "paths that can be compressed",
 			files: []*models.CommitFile{
 				{
-					Name: "dir1/a",
+					Path: "dir1/a",
 				},
 				{
-					Name: "dir2/b",
+					Path: "dir2/b",
 				},
 			},
 			expected: &Node[models.CommitFile]{
 				Path: "",
 				Children: []*Node[models.CommitFile]{
 					{
-						File:             &models.CommitFile{Name: "dir1/a"},
+						File:             &models.CommitFile{Path: "dir1/a"},
 						Path:             "dir1/a",
 						CompressionLevel: 0,
 					},
 					{
-						File:             &models.CommitFile{Name: "dir2/b"},
+						File:             &models.CommitFile{Path: "dir2/b"},
 						Path:             "dir2/b",
 						CompressionLevel: 0,
 					},
@@ -498,21 +498,21 @@ func TestBuildFlatTreeFromCommitFiles(t *testing.T) {
 			name: "paths that can be sorted",
 			files: []*models.CommitFile{
 				{
-					Name: "b",
+					Path: "b",
 				},
 				{
-					Name: "a",
+					Path: "a",
 				},
 			},
 			expected: &Node[models.CommitFile]{
 				Path: "",
 				Children: []*Node[models.CommitFile]{
 					{
-						File: &models.CommitFile{Name: "a"},
+						File: &models.CommitFile{Path: "a"},
 						Path: "a",
 					},
 					{
-						File: &models.CommitFile{Name: "b"},
+						File: &models.CommitFile{Path: "b"},
 						Path: "b",
 					},
 				},

--- a/pkg/gui/filetree/commit_file_tree.go
+++ b/pkg/gui/filetree/commit_file_tree.go
@@ -105,7 +105,7 @@ func (self *CommitFileTree) CollapsedPaths() *CollapsedPaths {
 
 func (self *CommitFileTree) GetFile(path string) *models.CommitFile {
 	for _, file := range self.getFiles() {
-		if file.Name == path {
+		if file.Path == path {
 			return file
 		}
 	}

--- a/pkg/gui/presentation/files.go
+++ b/pkg/gui/presentation/files.go
@@ -51,11 +51,11 @@ func commitFilePatchStatus(node *filetree.Node[models.CommitFile], tree *filetre
 	// be whatever status it is, but if it's a non-leaf it will determine its status
 	// based on the leaves of that subtree
 	if node.EveryFile(func(file *models.CommitFile) bool {
-		return patchBuilder.GetFileStatus(file.Name, tree.GetRef().RefName()) == patch.WHOLE
+		return patchBuilder.GetFileStatus(file.Path, tree.GetRef().RefName()) == patch.WHOLE
 	}) {
 		return patch.WHOLE
 	} else if node.EveryFile(func(file *models.CommitFile) bool {
-		return patchBuilder.GetFileStatus(file.Name, tree.GetRef().RefName()) == patch.UNSELECTED
+		return patchBuilder.GetFileStatus(file.Path, tree.GetRef().RefName()) == patch.UNSELECTED
 	}) {
 		return patch.UNSELECTED
 	} else {

--- a/pkg/gui/presentation/files_test.go
+++ b/pkg/gui/presentation/files_test.go
@@ -95,19 +95,19 @@ func TestRenderCommitFileTree(t *testing.T) {
 		{
 			name: "leaf node",
 			files: []*models.CommitFile{
-				{Name: "test", ChangeStatus: "A"},
+				{Path: "test", ChangeStatus: "A"},
 			},
 			expected: []string{"A test"},
 		},
 		{
 			name: "big example",
 			files: []*models.CommitFile{
-				{Name: "dir1/file2", ChangeStatus: "M"},
-				{Name: "dir1/file3", ChangeStatus: "A"},
-				{Name: "dir2/dir2/file3", ChangeStatus: "D"},
-				{Name: "dir2/dir2/file4", ChangeStatus: "M"},
-				{Name: "dir2/file5", ChangeStatus: "M"},
-				{Name: "file1", ChangeStatus: "M"},
+				{Path: "dir1/file2", ChangeStatus: "M"},
+				{Path: "dir1/file3", ChangeStatus: "A"},
+				{Path: "dir2/dir2/file3", ChangeStatus: "D"},
+				{Path: "dir2/dir2/file4", ChangeStatus: "M"},
+				{Path: "dir2/file5", ChangeStatus: "M"},
+				{Path: "file1", ChangeStatus: "M"},
 			},
 			expected: toStringSlice(
 				`


### PR DESCRIPTION
- **PR Description**
- Change `Name` field to `Path` in CommitFile and removed the original TODO comment.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
