### PR TITLE
Fix deadlock reporting

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -662,7 +662,7 @@ func (gui *Gui) Run(startArgs appTypes.StartArgs) error {
 	// disable deadlock reporting if we're not running in debug mode, or if
 	// we're debugging an integration test. In this latter case, stopping at
 	// breakpoints and stepping through code can easily take more than 30s.
-	deadlock.Opts.Disable = !gui.Debug || os.Getenv(components.WAIT_FOR_DEBUGGER_ENV_VAR) == ""
+	deadlock.Opts.Disable = !gui.Debug || os.Getenv(components.WAIT_FOR_DEBUGGER_ENV_VAR) != ""
 
 	if err := gui.Config.ReloadUserConfig(); err != nil {
 		return nil


### PR DESCRIPTION
Deadlock reporting broke in e1ceb6892a (last September); since then, it was *off* when running debug builds normally, but *on* when debugging an integration test. Both of which are exactly opposite of what we want.
