### PR TITLE
Upgrade to Alpine Linux v3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build
 
-FROM alpine:3.15
+FROM alpine:3.19
 RUN apk add --no-cache -U git xdg-utils
 WORKDIR /go/src/github.com/jesseduffield/lazygit/
 COPY --from=build /go/src/github.com/jesseduffield/lazygit ./


### PR DESCRIPTION
- **PR Description**

Alpine v3.15 is out-of-date since 2023-11-01 and is not getting any security updates anymore: https://alpinelinux.org/releases/

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
