### PR TITLE
Make commit author length configurable

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -181,9 +181,11 @@ gui:
   # If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.
   showFileIcons: true
 
-  # Whether to show full author names or their shortened form in the commit graph.
-  # One of 'auto' (default) | 'full' | 'short'
-  # If 'auto', initials will be shown in small windows, and full names - in larger ones.
+  # How to show author names in the Commits view.
+  # One of 'auto' (default) | 'full' | 'short | 'truncateTo:<n,m>'
+  # If 'short', show initials both in the normal view and the expanded view.
+  # If 'auto', initials will be shown in the normal view, and full names (truncated to 17 characters) in the expanded view.
+  # If 'truncateTo:<n,m>', truncate to n characters in the normal view and m characters in the expanded view.
   commitAuthorFormat: auto
 
   # Length of commit hash in commits view. 0 shows '*' if NF icons aren't on.

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -125,10 +125,12 @@ type GuiConfig struct {
 	NerdFontsVersion string `yaml:"nerdFontsVersion" jsonschema:"enum=2,enum=3,enum="`
 	// If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.
 	ShowFileIcons bool `yaml:"showFileIcons"`
-	// Whether to show full author names or their shortened form in the commit graph.
-	// One of 'auto' (default) | 'full' | 'short'
-	// If 'auto', initials will be shown in small windows, and full names - in larger ones.
-	CommitAuthorFormat string `yaml:"commitAuthorFormat" jsonschema:"enum=auto,enum=short,enum=full"`
+	// How to show author names in the Commits view.
+	// One of 'auto' (default) | 'full' | 'short | 'truncateTo:<n,m>'
+	// If 'short', show initials both in the normal view and the expanded view.
+	// If 'auto', initials will be shown in the normal view, and full names (truncated to 17 characters) in the expanded view.
+	// If 'truncateTo:<n,m>', truncate to n characters in the normal view and m characters in the expanded view.
+	CommitAuthorFormat CommitAuthorFormat `yaml:"commitAuthorFormat"`
 	// Length of commit hash in commits view. 0 shows '*' if NF icons aren't on.
 	CommitHashLength int `yaml:"commitHashLength" jsonschema:"minimum=0"`
 	// If true, show commit hashes alongside branch names in the branches view.
@@ -161,6 +163,16 @@ type GuiConfig struct {
 	// Status panel view.
 	// One of 'dashboard' (default) | 'allBranchesLog'
 	StatusPanelView string `yaml:"statusPanelView" jsonschema:"enum=dashboard,enum=allBranchesLog"`
+}
+
+type CommitAuthorFormat string
+
+func (CommitAuthorFormat) JSONSchemaExtend(schema *jsonschema.Schema) {
+	schema.Type = ""
+	schema.OneOf = []*jsonschema.Schema{
+		{Type: "string", Enum: []any{"auto", "short", "full"}},
+		{Type: "string", Pattern: `^truncateTo:\d+(,\d+)?$`},
+	}
 }
 
 func (c *GuiConfig) UseFuzzySearch() bool {

--- a/pkg/config/user_config_validation.go
+++ b/pkg/config/user_config_validation.go
@@ -2,12 +2,18 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 )
 
 func (config *UserConfig) Validate() error {
-	if err := validateEnum("gui.commitAuthorFormat", config.Gui.CommitAuthorFormat,
+	if strings.HasPrefix(string(config.Gui.CommitAuthorFormat), "truncateTo:") {
+		regex := regexp.MustCompile(`truncateTo:\d+(,\d+)?$`)
+		if !regex.MatchString(string(config.Gui.CommitAuthorFormat)) {
+			return fmt.Errorf("Invalid value for 'gui.commitAuthorFormat'. Expected format: 'truncateTo:<normal_length>[,<extended_length>]'")
+		}
+	} else if err := validateEnum("gui.commitAuthorFormat", string(config.Gui.CommitAuthorFormat),
 		[]string{"auto", "short", "full"}); err != nil {
 		return err
 	}

--- a/pkg/config/user_config_validation_test.go
+++ b/pkg/config/user_config_validation_test.go
@@ -47,3 +47,52 @@ func TestUserConfigValidate_enums(t *testing.T) {
 		})
 	}
 }
+
+func TestUserConfigValidate_commitAuthorFormat(t *testing.T) {
+	type testCase struct {
+		value string
+		valid bool
+	}
+
+	scenarios := []struct {
+		name      string
+		setup     func(config *UserConfig, value string)
+		testCases []testCase
+	}{
+		{
+			name: "Gui.CommitAuthorFormat",
+			setup: func(config *UserConfig, value string) {
+				config.Gui.CommitAuthorFormat = CommitAuthorFormat(value)
+			},
+			testCases: []testCase{
+				{value: "auto", valid: true},
+				{value: "short", valid: true},
+				{value: "full", valid: true},
+				{value: "truncateTo:", valid: false},
+				{value: "truncateTo:xyz", valid: false},
+				{value: "truncateTo:1", valid: true},
+				{value: "truncateTo:1,", valid: false},
+				{value: "truncateTo:,2", valid: false},
+				{value: "truncateTo:12,35", valid: true},
+				{value: "junk", valid: false},
+				{value: "", valid: false},
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			for _, testCase := range s.testCases {
+				config := GetDefaultConfig()
+				s.setup(config, testCase.value)
+				err := config.Validate()
+
+				if testCase.valid {
+					assert.NoError(t, err)
+				} else {
+					assert.Error(t, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/gui/presentation/authors/authors.go
+++ b/pkg/gui/presentation/authors/authors.go
@@ -11,11 +11,16 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
+type authorNameCacheKey struct {
+	authorName string
+	truncateTo int
+}
+
 // if these being global variables causes trouble we can wrap them in a struct
 // attached to the gui state.
 var (
 	authorInitialCache = make(map[string]string)
-	authorNameCache    = make(map[string]string)
+	authorNameCache    = make(map[authorNameCacheKey]string)
 	authorStyleCache   = make(map[string]style.TextStyle)
 )
 
@@ -38,14 +43,19 @@ func ShortAuthor(authorName string) string {
 }
 
 func LongAuthor(authorName string) string {
-	if value, ok := authorNameCache[authorName]; ok {
+	return LongAuthorWithCustomLength(authorName, 17)
+}
+
+func LongAuthorWithCustomLength(authorName string, length int) string {
+	cacheKey := authorNameCacheKey{authorName: authorName, truncateTo: length}
+	if value, ok := authorNameCache[cacheKey]; ok {
 		return value
 	}
 
-	paddedAuthorName := utils.WithPadding(authorName, 17, utils.AlignLeft)
-	truncatedName := utils.TruncateWithEllipsis(paddedAuthorName, 17)
+	paddedAuthorName := utils.WithPadding(authorName, length, utils.AlignLeft)
+	truncatedName := utils.TruncateWithEllipsis(paddedAuthorName, length)
 	value := AuthorStyle(authorName).Sprint(truncatedName)
-	authorNameCache[authorName] = value
+	authorNameCache[cacheKey] = value
 
 	return value
 }

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -440,15 +440,7 @@ func displayCommit(
 		mark = fmt.Sprintf("%s ", willBeRebased)
 	}
 
-	var authorFunc func(string) string
-	switch common.UserConfig.Gui.CommitAuthorFormat {
-	case "short":
-		authorFunc = authors.ShortAuthor
-	case "full":
-		authorFunc = authors.LongAuthor
-	default:
-		authorFunc = lo.Ternary(fullDescription, authors.LongAuthor, authors.ShortAuthor)
-	}
+	authorFunc := getAuthorFunc(common.UserConfig.Gui.CommitAuthorFormat, fullDescription)
 
 	cols := make([]string, 0, 7)
 	cols = append(
@@ -463,6 +455,17 @@ func displayCommit(
 	)
 
 	return cols
+}
+
+func getAuthorFunc(commitAuthorFormat string, fullDescription bool) func(string) string {
+	switch commitAuthorFormat {
+	case "short":
+		return authors.ShortAuthor
+	case "full":
+		return authors.LongAuthor
+	default:
+		return lo.Ternary(fullDescription, authors.LongAuthor, authors.ShortAuthor)
+	}
 }
 
 func getBisectStatusColor(status BisectStatus) style.TextStyle {

--- a/pkg/utils/formatting.go
+++ b/pkg/utils/formatting.go
@@ -161,10 +161,10 @@ func MaxFn[T any](items []T, fn func(T) int) int {
 
 // TruncateWithEllipsis returns a string, truncated to a certain length, with an ellipsis
 func TruncateWithEllipsis(str string, limit int) string {
-	if runewidth.StringWidth(str) > limit && limit <= 3 {
+	if runewidth.StringWidth(str) > limit && limit <= 2 {
 		return strings.Repeat(".", limit)
 	}
-	return runewidth.Truncate(str, limit, "...")
+	return runewidth.Truncate(str, limit, "…")
 }
 
 func SafeTruncate(str string, limit int) string {

--- a/pkg/utils/formatting_test.go
+++ b/pkg/utils/formatting_test.go
@@ -107,22 +107,22 @@ func TestTruncateWithEllipsis(t *testing.T) {
 		{
 			"hello world !",
 			3,
-			"...",
+			"he…",
 		},
 		{
 			"hello world !",
 			4,
-			"h...",
+			"hel…",
 		},
 		{
 			"hello world !",
 			5,
-			"he...",
+			"hell…",
 		},
 		{
 			"hello world !",
 			12,
-			"hello wor...",
+			"hello world…",
 		},
 		{
 			"hello world !",
@@ -137,12 +137,17 @@ func TestTruncateWithEllipsis(t *testing.T) {
 		{
 			"大大大大",
 			5,
-			"大...",
+			"大大…",
 		},
 		{
 			"大大大大",
 			2,
 			"..",
+		},
+		{
+			"大大大大",
+			1,
+			".",
 		},
 		{
 			"大大大大",

--- a/schema/config.json
+++ b/schema/config.json
@@ -321,13 +321,21 @@
           "default": true
         },
         "commitAuthorFormat": {
-          "type": "string",
-          "enum": [
-            "auto",
-            "short",
-            "full"
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "auto",
+                "short",
+                "full"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^truncateTo:\\d+(,\\d+)?$"
+            }
           ],
-          "description": "Whether to show full author names or their shortened form in the commit graph.\nOne of 'auto' (default) | 'full' | 'short'\nIf 'auto', initials will be shown in small windows, and full names - in larger ones.",
+          "description": "How to show author names in the Commits view.\nOne of 'auto' (default) | 'full' | 'short | 'truncateTo:\u003cn,m\u003e'\nIf 'short', show initials both in the normal view and the expanded view.\nIf 'auto', initials will be shown in the normal view, and full names (truncated to 17 characters) in the expanded view.\nIf 'truncateTo:\u003cn,m\u003e', truncate to n characters in the normal view and m characters in the expanded view.",
           "default": "auto"
         },
         "commitHashLength": {


### PR DESCRIPTION
- **PR Description**

Following up on #3625, make it possible to configure the length of the author names in the Commits view by setting `gui.commitAuthorFormat` to `truncateTo:<n,m>`, where n is the length in the normal view and m the length in the expanded view.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
