### PR TITLE
Pin golangci version to 1.58

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
-          version: latest
+          version: v1.58
       - name: errors
         run: golangci-lint run
         if: ${{ failure() }}


### PR DESCRIPTION
Pin golangci version to 1.58.

It is annoying when CI builds suddenly start to fail because the linter was updated and finds new things to complain about.

Updating the linter and fixing the code accordingly should be a dedicated activity.
