### PR TITLE
Fix duplicate keybinding suggestions in status bar after switching repos

### DIFF
--- a/pkg/gui/context/base_context.go
+++ b/pkg/gui/context/base_context.go
@@ -133,6 +133,11 @@ func (self *BaseContext) AddMouseKeybindingsFn(fn types.MouseKeybindingsFn) {
 	self.mouseKeybindingsFns = append(self.mouseKeybindingsFns, fn)
 }
 
+func (self *BaseContext) ClearAllBindingsFn() {
+	self.keybindingsFns = []types.KeybindingsFn{}
+	self.mouseKeybindingsFns = []types.MouseKeybindingsFn{}
+}
+
 func (self *BaseContext) AddOnClickFn(fn func() error) {
 	if fn != nil {
 		self.onClickFn = fn

--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -20,6 +20,10 @@ func (gui *Gui) Helpers() *helpers.Helpers {
 // in the keybinding menu: the earlier that the controller is attached to a context,
 // the lower in the list the keybindings will appear.
 func (gui *Gui) resetHelpersAndControllers() {
+	for _, context := range gui.Contexts().Flatten() {
+		context.ClearAllBindingsFn()
+	}
+
 	helperCommon := gui.c
 	recordDirectoryHelper := helpers.NewRecordDirectoryHelper(helperCommon)
 	reposHelper := helpers.NewRecentReposHelper(helperCommon, recordDirectoryHelper, gui.onNewRepo)

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -74,6 +74,7 @@ type IBaseContext interface {
 
 	AddKeybindingsFn(KeybindingsFn)
 	AddMouseKeybindingsFn(MouseKeybindingsFn)
+	ClearAllBindingsFn()
 
 	// This is a bit of a hack at the moment: we currently only set an onclick function so that
 	// our list controller can come along and wrap it in a list-specific click handler.

--- a/pkg/integration/components/shell.go
+++ b/pkg/integration/components/shell.go
@@ -360,6 +360,12 @@ func (self *Shell) Clone(repoName string) *Shell {
 	return self
 }
 
+func (self *Shell) CloneNonBare(repoName string) *Shell {
+	self.RunCommand([]string{"git", "clone", ".", "../" + repoName})
+
+	return self
+}
+
 func (self *Shell) SetBranchUpstream(branch string, upstream string) *Shell {
 	self.RunCommand([]string{"git", "branch", "--set-upstream-to=" + upstream, branch})
 

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -315,6 +315,7 @@ var tests = []*components.IntegrationTest{
 	ui.Accordion,
 	ui.DoublePopup,
 	ui.EmptyMenu,
+	ui.KeybindingSuggestionsWhenSwitchingRepos,
 	ui.ModeSpecificKeybindingSuggestions,
 	ui.OpenLinkFailure,
 	ui.RangeSelect,

--- a/pkg/integration/tests/ui/keybinding_suggestions_when_switching_repos.go
+++ b/pkg/integration/tests/ui/keybinding_suggestions_when_switching_repos.go
@@ -37,9 +37,6 @@ var KeybindingSuggestionsWhenSwitchingRepos = NewIntegrationTest(NewIntegrationT
 		switchToRepo("repo")
 
 		t.Views().Options().Content(
-			/* EXPECTED:
 			Equals("Commit: c | Stash: s | Reset: D | Keybindings: ? | Cancel: <esc>"))
-			ACTUAL (all keybindings appear twice): */
-			Equals("Commit: c | Stash: s | Reset: D | Commit: c | Stash: s | Reset: D | Keybindings: ? | Cancel: <esc> | Keybindings: ? | Cancel: <esc>"))
 	},
 })

--- a/pkg/integration/tests/ui/keybinding_suggestions_when_switching_repos.go
+++ b/pkg/integration/tests/ui/keybinding_suggestions_when_switching_repos.go
@@ -1,0 +1,45 @@
+package ui
+
+import (
+	"path/filepath"
+
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var KeybindingSuggestionsWhenSwitchingRepos = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Show correct keybinding suggestions after switching between repos",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		otherRepo, _ := filepath.Abs("../other")
+		config.AppState.RecentRepos = []string{otherRepo}
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.CloneNonBare("other")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		switchToRepo := func(repo string) {
+			t.GlobalPress(keys.Universal.OpenRecentRepos)
+			t.ExpectPopup().Menu().Title(Equals("Recent repositories")).
+				Lines(
+					Contains(repo).IsSelected(),
+					Contains("Cancel"),
+				).Confirm()
+			t.Views().Status().Content(Contains(repo + " → master"))
+		}
+
+		t.Views().Files().Focus()
+		t.Views().Options().Content(
+			Equals("Commit: c | Stash: s | Reset: D | Keybindings: ? | Cancel: <esc>"))
+
+		switchToRepo("other")
+		switchToRepo("repo")
+
+		t.Views().Options().Content(
+			/* EXPECTED:
+			Equals("Commit: c | Stash: s | Reset: D | Keybindings: ? | Cancel: <esc>"))
+			ACTUAL (all keybindings appear twice): */
+			Equals("Commit: c | Stash: s | Reset: D | Commit: c | Stash: s | Reset: D | Keybindings: ? | Cancel: <esc> | Keybindings: ? | Cancel: <esc>"))
+	},
+})


### PR DESCRIPTION
- **PR Description**

When switching to a repo that was open before, all keybinding suggestions in the status bar would show twice.

Fixes #3612.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
