### PR TITLE
Improve "Find base commit for fixup" command when there are changes for master commits

### DIFF
--- a/pkg/integration/tests/commit/find_base_commit_for_fixup_disregard_main_branch.go
+++ b/pkg/integration/tests/commit/find_base_commit_for_fixup_disregard_main_branch.go
@@ -35,7 +35,6 @@ var FindBaseCommitForFixupDisregardMainBranch = NewIntegrationTest(NewIntegratio
 			Focus().
 			Press(keys.Files.FindBaseCommitForFixup)
 
-		/* EXPECTED:
 		t.Views().Commits().
 			IsFocused().
 			Lines(
@@ -44,13 +43,5 @@ var FindBaseCommitForFixupDisregardMainBranch = NewIntegrationTest(NewIntegratio
 				Contains("2nd commit"),
 				Contains("1st commit"),
 			)
-		*/
-
-		// ACTUAL:
-		t.ExpectPopup().Alert().Title(Equals("Error")).Content(
-			Contains("Multiple base commits found.").
-				Contains("2nd commit").
-				Contains("3rd commit"),
-		).Confirm()
 	},
 })

--- a/pkg/integration/tests/commit/find_base_commit_for_fixup_disregard_main_branch.go
+++ b/pkg/integration/tests/commit/find_base_commit_for_fixup_disregard_main_branch.go
@@ -1,0 +1,56 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var FindBaseCommitForFixupDisregardMainBranch = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Finds the base commit to create a fixup for, disregarding changes to a commit that is already on master",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			EmptyCommit("1st commit").
+			CreateFileAndAdd("file1", "file1 content\n").
+			Commit("2nd commit").
+			NewBranch("mybranch").
+			CreateFileAndAdd("file2", "file2 content\n").
+			Commit("3rd commit").
+			EmptyCommit("4th commit").
+			UpdateFile("file1", "file1 changed content").
+			UpdateFile("file2", "file2 changed content")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Lines(
+				Contains("4th commit").IsSelected(),
+				Contains("3rd commit"),
+				Contains("2nd commit"),
+				Contains("1st commit"),
+			)
+
+		t.Views().Files().
+			Focus().
+			Press(keys.Files.FindBaseCommitForFixup)
+
+		/* EXPECTED:
+		t.Views().Commits().
+			IsFocused().
+			Lines(
+				Contains("4th commit"),
+				Contains("3rd commit").IsSelected(),
+				Contains("2nd commit"),
+				Contains("1st commit"),
+			)
+		*/
+
+		// ACTUAL:
+		t.ExpectPopup().Alert().Title(Equals("Error")).Content(
+			Contains("Multiple base commits found.").
+				Contains("2nd commit").
+				Contains("3rd commit"),
+		).Confirm()
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -82,6 +82,7 @@ var tests = []*components.IntegrationTest{
 	commit.CreateTag,
 	commit.DiscardOldFileChanges,
 	commit.FindBaseCommitForFixup,
+	commit.FindBaseCommitForFixupDisregardMainBranch,
 	commit.FindBaseCommitForFixupOnlyAddedLines,
 	commit.FindBaseCommitForFixupWarningForAddedLines,
 	commit.Highlight,


### PR DESCRIPTION
- **PR Description**

If exactly one candidate from inside the current branch is found, we return that one even if there are also hunks belonging to master commits; we disregard those in this case.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
