### PR TITLE
Update `rebase_onto` demo test to match new the rebase menu title

### DIFF
--- a/pkg/integration/tests/demo/rebase_onto.go
+++ b/pkg/integration/tests/demo/rebase_onto.go
@@ -64,7 +64,7 @@ var RebaseOnto = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Branches.RebaseBranch).
 			Tap(func() {
 				t.ExpectPopup().Menu().
-					Title(Contains("Rebase 'feature/demo' from marked base onto 'master'")).
+					Title(Contains("Rebase 'feature/demo' from marked base")).
 					Select(Contains("Simple rebase")).
 					Confirm()
 			}).


### PR DESCRIPTION
- **PR Description**

This PR updates the `rebase_onto` demo integration test, which is currently failing on master due to [this change](https://github.com/jesseduffield/lazygit/pull/3615/files#diff-3eb5426752dae525c92f1ecce2f7215d15bfdec91bd459e08f78574876583910R1259).
Our CI does not throw the issue, but it's still annoying to cope with it for local development.

@jesseduffield @stefanhaller, I'm unaware of a particular workflow for updating demo tests, but let me know if this needs some tweaks.  

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
