### PR TITLE
Remove hint about Config.md from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 * [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
 * [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
 * [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
-* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
+* [ ] Docs have been updated if necessary
 * [ ] You've read through your own file changes for silly mistakes etc
 
 <!--


### PR DESCRIPTION
It used to be a common thing to have to update `Config.md` in a PR (and we often forgot despite the template). As of #3565 this is no longer necessary, so remove this from the template.

Updating docs in general is still a good thing to think about, so we leave this in.
