### PR TITLE
Bump go version to 1.22

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: Continuous Delivery
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   goreleaser:
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 
 env:
-  GO_VERSION: 1.21
+  GO_VERSION: 1.22
 
 on:
   push:
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Test code
         # we're passing -short so that we skip the integration tests, which will be run in parallel below
         run: |
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Print git version
         run: git --version
       - name: Test code
@@ -115,7 +115,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Build linux binary
         run: |
           GOOS=linux go build
@@ -142,7 +142,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Check Vendor Directory
         # ensure our vendor directory matches up with our go modules
         run: |
@@ -168,7 +168,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
@@ -193,6 +193,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.22.x
 
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,5 +30,5 @@ linters-settings:
     max-func-lines: 0
 
 run:
-  go: '1.21'
+  go: '1.22'
   timeout: 10m

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # docker build -t lazygit .
 # docker run -it lazygit:latest /bin/sh
 
-FROM golang:1.21 as build
+FROM golang:1.22 as build
 WORKDIR /go/src/github.com/jesseduffield/lazygit/
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jesseduffield/lazygit
 
-go 1.21
+go 1.22
 
 require (
 	github.com/adrg/xdg v0.4.0

--- a/pkg/commands/git_commands/branch_test.go
+++ b/pkg/commands/git_commands/branch_test.go
@@ -41,7 +41,6 @@ func TestBranchGetCommitDifferences(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildBranchCommands(commonDeps{runner: s.runner})
 			pushables, pullables := instance.GetCommitDifferences("HEAD", "@{u}")
@@ -89,7 +88,6 @@ func TestBranchDeleteBranch(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildBranchCommands(commonDeps{runner: s.runner})
 
@@ -150,7 +148,6 @@ func TestBranchMerge(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			runner := oscommands.NewFakeRunner(t).
 				ExpectGitArgs(s.expected, "", nil)
@@ -190,7 +187,6 @@ func TestBranchCheckout(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildBranchCommands(commonDeps{runner: s.runner})
 			s.test(instance.Checkout("test", CheckoutOptions{Force: s.force}))
@@ -279,7 +275,6 @@ func TestBranchCurrentBranchInfo(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildBranchCommands(commonDeps{runner: s.runner})
 			s.test(instance.CurrentBranchInfo())

--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -505,8 +505,6 @@ func (self *CommitLoader) getExistingMainBranches() []string {
 
 	for i, branchName := range mainBranches {
 		wg.Add(1)
-		i := i
-		branchName := branchName
 		go utils.Safe(func() {
 			defer wg.Done()
 

--- a/pkg/commands/git_commands/commit_loader_test.go
+++ b/pkg/commands/git_commands/commit_loader_test.go
@@ -303,7 +303,6 @@ func TestGetCommits(t *testing.T) {
 	}
 
 	for _, scenario := range scenarios {
-		scenario := scenario
 		t.Run(scenario.testName, func(t *testing.T) {
 			common := utils.NewDummyCommon()
 			common.AppState = &config.AppState{}

--- a/pkg/commands/git_commands/commit_test.go
+++ b/pkg/commands/git_commands/commit_test.go
@@ -30,7 +30,6 @@ func TestCommitRewordCommit(t *testing.T) {
 		},
 	}
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildCommitCommands(commonDeps{runner: s.runner})
 
@@ -100,7 +99,6 @@ func TestCommitCommitCmdObj(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			userConfig := config.GetDefaultConfig()
 			userConfig.Git.Commit.SignOff = s.configSignoff
@@ -136,7 +134,6 @@ func TestCommitCommitEditorCmdObj(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			userConfig := config.GetDefaultConfig()
 			userConfig.Git.Commit.SignOff = s.configSignoff
@@ -171,7 +168,6 @@ func TestCommitCreateFixupCommit(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildCommitCommands(commonDeps{runner: s.runner})
 			s.test(instance.CreateFixupCommit(s.hash))
@@ -221,7 +217,6 @@ func TestCommitCreateAmendCommit(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildCommitCommands(commonDeps{runner: s.runner})
 			err := instance.CreateAmendCommit(s.originalSubject, s.newSubject, s.newDescription, s.includeFileChanges)
@@ -285,7 +280,6 @@ func TestCommitShowCmdObj(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			userConfig := config.GetDefaultConfig()
 			userConfig.Git.Paging.ExternalDiffCommand = s.extDiffCmd
@@ -334,7 +328,6 @@ func TestGetCommitMsg(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildCommitCommands(commonDeps{
 				runner: oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"-c", "log.showsignature=false", "log", "--format=%B", "--max-count=1", "deadbeef"}, s.input, nil),
@@ -374,7 +367,6 @@ func TestGetCommitMessageFromHistory(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildCommitCommands(commonDeps{runner: s.runner})
 

--- a/pkg/commands/git_commands/file_loader_test.go
+++ b/pkg/commands/git_commands/file_loader_test.go
@@ -172,7 +172,6 @@ func TestFileGetStatusFiles(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			cmd := oscommands.NewDummyCmdObjBuilder(s.runner)
 

--- a/pkg/commands/git_commands/flow_test.go
+++ b/pkg/commands/git_commands/flow_test.go
@@ -23,7 +23,6 @@ func TestStartCmdObj(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildFlowCommands(commonDeps{})
 
@@ -69,7 +68,6 @@ func TestFinishCmdObj(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildFlowCommands(commonDeps{
 				gitConfig: git_config.NewFakeGitConfig(s.gitConfigMockResponses),

--- a/pkg/commands/git_commands/rebase_test.go
+++ b/pkg/commands/git_commands/rebase_test.go
@@ -67,7 +67,6 @@ func TestRebaseRebaseBranch(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildRebaseCommands(commonDeps{runner: s.runner, gitVersion: s.gitVersion})
 			s.test(instance.RebaseBranch(s.arg))
@@ -89,7 +88,6 @@ func TestRebaseSkipEditorCommand(t *testing.T) {
 			`^GIT_SEQUENCE_EDITOR=.*$`,
 			"^" + daemon.DaemonKindEnvKey + "=" + strconv.Itoa(int(daemon.DaemonKindExitImmediately)) + "$",
 		} {
-			regexStr := regexStr
 			foundMatch := lo.ContainsBy(envVars, func(envVar string) bool {
 				return regexp.MustCompile(regexStr).MatchString(envVar)
 			})
@@ -163,7 +161,6 @@ func TestRebaseDiscardOldFileChanges(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildRebaseCommands(commonDeps{
 				runner:     s.runner,

--- a/pkg/commands/git_commands/reflog_commit_loader_test.go
+++ b/pkg/commands/git_commands/reflog_commit_loader_test.go
@@ -176,7 +176,6 @@ func TestGetReflogCommits(t *testing.T) {
 	}
 
 	for _, scenario := range scenarios {
-		scenario := scenario
 		t.Run(scenario.testName, func(t *testing.T) {
 			builder := &ReflogCommitLoader{
 				Common: utils.NewDummyCommon(),

--- a/pkg/commands/git_commands/repo_paths_test.go
+++ b/pkg/commands/git_commands/repo_paths_test.go
@@ -101,7 +101,6 @@ func TestGetRepoPaths(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.Name, func(t *testing.T) {
 			runner := oscommands.NewFakeRunner(t)
 			cmd := oscommands.NewDummyCmdObjBuilder(runner)

--- a/pkg/commands/git_commands/stash_loader_test.go
+++ b/pkg/commands/git_commands/stash_loader_test.go
@@ -47,7 +47,6 @@ func TestGetStashEntries(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			cmd := oscommands.NewDummyCmdObjBuilder(s.runner)
 

--- a/pkg/commands/git_commands/stash_test.go
+++ b/pkg/commands/git_commands/stash_test.go
@@ -74,7 +74,6 @@ func TestStashStore(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			runner := oscommands.NewFakeRunner(t).
 				ExpectGitArgs(s.expected, "", nil)
@@ -131,7 +130,6 @@ func TestStashStashEntryCmdObj(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			userConfig := config.GetDefaultConfig()
 			appState := &config.AppState{}
@@ -181,7 +179,6 @@ func TestStashRename(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			runner := oscommands.NewFakeRunner(t).
 				ExpectGitArgs(s.expectedHashCmd, s.hashResult, nil).

--- a/pkg/commands/git_commands/sync_test.go
+++ b/pkg/commands/git_commands/sync_test.go
@@ -86,7 +86,6 @@ func TestSyncPush(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildSyncCommands(commonDeps{})
 			task := gocui.NewFakeTask()
@@ -124,7 +123,6 @@ func TestSyncFetch(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildSyncCommands(commonDeps{})
 			instance.UserConfig.Git.FetchAll = s.fetchAllConfig
@@ -163,7 +161,6 @@ func TestSyncFetchBackground(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildSyncCommands(commonDeps{})
 			instance.UserConfig.Git.FetchAll = s.fetchAllConfig

--- a/pkg/commands/git_commands/tag_loader_test.go
+++ b/pkg/commands/git_commands/tag_loader_test.go
@@ -44,7 +44,6 @@ func TestGetTags(t *testing.T) {
 	}
 
 	for _, scenario := range scenarios {
-		scenario := scenario
 		t.Run(scenario.testName, func(t *testing.T) {
 			loader := &TagLoader{
 				Common: utils.NewDummyCommon(),

--- a/pkg/commands/git_commands/working_tree_test.go
+++ b/pkg/commands/git_commands/working_tree_test.go
@@ -61,7 +61,6 @@ func TestWorkingTreeUnstageFile(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildWorkingTreeCommands(commonDeps{runner: s.runner})
 			s.test(instance.UnStageFile([]string{"test.txt"}, s.reset))
@@ -190,7 +189,6 @@ func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildWorkingTreeCommands(commonDeps{runner: s.runner, removeFile: s.removeFile})
 			err := instance.DiscardAllFileChanges(s.file)
@@ -306,7 +304,6 @@ func TestWorkingTreeDiff(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			userConfig := config.GetDefaultConfig()
 			appState := &config.AppState{}
@@ -375,7 +372,6 @@ func TestWorkingTreeShowFileDiff(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			userConfig := config.GetDefaultConfig()
 			appState := &config.AppState{}
@@ -428,7 +424,6 @@ func TestWorkingTreeCheckoutFile(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildWorkingTreeCommands(commonDeps{runner: s.runner})
 
@@ -459,7 +454,6 @@ func TestWorkingTreeDiscardUnstagedFileChanges(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildWorkingTreeCommands(commonDeps{runner: s.runner})
 			s.test(instance.DiscardUnstagedFileChanges(s.file))
@@ -487,7 +481,6 @@ func TestWorkingTreeDiscardAnyUnstagedFileChanges(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildWorkingTreeCommands(commonDeps{runner: s.runner})
 			s.test(instance.DiscardAnyUnstagedFileChanges())
@@ -515,7 +508,6 @@ func TestWorkingTreeRemoveUntrackedFiles(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildWorkingTreeCommands(commonDeps{runner: s.runner})
 			s.test(instance.RemoveUntrackedFiles())
@@ -545,7 +537,6 @@ func TestWorkingTreeResetHard(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildWorkingTreeCommands(commonDeps{runner: s.runner})
 			s.test(instance.ResetHard(s.ref))

--- a/pkg/commands/git_commands/worktree_loader.go
+++ b/pkg/commands/git_commands/worktree_loader.go
@@ -76,8 +76,6 @@ func (self *WorktreeLoader) GetWorktrees() ([]*models.Worktree, error) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(worktrees))
 	for _, worktree := range worktrees {
-		worktree := worktree
-
 		go utils.Safe(func() {
 			defer wg.Done()
 

--- a/pkg/commands/git_commands/worktree_loader_test.go
+++ b/pkg/commands/git_commands/worktree_loader_test.go
@@ -181,7 +181,6 @@ branch refs/heads/mybranch-worktree
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			runner := oscommands.NewFakeRunner(t)
 			fs := afero.NewMemMapFs()

--- a/pkg/commands/git_config/cached_git_config_test.go
+++ b/pkg/commands/git_config/cached_git_config_test.go
@@ -50,7 +50,6 @@ func TestGetBool(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			fake := NewFakeGitConfig(s.mockResponses)
 			real := NewCachedGitConfig(
@@ -87,7 +86,6 @@ func TestGet(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			fake := NewFakeGitConfig(s.mockResponses)
 			real := NewCachedGitConfig(

--- a/pkg/commands/hosting_service/hosting_service_test.go
+++ b/pkg/commands/hosting_service/hosting_service_test.go
@@ -413,7 +413,6 @@ func TestGetPullRequestURL(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			tr := i18n.EnglishTranslationSet()
 			log := &fakes.FakeFieldLogger{}

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -239,14 +239,13 @@ func (c *OSCommand) PipeCommands(cmdObjs ...ICmdObj) error {
 	wg.Add(len(cmds))
 
 	for _, cmd := range cmds {
-		currentCmd := cmd
 		go utils.Safe(func() {
-			stderr, err := currentCmd.StderrPipe()
+			stderr, err := cmd.StderrPipe()
 			if err != nil {
 				c.Log.Error(err)
 			}
 
-			if err := currentCmd.Start(); err != nil {
+			if err := cmd.Start(); err != nil {
 				c.Log.Error(err)
 			}
 
@@ -256,7 +255,7 @@ func (c *OSCommand) PipeCommands(cmdObjs ...ICmdObj) error {
 				}
 			}
 
-			if err := currentCmd.Wait(); err != nil {
+			if err := cmd.Wait(); err != nil {
 				c.Log.Error(err)
 			}
 

--- a/pkg/commands/patch/patch_test.go
+++ b/pkg/commands/patch/patch_test.go
@@ -509,7 +509,6 @@ func TestTransform(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			lineIndices := ExpandRange(s.firstLineIndex, s.lastLineIndex)
 
@@ -566,7 +565,6 @@ func TestParseAndFormatPlain(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			// here we parse the patch, then format it, and ensure the result
 			// matches the original patch. Note that unified diffs allow omitting
@@ -604,7 +602,6 @@ func TestLineNumberOfLine(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			for i, idx := range s.indexes {
 				patch := Parse(s.patchStr)
@@ -633,7 +630,6 @@ func TestGetNextStageableLineIndex(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			for i, idx := range s.indexes {
 				patch := Parse(s.patchStr)

--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -105,7 +105,6 @@ func (self *MenuViewModel) GetNonModelItems() []*NonModelItem {
 	menuItems := self.FilteredListViewModel.GetItems()
 	var prevSection *types.MenuSection = nil
 	for i, menuItem := range menuItems {
-		menuItem := menuItem
 		if menuItem.Section != nil && menuItem.Section != prevSection {
 			if prevSection != nil {
 				result = append(result, &NonModelItem{

--- a/pkg/gui/controllers/diffing_menu_action.go
+++ b/pkg/gui/controllers/diffing_menu_action.go
@@ -17,7 +17,6 @@ func (self *DiffingMenuAction) Call() error {
 
 	menuItems := []*types.MenuItem{}
 	for _, name := range names {
-		name := name
 		menuItems = append(menuItems, []*types.MenuItem{
 			{
 				Label: fmt.Sprintf("%s %s", self.c.Tr.Diff, name),

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -801,7 +801,6 @@ func (self *LocalCommitsController) revert(commit *models.Commit) error {
 func (self *LocalCommitsController) createRevertMergeCommitMenu(commit *models.Commit) error {
 	menuItems := make([]*types.MenuItem, len(commit.Parents))
 	for i, parentHash := range commit.Parents {
-		i := i
 		message, err := self.c.Git().Commit.GetCommitMessageFirstLine(parentHash)
 		if err != nil {
 			return err

--- a/pkg/gui/filetree/build_tree_test.go
+++ b/pkg/gui/filetree/build_tree_test.go
@@ -147,7 +147,6 @@ func TestBuildTreeFromFiles(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			result := BuildTreeFromFiles(s.files)
 			assert.EqualValues(t, s.expected, result)
@@ -306,7 +305,6 @@ func TestBuildFlatTreeFromFiles(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			result := BuildFlatTreeFromFiles(s.files)
 			assert.EqualValues(t, s.expected, result)
@@ -420,7 +418,6 @@ func TestBuildTreeFromCommitFiles(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			result := BuildTreeFromCommitFiles(s.files)
 			assert.EqualValues(t, s.expected, result)
@@ -521,7 +518,6 @@ func TestBuildFlatTreeFromCommitFiles(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			result := BuildFlatTreeFromCommitFiles(s.files)
 			assert.EqualValues(t, s.expected, result)

--- a/pkg/gui/filetree/file_node_test.go
+++ b/pkg/gui/filetree/file_node_test.go
@@ -125,7 +125,6 @@ func TestCompress(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			s.root.Compress()
 			assert.EqualValues(t, s.expected, s.root)
@@ -155,7 +154,6 @@ func TestGetFile(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			assert.EqualValues(t, s.expected, s.viewModel.GetFile(s.path))
 		})

--- a/pkg/gui/filetree/file_tree_test.go
+++ b/pkg/gui/filetree/file_tree_test.go
@@ -71,7 +71,6 @@ func TestFilterAction(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			mngr := &FileTree{getFiles: func() []*models.File { return s.files }, filter: s.filter}
 			result := mngr.getFilesForDisplay()

--- a/pkg/gui/mergeconflicts/state_test.go
+++ b/pkg/gui/mergeconflicts/state_test.go
@@ -115,7 +115,6 @@ baz
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			assert.EqualValues(t, s.expected, findConflicts(s.content))
 		})

--- a/pkg/gui/patch_exploring/focus_test.go
+++ b/pkg/gui/patch_exploring/focus_test.go
@@ -122,7 +122,6 @@ func TestNewOrigin(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			assert.EqualValues(t, s.expected, calculateOrigin(s.origin, s.bufferHeight, s.numLines, s.firstLineIdx, s.lastLineIdx, s.selectedLineIdx, s.selectMode))
 		})

--- a/pkg/gui/presentation/commits_test.go
+++ b/pkg/gui/presentation/commits_test.go
@@ -575,7 +575,6 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 	common := utils.NewDummyCommon()
 
 	for _, s := range scenarios {
-		s := s
 		if !focusing || s.focus {
 			t.Run(s.testName, func(t *testing.T) {
 				result := GetCommitListDisplayStrings(

--- a/pkg/gui/presentation/files_test.go
+++ b/pkg/gui/presentation/files_test.go
@@ -66,7 +66,6 @@ M  file1
 	defer color.ForceSetColorLevel(oldColorLevel)
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			viewModel := filetree.NewFileTree(func() []*models.File { return s.files }, utils.NewDummyLog(), true)
 			viewModel.SetTree()
@@ -128,7 +127,6 @@ M file1
 	defer color.ForceSetColorLevel(oldColorLevel)
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			viewModel := filetree.NewCommitFileTreeViewModel(func() []*models.CommitFile { return s.files }, utils.NewDummyLog(), true)
 			viewModel.SetRef(&models.Commit{})

--- a/pkg/gui/presentation/graph/graph.go
+++ b/pkg/gui/presentation/graph/graph.go
@@ -84,7 +84,6 @@ func RenderAux(pipeSets [][]*Pipe, commits []*models.Commit, selectedCommitHash 
 	wg.Add(maxProcs)
 
 	for i := 0; i < maxProcs; i++ {
-		i := i
 		go func() {
 			from := i * perProc
 			to := (i + 1) * perProc

--- a/pkg/gui/presentation/graph/graph_test.go
+++ b/pkg/gui/presentation/graph/graph_test.go
@@ -217,7 +217,6 @@ func TestRenderCommitGraph(t *testing.T) {
 	defer color.ForceSetColorLevel(oldColorLevel)
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			getStyle := func(c *models.Commit) style.TextStyle { return style.FgDefault }
 			lines := RenderCommitGraph(test.commits, "blah", getStyle)
@@ -454,7 +453,6 @@ func TestRenderPipeSet(t *testing.T) {
 	defer color.ForceSetColorLevel(oldColorLevel)
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			actualStr := renderPipeSet(test.pipes, "selected", test.prevCommit)
 			t.Log("actual cells:")

--- a/pkg/gui/services/custom_commands/menu_generator_test.go
+++ b/pkg/gui/services/custom_commands/menu_generator_test.go
@@ -81,7 +81,6 @@ func TestMenuGenerator(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			s.test(NewMenuGenerator(utils.NewDummyCommon()).call(s.cmdOut, s.filter, s.valueFormat, s.labelFormat))
 		})

--- a/pkg/gui/services/custom_commands/resolver.go
+++ b/pkg/gui/services/custom_commands/resolver.go
@@ -72,7 +72,6 @@ func (self *Resolver) resolvePrompt(
 func (self *Resolver) resolveMenuOptions(prompt *config.CustomCommandPrompt, resolveTemplate func(string) (string, error)) ([]config.CustomCommandMenuOption, error) {
 	newOptions := make([]config.CustomCommandMenuOption, 0, len(prompt.Options))
 	for _, option := range prompt.Options {
-		option := option
 		newOption, err := self.resolveMenuOption(&option, resolveTemplate)
 		if err != nil {
 			return nil, err

--- a/pkg/gui/style/style_test.go
+++ b/pkg/gui/style/style_test.go
@@ -161,7 +161,6 @@ func TestMerge(t *testing.T) {
 	defer color.ForceSetColorLevel(oldColorLevel)
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			style := New()
 			for _, other := range s.toMerge {
@@ -212,7 +211,6 @@ func TestTemplateFuncMapAddColors(t *testing.T) {
 	defer color.ForceSetColorLevel(oldColorLevel)
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.name, func(t *testing.T) {
 			tmpl, err := template.New("test template").Funcs(TemplateFuncMapAddColors(template.FuncMap{})).Parse(s.tmpl)
 			assert.NoError(t, err)

--- a/pkg/integration/components/runner.go
+++ b/pkg/integration/components/runner.go
@@ -48,8 +48,6 @@ func RunTests(args RunTestArgs) error {
 	}
 
 	for _, test := range args.Tests {
-		test := test
-
 		args.TestWrapper(test, func() error { //nolint: thelper
 			paths := NewPaths(
 				filepath.Join(testDir, test.Name()),

--- a/pkg/utils/slice_test.go
+++ b/pkg/utils/slice_test.go
@@ -49,7 +49,6 @@ func TestNextIndex(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			assert.EqualValues(t, s.expected, NextIndex(s.list, s.element))
 		})
@@ -93,7 +92,6 @@ func TestPrevIndex(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			assert.EqualValues(t, s.expected, PrevIndex(s.list, s.element))
 		})
@@ -126,7 +124,6 @@ func TestEscapeSpecialChars(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			assert.EqualValues(t, s.expected, EscapeSpecialChars(s.input))
 		})
@@ -303,7 +300,6 @@ func TestMoveElement(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		s := s
 		t.Run(s.testName, func(t *testing.T) {
 			assert.EqualValues(t, s.expected, MoveElement(s.list, s.from, s.to))
 		})

--- a/pkg/utils/yaml_utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils/yaml_utils_test.go
@@ -102,7 +102,6 @@ func TestUpdateYamlValue(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			out, actualErr := UpdateYamlValue([]byte(test.in), test.path, test.value)
 			if test.expectedErr == "" {


### PR DESCRIPTION
- **PR Description**

Bumps go from 1.21 to 1.22, and removes newly redundant loop variable re-declarations now that in 1.22 the variables are automatically redeclared in each iteration for us.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
