### PR TITLE
Allow creating a branch with a default name

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -265,6 +265,9 @@ git:
     # Replace directive. E.g. for 'feature/AB-123' to start the commit message with 'AB-123 ' use "[$1] "
     replace: ""
 
+  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-branch-name-prefix
+  branchPrefix: ""
+
   # Config for showing the log in the commits view
   log:
     # One of: 'date-order' | 'author-date-order' | 'topo-order' | 'default'
@@ -799,6 +802,30 @@ git:
     my_project: # This is repository folder name
       pattern: "^\\w+\\/(\\w+-\\w+).*"
       replace: '[$1] '
+```
+
+## Predefined branch name prefix
+
+In situations where certain naming pattern is used for branches, this can be used to populate new branch creation with a static prefix.
+
+Example:
+
+Some branches:
+- jsmith/AB-123
+- cwilson/AB-125
+
+```yaml
+git:
+  branchPrefix: "firstlast/"
+```
+
+For repository-specific prefixes, you can map them with `branchPrefixes`. If you have both `branchPrefix` defined and an entry in `branchPrefixes` for the current repo, the `branchPrefix` entry is given higher precedence. Repository folder names must be an exact match.
+
+```yaml
+git:
+  branchPrefixes:
+    my_project: > # This is repository folder name
+      "lastfirst/"
 ```
 
 ## Custom git log command

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -225,6 +225,10 @@ type GitConfig struct {
 	CommitPrefix *CommitPrefixConfig `yaml:"commitPrefix"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix
 	CommitPrefixes map[string]CommitPrefixConfig `yaml:"commitPrefixes"`
+	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-branch-name-prefix
+	BranchPrefix string `yaml:"branchPrefix"`
+	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-branch-name-prefix
+	BranchPrefixes map[string]string `yaml:"branchPrefixes"`
 	// If true, parse emoji strings in commit messages e.g. render :rocket: as 🚀
 	// (This should really be under 'gui', not 'git')
 	ParseEmoji bool `yaml:"parseEmoji"`
@@ -727,6 +731,8 @@ func GetDefaultConfig() *UserConfig {
 			AllBranchesLogCmd:            "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium",
 			DisableForcePushing:          false,
 			CommitPrefixes:               map[string]CommitPrefixConfig(nil),
+			BranchPrefix:                 "",
+			BranchPrefixes:               map[string]string(nil),
 			ParseEmoji:                   false,
 			TruncateCopiedCommitHashesTo: 12,
 		},

--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -272,6 +272,10 @@ func (self *RefsHelper) NewBranch(from string, fromFormattedName string, suggest
 		},
 	)
 
+	if suggestedBranchName == "" {
+		suggestedBranchName = self.branchPrefixConfigForRepo()
+	}
+
 	return self.c.Prompt(types.PromptOpts{
 		Title:          message,
 		InitialContent: suggestedBranchName,
@@ -317,4 +321,13 @@ func (self *RefsHelper) ParseRemoteBranchName(fullBranchName string) (string, st
 	}
 
 	return remoteName, branchName, true
+}
+
+func (self *RefsHelper) branchPrefixConfigForRepo() string {
+	cfg, ok := self.c.UserConfig.Git.BranchPrefixes[self.c.Git().RepoPaths.RepoName()]
+	if ok {
+		return cfg
+	}
+
+	return self.c.UserConfig.Git.BranchPrefix
 }

--- a/pkg/integration/tests/commit/new_branch_with_prefix.go
+++ b/pkg/integration/tests/commit/new_branch_with_prefix.go
@@ -1,0 +1,41 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var NewBranchWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Creating a new branch from a commit with a default name",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.UserConfig.Git.BranchPrefix = "myprefix/"
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			EmptyCommit("commit 1").
+			EmptyCommit("commit 2").
+			EmptyCommit("commit 3")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("commit 3").IsSelected(),
+				Contains("commit 2"),
+				Contains("commit 1"),
+			).
+			SelectNextItem().
+			Press(keys.Universal.New).
+			Tap(func() {
+				branchName := "my-branch-name"
+				t.ExpectPopup().Prompt().Title(Contains("New branch name")).Type(branchName).Confirm()
+				t.Git().CurrentBranchName("myprefix/" + branchName)
+			}).
+			Lines(
+				Contains("commit 2"),
+				Contains("commit 1"),
+			)
+	},
+})

--- a/pkg/integration/tests/commit/new_branch_with_prefixes.go
+++ b/pkg/integration/tests/commit/new_branch_with_prefixes.go
@@ -1,0 +1,42 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var NewBranchWithPrefixes = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Creating a new branch from a commit with a default name for a specific repo",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.UserConfig.Git.BranchPrefix = "myprefix/"
+		cfg.UserConfig.Git.BranchPrefixes = map[string]string{"repo": "ourprefix/"}
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			EmptyCommit("commit 1").
+			EmptyCommit("commit 2").
+			EmptyCommit("commit 3")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("commit 3").IsSelected(),
+				Contains("commit 2"),
+				Contains("commit 1"),
+			).
+			SelectNextItem().
+			Press(keys.Universal.New).
+			Tap(func() {
+				branchName := "my-branch-name"
+				t.ExpectPopup().Prompt().Title(Contains("New branch name")).Type(branchName).Confirm()
+				t.Git().CurrentBranchName("ourprefix/" + branchName)
+			}).
+			Lines(
+				Contains("commit 2"),
+				Contains("commit 1"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -84,6 +84,8 @@ var tests = []*components.IntegrationTest{
 	commit.History,
 	commit.HistoryComplex,
 	commit.NewBranch,
+	commit.NewBranchWithPrefix,
+	commit.NewBranchWithPrefixes,
 	commit.PreserveCommitMessage,
 	commit.ResetAuthor,
 	commit.Revert,

--- a/schema/config.json
+++ b/schema/config.json
@@ -584,6 +584,17 @@
           "type": "object",
           "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix"
         },
+        "branchPrefix": {
+          "type": "string",
+          "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-branch-name-prefix"
+        },
+        "branchPrefixes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-branch-name-prefix"
+        },
         "parseEmoji": {
           "type": "boolean",
           "description": "If true, parse emoji strings in commit messages e.g. render :rocket: as 🚀\n(This should really be under 'gui', not 'git')"


### PR DESCRIPTION
- **PR Description**
This pull request adds 2 new configuration options that allow creating a new branch with global or repository-specific prefix.

This PR builds on the [following PR](https://github.com/jesseduffield/lazygit/pull/3487).

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation)) -- no user facing text, not sure this is relevant
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
