### PR TITLE
Add user config gui.commitAuthorFormat

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -181,6 +181,11 @@ gui:
   # If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.
   showFileIcons: true
 
+  # Whether to show full author names or their shortened form in the commit graph.
+  # One of 'auto' (default) | 'full' | 'short'
+  # If 'auto', initials will be shown in small windows, and full names - in larger ones.
+  commitAuthorFormat: auto
+
   # Length of commit hash in commits view. 0 shows '*' if NF icons aren't on.
   commitHashLength: 8
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -125,6 +125,10 @@ type GuiConfig struct {
 	NerdFontsVersion string `yaml:"nerdFontsVersion" jsonschema:"enum=2,enum=3,enum="`
 	// If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.
 	ShowFileIcons bool `yaml:"showFileIcons"`
+	// Whether to show full author names or their shortened form in the commit graph.
+	// One of 'auto' (default) | 'full' | 'short'
+	// If 'auto', initials will be shown in small windows, and full names - in larger ones.
+	CommitAuthorFormat string `yaml:"commitAuthorFormat" jsonschema:"enum=auto,enum=short,enum=full"`
 	// Length of commit hash in commits view. 0 shows '*' if NF icons aren't on.
 	CommitHashLength int `yaml:"commitHashLength" jsonschema:"minimum=0"`
 	// If true, show commit hashes alongside branch names in the branches view.
@@ -676,6 +680,7 @@ func GetDefaultConfig() *UserConfig {
 				UnstagedChangesColor:       []string{"red"},
 				DefaultFgColor:             []string{"default"},
 			},
+			CommitAuthorFormat:           "auto",
 			CommitLength:                 CommitLengthConfig{Show: true},
 			SkipNoStagedFilesWarning:     false,
 			ShowListFooter:               true,

--- a/pkg/config/user_config_validation.go
+++ b/pkg/config/user_config_validation.go
@@ -7,6 +7,11 @@ import (
 )
 
 func (config *UserConfig) Validate() error {
+	if err := validateEnum("gui.commitAuthorFormat", config.Gui.CommitAuthorFormat,
+		[]string{"auto", "short", "full"}); err != nil {
+		return err
+	}
+
 	if err := validateEnum("gui.statusPanelView", config.Gui.StatusPanelView,
 		[]string{"dashboard", "allBranchesLog"}); err != nil {
 		return err

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -440,9 +440,14 @@ func displayCommit(
 		mark = fmt.Sprintf("%s ", willBeRebased)
 	}
 
-	authorFunc := authors.ShortAuthor
-	if fullDescription {
+	var authorFunc func(string) string
+	switch common.UserConfig.Gui.CommitAuthorFormat {
+	case "short":
+		authorFunc = authors.ShortAuthor
+	case "full":
 		authorFunc = authors.LongAuthor
+	default:
+		authorFunc = lo.Ternary(fullDescription, authors.LongAuthor, authors.ShortAuthor)
 	}
 
 	cols := make([]string, 0, 7)

--- a/schema/config.json
+++ b/schema/config.json
@@ -320,6 +320,16 @@
           "description": "If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.",
           "default": true
         },
+        "commitAuthorFormat": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "short",
+            "full"
+          ],
+          "description": "Whether to show full author names or their shortened form in the commit graph.\nOne of 'auto' (default) | 'full' | 'short'\nIf 'auto', initials will be shown in small windows, and full names - in larger ones.",
+          "default": "auto"
+        },
         "commitHashLength": {
           "type": "integer",
           "minimum": 0,


### PR DESCRIPTION
- **PR Description**
Adds configuration option defining whether to show full author names or their shortened form in the commit graph.

Closes [#3624](https://github.com/jesseduffield/lazygit/issues/3624).

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
