### PR TITLE
Enable `goconst`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
     - exhaustive
     - makezero
     - nakedret
-    # - goconst # TODO: enable and fix issues
+    - goconst
   fast: false
 
 linters-settings:

--- a/pkg/commands/git_commands/branch_loader.go
+++ b/pkg/commands/git_commands/branch_loader.go
@@ -155,6 +155,11 @@ func (self *BranchLoader) obtainBranches(canUsePushTrack bool) []*models.Branch 
 }
 
 func (self *BranchLoader) getRawBranches() (string, error) {
+	const (
+		sortOrderRefname = "refname"
+		sortOrderDate    = "-committerdate"
+	)
+
 	format := strings.Join(
 		lo.Map(branchFields, func(thing string, _ int) string {
 			return "%(" + thing + ")"
@@ -165,11 +170,11 @@ func (self *BranchLoader) getRawBranches() (string, error) {
 	var sortOrder string
 	switch strings.ToLower(self.AppState.LocalBranchSortOrder) {
 	case "recency", "date":
-		sortOrder = "-committerdate"
+		sortOrder = sortOrderDate
 	case "alphabetical":
-		sortOrder = "refname"
+		sortOrder = sortOrderRefname
 	default:
-		sortOrder = "refname"
+		sortOrder = sortOrderRefname
 	}
 
 	cmdArgs := NewGitCmd("for-each-ref").

--- a/pkg/commands/git_commands/file.go
+++ b/pkg/commands/git_commands/file.go
@@ -11,6 +11,16 @@ import (
 	"github.com/samber/lo"
 )
 
+const (
+	editorNameEmacs            = "emacs"
+	editorNameNano             = "nano"
+	editorNameVi               = "vi"
+	editorNameVim              = "vim"
+	editorNameNvim             = "nvim"
+	editorNameSublimeText      = "subl"
+	editorNameVisualStudioCode = "code"
+)
+
 type FileCommands struct {
 	*GitCommon
 }
@@ -63,11 +73,11 @@ func (self *FileCommands) GetEditCmdStrLegacy(filename string, lineNumber int) (
 	editCmdTemplate := self.UserConfig.OS.EditCommandTemplate
 	if len(editCmdTemplate) == 0 {
 		switch editor {
-		case "emacs", "nano", "vi", "vim", "nvim":
+		case editorNameEmacs, editorNameNano, editorNameVi, editorNameVim, editorNameNvim:
 			editCmdTemplate = "{{editor}} +{{line}} -- {{filename}}"
-		case "subl":
+		case editorNameSublimeText:
 			editCmdTemplate = "{{editor}} -- {{filename}}:{{line}}"
-		case "code":
+		case editorNameVisualStudioCode:
 			editCmdTemplate = "{{editor}} -r --goto -- {{filename}}:{{line}}"
 		default:
 			editCmdTemplate = "{{editor}} -- {{filename}}"

--- a/pkg/commands/git_commands/remote_loader.go
+++ b/pkg/commands/git_commands/remote_loader.go
@@ -82,16 +82,21 @@ func (self *RemoteLoader) GetRemotes() ([]*models.Remote, error) {
 }
 
 func (self *RemoteLoader) getRemoteBranchesByRemoteName() (map[string][]*models.RemoteBranch, error) {
+	const (
+		sortOrderRefname = "refname"
+		sortOrderDate    = "-committerdate"
+	)
+
 	remoteBranchesByRemoteName := make(map[string][]*models.RemoteBranch)
 
 	var sortOrder string
 	switch strings.ToLower(self.AppState.RemoteBranchSortOrder) {
 	case "alphabetical":
-		sortOrder = "refname"
+		sortOrder = sortOrderRefname
 	case "date":
-		sortOrder = "-committerdate"
+		sortOrder = sortOrderDate
 	default:
-		sortOrder = "refname"
+		sortOrder = sortOrderRefname
 	}
 
 	cmdArgs := NewGitCmd("for-each-ref").

--- a/pkg/commands/oscommands/cmd_obj_builder.go
+++ b/pkg/commands/oscommands/cmd_obj_builder.go
@@ -45,7 +45,7 @@ func (self *CmdObjBuilder) NewWithEnviron(args []string, env []string) ICmdObj {
 func (self *CmdObjBuilder) NewShell(commandStr string) ICmdObj {
 	var quotedCommand string
 	// Windows does not seem to like quotes around the command
-	if self.platform.OS == "windows" {
+	if self.platform.OS == osWindows {
 		quotedCommand = strings.NewReplacer(
 			"^", "^^",
 			"&", "^&",
@@ -77,7 +77,7 @@ const CHARS_REQUIRING_QUOTES = "\"\\$` "
 // If you update this method, be sure to update CHARS_REQUIRING_QUOTES
 func (self *CmdObjBuilder) Quote(message string) string {
 	var quote string
-	if self.platform.OS == "windows" {
+	if self.platform.OS == osWindows {
 		quote = `\"`
 		message = strings.NewReplacer(
 			`"`, `"'"'"`,

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -33,6 +33,11 @@ type OSCommand struct {
 	tempDir string
 }
 
+const (
+	osLinux   = "linux"
+	osWindows = "windows"
+)
+
 // Platform stores the os state
 type Platform struct {
 	OS              string

--- a/pkg/commands/oscommands/os_test.go
+++ b/pkg/commands/oscommands/os_test.go
@@ -32,7 +32,7 @@ func TestOSCommandRun(t *testing.T) {
 func TestOSCommandQuote(t *testing.T) {
 	osCommand := NewDummyOSCommand()
 
-	osCommand.Platform.OS = "linux"
+	osCommand.Platform.OS = osLinux
 
 	actual := osCommand.Quote("hello `test`")
 
@@ -45,7 +45,7 @@ func TestOSCommandQuote(t *testing.T) {
 func TestOSCommandQuoteSingleQuote(t *testing.T) {
 	osCommand := NewDummyOSCommand()
 
-	osCommand.Platform.OS = "linux"
+	osCommand.Platform.OS = osLinux
 
 	actual := osCommand.Quote("hello 'test'")
 
@@ -58,7 +58,7 @@ func TestOSCommandQuoteSingleQuote(t *testing.T) {
 func TestOSCommandQuoteDoubleQuote(t *testing.T) {
 	osCommand := NewDummyOSCommand()
 
-	osCommand.Platform.OS = "linux"
+	osCommand.Platform.OS = osLinux
 
 	actual := osCommand.Quote(`hello "test"`)
 
@@ -71,7 +71,7 @@ func TestOSCommandQuoteDoubleQuote(t *testing.T) {
 func TestOSCommandQuoteWindows(t *testing.T) {
 	osCommand := NewDummyOSCommand()
 
-	osCommand.Platform.OS = "windows"
+	osCommand.Platform.OS = osWindows
 
 	actual := osCommand.Quote(`hello "test" 'test2'`)
 

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -27,6 +27,8 @@ type AppConfig struct {
 	IsNewRepo        bool
 }
 
+const VersionUnversioned = "unversioned"
+
 type AppConfigurer interface {
 	GetDebug() bool
 

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -357,6 +357,11 @@ func loadAppState() (*AppState, error) {
 	return appState, nil
 }
 
+const (
+	LocalBranchSortOrderRecency = "recency"
+	LocalBranchSortOrderDate    = "date"
+)
+
 // AppState stores data between runs of the app like when the last update check
 // was performed and which other repos have been checked out
 type AppState struct {

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -49,6 +49,8 @@ type RefresherConfig struct {
 	FetchInterval int `yaml:"fetchInterval" jsonschema:"minimum=0"`
 }
 
+const GuiConfigEnlargedSideViewLocationTop = "top"
+
 type GuiConfig struct {
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-author-color
 	AuthorColors map[string]string `yaml:"authorColors"`

--- a/pkg/gui/controllers/helpers/patch_building_helper.go
+++ b/pkg/gui/controllers/helpers/patch_building_helper.go
@@ -58,7 +58,7 @@ func (self *PatchBuildingHelper) Reset() error {
 
 func (self *PatchBuildingHelper) RefreshPatchBuildingPanel(opts types.OnFocusOpts) error {
 	selectedLineIdx := -1
-	if opts.ClickedWindowName == "main" {
+	if opts.ClickedWindowName == windowArrangementArgsWindowNameMain {
 		selectedLineIdx = opts.ClickedViewLineIdx
 	}
 

--- a/pkg/gui/controllers/helpers/window_arrangement_helper.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper.go
@@ -108,7 +108,7 @@ func (self *WindowArrangementHelper) GetWindowDimensions(informationStr string, 
 
 func shouldUsePortraitMode(args WindowArrangementArgs) bool {
 	if args.ScreenMode == types.SCREEN_HALF {
-		return args.UserConfig.Gui.EnlargedSideViewLocation == "top"
+		return args.UserConfig.Gui.EnlargedSideViewLocation == config.GuiConfigEnlargedSideViewLocationTop
 	}
 
 	switch args.UserConfig.Gui.PortraitMode {
@@ -245,7 +245,7 @@ func getMidSectionWeights(args WindowArrangementArgs) (int, int) {
 		}
 	} else {
 		if args.ScreenMode == types.SCREEN_HALF {
-			if args.UserConfig.Gui.EnlargedSideViewLocation == "top" {
+			if args.UserConfig.Gui.EnlargedSideViewLocation == config.GuiConfigEnlargedSideViewLocationTop {
 				mainSectionWeight = 2
 			} else {
 				mainSectionWeight = 1

--- a/pkg/gui/controllers/helpers/window_arrangement_helper.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper.go
@@ -12,6 +12,11 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+const (
+	windowArrangementArgsWindowNameMain      = "main"
+	windowArrangementArgsWindowNameSecondary = "secondary"
+)
+
 // In this file we use the boxlayout package, along with knowledge about the app's state,
 // to arrange the windows (i.e. panels) on the screen.
 
@@ -207,10 +212,10 @@ func MergeMaps[K comparable, V any](maps ...map[K]V) map[K]V {
 func mainSectionChildren(args WindowArrangementArgs) []*boxlayout.Box {
 	// if we're not in split mode we can just show the one main panel. Likewise if
 	// the main panel is focused and we're in full-screen mode
-	if !args.SplitMainPanel || (args.ScreenMode == types.SCREEN_FULL && args.CurrentWindow == "main") {
+	if !args.SplitMainPanel || (args.ScreenMode == types.SCREEN_FULL && args.CurrentWindow == windowArrangementArgsWindowNameMain) {
 		return []*boxlayout.Box{
 			{
-				Window: "main",
+				Window: windowArrangementArgsWindowNameMain,
 				Weight: 1,
 			},
 		}
@@ -218,11 +223,11 @@ func mainSectionChildren(args WindowArrangementArgs) []*boxlayout.Box {
 
 	return []*boxlayout.Box{
 		{
-			Window: "main",
+			Window: windowArrangementArgsWindowNameMain,
 			Weight: 1,
 		},
 		{
-			Window: "secondary",
+			Window: windowArrangementArgsWindowNameSecondary,
 			Weight: 1,
 		},
 	}
@@ -239,7 +244,7 @@ func getMidSectionWeights(args WindowArrangementArgs) (int, int) {
 		mainSectionWeight = 5 // need to shrink side panel to make way for main panels if side-by-side
 	}
 
-	if args.CurrentWindow == "main" {
+	if args.CurrentWindow == windowArrangementArgsWindowNameMain {
 		if args.ScreenMode == types.SCREEN_HALF || args.ScreenMode == types.SCREEN_FULL {
 			sideSectionWeight = 0
 		}

--- a/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
@@ -12,6 +12,8 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+const appStateRebasing = "Rebasing /"
+
 // The best way to add test cases here is to set your args and then get the
 // test to fail and copy+paste the output into the test case's expected string.
 // TODO: add more test cases
@@ -205,7 +207,7 @@ func TestGetWindowDimensions(t *testing.T) {
 		{
 			name: "app status present",
 			mutateArgs: func(args *WindowArrangementArgs) {
-				args.AppStatus = "Rebasing /"
+				args.AppStatus = appStateRebasing
 				args.Height = 6 // small height cos we only care about the bottom line
 			},
 			// We expect single-character spacers between the windows of the bottom line
@@ -248,7 +250,7 @@ func TestGetWindowDimensions(t *testing.T) {
 				args.Height = 6                            // small height cos we only care about the bottom line
 				args.UserConfig.Gui.ShowBottomLine = false // this hides the options window
 				args.IsAnyModeActive = false
-				args.AppStatus = "Rebasing /"
+				args.AppStatus = appStateRebasing
 			},
 			// We expect the app status window to take up all the available space
 			expected: `
@@ -266,7 +268,7 @@ func TestGetWindowDimensions(t *testing.T) {
 				args.Height = 6                            // small height cos we only care about the bottom line
 				args.UserConfig.Gui.ShowBottomLine = false // this hides the options window
 				args.IsAnyModeActive = true
-				args.AppStatus = "Rebasing /"
+				args.AppStatus = appStateRebasing
 			},
 			expected: `
 			<status─────────────────>╭main────────────────────────────────────────────╮
@@ -287,7 +289,7 @@ func TestGetWindowDimensions(t *testing.T) {
 				args.Width = 55                            // smaller width so that not all bottom line views fit
 				args.UserConfig.Gui.ShowBottomLine = false // this hides the options window
 				args.IsAnyModeActive = true
-				args.AppStatus = "Rebasing /"
+				args.AppStatus = appStateRebasing
 				args.InformationStr = "Showing output for: git diff deadbeef fa1afe1 -- (Reset)"
 			},
 			expected: `

--- a/pkg/gui/presentation/graph/cell.go
+++ b/pkg/gui/presentation/graph/cell.go
@@ -146,13 +146,13 @@ func (cell *Cell) setType(cellType cellType) *Cell {
 
 func getBoxDrawingChars(up, down, left, right bool) (string, string) {
 	if up && down && left && right {
-		return "│", "─"
+		return "│", "─" //nolint:goconst // string literal is better for readability for this case
 	} else if up && down && left && !right {
-		return "│", " "
+		return "│", " " //nolint:goconst // string literal is better for readability for this case
 	} else if up && down && !left && right {
-		return "│", "─"
+		return "│", "─" //nolint:goconst // string literal is better for readability for this case
 	} else if up && down && !left && !right {
-		return "│", " "
+		return "│", " " //nolint:goconst // string literal is better for readability for this case
 	} else if up && !down && left && right {
 		return "┴", "─"
 	} else if up && !down && left && !right {

--- a/pkg/integration/components/popup.go
+++ b/pkg/integration/components/popup.go
@@ -1,5 +1,7 @@
 package components
 
+const viewNameConfirmation = "confirmation"
+
 type Popup struct {
 	t *TestDriver
 }
@@ -13,7 +15,7 @@ func (self *Popup) Confirmation() *ConfirmationDriver {
 func (self *Popup) inConfirm() {
 	self.t.assertWithRetries(func() (bool, string) {
 		currentView := self.t.gui.CurrentContext().GetView()
-		return currentView.Name() == "confirmation" && !currentView.Editable, "Expected confirmation popup to be focused"
+		return currentView.Name() == viewNameConfirmation && !currentView.Editable, "Expected confirmation popup to be focused"
 	})
 }
 
@@ -26,7 +28,7 @@ func (self *Popup) Prompt() *PromptDriver {
 func (self *Popup) inPrompt() {
 	self.t.assertWithRetries(func() (bool, string) {
 		currentView := self.t.gui.CurrentContext().GetView()
-		return currentView.Name() == "confirmation" && currentView.Editable, "Expected prompt popup to be focused"
+		return currentView.Name() == viewNameConfirmation && currentView.Editable, "Expected prompt popup to be focused"
 	})
 }
 
@@ -40,7 +42,7 @@ func (self *Popup) inAlert() {
 	// basically the same thing as a confirmation popup with the current implementation
 	self.t.assertWithRetries(func() (bool, string) {
 		currentView := self.t.gui.CurrentContext().GetView()
-		return currentView.Name() == "confirmation" && !currentView.Editable, "Expected alert popup to be focused"
+		return currentView.Name() == viewNameConfirmation && !currentView.Editable, "Expected alert popup to be focused"
 	})
 }
 

--- a/pkg/integration/tests/bisect/basic.go
+++ b/pkg/integration/tests/bisect/basic.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
+const configAppStateGitLogShowGraphNever = "never"
+
 var Basic = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Start a git bisect to find a bad commit",
 	ExtraCmdArgs: []string{},
@@ -15,7 +17,7 @@ var Basic = NewIntegrationTest(NewIntegrationTestArgs{
 			CreateNCommits(10)
 	},
 	SetupConfig: func(cfg *config.AppConfig) {
-		cfg.AppState.GitLogShowGraph = "never"
+		cfg.AppState.GitLogShowGraph = configAppStateGitLogShowGraphNever
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		markCommitAsBad := func() {

--- a/pkg/integration/tests/bisect/choose_terms.go
+++ b/pkg/integration/tests/bisect/choose_terms.go
@@ -15,7 +15,7 @@ var ChooseTerms = NewIntegrationTest(NewIntegrationTestArgs{
 			CreateNCommits(10)
 	},
 	SetupConfig: func(cfg *config.AppConfig) {
-		cfg.AppState.GitLogShowGraph = "never"
+		cfg.AppState.GitLogShowGraph = configAppStateGitLogShowGraphNever
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		markCommitAsFixed := func() {

--- a/pkg/integration/tests/bisect/skip.go
+++ b/pkg/integration/tests/bisect/skip.go
@@ -14,7 +14,7 @@ var Skip = NewIntegrationTest(NewIntegrationTestArgs{
 			CreateNCommits(10)
 	},
 	SetupConfig: func(cfg *config.AppConfig) {
-		cfg.AppState.GitLogShowGraph = "never"
+		cfg.AppState.GitLogShowGraph = configAppStateGitLogShowGraphNever
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().

--- a/pkg/integration/tests/branch/suggestions.go
+++ b/pkg/integration/tests/branch/suggestions.go
@@ -12,7 +12,7 @@ var Suggestions = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
 		shell.
-			EmptyCommit("my commit message").
+			EmptyCommit("my commit message"). //nolint:goconst // Values for tests should not be commonized for changeability.
 			NewBranch("new-branch").
 			NewBranch("new-branch-2").
 			NewBranch("new-branch-3").

--- a/pkg/integration/tests/commit/commit.go
+++ b/pkg/integration/tests/commit/commit.go
@@ -37,7 +37,7 @@ var Commit = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			Press(keys.Files.CommitChanges)
 
-		commitMessage := "my commit message"
+		commitMessage := "my commit message" //nolint:goconst // Values for tests should not be commonized for changeability.
 
 		t.ExpectPopup().CommitMessagePanel().Type(commitMessage).Confirm()
 

--- a/pkg/integration/tests/commit/commit_with_global_prefix.go
+++ b/pkg/integration/tests/commit/commit_with_global_prefix.go
@@ -25,11 +25,11 @@ var CommitWithGlobalPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 			PressPrimaryAction().
 			Press(keys.Files.CommitChanges)
 
-		t.ExpectPopup().CommitMessagePanel().
-			Title(Equals("Commit summary")).
-			InitialText(Equals("[TEST-001]: ")).
-			Type("my commit message").
-			Cancel()
+		t.ExpectPopup().CommitMessagePanel(). //nolint:goconst // Values for tests should not be commonized for changeability.
+							Title(Equals("Commit summary")).
+							InitialText(Equals("[TEST-001]: ")).
+							Type("my commit message").
+							Cancel()
 
 		t.Views().Files().
 			IsFocused().

--- a/pkg/integration/tests/commit/commit_with_prefix.go
+++ b/pkg/integration/tests/commit/commit_with_prefix.go
@@ -25,11 +25,11 @@ var CommitWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 			PressPrimaryAction().
 			Press(keys.Files.CommitChanges)
 
-		t.ExpectPopup().CommitMessagePanel().
-			Title(Equals("Commit summary")).
-			InitialText(Equals("[TEST-001]: ")).
-			Type("my commit message").
-			Cancel()
+		t.ExpectPopup().CommitMessagePanel(). //nolint:goconst // Values for tests should not be commonized for changeability.
+							Title(Equals("Commit summary")).
+							InitialText(Equals("[TEST-001]: ")).
+							Type("my commit message").
+							Cancel()
 
 		t.Views().Files().
 			IsFocused().

--- a/pkg/integration/tests/commit/history.go
+++ b/pkg/integration/tests/commit/history.go
@@ -25,7 +25,7 @@ var History = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().CommitMessagePanel().
 			InitialText(Equals("")).
-			Type("my commit message").
+			Type("my commit message"). //nolint:goconst // Values for tests should not be commonized for changeability.
 			SelectPreviousMessage().
 			Content(Equals("commit 3")).
 			SelectPreviousMessage().
@@ -39,9 +39,10 @@ var History = NewIntegrationTest(NewIntegrationTestArgs{
 			SelectNextMessage().
 			Content(Equals("commit 3")).
 			SelectNextMessage().
-			Content(Equals("my commit message")).
+			Content(Equals("my commit message")). //nolint:goconst // Values for tests should not be commonized for changeability.
 			SelectNextMessage().
-			Content(Equals("my commit message")). // we hit the beginning
+			// we hit the beginning
+			Content(Equals("my commit message")). //nolint:goconst // Values for tests should not be commonized for changeability.
 			Type(" with extra added").
 			Confirm()
 

--- a/pkg/integration/tests/commit/history_complex.go
+++ b/pkg/integration/tests/commit/history_complex.go
@@ -30,7 +30,7 @@ var HistoryComplex = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().CommitMessagePanel().
 			InitialText(Equals("")).
-			Type("my commit message").
+			Type("my commit message"). //nolint:goconst // Values for tests should not be commonized for changeability.
 			Cancel()
 
 		t.Views().Commits().
@@ -54,6 +54,6 @@ var HistoryComplex = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Files.CommitChanges)
 
 		t.ExpectPopup().CommitMessagePanel().
-			InitialText(Equals("my commit message"))
+			InitialText(Equals("my commit message")) //nolint:goconst // Values for tests should not be commonized for changeability.
 	},
 })

--- a/pkg/integration/tests/commit/preserve_commit_message.go
+++ b/pkg/integration/tests/commit/preserve_commit_message.go
@@ -20,7 +20,7 @@ var PreserveCommitMessage = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().CommitMessagePanel().
 			InitialText(Equals("")).
-			Type("my commit message").
+			Type("my commit message"). //nolint:goconst // Values for tests should not be commonized for changeability.
 			SwitchToDescription().
 			Type("first paragraph").
 			AddNewline().
@@ -33,7 +33,7 @@ var PreserveCommitMessage = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Files.CommitChanges)
 
 		t.ExpectPopup().CommitMessagePanel().
-			Content(Equals("my commit message")).
+			Content(Equals("my commit message")). //nolint:goconst // Values for tests should not be commonized for changeability.
 			SwitchToDescription().
 			Content(Equals("first paragraph\n\nsecond paragraph"))
 	},

--- a/pkg/integration/tests/commit/reword.go
+++ b/pkg/integration/tests/commit/reword.go
@@ -23,7 +23,7 @@ var Reword = NewIntegrationTest(NewIntegrationTestArgs{
 			PressPrimaryAction().
 			Press(keys.Files.CommitChanges)
 
-		commitMessage := "my commit message"
+		commitMessage := "my commit message" //nolint:goconst // Values for tests should not be commonized for changeability.
 
 		t.ExpectPopup().CommitMessagePanel().Type(commitMessage).Confirm()
 		t.Views().Commits().

--- a/pkg/integration/tests/commit/staged.go
+++ b/pkg/integration/tests/commit/staged.go
@@ -45,7 +45,7 @@ var Staged = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Press(keys.Files.CommitChanges)
 
-		commitMessage := "my commit message"
+		commitMessage := "my commit message" //nolint:goconst // Values for tests should not be commonized for changeability.
 		t.ExpectPopup().CommitMessagePanel().Type(commitMessage).Confirm()
 
 		t.Views().Commits().

--- a/pkg/integration/tests/commit/unstaged.go
+++ b/pkg/integration/tests/commit/unstaged.go
@@ -39,7 +39,7 @@ var Unstaged = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Press(keys.Files.CommitChanges)
 
-		commitMessage := "my commit message"
+		commitMessage := "my commit message" //nolint:goconst // Values for tests should not be commonized for changeability.
 		t.ExpectPopup().CommitMessagePanel().Type(commitMessage).Confirm()
 
 		t.Views().Commits().

--- a/pkg/integration/tests/interactive_rebase/dont_show_branch_heads_for_todo_items.go
+++ b/pkg/integration/tests/interactive_rebase/dont_show_branch_heads_for_todo_items.go
@@ -5,13 +5,15 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
+const configAppStateGitLogShowGraphNever = "never"
+
 var DontShowBranchHeadsForTodoItems = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Check that branch heads are shown for normal commits during interactive rebase, but not for todo items",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {
-		config.AppState.GitLogShowGraph = "never"
+		config.AppState.GitLogShowGraph = configAppStateGitLogShowGraphNever
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/interactive_rebase/drop_commit_in_copied_branch_with_update_ref.go
+++ b/pkg/integration/tests/interactive_rebase/drop_commit_in_copied_branch_with_update_ref.go
@@ -11,7 +11,7 @@ var DropCommitInCopiedBranchWithUpdateRef = NewIntegrationTest(NewIntegrationTes
 	Skip:         false,
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {
-		config.AppState.GitLogShowGraph = "never"
+		config.AppState.GitLogShowGraph = configAppStateGitLogShowGraphNever
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
@@ -12,7 +12,7 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {
 		config.GetUserConfig().Git.MainBranches = []string{"master"}
-		config.AppState.GitLogShowGraph = "never"
+		config.AppState.GitLogShowGraph = configAppStateGitLogShowGraphNever
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/interactive_rebase/interactive_rebase_of_copied_branch.go
+++ b/pkg/integration/tests/interactive_rebase/interactive_rebase_of_copied_branch.go
@@ -11,7 +11,7 @@ var InteractiveRebaseOfCopiedBranch = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {
-		config.AppState.GitLogShowGraph = "never"
+		config.AppState.GitLogShowGraph = configAppStateGitLogShowGraphNever
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/interactive_rebase/quick_start_keep_selection.go
+++ b/pkg/integration/tests/interactive_rebase/quick_start_keep_selection.go
@@ -12,7 +12,7 @@ var QuickStartKeepSelection = NewIntegrationTest(NewIntegrationTestArgs{
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {
 		config.GetUserConfig().Git.MainBranches = []string{"master"}
-		config.AppState.GitLogShowGraph = "never"
+		config.AppState.GitLogShowGraph = configAppStateGitLogShowGraphNever
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/interactive_rebase/quick_start_keep_selection_range.go
+++ b/pkg/integration/tests/interactive_rebase/quick_start_keep_selection_range.go
@@ -12,7 +12,7 @@ var QuickStartKeepSelectionRange = NewIntegrationTest(NewIntegrationTestArgs{
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {
 		config.GetUserConfig().Git.MainBranches = []string{"master"}
-		config.AppState.GitLogShowGraph = "never"
+		config.AppState.GitLogShowGraph = configAppStateGitLogShowGraphNever
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/interactive_rebase/view_files_of_todo_entries.go
+++ b/pkg/integration/tests/interactive_rebase/view_files_of_todo_entries.go
@@ -11,7 +11,7 @@ var ViewFilesOfTodoEntries = NewIntegrationTest(NewIntegrationTestArgs{
 	Skip:         false,
 	GitVersion:   AtLeast("2.38.0"),
 	SetupConfig: func(config *config.AppConfig) {
-		config.AppState.GitLogShowGraph = "never"
+		config.AppState.GitLogShowGraph = configAppStateGitLogShowGraphNever
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.

--- a/pkg/integration/tests/sync/fetch_prune.go
+++ b/pkg/integration/tests/sync/fetch_prune.go
@@ -15,7 +15,7 @@ var FetchPrune = NewIntegrationTest(NewIntegrationTestArgs{
 		// upon fetching.
 		shell.SetConfig("fetch.prune", "true")
 
-		shell.EmptyCommit("my commit message")
+		shell.EmptyCommit("my commit message") //nolint:goconst // Values for tests should not be commonized for changeability.
 
 		shell.NewBranch("branch_to_remove")
 		shell.Checkout("master")

--- a/pkg/updates/updates.go
+++ b/pkg/updates/updates.go
@@ -76,7 +76,7 @@ func (u *Updater) RecordLastUpdateCheck() error {
 
 // expecting version to be of the form `v12.34.56`
 func (u *Updater) majorVersionDiffers(oldVersion, newVersion string) bool {
-	if oldVersion == "unversioned" {
+	if oldVersion == config.VersionUnversioned {
 		return false
 	}
 	oldVersion = strings.TrimPrefix(oldVersion, "v")
@@ -86,7 +86,7 @@ func (u *Updater) majorVersionDiffers(oldVersion, newVersion string) bool {
 
 func (u *Updater) currentVersion() string {
 	versionNumber := u.Config.GetVersion()
-	if versionNumber == "unversioned" {
+	if versionNumber == config.VersionUnversioned {
 		return versionNumber
 	}
 
@@ -158,7 +158,7 @@ func (u *Updater) skipUpdateCheck() bool {
 		return true
 	}
 
-	if u.Config.GetVersion() == "unversioned" {
+	if u.Config.GetVersion() == config.VersionUnversioned {
 		u.Log.Info("Current version is not built from an official release so we won't check for an update")
 		return true
 	}


### PR DESCRIPTION
Resolves #3591

## **PR Description**
- This PR enables `goconst`.
- I separated commits by variables. Please check by commit when you review.
- At some commits, I don't know where the variable should be. Please let me know you know where they should be.

## **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->

## Output of golangci-lint
Nothing! As you may know, it means there is no problem. 🎉 

By the way, the warning [is fixed](https://github.com/golangci/golangci-lint/issues/4743).
The next version will not report that warning.

<img width="1088" alt="image" src="https://github.com/jesseduffield/lazygit/assets/49891479/25e11aeb-b8c1-4f07-95ff-09c134108aca">
