### PR TITLE
Enable the commit graph in the divergence view

### DIFF
--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -75,7 +75,7 @@ func NewSubCommitsContext(
 			endIdx,
 			// Don't show the graph in the left/right view; we'd like to, but
 			// it's too complicated:
-			shouldShowGraph(c) && viewModel.GetRefToShowDivergenceFrom() == "",
+			shouldShowGraph(c),
 			git_commands.NewNullBisectInfo(),
 			false,
 		)

--- a/pkg/gui/presentation/commits_test.go
+++ b/pkg/gui/presentation/commits_test.go
@@ -360,6 +360,185 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 				`),
 		},
 		{
+			testName: "graph in divergence view - all commits visible",
+			commits: []*models.Commit{
+				{Name: "commit1", Hash: "hash1r", Parents: []string{"hash2r"}, Divergence: models.DivergenceRight},
+				{Name: "commit2", Hash: "hash2r", Parents: []string{"hash3r", "hash5r"}, Divergence: models.DivergenceRight},
+				{Name: "commit3", Hash: "hash3r", Parents: []string{"hash4r"}, Divergence: models.DivergenceRight},
+				{Name: "commit1", Hash: "hash1l", Parents: []string{"hash2l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit2", Hash: "hash2l", Parents: []string{"hash3l", "hash4l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit3", Hash: "hash3l", Parents: []string{"hash4l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit4", Hash: "hash4l", Parents: []string{"hash5l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit5", Hash: "hash5l", Parents: []string{"hash6l"}, Divergence: models.DivergenceLeft},
+			},
+			startIdx:                  0,
+			endIdx:                    8,
+			showGraph:                 true,
+			bisectInfo:                git_commands.NewNullBisectInfo(),
+			cherryPickedCommitHashSet: set.New[string](),
+			showYouAreHereLabel:       false,
+			now:                       time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: formatExpected(`
+		↓ hash1r ◯ commit1
+		↓ hash2r ⏣─╮ commit2
+		↓ hash3r ◯ │ commit3
+		↑ hash1l ◯ commit1
+		↑ hash2l ⏣─╮ commit2
+		↑ hash3l ◯ │ commit3
+		↑ hash4l ◯─╯ commit4
+		↑ hash5l ◯ commit5
+				`),
+		},
+		{
+			testName: "graph in divergence view - not all remote commits visible",
+			commits: []*models.Commit{
+				{Name: "commit1", Hash: "hash1r", Parents: []string{"hash2r"}, Divergence: models.DivergenceRight},
+				{Name: "commit2", Hash: "hash2r", Parents: []string{"hash3r", "hash5r"}, Divergence: models.DivergenceRight},
+				{Name: "commit3", Hash: "hash3r", Parents: []string{"hash4r"}, Divergence: models.DivergenceRight},
+				{Name: "commit1", Hash: "hash1l", Parents: []string{"hash2l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit2", Hash: "hash2l", Parents: []string{"hash3l", "hash4l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit3", Hash: "hash3l", Parents: []string{"hash4l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit4", Hash: "hash4l", Parents: []string{"hash5l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit5", Hash: "hash5l", Parents: []string{"hash6l"}, Divergence: models.DivergenceLeft},
+			},
+			startIdx:                  2,
+			endIdx:                    8,
+			showGraph:                 true,
+			bisectInfo:                git_commands.NewNullBisectInfo(),
+			cherryPickedCommitHashSet: set.New[string](),
+			showYouAreHereLabel:       false,
+			now:                       time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: formatExpected(`
+		↓ hash3r ◯ │ commit3
+		↑ hash1l ◯ commit1
+		↑ hash2l ⏣─╮ commit2
+		↑ hash3l ◯ │ commit3
+		↑ hash4l ◯─╯ commit4
+		↑ hash5l ◯ commit5
+				`),
+		},
+		{
+			testName: "graph in divergence view - not all local commits",
+			commits: []*models.Commit{
+				{Name: "commit1", Hash: "hash1r", Parents: []string{"hash2r"}, Divergence: models.DivergenceRight},
+				{Name: "commit2", Hash: "hash2r", Parents: []string{"hash3r", "hash5r"}, Divergence: models.DivergenceRight},
+				{Name: "commit3", Hash: "hash3r", Parents: []string{"hash4r"}, Divergence: models.DivergenceRight},
+				{Name: "commit1", Hash: "hash1l", Parents: []string{"hash2l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit2", Hash: "hash2l", Parents: []string{"hash3l", "hash4l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit3", Hash: "hash3l", Parents: []string{"hash4l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit4", Hash: "hash4l", Parents: []string{"hash5l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit5", Hash: "hash5l", Parents: []string{"hash6l"}, Divergence: models.DivergenceLeft},
+			},
+			startIdx:                  0,
+			endIdx:                    5,
+			showGraph:                 true,
+			bisectInfo:                git_commands.NewNullBisectInfo(),
+			cherryPickedCommitHashSet: set.New[string](),
+			showYouAreHereLabel:       false,
+			now:                       time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: formatExpected(`
+		↓ hash1r ◯ commit1
+		↓ hash2r ⏣─╮ commit2
+		↓ hash3r ◯ │ commit3
+		↑ hash1l ◯ commit1
+		↑ hash2l ⏣─╮ commit2
+				`),
+		},
+		{
+			testName: "graph in divergence view - no remote commits visible",
+			commits: []*models.Commit{
+				{Name: "commit1", Hash: "hash1r", Parents: []string{"hash2r"}, Divergence: models.DivergenceRight},
+				{Name: "commit2", Hash: "hash2r", Parents: []string{"hash3r", "hash5r"}, Divergence: models.DivergenceRight},
+				{Name: "commit3", Hash: "hash3r", Parents: []string{"hash4r"}, Divergence: models.DivergenceRight},
+				{Name: "commit1", Hash: "hash1l", Parents: []string{"hash2l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit2", Hash: "hash2l", Parents: []string{"hash3l", "hash4l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit3", Hash: "hash3l", Parents: []string{"hash4l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit4", Hash: "hash4l", Parents: []string{"hash5l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit5", Hash: "hash5l", Parents: []string{"hash6l"}, Divergence: models.DivergenceLeft},
+			},
+			startIdx:                  4,
+			endIdx:                    8,
+			showGraph:                 true,
+			bisectInfo:                git_commands.NewNullBisectInfo(),
+			cherryPickedCommitHashSet: set.New[string](),
+			showYouAreHereLabel:       false,
+			now:                       time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: formatExpected(`
+		↑ hash2l ⏣─╮ commit2
+		↑ hash3l ◯ │ commit3
+		↑ hash4l ◯─╯ commit4
+		↑ hash5l ◯ commit5
+				`),
+		},
+		{
+			testName: "graph in divergence view - no local commits visible",
+			commits: []*models.Commit{
+				{Name: "commit1", Hash: "hash1r", Parents: []string{"hash2r"}, Divergence: models.DivergenceRight},
+				{Name: "commit2", Hash: "hash2r", Parents: []string{"hash3r", "hash5r"}, Divergence: models.DivergenceRight},
+				{Name: "commit3", Hash: "hash3r", Parents: []string{"hash4r"}, Divergence: models.DivergenceRight},
+				{Name: "commit1", Hash: "hash1l", Parents: []string{"hash2l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit2", Hash: "hash2l", Parents: []string{"hash3l", "hash4l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit3", Hash: "hash3l", Parents: []string{"hash4l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit4", Hash: "hash4l", Parents: []string{"hash5l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit5", Hash: "hash5l", Parents: []string{"hash6l"}, Divergence: models.DivergenceLeft},
+			},
+			startIdx:                  0,
+			endIdx:                    2,
+			showGraph:                 true,
+			bisectInfo:                git_commands.NewNullBisectInfo(),
+			cherryPickedCommitHashSet: set.New[string](),
+			showYouAreHereLabel:       false,
+			now:                       time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: formatExpected(`
+		↓ hash1r ◯ commit1
+		↓ hash2r ⏣─╮ commit2
+				`),
+		},
+		{
+			testName: "graph in divergence view - no remote commits present",
+			commits: []*models.Commit{
+				{Name: "commit1", Hash: "hash1l", Parents: []string{"hash2l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit2", Hash: "hash2l", Parents: []string{"hash3l", "hash4l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit3", Hash: "hash3l", Parents: []string{"hash4l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit4", Hash: "hash4l", Parents: []string{"hash5l"}, Divergence: models.DivergenceLeft},
+				{Name: "commit5", Hash: "hash5l", Parents: []string{"hash6l"}, Divergence: models.DivergenceLeft},
+			},
+			startIdx:                  0,
+			endIdx:                    5,
+			showGraph:                 true,
+			bisectInfo:                git_commands.NewNullBisectInfo(),
+			cherryPickedCommitHashSet: set.New[string](),
+			showYouAreHereLabel:       false,
+			now:                       time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: formatExpected(`
+		↑ hash1l ◯ commit1
+		↑ hash2l ⏣─╮ commit2
+		↑ hash3l ◯ │ commit3
+		↑ hash4l ◯─╯ commit4
+		↑ hash5l ◯ commit5
+				`),
+		},
+		{
+			testName: "graph in divergence view - no local commits present",
+			commits: []*models.Commit{
+				{Name: "commit1", Hash: "hash1r", Parents: []string{"hash2r"}, Divergence: models.DivergenceRight},
+				{Name: "commit2", Hash: "hash2r", Parents: []string{"hash3r", "hash5r"}, Divergence: models.DivergenceRight},
+				{Name: "commit3", Hash: "hash3r", Parents: []string{"hash4r"}, Divergence: models.DivergenceRight},
+			},
+			startIdx:                  0,
+			endIdx:                    3,
+			showGraph:                 true,
+			bisectInfo:                git_commands.NewNullBisectInfo(),
+			cherryPickedCommitHashSet: set.New[string](),
+			showYouAreHereLabel:       false,
+			now:                       time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: formatExpected(`
+		↓ hash1r ◯ commit1
+		↓ hash2r ⏣─╮ commit2
+		↓ hash3r ◯ │ commit3
+				`),
+		},
+		{
 			testName: "custom time format",
 			commits: []*models.Commit{
 				{Name: "commit1", Hash: "hash1", UnixTimestamp: 1577844184, AuthorName: "Jesse Duffield"},


### PR DESCRIPTION
- **PR Description**

In the "View divergence from upstream" view we have so far disabled the commit graph because it was too difficult to implement properly. I really miss it though, so here's a PR that enables it there, too.

For feature branches it is not essential, because these usually don't contain merges and the graph is a trivial line. However, for the master branch against its upstream it is useful too see how many PRs were merged since you last fetched it, and the graph helps a lot with that. Also, when we implement #3536 it will be very useful there, too.