### PR TITLE
Fix Stashing partial files for git version >= 2.35.0

### DIFF
--- a/pkg/integration/tests/stash/stash_staged_partial_file.go
+++ b/pkg/integration/tests/stash/stash_staged_partial_file.go
@@ -1,0 +1,70 @@
+package stash
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var StashStagedPartialFile = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Stash staged changes when a file is partially staged",
+	ExtraCmdArgs: []string{},
+	GitVersion:   AtLeast("git version 2.35.0"),
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file-staged", "line1\nline2\nline3\nline4\n")
+		shell.Commit("initial commit")
+		shell.UpdateFile("file-staged", "line1\nline2 mod\nline3\nline4 mod\n")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			IsFocused().
+			PressEnter()
+
+		t.Views().Staging().
+			Content(
+				Contains(" line1\n-line2\n+line2 mod\n line3\n-line4\n+line4 mod\n"),
+			).
+			PressPrimaryAction().
+			PressPrimaryAction().
+			Content(
+				Contains(" line1\n line2 mod\n line3\n-line4\n+line4 mod\n"),
+			).
+			PressEscape()
+
+		t.Views().Files().
+			IsFocused().
+			Press(keys.Files.ViewStashOptions)
+
+		t.ExpectPopup().Menu().Title(Equals("Stash options")).Select(MatchesRegexp("Stash staged changes$")).Confirm()
+
+		t.ExpectPopup().Prompt().Title(Equals("Stash changes")).Type("my stashed file").Confirm()
+
+		t.Views().Stash().
+			Focus().
+			Lines(
+				Contains("my stashed file"),
+			).
+			PressEnter()
+
+		t.Views().CommitFiles().
+			IsFocused().
+			Lines(
+				Contains("file-staged").IsSelected(),
+			)
+		t.Views().Main().
+			Content(
+				Contains(" line1\n-line2\n+line2 mod\n line3\n line4\n"),
+			)
+
+		t.Views().Files().
+			Lines(
+				Contains("file-staged"),
+			)
+
+		t.Views().Staging().
+			Content(
+				Contains(" line1\n line2\n line3\n-line4\n+line4 mod\n"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -257,6 +257,7 @@ var tests = []*components.IntegrationTest{
 	stash.StashAndKeepIndex,
 	stash.StashIncludingUntrackedFiles,
 	stash.StashStaged,
+	stash.StashStagedPartialFile,
 	stash.StashUnstaged,
 	status.ClickRepoNameToOpenReposMenu,
 	status.ClickToFocus,


### PR DESCRIPTION
- **PR Description**
Use git's `--staged` flag to stash staged changes if available (requires git 2.35.0 or later), and fall back to our previous method if not. This is a lot faster than our previous method, and it fixes two bugs, see linked issues.

Fixes #3333 and #3563.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
