### PR TITLE
Show current value in menus

### DIFF
--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -107,7 +107,21 @@ func (self *MenuViewModel) GetDisplayStrings(_ int, _ int) [][]string {
 			keyLabel = style.FgCyan.Sprint(keybindings.LabelFromKey(item.Key))
 		}
 
-		displayStrings = utils.Prepend(displayStrings, keyLabel)
+		checkMark := ""
+		switch item.Widget {
+		case types.MenuWidgetNone:
+			// do nothing
+		case types.MenuWidgetRadioButtonSelected:
+			checkMark = "(•)"
+		case types.MenuWidgetRadioButtonUnselected:
+			checkMark = "( )"
+		case types.MenuWidgetCheckboxSelected:
+			checkMark = "[✓]"
+		case types.MenuWidgetCheckboxUnselected:
+			checkMark = "[ ]"
+		}
+
+		displayStrings = utils.Prepend(displayStrings, keyLabel, checkMark)
 		return displayStrings
 	})
 }

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -696,7 +696,8 @@ func (self *BranchesController) createSortMenu() error {
 			return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.BRANCHES}})
 		}
 		return nil
-	})
+	},
+		self.c.GetAppState().LocalBranchSortOrder)
 }
 
 func (self *BranchesController) createResetMenu(selectedBranch *models.Branch) error {

--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -190,7 +190,7 @@ func (self *RefsHelper) ResetToRef(ref string, strength string, envVars []string
 	return nil
 }
 
-func (self *RefsHelper) CreateSortOrderMenu(sortOptionsOrder []string, onSelected func(sortOrder string) error) error {
+func (self *RefsHelper) CreateSortOrderMenu(sortOptionsOrder []string, onSelected func(sortOrder string) error, currentValue string) error {
 	type sortMenuOption struct {
 		key         types.Key
 		label       string
@@ -221,7 +221,8 @@ func (self *RefsHelper) CreateSortOrderMenu(sortOptionsOrder []string, onSelecte
 			OnPress: func() error {
 				return onSelected(opt.sortOrder)
 			},
-			Key: opt.key,
+			Key:    opt.key,
+			Widget: types.MakeMenuRadioButton(opt.sortOrder == currentValue),
 		}
 	})
 	return self.c.Menu(types.CreateMenuOptions{

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -1085,6 +1085,7 @@ func (self *LocalCommitsController) handleOpenLogMenu() error {
 				Label:     self.c.Tr.ShowGitGraph,
 				OpensMenu: true,
 				OnPress: func() error {
+					currentValue := self.c.GetAppState().GitLogShowGraph
 					onPress := func(value string) func() error {
 						return func() error {
 							self.c.GetAppState().GitLogShowGraph = value
@@ -1101,14 +1102,17 @@ func (self *LocalCommitsController) handleOpenLogMenu() error {
 							{
 								Label:   "always",
 								OnPress: onPress("always"),
+								Widget:  types.MakeMenuRadioButton(currentValue == "always"),
 							},
 							{
 								Label:   "never",
 								OnPress: onPress("never"),
+								Widget:  types.MakeMenuRadioButton(currentValue == "never"),
 							},
 							{
 								Label:   "when maximised",
 								OnPress: onPress("when-maximised"),
+								Widget:  types.MakeMenuRadioButton(currentValue == "when-maximised"),
 							},
 						},
 					})
@@ -1118,6 +1122,7 @@ func (self *LocalCommitsController) handleOpenLogMenu() error {
 				Label:     self.c.Tr.SortCommits,
 				OpensMenu: true,
 				OnPress: func() error {
+					currentValue := self.c.GetAppState().GitLogOrder
 					onPress := func(value string) func() error {
 						return func() error {
 							self.c.GetAppState().GitLogOrder = value
@@ -1139,14 +1144,17 @@ func (self *LocalCommitsController) handleOpenLogMenu() error {
 							{
 								Label:   "topological (topo-order)",
 								OnPress: onPress("topo-order"),
+								Widget:  types.MakeMenuRadioButton(currentValue == "topo-order"),
 							},
 							{
 								Label:   "date-order",
 								OnPress: onPress("date-order"),
+								Widget:  types.MakeMenuRadioButton(currentValue == "date-order"),
 							},
 							{
 								Label:   "author-date-order",
 								OnPress: onPress("author-date-order"),
+								Widget:  types.MakeMenuRadioButton(currentValue == "author-date-order"),
 							},
 						},
 					})

--- a/pkg/gui/controllers/remote_branches_controller.go
+++ b/pkg/gui/controllers/remote_branches_controller.go
@@ -145,7 +145,8 @@ func (self *RemoteBranchesController) createSortMenu() error {
 			return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.REMOTES}})
 		}
 		return nil
-	})
+	},
+		self.c.GetAppState().RemoteBranchSortOrder)
 }
 
 func (self *RemoteBranchesController) createResetMenu(selectedBranch *models.RemoteBranch) error {

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -217,6 +217,30 @@ type DisabledReason struct {
 	ShowErrorInPanel bool
 }
 
+type MenuWidget int
+
+const (
+	MenuWidgetNone MenuWidget = iota
+	MenuWidgetRadioButtonSelected
+	MenuWidgetRadioButtonUnselected
+	MenuWidgetCheckboxSelected
+	MenuWidgetCheckboxUnselected
+)
+
+func MakeMenuRadioButton(value bool) MenuWidget {
+	if value {
+		return MenuWidgetRadioButtonSelected
+	}
+	return MenuWidgetRadioButtonUnselected
+}
+
+func MakeMenuCheckBox(value bool) MenuWidget {
+	if value {
+		return MenuWidgetCheckboxSelected
+	}
+	return MenuWidgetCheckboxUnselected
+}
+
 type MenuItem struct {
 	Label string
 
@@ -231,6 +255,12 @@ type MenuItem struct {
 	// If Key is defined it allows the user to press the key to invoke the menu
 	// item, as opposed to having to navigate to it
 	Key Key
+
+	// A widget to show in front of the menu item. Supported widget types are
+	// checkboxes and radio buttons,
+	// This only handles the rendering of the widget; the behavior needs to be
+	// provided by the client.
+	Widget MenuWidget
 
 	// The tooltip will be displayed upon highlighting the menu item
 	Tooltip string

--- a/pkg/integration/tests/branch/sort_local_branches.go
+++ b/pkg/integration/tests/branch/sort_local_branches.go
@@ -37,6 +37,12 @@ var SortLocalBranches = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Branches.SortOrder)
 
 		t.ExpectPopup().Menu().Title(Equals("Sort order")).
+			Lines(
+				Contains("r (•) Recency").IsSelected(),
+				Contains("a ( ) Alphabetical"),
+				Contains("d ( ) Date"),
+				Contains("      Cancel"),
+			).
 			Select(Contains("-committerdate")).
 			Confirm()
 
@@ -53,6 +59,12 @@ var SortLocalBranches = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Branches.SortOrder)
 
 		t.ExpectPopup().Menu().Title(Equals("Sort order")).
+			Lines(
+				Contains("r ( ) Recency").IsSelected(),
+				Contains("a ( ) Alphabetical"),
+				Contains("d (•) Date"),
+				Contains("      Cancel"),
+			).
 			Select(Contains("refname")).
 			Confirm()
 

--- a/pkg/integration/tests/branch/sort_remote_branches.go
+++ b/pkg/integration/tests/branch/sort_remote_branches.go
@@ -41,6 +41,11 @@ var SortRemoteBranches = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Branches.SortOrder)
 
 		t.ExpectPopup().Menu().Title(Equals("Sort order")).
+			Lines(
+				Contains("a (•) Alphabetical").IsSelected(),
+				Contains("d ( ) Date"),
+				Contains("      Cancel"),
+			).
 			Select(Contains("-committerdate")).
 			Confirm()
 


### PR DESCRIPTION
- **PR Description**

Some of our menus let you pick a value for some option (e.g. the sort order menus for branches and commits). It's nice to see which one is the current value when opening such a menu, so this PR implements that.

<img width="250" alt="image" src="https://github.com/jesseduffield/lazygit/assets/1225667/670fda78-6d2b-412f-88cf-5cb1a180f802">

For menus that also have key bindings, the radio button goes between the key and the label.

As an alternative, I considered selecting the current value when the menu is opened; however, we currently have no menus where we select a different entry than the first one, and it might be confusing for people who are used to opening a menu and then pressing down-arrow a certain number of times to get to a particular value.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
