### PR TITLE
Include demos when running integration tests on CI

### DIFF
--- a/pkg/gui/gui_driver.go
+++ b/pkg/gui/gui_driver.go
@@ -21,6 +21,7 @@ type GuiDriver struct {
 	gui        *Gui
 	isIdleChan chan struct{}
 	toastChan  chan string
+	headless   bool
 }
 
 var _ integrationTypes.GuiDriver = &GuiDriver{}
@@ -160,4 +161,8 @@ func (self *GuiDriver) NextToast() *string {
 	default:
 		return nil
 	}
+}
+
+func (self *GuiDriver) Headless() bool {
+	return self.headless
 }

--- a/pkg/gui/test_mode.go
+++ b/pkg/gui/test_mode.go
@@ -38,7 +38,7 @@ func (gui *Gui) handleTestMode() {
 			gui.PopupHandler.(*popup.PopupHandler).SetToastFunc(
 				func(message string, kind types.ToastKind) { toastChan <- message })
 
-			test.Run(&GuiDriver{gui: gui, isIdleChan: isIdleChan, toastChan: toastChan})
+			test.Run(&GuiDriver{gui: gui, isIdleChan: isIdleChan, toastChan: toastChan, headless: Headless()})
 
 			gui.g.Update(func(*gocui.Gui) error {
 				return gocui.ErrQuit

--- a/pkg/integration/clients/go_test.go
+++ b/pkg/integration/clients/go_test.go
@@ -45,12 +45,6 @@ func TestIntegration(t *testing.T) {
 				return
 			}
 
-			// not running demoes right now. Arguably we should, but we'd need to
-			// strip away any artificial lag they use.
-			if test.IsDemo() {
-				return
-			}
-
 			t.Run(test.Name(), func(t *testing.T) {
 				t.Parallel()
 				err := f()

--- a/pkg/integration/components/test_test.go
+++ b/pkg/integration/components/test_test.go
@@ -84,6 +84,8 @@ func (self *fakeGuiDriver) NextToast() *string {
 
 func (self *fakeGuiDriver) CheckAllToastsAcknowledged() {}
 
+func (self *fakeGuiDriver) Headless() bool { return false }
+
 func TestManualFailure(t *testing.T) {
 	test := NewIntegrationTest(NewIntegrationTestArgs{
 		Description: unitTestDescription,

--- a/pkg/integration/components/view_driver.go
+++ b/pkg/integration/components/view_driver.go
@@ -601,7 +601,9 @@ func (self *ViewDriver) SetCaptionPrefix(prefix string) *ViewDriver {
 }
 
 func (self *ViewDriver) Wait(milliseconds int) *ViewDriver {
-	self.t.Wait(milliseconds)
+	if !self.t.gui.Headless() {
+		self.t.Wait(milliseconds)
+	}
 
 	return self
 }

--- a/pkg/integration/types/types.go
+++ b/pkg/integration/types/types.go
@@ -46,4 +46,5 @@ type GuiDriver interface {
 	// Pop the next toast that was displayed; returns nil if there was none
 	NextToast() *string
 	CheckAllToastsAcknowledged()
+	Headless() bool
 }


### PR DESCRIPTION
- **PR Description**

This includes the demos when using `make integration-test-all`, and speeds them up a little bit when run in this way by disabling Wait calls when running in headless mode.

This will guard against demos breaking when we make behavior changes, as happened several times in the past (most recently in #3636.