### PR TITLE
Show "exec" todos in the list of rebase todos

### DIFF
--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -344,6 +344,8 @@ func (self *CommitLoader) getRebasingCommits(rebaseMode enums.RebaseMode) []*mod
 	for _, t := range todos {
 		if t.Command == todo.UpdateRef {
 			t.Msg = t.Ref
+		} else if t.Command == todo.Exec {
+			t.Msg = t.ExecCommand
 		} else if t.Commit == "" {
 			// Command does not have a commit associated, skip
 			continue

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -284,6 +284,9 @@ func (self *LocalCommitsController) GetOnRenderToMain() func() error {
 						map[string]string{
 							"ref": strings.TrimPrefix(commit.Name, "refs/heads/"),
 						}))
+			} else if commit.Action == todo.Exec {
+				task = types.NewRenderStringTask(
+					self.c.Tr.ExecCommandHere + "\n\n" + commit.Name)
 			} else {
 				cmdObj := self.c.Git().Commit.ShowCmdObj(commit.Hash, self.c.Modes().Filtering.GetPath())
 				task = types.NewRunPtyTask(cmdObj.GetCmd())

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -164,6 +164,7 @@ type TranslationSet struct {
 	RewordCommitEditor                    string
 	NoCommitsThisBranch                   string
 	UpdateRefHere                         string
+	ExecCommandHere                       string
 	Error                                 string
 	Undo                                  string
 	UndoReflog                            string
@@ -1093,6 +1094,7 @@ func EnglishTranslationSet() TranslationSet {
 		SquashTooltip:                        "Squash the selected commit into the commit below it. The selected commit's message will be appended to the commit below it.",
 		NoCommitsThisBranch:                  "No commits for this branch",
 		UpdateRefHere:                        "Update branch '{{.ref}}' here",
+		ExecCommandHere:                      "Execute the following command here:",
 		CannotSquashOrFixupFirstCommit:       "There's no commit below to squash into",
 		Fixup:                                "Fixup",
 		SureFixupThisCommit:                  "Are you sure you want to 'fixup' the selected commit(s) into the commit below?",

--- a/pkg/integration/tests/interactive_rebase/show_exec_todos.go
+++ b/pkg/integration/tests/interactive_rebase/show_exec_todos.go
@@ -38,7 +38,7 @@ var ShowExecTodos = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			Tap(func() {
 				t.Common().ContinueRebase()
-				t.ExpectPopup().Alert().Title(Equals("Error")).Content(Contains("Rebasing (4/4)Executing: false")).Confirm()
+				t.ExpectPopup().Alert().Title(Equals("Error")).Content(Contains("exit status 1")).Confirm()
 			}).
 			Lines(
 				Contains("CI ◯ <-- YOU ARE HERE --- commit 03"),

--- a/pkg/integration/tests/interactive_rebase/show_exec_todos.go
+++ b/pkg/integration/tests/interactive_rebase/show_exec_todos.go
@@ -1,0 +1,57 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ShowExecTodos = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Show exec todos in the rebase todo list",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.UserConfig.CustomCommands = []config.CustomCommand{
+			{
+				Key:     "X",
+				Context: "commits",
+				Command: "git -c core.editor=: rebase -i -x false HEAD^^",
+			},
+		}
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			NewBranch("branch1").
+			CreateNCommits(3)
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Press("X").
+			Tap(func() {
+				t.ExpectPopup().Alert().Title(Equals("Error")).Content(Contains("Rebasing (2/4)Executing: false")).Confirm()
+			}).
+			Lines(
+				Contains("exec").Contains("false"),
+				Contains("pick").Contains("CI commit 03"),
+				Contains("CI ◯ <-- YOU ARE HERE --- commit 02"),
+				Contains("CI ◯ commit 01"),
+			).
+			Tap(func() {
+				t.Common().ContinueRebase()
+				t.ExpectPopup().Alert().Title(Equals("Error")).Content(Contains("Rebasing (4/4)Executing: false")).Confirm()
+			}).
+			Lines(
+				Contains("CI ◯ <-- YOU ARE HERE --- commit 03"),
+				Contains("CI ◯ commit 02"),
+				Contains("CI ◯ commit 01"),
+			).
+			Tap(func() {
+				t.Common().ContinueRebase()
+			}).
+			Lines(
+				Contains("CI ◯ commit 03"),
+				Contains("CI ◯ commit 02"),
+				Contains("CI ◯ commit 01"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -209,6 +209,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.RewordLastCommit,
 	interactive_rebase.RewordYouAreHereCommit,
 	interactive_rebase.RewordYouAreHereCommitWithEditor,
+	interactive_rebase.ShowExecTodos,
 	interactive_rebase.SquashDownFirstCommit,
 	interactive_rebase.SquashDownSecondCommit,
 	interactive_rebase.SquashFixupsAbove,


### PR DESCRIPTION
- **PR Description**

It is sometimes useful to perform a `git rebase -x "make test" origin/main` in order to verify that all commits of the current branch are green. However, if the rebase stops in the middle because one of those tests fail, it's easy to accidentally press `m <enter>` in lazygit after amending some fix, not realizing that the rest of the tests will now run invisibly inside lazygit.

This PR makes two changes to improve this situation:
- It shows exec todos in the commits panel: 
<img width="482" alt="image" src="https://github.com/jesseduffield/lazygit/assets/1225667/608b24e8-9f3d-4a5f-9bb5-e16268c86e83">
- when continuing a rebase and there are exec todos, it suspends itself to the background so that you can see the output of the test runs in the terminal.

We can improve this further in the future; for example, it would often be useful to be able to delete some of the exec commands, this is not currently possible. But it's still better than before.