### PR TITLE
Fix pre-commit skip hook checks

### DIFF
--- a/pkg/integration/tests/commit/commit_skip_hook.go
+++ b/pkg/integration/tests/commit/commit_skip_hook.go
@@ -57,24 +57,15 @@ var CommitSkipHook = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().Focus().Press(keys.Commits.RenameCommit)
 		t.ExpectPopup().CommitMessagePanel().Type(" (reworded)").Confirm()
 
-		/* EXPECTED:
-						t.Views().Commits().IsFocused().
-							Lines(
-		                        Contains("skip! my commit message (reworded)"),
-		                        Contains("initial commit"),
-		                    )
-				            ACTUAL:
-		*/
-		t.ExpectPopup().Alert().Title(Equals("Error")).Content(Contains("exit status 1")).Confirm()
+		t.Views().Commits().IsFocused().
+			Lines(
+				Contains("skip! my commit message (reworded)"),
+				Contains("initial commit"),
+			)
 
 		// we should be able to skip hooks when changing authors
-		t.Views().Commits().IsFocused().SelectedLine(Contains("CI").IsSelected())
+		t.Views().Commits().IsFocused().SelectedLine(Contains("JS").IsSelected())
 		t.Views().Commits().Focus().Press(keys.Commits.ResetCommitAuthor)
-		/* EXPECTED:
-		        t.Views().Commits().IsFocused().Lines(Contains("JS").IsSelected())
-				   ACTUAL:
-		*/
-		t.ExpectPopup().Alert().Title(Equals("Error")).Content(Contains("exit status 1")).Confirm()
-
+		t.Views().Commits().IsFocused().Lines(Contains("JS").IsSelected())
 	},
 })

--- a/pkg/integration/tests/commit/commit_skip_hook.go
+++ b/pkg/integration/tests/commit/commit_skip_hook.go
@@ -1,0 +1,80 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+const preCommitHook = `#!/bin/bash
+
+exit 1
+`
+
+var CommitSkipHook = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Commit with pre-commit hook and skip hook config option in various situations.",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(testConfig *config.AppConfig) {
+		testConfig.UserConfig.Git.SkipHookPrefix = "skip! "
+
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.SetConfig("user.email", "Bill@example.com")
+		shell.SetConfig("user.name", "Bill Smith")
+
+		shell.CreateFileAndAdd("initial file", "initial content")
+		shell.Commit("initial commit")
+
+		shell.SetConfig("user.email", "John@example.com")
+		shell.SetConfig("user.name", "John Smith")
+
+		shell.CreateFile(".git/hooks/pre-commit", preCommitHook)
+		shell.MakeExecutable(".git/hooks/pre-commit")
+
+		shell.CreateFileAndAdd("testfile", "I'm just testing pre-commit hooks")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			Focus().
+			Press(keys.Files.CommitChanges)
+
+		// hook should trigger when creating a regular commit
+		t.ExpectPopup().CommitMessagePanel().Type("my commit message").Confirm()
+		t.ExpectPopup().Alert().Title(Equals("Error")).Content(Contains("Git command failed")).Confirm()
+
+		t.Views().Files().
+			Focus().
+			Press(keys.Files.CommitChanges)
+
+			// we should be able to skip hooks when creating a regular commit
+		t.ExpectPopup().CommitMessagePanel().Clear().Type("skip! my commit message").Confirm()
+		t.Views().Commits().Focus().Lines(
+			Contains("skip! my commit message"),
+			Contains("initial commit"),
+		)
+
+		// we should be able to skip hooks when rewording a commit
+		t.Views().Commits().Focus().Press(keys.Commits.RenameCommit)
+		t.ExpectPopup().CommitMessagePanel().Type(" (reworded)").Confirm()
+
+		/* EXPECTED:
+						t.Views().Commits().IsFocused().
+							Lines(
+		                        Contains("skip! my commit message (reworded)"),
+		                        Contains("initial commit"),
+		                    )
+				            ACTUAL:
+		*/
+		t.ExpectPopup().Alert().Title(Equals("Error")).Content(Contains("exit status 1")).Confirm()
+
+		// we should be able to skip hooks when changing authors
+		t.Views().Commits().IsFocused().SelectedLine(Contains("CI").IsSelected())
+		t.Views().Commits().Focus().Press(keys.Commits.ResetCommitAuthor)
+		/* EXPECTED:
+		        t.Views().Commits().IsFocused().Lines(Contains("JS").IsSelected())
+				   ACTUAL:
+		*/
+		t.ExpectPopup().Alert().Title(Equals("Error")).Content(Contains("exit status 1")).Confirm()
+
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -71,6 +71,7 @@ var tests = []*components.IntegrationTest{
 	commit.Commit,
 	commit.CommitMultiline,
 	commit.CommitSwitchToEditor,
+	commit.CommitSkipHook,
 	commit.CommitWipWithPrefix,
 	commit.CommitWithPrefix,
 	commit.CreateAmendCommit,


### PR DESCRIPTION
- **PR Description**
This tests for `pre-commit` hooks in several previously unchecked situations, e.g. when amending, rewording, (re)setting the author, extracting custom patch to a new commit.

It's a draft because I haven't implemented _all_ of those yet and because those that have been implemented haven't yet been added as tests (some have, some haven't).

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
