### PR TITLE
Add user config `gui.expandedSidePanelWeight`

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -68,6 +68,10 @@ gui:
   # If true, increase the height of the focused side window; creating an accordion effect.
   expandFocusedSidePanel: false
 
+  # The weight of the expanded side panel, relative to the other panels. 2 means
+  # twice as tall as the other panels. Only relevant if `expandFocusedSidePanel` is true.
+  expandedSidePanelWeight: 2
+
   # Sometimes the main window is split in two (e.g. when the selected file has both staged and unstaged changes). This setting controls how the two sections are split.
   # Options are:
   # - 'horizontal': split the window horizontally

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -77,6 +77,9 @@ type GuiConfig struct {
 	SidePanelWidth float64 `yaml:"sidePanelWidth" jsonschema:"maximum=1,minimum=0"`
 	// If true, increase the height of the focused side window; creating an accordion effect.
 	ExpandFocusedSidePanel bool `yaml:"expandFocusedSidePanel"`
+	// The weight of the expanded side panel, relative to the other panels. 2 means
+	// twice as tall as the other panels. Only relevant if `expandFocusedSidePanel` is true.
+	ExpandedSidePanelWeight int `yaml:"expandedSidePanelWeight"`
 	// Sometimes the main window is split in two (e.g. when the selected file has both staged and unstaged changes). This setting controls how the two sections are split.
 	// Options are:
 	// - 'horizontal': split the window horizontally
@@ -651,6 +654,7 @@ func GetDefaultConfig() *UserConfig {
 			SkipStashWarning:         false,
 			SidePanelWidth:           0.3333,
 			ExpandFocusedSidePanel:   false,
+			ExpandedSidePanelWeight:  2,
 			MainPanelSplitMode:       "flexible",
 			EnlargedSideViewLocation: "left",
 			Language:                 "auto",

--- a/pkg/gui/controllers/helpers/window_arrangement_helper.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper.go
@@ -443,7 +443,7 @@ func sidePanelChildren(args WindowArrangementArgs) func(width int, height int) [
 				if accordionMode && defaultBox.Window == args.CurrentSideWindow {
 					return &boxlayout.Box{
 						Window: defaultBox.Window,
-						Weight: 2,
+						Weight: args.UserConfig.Gui.ExpandedSidePanelWeight,
 					}
 				}
 

--- a/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
@@ -162,6 +162,47 @@ func TestGetWindowDimensions(t *testing.T) {
 			`,
 		},
 		{
+			name: "expandSidePanelWeight",
+			mutateArgs: func(args *WindowArrangementArgs) {
+				args.UserConfig.Gui.ExpandFocusedSidePanel = true
+				args.UserConfig.Gui.ExpandedSidePanelWeight = 4
+			},
+			expected: `
+			╭status─────────────────╮╭main────────────────────────────────────────────╮
+			│                       ││                                                │
+			╰───────────────────────╯│                                                │
+			╭files──────────────────╮│                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			╰───────────────────────╯│                                                │
+			╭branches───────────────╮│                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			╰───────────────────────╯│                                                │
+			╭commits────────────────╮│                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			╰───────────────────────╯│                                                │
+			╭stash──────────────────╮│                                                │
+			│                       ││                                                │
+			╰───────────────────────╯╰────────────────────────────────────────────────╯
+			<options──────────────────────────────────────────────────────>A<B────────>
+			A: statusSpacer1
+			B: information
+			`,
+		},
+		{
 			name: "half screen mode, enlargedSideViewLocation left",
 			mutateArgs: func(args *WindowArrangementArgs) {
 				args.Height = 20 // smaller height because we don't more here

--- a/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
@@ -122,6 +122,46 @@ func TestGetWindowDimensions(t *testing.T) {
 			`,
 		},
 		{
+			name: "expandFocusedSidePanel",
+			mutateArgs: func(args *WindowArrangementArgs) {
+				args.UserConfig.Gui.ExpandFocusedSidePanel = true
+			},
+			expected: `
+			╭status─────────────────╮╭main────────────────────────────────────────────╮
+			│                       ││                                                │
+			╰───────────────────────╯│                                                │
+			╭files──────────────────╮│                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			╰───────────────────────╯│                                                │
+			╭branches───────────────╮│                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			╰───────────────────────╯│                                                │
+			╭commits────────────────╮│                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			│                       ││                                                │
+			╰───────────────────────╯│                                                │
+			╭stash──────────────────╮│                                                │
+			│                       ││                                                │
+			╰───────────────────────╯╰────────────────────────────────────────────────╯
+			<options──────────────────────────────────────────────────────>A<B────────>
+			A: statusSpacer1
+			B: information
+			`,
+		},
+		{
 			name: "half screen mode, enlargedSideViewLocation left",
 			mutateArgs: func(args *WindowArrangementArgs) {
 				args.Height = 20 // smaller height because we don't more here

--- a/schema/config.json
+++ b/schema/config.json
@@ -76,6 +76,11 @@
           "description": "If true, increase the height of the focused side window; creating an accordion effect.",
           "default": false
         },
+        "expandedSidePanelWeight": {
+          "type": "integer",
+          "description": "The weight of the expanded side panel, relative to the other panels. 2 means\ntwice as tall as the other panels. Only relevant if `expandFocusedSidePanel` is true.",
+          "default": 2
+        },
         "mainPanelSplitMode": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
- **PR Description**

Add a user config `gui.expandedSidePanelWeight` which lets you change the default weight of 2 that gets assigned to the expanded side panel if `expandFocusedSidePanel` is true.

Closes #3621.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
