### PR TITLE
Fix PTY layout problems

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -959,3 +959,12 @@ func (gui *Gui) onWorker(f func(gocui.Task) error) {
 func (gui *Gui) getWindowDimensions(informationStr string, appStatus string) map[string]boxlayout.Dimensions {
 	return gui.helpers.WindowArrangement.GetWindowDimensions(informationStr, appStatus)
 }
+
+func (gui *Gui) afterLayout(f func() error) {
+	select {
+	case gui.afterLayoutFuncs <- f:
+	default:
+		// hopefully this never happens
+		gui.c.Log.Error("afterLayoutFuncs channel is full, skipping function")
+	}
+}

--- a/pkg/gui/gui_common.go
+++ b/pkg/gui/gui_common.go
@@ -189,12 +189,7 @@ func (self *guiCommon) GetInitialKeybindingsWithCustomCommands() ([]*types.Bindi
 }
 
 func (self *guiCommon) AfterLayout(f func() error) {
-	select {
-	case self.gui.afterLayoutFuncs <- f:
-	default:
-		// hopefully this never happens
-		self.gui.c.Log.Error("afterLayoutFuncs channel is full, skipping function")
-	}
+	self.gui.afterLayout(f)
 }
 
 func (self *guiCommon) RunningIntegrationTest() bool {

--- a/pkg/gui/main_panels.go
+++ b/pkg/gui/main_panels.go
@@ -20,7 +20,10 @@ func (gui *Gui) runTaskForView(view *gocui.View, task types.UpdateTask) error {
 		return gui.newCmdTask(view, v.Cmd, v.Prefix)
 
 	case *types.RunPtyTask:
-		return gui.newPtyTask(view, v.Cmd, v.Prefix)
+		gui.afterLayout(func() error {
+			return gui.newPtyTask(view, v.Cmd, v.Prefix)
+		})
+		return nil
 	}
 
 	return nil


### PR DESCRIPTION
- **PR Description**

This fixes two layout problems with pagers that draw a horizontal line across the entire width of the view (e.g. delta):
- sometimes the width of that line was one character too long or too short in the staged changes view
- when changing from a file or directory that has only staged or only unstaged changes to one that has both, the length of the horizontal line was totally off and only redraw correctly at the next refresh