### PR TITLE
Only run code coverage report on non-fork branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
   upload-coverage:
     # List all jobs that produce coverage files
     needs: [unit-tests, integration-tests]
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
- **PR Description**

Codacy's coverage report feature requires the use of a secret key, which is only available on the main repo and is not available on forks. So, the step has been always failing on any forks. This commit ensures that we only run it on non-forks.

This greatly diminishes the value of the coverage reports. I've talked to one of the Codacy people and advised that they should just have an API key for coverage reports which is not a secret, like what bugsnag does.

I've disabled the gate in codacy meaning if the coverage ever drops beneath some percentage, the job won't fail. It wouldn't make sense to fail the job if some other PR from a fork was responsible for reducing the coverage percentage beneath some threshold.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
