### PR TITLE
Add `copyloopvar` to enabled linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,10 +14,16 @@ linters:
     - exhaustive
     - makezero
     - nakedret
+    - copyloopvar
     # - goconst # TODO: enable and fix issues
   fast: false
 
 linters-settings:
+  copyloopvar:
+    # Check all assigning the loop variable to another variable.
+    # Default: false
+    # If true, an assignment like `a := x` will be detected as an error.
+    check-alias: true
   exhaustive:
     default-signifies-exhaustive: true
   staticcheck:


### PR DESCRIPTION
Resolves #3573 
It looks like the update to go1.22 is done by https://github.com/jesseduffield/lazygit/pull/3574. So it should be OK to close #3573 when this PR is merged.

## PR Description
Add [`copyloopvar`](https://github.com/karamaru-alpha/copyloopvar) to enabled linters to detect unnecessary assignments in `for` loops.

## Context
@jesseduffield and I were talking about necessity of this linter here. https://github.com/jesseduffield/lazygit/issues/3573#issuecomment-2123732829