### PR TITLE
Add textbox custom command prompt

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -94,7 +94,7 @@ These fields are applicable to all prompts.
 
 | _field_           | _description_                                                                                  | _required_ |
 | ------------      | -----------------------------------------------------------------------------------------------| ---------- |
-| type              | One of 'input', 'confirm', 'menu', 'menuFromCommand'                                                           | yes        |
+| type              | One of 'input', 'confirm', 'menu', 'menuFromCommand', 'textbox                                 | yes        |
 | title             | The title to display in the popup panel                                                        | no         |
 | key | Used to reference the entered value from within the custom command. E.g. a prompt with `key: 'Branch'` can be referred to as `{{.Form.Branch}}` in the command | yes |
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -586,7 +586,7 @@ type CustomCommand struct {
 }
 
 type CustomCommandPrompt struct {
-	// One of: 'input' | 'menu' | 'confirm' | 'menuFromCommand'
+	// One of: 'input' | 'menu' | 'confirm' | 'menuFromCommand' | 'textbox'
 	Type string `yaml:"type"`
 	// Used to reference the entered value from within the custom command. E.g. a prompt with `key: 'Branch'` can be referred to as `{{.Form.Branch}}` in the command
 	Key string `yaml:"key"`

--- a/pkg/gui/context/context.go
+++ b/pkg/gui/context/context.go
@@ -41,6 +41,7 @@ const (
 
 	MENU_CONTEXT_KEY               types.ContextKey = "menu"
 	CONFIRMATION_CONTEXT_KEY       types.ContextKey = "confirmation"
+	TEXTBOX_CONTEXT_KEY            types.ContextKey = "textbox"
 	SEARCH_CONTEXT_KEY             types.ContextKey = "search"
 	COMMIT_MESSAGE_CONTEXT_KEY     types.ContextKey = "commitMessage"
 	COMMIT_DESCRIPTION_CONTEXT_KEY types.ContextKey = "commitDescription"
@@ -106,6 +107,7 @@ type ContextTree struct {
 	CustomPatchBuilderSecondary types.Context
 	MergeConflicts              *MergeConflictsContext
 	Confirmation                *ConfirmationContext
+	Textbox                     *TextboxContext
 	CommitMessage               *CommitMessageContext
 	CommitDescription           types.Context
 	CommandLog                  types.Context
@@ -141,6 +143,7 @@ func (self *ContextTree) Flatten() []types.Context {
 		self.Stash,
 		self.Menu,
 		self.Confirmation,
+		self.Textbox,
 		self.CommitMessage,
 		self.CommitDescription,
 

--- a/pkg/gui/context/setup.go
+++ b/pkg/gui/context/setup.go
@@ -100,6 +100,7 @@ func NewContextTree(c *ContextCommon) *ContextTree {
 			c,
 		),
 		Confirmation:  NewConfirmationContext(c),
+		Textbox:       NewTextboxContext(c),
 		CommitMessage: NewCommitMessageContext(c),
 		CommitDescription: NewSimpleContext(
 			NewBaseContext(NewBaseContextOpts{

--- a/pkg/gui/context/textbox_context.go
+++ b/pkg/gui/context/textbox_context.go
@@ -1,0 +1,35 @@
+package context
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+)
+
+type TextboxContext struct {
+	*SimpleContext
+	c *ContextCommon
+
+	State TextboxContextState
+}
+
+type TextboxContextState struct {
+	OnConfirm func() error
+	OnClose   func() error
+}
+
+var _ types.Context = (*TextboxContext)(nil)
+
+func NewTextboxContext(
+	c *ContextCommon,
+) *TextboxContext {
+	return &TextboxContext{
+		c: c,
+		SimpleContext: NewSimpleContext(NewBaseContext(NewBaseContextOpts{
+			View:                  c.Views().Textbox,
+			WindowName:            "textbox",
+			Key:                   TEXTBOX_CONTEXT_KEY,
+			Kind:                  types.TEMPORARY_POPUP,
+			Focusable:             true,
+			HasUncontrolledBounds: true,
+		})),
+	}
+}

--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -121,6 +121,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 		View:            viewHelper,
 		Refresh:         refreshHelper,
 		Confirmation:    helpers.NewConfirmationHelper(helperCommon),
+		Textbox:         helpers.NewTextboxHelper(helperCommon),
 		Mode:            modeHelper,
 		AppStatus:       appStatusHelper,
 		InlineStatus:    helpers.NewInlineStatusHelper(helperCommon, windowHelper),
@@ -191,6 +192,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 	statusController := controllers.NewStatusController(common)
 	commandLogController := controllers.NewCommandLogController(common)
 	confirmationController := controllers.NewConfirmationController(common)
+	textboxController := controllers.NewTextboxController(common)
 	suggestionsController := controllers.NewSuggestionsController(common)
 	jumpToSideWindowController := controllers.NewJumpToSideWindowController(common)
 
@@ -365,6 +367,10 @@ func (gui *Gui) resetHelpersAndControllers() {
 
 	controllers.AttachControllers(gui.State.Contexts.Confirmation,
 		confirmationController,
+	)
+
+	controllers.AttachControllers(gui.State.Contexts.Textbox,
+		textboxController,
 	)
 
 	controllers.AttachControllers(gui.State.Contexts.Suggestions,

--- a/pkg/gui/controllers/helpers/helpers.go
+++ b/pkg/gui/controllers/helpers/helpers.go
@@ -45,6 +45,7 @@ type Helpers struct {
 	View              *ViewHelper
 	Refresh           *RefreshHelper
 	Confirmation      *ConfirmationHelper
+	Textbox           *TextboxHelper
 	Mode              *ModeHelper
 	AppStatus         *AppStatusHelper
 	InlineStatus      *InlineStatusHelper
@@ -82,6 +83,7 @@ func NewStubHelpers() *Helpers {
 		View:              &ViewHelper{},
 		Refresh:           &RefreshHelper{},
 		Confirmation:      &ConfirmationHelper{},
+		Textbox:           &TextboxHelper{},
 		Mode:              &ModeHelper{},
 		AppStatus:         &AppStatusHelper{},
 		InlineStatus:      &InlineStatusHelper{},

--- a/pkg/gui/controllers/helpers/textbox_helper.go
+++ b/pkg/gui/controllers/helpers/textbox_helper.go
@@ -1,0 +1,151 @@
+package helpers
+
+import (
+	goContext "context"
+
+	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/theme"
+	"github.com/jesseduffield/lazygit/pkg/utils"
+)
+
+type TextboxHelper struct {
+	c *HelperCommon
+}
+
+func NewTextboxHelper(c *HelperCommon) *TextboxHelper {
+	return &TextboxHelper{
+		c: c,
+	}
+}
+
+func (self *TextboxHelper) DeactivateTextboxPrompt() {
+	self.c.Mutexes().PopupMutex.Lock()
+	self.c.State().GetRepoState().SetCurrentPopupOpts(nil)
+	self.c.Mutexes().PopupMutex.Unlock()
+
+	self.c.Views().Textbox.Visible = false
+	self.clearTextboxViewKeyBindings()
+}
+
+func (self *TextboxHelper) clearTextboxViewKeyBindings() {
+	noop := func() error { return nil }
+	self.c.Contexts().Textbox.State.OnConfirm = noop
+	self.c.Contexts().Textbox.State.OnClose = noop
+}
+
+func (self *TextboxHelper) CreatePopupPanel(ctx goContext.Context, opts types.CreatePopupPanelOpts) error {
+	self.c.Mutexes().PopupMutex.Lock()
+	defer self.c.Mutexes().PopupMutex.Unlock()
+
+	_, cancel := goContext.WithCancel(ctx)
+
+	// we don't allow interruptions of non-loader popups in case we get stuck somehow
+	// e.g. a credentials popup never gets its required user input so a process hangs
+	// forever.
+	// The proper solution is to have a queue of popup options
+	currentPopupOpts := self.c.State().GetRepoState().GetCurrentPopupOpts()
+	if currentPopupOpts != nil && !currentPopupOpts.HasLoader {
+		self.c.Log.Error("ignoring create popup panel because a popup panel is already open")
+		cancel()
+		return nil
+	}
+
+	textboxView := self.c.Views().Textbox
+
+	textboxView.Title = opts.Title
+	// Introduce confirm key bindings of textbox to users
+	textboxView.Subtitle = utils.ResolvePlaceholderString(self.c.Tr.TextboxSubTitle,
+		map[string]string{
+			"textboxConfirmBinding": keybindings.Label(self.c.UserConfig.Keybinding.Universal.ConfirmInEditor),
+		})
+
+	textboxView.Wrap = !opts.Editable
+	textboxView.FgColor = theme.GocuiDefaultTextColor
+	textboxView.Mask = runeForMask(opts.Mask)
+
+	// Set view position
+	width := self.getPopupPanelWidth()
+	height := self.getPopupPanelHeight()
+	x0, y0, x1, y1 := self.getPosition(width, height)
+	self.c.GocuiGui().SetView(textboxView.Name(), x0, y0, x1, y1, 0)
+
+	// Render text in textbox
+	textboxView.Editable = opts.Editable
+	textArea := textboxView.TextArea
+	textArea.Clear()
+	textArea.TypeString(opts.Prompt)
+	textboxView.RenderTextArea()
+
+	// Setting Handlers
+	self.c.Contexts().Textbox.State.OnConfirm = self.wrappedPromptTextboxFunction(cancel, opts.HandleConfirmPrompt, func() string { return self.c.Views().Textbox.TextArea.GetContent() })
+	self.c.Contexts().Textbox.State.OnClose = self.wrappedTextboxFunction(cancel, opts.HandleClose)
+
+	// Set text box to current popup
+	self.c.State().GetRepoState().SetCurrentPopupOpts(&opts)
+
+	return self.c.PushContext(self.c.Contexts().Textbox)
+}
+
+func (self *TextboxHelper) wrappedPromptTextboxFunction(cancel goContext.CancelFunc, function func(string) error, getResponse func() string) func() error {
+	return self.wrappedTextboxFunction(cancel, func() error {
+		return function(getResponse())
+	})
+}
+
+func (self *TextboxHelper) wrappedTextboxFunction(cancel goContext.CancelFunc, function func() error) func() error {
+	return func() error {
+		cancel()
+
+		if err := self.c.PopContext(); err != nil {
+			return err
+		}
+
+		if function != nil {
+			if err := function(); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+func (self *TextboxHelper) getPosition(panelWidth int, panelHeight int) (int, int, int, int) {
+	width, height := self.c.GocuiGui().Size()
+	if panelHeight > height * 3 / 4 {
+		panelHeight = height * 3 / 4
+	}
+	return width / 2 - panelWidth / 2,
+		height / 2 - panelHeight / 2 - panelHeight % 2 - 1,
+		width / 2 + panelWidth / 2,
+		height / 2 + panelHeight / 2
+}
+
+func (self *TextboxHelper) getPopupPanelWidth() int {
+	width, _ := self.c.GocuiGui().Size()
+	panelWidth := 4 * width / 7
+	minWidth := 80
+	if panelWidth < minWidth {
+		if width - 2 < minWidth {
+			panelWidth = width - 2
+		} else {
+			panelWidth = minWidth
+		}
+	}
+
+	return panelWidth
+}
+
+func (self *TextboxHelper) getPopupPanelHeight() int {
+	_, height := self.c.GocuiGui().Size()
+	var panelHeight int
+	maxHeight := 11
+	if height - 2 > maxHeight {
+		panelHeight = maxHeight
+	} else {
+		panelHeight = height - 2
+	}
+
+	return panelHeight
+}

--- a/pkg/gui/controllers/textbox_controller.go
+++ b/pkg/gui/controllers/textbox_controller.go
@@ -1,0 +1,55 @@
+package controllers
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/gui/context"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+)
+
+type TextboxController struct {
+	baseController
+	c *ControllerCommon
+}
+
+var _ types.IController = &TextboxController{}
+
+func NewTextboxController(
+	c *ControllerCommon,
+) *TextboxController {
+	return &TextboxController{
+		baseController: baseController{},
+		c:              c,
+	}
+}
+
+func (self *TextboxController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
+	bindings := []*types.Binding{
+		{
+			Key:             opts.GetKey(opts.Config.Universal.ConfirmInEditor),
+			Handler:         func() error { return self.context().State.OnConfirm() },
+			Description:     self.c.Tr.Confirm,
+			DisplayOnScreen: true,
+		},
+		{
+			Key:             opts.GetKey(opts.Config.Universal.Return),
+			Handler:         func() error { return self.context().State.OnClose() },
+			Description:     self.c.Tr.CloseCancel,
+			DisplayOnScreen: true,
+		},
+	}
+	return bindings
+}
+
+func (self *TextboxController) GetOnFocusLost() func(types.OnFocusLostOpts) error {
+	return func(types.OnFocusLostOpts) error {
+		self.c.Helpers().Textbox.DeactivateTextboxPrompt()
+		return nil
+	}
+}
+
+func (self *TextboxController) Context() types.Context {
+	return self.context()
+}
+
+func (self *TextboxController) context() *context.TextboxContext {
+	return self.c.Contexts().Textbox
+}

--- a/pkg/gui/editors.go
+++ b/pkg/gui/editors.go
@@ -89,6 +89,13 @@ func (gui *Gui) promptEditor(v *gocui.View, key gocui.Key, ch rune, mod gocui.Mo
 	return matched
 }
 
+
+func (gui *Gui) textboxEditor(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) bool {
+	matched := gui.handleEditorKeypress(v.TextArea, key, ch, mod, true)
+	v.RenderTextArea()
+	return matched
+}
+
 func (gui *Gui) searchEditor(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) bool {
 	matched := gui.handleEditorKeypress(v.TextArea, key, ch, mod, false)
 	v.RenderTextArea()

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -509,6 +509,9 @@ func NewGui(
 	gui.PopupHandler = popup.NewPopupHandler(
 		cmn,
 		func(ctx goContext.Context, opts types.CreatePopupPanelOpts) error {
+			if opts.Multiline {
+				return gui.helpers.Textbox.CreatePopupPanel(ctx, opts)
+			}
 			return gui.helpers.Confirmation.CreatePopupPanel(ctx, opts)
 		},
 		func() error { return gui.c.Refresh(types.RefreshOptions{Mode: types.ASYNC}) },

--- a/pkg/gui/popup/popup_handler.go
+++ b/pkg/gui/popup/popup_handler.go
@@ -114,6 +114,16 @@ func (self *PopupHandler) Prompt(opts types.PromptOpts) error {
 	})
 }
 
+func (self *PopupHandler) Textbox(opts types.PromptOpts) error {
+	return self.createPopupPanelFn(context.Background(), types.CreatePopupPanelOpts{
+		Title:               opts.Title,
+		Multiline:           true,
+		Editable:            true,
+		HandleConfirmPrompt: opts.HandleConfirm,
+		HandleClose:         opts.HandleClose,
+	})
+}
+
 // returns the content that has currently been typed into the prompt. Useful for
 // asynchronously updating the suggestions list under the prompt.
 func (self *PopupHandler) GetPromptInput() string {

--- a/pkg/gui/services/custom_commands/handler_creator.go
+++ b/pkg/gui/services/custom_commands/handler_creator.go
@@ -79,6 +79,14 @@ func (self *HandlerCreator) call(customCommand config.CustomCommand) func() erro
 					}
 					return self.inputPrompt(resolvedPrompt, wrappedF)
 				}
+			case "textbox":
+				f = func() error {
+					resolvedPrompt, err := self.resolver.resolvePrompt(&prompt, resolveTemplate)
+					if err != nil {
+						return err
+					}
+					return self.textboxPrompt(resolvedPrompt, wrappedF)
+				}
 			case "menu":
 				f = func() error {
 					resolvedPrompt, err := self.resolver.resolvePrompt(&prompt, resolveTemplate)
@@ -122,6 +130,16 @@ func (self *HandlerCreator) inputPrompt(prompt *config.CustomCommandPrompt, wrap
 		Title:               prompt.Title,
 		InitialContent:      prompt.InitialValue,
 		FindSuggestionsFunc: findSuggestionsFn,
+		HandleConfirm: func(str string) error {
+			return wrappedF(str)
+		},
+	})
+}
+
+func (self *HandlerCreator) textboxPrompt(prompt *config.CustomCommandPrompt, wrappedF func(string) error) error {
+	return self.c.Textbox(types.PromptOpts{
+		Title:          prompt.Title,
+		InitialContent: prompt.InitialValue,
 		HandleConfirm: func(str string) error {
 			return wrappedF(str)
 		},

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -141,6 +141,7 @@ type IPopupHandler interface {
 	Confirm(opts ConfirmOpts) error
 	// Shows a popup prompting the user for input.
 	Prompt(opts PromptOpts) error
+	Textbox(opts PromptOpts) error
 	WithWaitingStatus(message string, f func(gocui.Task) error) error
 	WithWaitingStatusSync(message string, f func() error) error
 	Menu(opts CreateMenuOptions) error
@@ -167,6 +168,7 @@ type CreateMenuOptions struct {
 type CreatePopupPanelOpts struct {
 	HasLoader           bool
 	Editable            bool
+	Multiline           bool
 	Title               string
 	Prompt              string
 	HandleConfirm       func() error

--- a/pkg/gui/types/views.go
+++ b/pkg/gui/types/views.go
@@ -25,6 +25,7 @@ type Views struct {
 
 	Options           *gocui.View
 	Confirmation      *gocui.View
+	Textbox           *gocui.View
 	Menu              *gocui.View
 	CommitMessage     *gocui.View
 	CommitDescription *gocui.View

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -65,6 +65,7 @@ func (gui *Gui) orderedViewNameMappings() []viewNameMapping {
 		{viewPtr: &gui.Views.Menu, name: "menu"},
 		{viewPtr: &gui.Views.Suggestions, name: "suggestions"},
 		{viewPtr: &gui.Views.Confirmation, name: "confirmation"},
+		{viewPtr: &gui.Views.Textbox, name: "textbox"},
 		{viewPtr: &gui.Views.Tooltip, name: "tooltip"},
 
 		// this guy will cover everything else when it appears
@@ -173,6 +174,9 @@ func (gui *Gui) createAllViews() error {
 
 	gui.Views.Confirmation.Visible = false
 	gui.Views.Confirmation.Editor = gocui.EditorFunc(gui.promptEditor)
+
+	gui.Views.Textbox.Visible = false
+	gui.Views.Textbox.Editor = gocui.EditorFunc(gui.textboxEditor)
 
 	gui.Views.Suggestions.Visible = false
 

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -272,6 +272,7 @@ type TranslationSet struct {
 	CommitSummaryTitle                    string
 	CommitDescriptionTitle                string
 	CommitDescriptionSubTitle             string
+	TextboxSubTitle                       string
 	LocalBranchesTitle                    string
 	SearchTitle                           string
 	TagsTitle                             string
@@ -1232,6 +1233,7 @@ func EnglishTranslationSet() TranslationSet {
 		CommitSummaryTitle:                   "Commit summary",
 		CommitDescriptionTitle:               "Commit description",
 		CommitDescriptionSubTitle:            "Press {{.togglePanelKeyBinding}} to toggle focus, {{.commitMenuKeybinding}} to open menu",
+		TextboxSubTitle:                      "Press {{.textboxConfirmBinding}} to confirm",
 		LocalBranchesTitle:                   "Local branches",
 		SearchTitle:                          "Search",
 		TagsTitle:                            "Tags",

--- a/pkg/integration/components/popup.go
+++ b/pkg/integration/components/popup.go
@@ -56,6 +56,18 @@ func (self *Popup) inMenu() {
 	})
 }
 
+func (self *Popup) Textbox() *TextboxDriver {
+	self.inTextbox()
+
+	return &TextboxDriver{t: self.t}
+}
+
+func (self *Popup) inTextbox() {
+	self.t.assertWithRetries(func() (bool, string) {
+		return self.t.gui.CurrentContext().GetView().Name() == "textbox", "Expected popup textbox to be focused"
+	})
+}
+
 func (self *Popup) CommitMessagePanel() *CommitMessagePanelDriver {
 	self.inCommitMessagePanel()
 

--- a/pkg/integration/components/textbox_driver.go
+++ b/pkg/integration/components/textbox_driver.go
@@ -1,0 +1,42 @@
+package components
+
+type TextboxDriver struct {
+	t               *TestDriver
+	hasCheckedTitle bool
+}
+
+func (self *TextboxDriver) getViewDriver() *ViewDriver {
+	return self.t.Views().Textbox()
+}
+
+func (self *TextboxDriver) Title(expected *TextMatcher) *TextboxDriver {
+	self.getViewDriver().Title(expected)
+
+	self.hasCheckedTitle = true
+
+	return self
+}
+
+func (self *TextboxDriver) Type(value string) *TextboxDriver {
+	self.t.typeContent(value)
+
+	return self
+}
+
+func (self *TextboxDriver) NewLine() *TextboxDriver {
+	self.getViewDriver().PressEnter()
+
+	return self
+}
+
+func (self *TextboxDriver) Confirm() *TextboxDriver {
+	self.getViewDriver().PressAltEnter()
+
+	return self
+}
+
+func (self *TextboxDriver) checkNecessaryChecksCompleted() {
+	if !self.hasCheckedTitle {
+		self.t.Fail("You must check the title of a menu popup by calling Title() before calling Confirm()/Cancel().")
+	}
+}

--- a/pkg/integration/components/view_driver.go
+++ b/pkg/integration/components/view_driver.go
@@ -441,6 +441,10 @@ func (self *ViewDriver) PressEnter() *ViewDriver {
 	return self.Press(self.t.keys.Universal.Confirm)
 }
 
+func (self *ViewDriver) PressAltEnter() *ViewDriver {
+	return self.Press(self.t.keys.Universal.ConfirmInEditor)
+}
+
 // i.e. pressing tab
 func (self *ViewDriver) PressTab() *ViewDriver {
 	return self.Press(self.t.keys.Universal.TogglePanel)

--- a/pkg/integration/components/views.go
+++ b/pkg/integration/components/views.go
@@ -128,6 +128,10 @@ func (self *Views) Confirmation() *ViewDriver {
 	return self.regularView("confirmation")
 }
 
+func (self *Views) Textbox() *ViewDriver {
+	return self.regularView("textbox")
+}
+
 func (self *Views) CommitMessage() *ViewDriver {
 	return self.regularView("commitMessage")
 }

--- a/pkg/integration/tests/custom_commands/textbox.go
+++ b/pkg/integration/tests/custom_commands/textbox.go
@@ -1,0 +1,57 @@
+package custom_commands
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var Textbox = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Using a custom command type multiline description",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("blah")
+	},
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.UserConfig.CustomCommands = []config.CustomCommand{
+			{
+				Key:     "a",
+				Context: "files",
+				Command: `echo "{{.Form.Description}}" > output.txt`,
+				Prompts: []config.CustomCommandPrompt{
+					{
+						Key:   "Description",
+						Type:  "textbox",
+						Title: "description",
+					},
+					{
+						Type:  "confirm",
+						Title: "Are you sure?",
+						Body:  "Are you REALLY sure you want to make this file? Up to you buddy.",
+					},
+				},
+			},
+		}
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			IsEmpty().
+			IsFocused().
+			Press("a")
+
+		t.ExpectPopup().Textbox().Title(Equals("description")).Type("hello").NewLine().Type("world~!").Confirm()
+
+		t.ExpectPopup().Confirmation().
+			Title(Equals("Are you sure?")).
+			Content(Equals("Are you REALLY sure you want to make this file? Up to you buddy.")).
+			Confirm()
+
+		t.Views().Files().
+			Focus().
+			Lines(
+				Contains("output.txt").IsSelected(),
+			)
+
+		t.Views().Main().Content(Contains("+hello\n+world~!"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -112,6 +112,7 @@ var tests = []*components.IntegrationTest{
 	custom_commands.OmitFromHistory,
 	custom_commands.SuggestionsCommand,
 	custom_commands.SuggestionsPreset,
+	custom_commands.Textbox,
 	demo.AmendOldCommit,
 	demo.Bisect,
 	demo.CherryPick,

--- a/schema/config.json
+++ b/schema/config.json
@@ -1450,7 +1450,7 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "description": "One of: 'input' | 'menu' | 'confirm' | 'menuFromCommand'"
+                  "description": "One of: 'input' | 'menu' | 'confirm' | 'menuFromCommand' | 'textbox'"
                 },
                 "key": {
                   "type": "string",


### PR DESCRIPTION
- **PR Description**
Add multiline prompt for custom command named textbox. To confirm textbox prompt, ConfirmInEditor is used. Add sub-title to inform confirm key-binding.
resolves #3476

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
