### PR TITLE
Add property outputTitle to CustomCommand

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -59,6 +59,7 @@ For a given custom command, here are the allowed fields:
 | description | Label for the custom command when displayed in the keybindings menu | no |
 | stream | Whether you want to stream the command's output to the Command Log panel | no |
 | showOutput | Whether you want to show the command's output in a popup within Lazygit | no |
+| outputTitle | The title to display in the popup panel if showOutput is true. If left unset, the command will be used as the title. | no |
 | after | Actions to take after the command has completed | no |
 
 Here are the options for the `after` key:

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -581,6 +581,8 @@ type CustomCommand struct {
 	Stream bool `yaml:"stream"`
 	// If true, show the command's output in a popup within Lazygit
 	ShowOutput bool `yaml:"showOutput"`
+	// The title to display in the popup panel if showOutput is true. If left unset, the command will be used as the title.
+	OutputTitle string `yaml:"outputTitle"`
 	// Actions to take after the command has completed
 	After CustomCommandAfterHook `yaml:"after"`
 }

--- a/pkg/gui/services/custom_commands/handler_creator.go
+++ b/pkg/gui/services/custom_commands/handler_creator.go
@@ -292,7 +292,17 @@ func (self *HandlerCreator) finalHandler(customCommand config.CustomCommand, ses
 			if strings.TrimSpace(output) == "" {
 				output = self.c.Tr.EmptyOutput
 			}
-			return self.c.Alert(cmdStr, output)
+
+			var title string
+			if customCommand.OutputTitle != "" {
+				title, err = resolveTemplate(customCommand.OutputTitle)
+				if err != nil {
+					return err
+				}
+			} else {
+				title = cmdStr
+			}
+			return self.c.Alert(title, output)
 		}
 
 		return nil

--- a/pkg/integration/tests/custom_commands/show_output_in_panel.go
+++ b/pkg/integration/tests/custom_commands/show_output_in_panel.go
@@ -1,0 +1,57 @@
+package custom_commands
+
+import (
+	"fmt"
+
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ShowOutputInPanel = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Run a command and show the output in a panel",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("my change")
+	},
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.UserConfig.CustomCommands = []config.CustomCommand{
+			{
+				Key:        "X",
+				Context:    "commits",
+				Command:    "printf '%s' '{{ .SelectedLocalCommit.Name }}'",
+				ShowOutput: true,
+			},
+			{
+				Key:         "Y",
+				Context:     "commits",
+				Command:     "printf '%s' '{{ .SelectedLocalCommit.Name }}'",
+				ShowOutput:  true,
+				OutputTitle: "Subject of commit {{ .SelectedLocalCommit.Hash }}",
+			},
+		}
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("my change").IsSelected(),
+			).
+			Press("X")
+
+		t.ExpectPopup().Alert().
+			// Uses cmd string as title if no outputTitle is provided
+			Title(Equals("printf '%s' 'my change'")).
+			Content(Equals("my change")).
+			Confirm()
+
+		t.Views().Commits().
+			Press("Y")
+
+		hash := t.Git().GetCommitHash("HEAD")
+		t.ExpectPopup().Alert().
+			// Uses provided outputTitle with template fields resolved
+			Title(Equals(fmt.Sprintf("Subject of commit %s", hash))).
+			Content(Equals("my change"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -113,6 +113,7 @@ var tests = []*components.IntegrationTest{
 	custom_commands.MenuFromCommandsOutput,
 	custom_commands.MultiplePrompts,
 	custom_commands.OmitFromHistory,
+	custom_commands.ShowOutputInPanel,
 	custom_commands.SuggestionsCommand,
 	custom_commands.SuggestionsPreset,
 	demo.AmendOldCommit,

--- a/schema/config.json
+++ b/schema/config.json
@@ -924,6 +924,10 @@
             "type": "boolean",
             "description": "If true, show the command's output in a popup within Lazygit"
           },
+          "outputTitle": {
+            "type": "string",
+            "description": "The title to display in the popup panel if showOutput is true. If left unset, the command will be used as the title."
+          },
           "after": {
             "properties": {
               "checkForConflicts": {


### PR DESCRIPTION
- **PR Description**

Add property `outputTitle` to CustomCommand. It can optionally be used to set the title of the panel that shows the output of a command (when `showOutput` is true). If left unset, the command string is used as the title.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs (specifically `docs/Config.md`) have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc