### PR TITLE
Delete the TODO comment about enabling `goconst` in the future from `.golangci.yml`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
     - makezero
     - nakedret
     - copyloopvar
-    # - goconst # TODO: enable and fix issues
   fast: false
 
 linters-settings:


### PR DESCRIPTION
## Context:
https://github.com/jesseduffield/lazygit/pull/3592#issuecomment-2129535231