### PR TITLE
Fix reporting of unexpected selections in integration tests

### DIFF
--- a/pkg/integration/components/view_driver.go
+++ b/pkg/integration/components/view_driver.go
@@ -263,8 +263,8 @@ func (self *ViewDriver) assertLines(offset int, matchers ...*TextMatcher) *ViewD
 				return false, fmt.Sprintf(
 					"Unexpected selection in view '%s'. Expected %s to be selected but got %s.\nExpected selected lines:\n---\n%s\n---\n\nActual selected lines:\n---\n%s\n---\n",
 					view.Name(),
-					formatLineRange(startIdx, endIdx),
 					formatLineRange(expectedStartIdx, expectedEndIdx),
+					formatLineRange(startIdx, endIdx),
 					strings.Join(expectedSelectedLines, "\n"),
 					strings.Join(lines, "\n"),
 				)


### PR DESCRIPTION
Expected and actual selection were swapped in the error message.
