### PR TITLE
Fix secondary window resize

### DIFF
--- a/pkg/gui/controllers/helpers/window_arrangement_helper.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper.go
@@ -216,6 +216,15 @@ func mainSectionChildren(args WindowArrangementArgs) []*boxlayout.Box {
 		}
 	}
 
+	if args.CurrentWindow == "secondary" && args.ScreenMode == types.SCREEN_FULL {
+		return []*boxlayout.Box{
+			{
+				Window: "secondary",
+				Weight: 1,
+			},
+		}
+	}
+
 	return []*boxlayout.Box{
 		{
 			Window: "main",
@@ -239,7 +248,7 @@ func getMidSectionWeights(args WindowArrangementArgs) (int, int) {
 		mainSectionWeight = 5 // need to shrink side panel to make way for main panels if side-by-side
 	}
 
-	if args.CurrentWindow == "main" {
+	if args.CurrentWindow == "main" || args.CurrentWindow == "secondary" {
 		if args.ScreenMode == types.SCREEN_HALF || args.ScreenMode == types.SCREEN_FULL {
 			sideSectionWeight = 0
 		}

--- a/pkg/integration/components/view_driver.go
+++ b/pkg/integration/components/view_driver.go
@@ -565,7 +565,7 @@ func (self *ViewDriver) IsVisible() *ViewDriver {
 
 func (self *ViewDriver) IsInvisible() *ViewDriver {
 	self.t.assertWithRetries(func() (bool, string) {
-		return !self.getView().Visible, fmt.Sprintf("%s: Expected view to be visible, but it was not", self.context)
+		return !self.getView().Visible, fmt.Sprintf("%s: Expected view to be invisible, but it was not", self.context)
 	})
 
 	return self

--- a/pkg/integration/tests/staging/diff_change_screen_mode.go
+++ b/pkg/integration/tests/staging/diff_change_screen_mode.go
@@ -1,0 +1,47 @@
+package staging
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var DiffChangeScreenMode = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Change the staged changes screen mode",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFile("file", "first line\nsecond line")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			Focus().
+			PressEnter()
+
+		t.Views().Staging().
+			IsFocused().
+			PressPrimaryAction().
+			Title(Equals("Unstaged changes")).
+			Content(Contains("+second line").DoesNotContain("+first line")).
+			PressTab()
+
+		t.Views().StagingSecondary().
+			IsFocused().
+			Title(Equals("Staged changes")).
+			Content(Contains("+first line").DoesNotContain("+second line")).
+			Press(keys.Universal.NextScreenMode).
+			Tap(func() {
+				t.Views().AppStatus().
+					IsInvisible()
+				t.Views().Staging().
+					IsVisible()
+			}).
+			Press(keys.Universal.NextScreenMode).
+			Tap(func() {
+				t.Views().AppStatus().
+					IsInvisible()
+				t.Views().Staging().
+					IsInvisible()
+			})
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -245,6 +245,7 @@ var tests = []*components.IntegrationTest{
 	reflog.DoNotShowBranchMarkersInReflogSubcommits,
 	reflog.Patch,
 	reflog.Reset,
+	staging.DiffChangeScreenMode,
 	staging.DiffContextChange,
 	staging.DiscardAllChanges,
 	staging.Search,


### PR DESCRIPTION
- **PR Description**
This PR fixes the behavior the staging secondary panel (staged lines) currently has in relation to changing its view mode. In particular, these changes allows the users to expand the secondary panels the same way all the others do.

This closes #3629.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
