### PR TITLE
Fix clicking in status side panel

### DIFF
--- a/pkg/integration/tests/status/click_repo_name_to_open_repos_menu.go
+++ b/pkg/integration/tests/status/click_repo_name_to_open_repos_menu.go
@@ -1,0 +1,18 @@
+package status
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ClickRepoNameToOpenReposMenu = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Click on the repo name in the status side panel to open the recent repositories menu",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo:    func(shell *Shell) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Status().Click(1, 0)
+		t.ExpectPopup().Menu().Title(Equals("Recent repositories"))
+	},
+})

--- a/pkg/integration/tests/status/click_to_focus.go
+++ b/pkg/integration/tests/status/click_to_focus.go
@@ -1,0 +1,35 @@
+package status
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ClickToFocus = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Click in the status side panel to activate it",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo:    func(shell *Shell) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().Focus()
+		t.Views().Main().Lines(
+			Contains("No changed files"),
+		)
+
+		t.Views().Status().Click(0, 0)
+		t.Views().Status().IsFocused()
+		t.Views().Main().ContainsLines(
+			Contains(`   _`),
+			Contains(`  | |                     (_) |`),
+			Contains(`  | | __ _ _____   _  __ _ _| |_`),
+			Contains("  | |/ _` |_  / | | |/ _` | | __|"),
+			Contains(`  | | (_| |/ /| |_| | (_| | | |_`),
+			Contains(`  |_|\__,_/___|\__, |\__, |_|\__|`),
+			Contains(`                __/ | __/ |`),
+			Contains(`               |___/ |___/`),
+			Contains(``),
+			Contains(`Copyright `),
+		)
+	},
+})

--- a/pkg/integration/tests/status/click_working_tree_state_to_open_rebase_options_menu.go
+++ b/pkg/integration/tests/status/click_working_tree_state_to_open_rebase_options_menu.go
@@ -1,0 +1,27 @@
+package status
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ClickWorkingTreeStateToOpenRebaseOptionsMenu = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Click on the working tree state in the status side panel to open the rebase options menu",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateNCommits(2)
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Press(keys.Universal.Edit)
+
+		t.Views().Status().
+			Content(Contains("(rebasing) repo")).
+			Click(1, 0)
+
+		t.ExpectPopup().Menu().Title(Equals("Rebase options"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/reflog"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/staging"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/stash"
+	"github.com/jesseduffield/lazygit/pkg/integration/tests/status"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/submodule"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/sync"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/tag"
@@ -257,6 +258,9 @@ var tests = []*components.IntegrationTest{
 	stash.StashIncludingUntrackedFiles,
 	stash.StashStaged,
 	stash.StashUnstaged,
+	status.ClickRepoNameToOpenReposMenu,
+	status.ClickToFocus,
+	status.ClickWorkingTreeStateToOpenRebaseOptionsMenu,
 	submodule.Add,
 	submodule.Enter,
 	submodule.EnterNested,


### PR DESCRIPTION
- **PR Description**

Clicking in the status side panel should activate it; also, clicking on the repo name should bring up the recent repositories menu, and clicking on the "(rebasing)" text should bring up the rebase options menu. All of this was broken for a long time, since somewhere around the big refactoring of March 2023. (The exact commit where it broke is hard to bisect, since many of the commits in that area either don't compile or crash at startup...)

I'm fixing this not because I think it's super important functionality (nobody seems to have missed it for over a year), but because I have to touch this code in another PR, and noticed that it wasn't working.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
