### PR TITLE
Add command to show divergence from base branch as a left-right log

### DIFF
--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -205,6 +205,40 @@ func (self *BranchesController) viewUpstreamOptions(selectedBranch *models.Branc
 		},
 	}
 
+	var disabledReason *types.DisabledReason
+	baseBranch, err := self.c.Git().Loaders.BranchLoader.GetBaseBranch(selectedBranch, self.c.Model().MainBranches)
+	if err != nil {
+		return err
+	}
+	if baseBranch == "" {
+		baseBranch = self.c.Tr.CouldNotDetermineBaseBranch
+		disabledReason = &types.DisabledReason{Text: self.c.Tr.CouldNotDetermineBaseBranch}
+	}
+	shortBaseBranchName := helpers.ShortBranchName(baseBranch)
+	label := utils.ResolvePlaceholderString(
+		self.c.Tr.ViewDivergenceFromBaseBranch,
+		map[string]string{"baseBranch": shortBaseBranchName},
+	)
+	viewDivergenceFromBaseBranchItem := &types.MenuItem{
+		LabelColumns: []string{label},
+		Key:          'b',
+		OnPress: func() error {
+			branch := self.context().GetSelected()
+			if branch == nil {
+				return nil
+			}
+
+			return self.c.Helpers().SubCommits.ViewSubCommits(helpers.ViewSubCommitsOpts{
+				Ref:                     branch,
+				TitleRef:                fmt.Sprintf("%s <-> %s", branch.RefName(), shortBaseBranchName),
+				RefToShowDivergenceFrom: baseBranch,
+				Context:                 self.context(),
+				ShowBranchHeads:         false,
+			})
+		},
+		DisabledReason: disabledReason,
+	}
+
 	unsetUpstreamItem := &types.MenuItem{
 		LabelColumns: []string{self.c.Tr.UnsetUpstream},
 		OnPress: func() error {
@@ -312,6 +346,7 @@ func (self *BranchesController) viewUpstreamOptions(selectedBranch *models.Branc
 
 	options := []*types.MenuItem{
 		viewDivergenceItem,
+		viewDivergenceFromBaseBranchItem,
 		unsetUpstreamItem,
 		setUpstreamItem,
 		upstreamResetItem,

--- a/pkg/gui/controllers/helpers/branches_helper.go
+++ b/pkg/gui/controllers/helpers/branches_helper.go
@@ -1,6 +1,8 @@
 package helpers
 
 import (
+	"strings"
+
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
@@ -43,4 +45,8 @@ func (self *BranchesHelper) ConfirmDeleteRemote(remoteName string, branchName st
 			})
 		},
 	})
+}
+
+func ShortBranchName(fullBranchName string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(fullBranchName, "refs/heads/"), "refs/remotes/")
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -468,6 +468,8 @@ type TranslationSet struct {
 	SetUpstream                           string
 	UnsetUpstream                         string
 	ViewDivergenceFromUpstream            string
+	ViewDivergenceFromBaseBranch          string
+	CouldNotDetermineBaseBranch           string
 	DivergenceSectionHeaderLocal          string
 	DivergenceSectionHeaderRemote         string
 	ViewUpstreamResetOptions              string
@@ -1434,6 +1436,8 @@ func EnglishTranslationSet() TranslationSet {
 		SetUpstream:                          "Set upstream of selected branch",
 		UnsetUpstream:                        "Unset upstream of selected branch",
 		ViewDivergenceFromUpstream:           "View divergence from upstream",
+		ViewDivergenceFromBaseBranch:         "View divergence from base branch ({{.baseBranch}})",
+		CouldNotDetermineBaseBranch:          "Couldn't determine base branch",
 		DivergenceSectionHeaderLocal:         "Local",
 		DivergenceSectionHeaderRemote:        "Remote",
 		ViewUpstreamResetOptions:             "Reset checked-out branch onto {{.upstream}}",

--- a/pkg/integration/tests/branch/show_divergence_from_base_branch.go
+++ b/pkg/integration/tests/branch/show_divergence_from_base_branch.go
@@ -1,0 +1,47 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ShowDivergenceFromBaseBranch = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Show divergence from base branch",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.UserConfig.Gui.ShowDivergenceFromBaseBranch = "arrowAndNumber"
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			EmptyCommit("master 1").
+			EmptyCommit("master 2").
+			EmptyCommit("master 3").
+			NewBranchFrom("feature", "master^").
+			EmptyCommit("feature 1").
+			EmptyCommit("feature 2")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("feature ↓1").IsSelected(),
+				Contains("master"),
+			).
+			Press(keys.Branches.SetUpstream)
+
+		t.ExpectPopup().Menu().Title(Contains("Upstream")).
+			Select(Contains("View divergence from base branch (master)")).Confirm()
+
+		t.Views().SubCommits().
+			IsFocused().
+			Title(Contains("Commits (feature <-> master)")).
+			Lines(
+				DoesNotContainAnyOf("↓", "↑").Contains("--- Remote ---"),
+				Contains("↓").Contains("master 3"),
+				DoesNotContainAnyOf("↓", "↑").Contains("--- Local ---"),
+				Contains("↑").Contains("feature 2"),
+				Contains("↑").Contains("feature 1"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -56,6 +56,7 @@ var tests = []*components.IntegrationTest{
 	branch.Reset,
 	branch.ResetToUpstream,
 	branch.SetUpstream,
+	branch.ShowDivergenceFromBaseBranch,
 	branch.ShowDivergenceFromUpstream,
 	branch.SortLocalBranches,
 	branch.SortRemoteBranches,


### PR DESCRIPTION
- **PR Description**

Add a command similar to the existing "Show divergence from upstream", but for the base branch instead. Useful to see what you would rebase onto if you were to rebase onto the base branch now.

It could be considered somewhat questionable that we display both the Remote and Local sections of the log here; the Local section isn't really interesting because it's always identical to what you see in the Commits view. I chose to still show it since it makes the divergence view look more familiar, and I think overall it makes it clearer what you're looking at.

This is sitting on top of #3613 and uses some of the code that was added there.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
