### PR TITLE
Add command to paste commit message from clipboard

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -415,8 +415,12 @@ os:
   openLinkCommand: ""
 
   # CopyToClipboardCmd is the command for copying to clipboard.
-  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-clipboard
+  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
   copyToClipboardCmd: ""
+
+  # ReadFromClipboardCmd is the command for reading the clipboard.
+  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
+  readFromClipboardCmd: ""
 
 # If true, don't display introductory popups upon opening Lazygit.
 disableStartupPopups: false
@@ -620,7 +624,7 @@ os:
   open: 'open {{filename}}'
 ```
 
-## Custom Command for Copying to Clipboard
+## Custom Command for Copying to and Pasting from Clipboard
 ```yaml
 os:
   copyToClipboardCmd: ''
@@ -633,6 +637,12 @@ os:
   copyToClipboardCmd: printf "\033]52;c;$(printf {{text}} | base64)\a" > /dev/tty
 ```
 
+A custom command for reading from the clipboard can be set using
+```yaml
+os:
+  readFromClipboardCmd: ''
+```
+It is used, for example, when pasting a commit message into the commit message panel. The command is supposed to output the clipboard content to stdout.
 
 ## Configuring File Editing
 

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -302,6 +302,23 @@ func (c *OSCommand) CopyToClipboard(str string) error {
 	return clipboard.WriteAll(str)
 }
 
+func (c *OSCommand) PasteFromClipboard() (string, error) {
+	var s string
+	var err error
+	if c.UserConfig.OS.CopyToClipboardCmd != "" {
+		cmdStr := c.UserConfig.OS.ReadFromClipboardCmd
+		s, err = c.Cmd.NewShell(cmdStr).RunWithOutput()
+	} else {
+		s, err = clipboard.ReadAll()
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return strings.ReplaceAll(s, "\r\n", "\n"), nil
+}
+
 func (c *OSCommand) RemoveFile(path string) error {
 	msg := utils.ResolvePlaceholderString(
 		c.Tr.Log.RemoveFile,

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -565,8 +565,12 @@ type OSConfig struct {
 	OpenLinkCommand string `yaml:"openLinkCommand,omitempty"`
 
 	// CopyToClipboardCmd is the command for copying to clipboard.
-	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-clipboard
+	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
 	CopyToClipboardCmd string `yaml:"copyToClipboardCmd,omitempty"`
+
+	// ReadFromClipboardCmd is the command for reading the clipboard.
+	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
+	ReadFromClipboardCmd string `yaml:"readFromClipboardCmd,omitempty"`
 }
 
 type CustomCommandAfterHook struct {

--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -238,6 +238,13 @@ func (self *CommitsHelper) OpenCommitMenu(suggestionFunc func(string) []*types.S
 			},
 			Key: 'c',
 		},
+		{
+			Label: self.c.Tr.PasteCommitMessageFromClipboard,
+			OnPress: func() error {
+				return self.pasteCommitMessageFromClipboard()
+			},
+			Key: 'p',
+		},
 	}
 	return self.c.Menu(types.CreateMenuOptions{
 		Title: self.c.Tr.CommitMenuTitle,
@@ -253,6 +260,31 @@ func (self *CommitsHelper) addCoAuthor(suggestionFunc func(string) []*types.Sugg
 			commitDescription := self.getCommitDescription()
 			commitDescription = git_commands.AddCoAuthorToDescription(commitDescription, value)
 			self.setCommitDescription(commitDescription)
+			return nil
+		},
+	})
+}
+
+func (self *CommitsHelper) pasteCommitMessageFromClipboard() error {
+	message, err := self.c.OS().PasteFromClipboard()
+	if err != nil {
+		return err
+	}
+	if message == "" {
+		return nil
+	}
+
+	if currentMessage := self.JoinCommitMessageAndUnwrappedDescription(); currentMessage == "" {
+		self.SetMessageAndDescriptionInView(message)
+		return nil
+	}
+
+	// Confirm before overwriting the commit message
+	return self.c.Confirm(types.ConfirmOpts{
+		Title:  self.c.Tr.PasteCommitMessageFromClipboard,
+		Prompt: self.c.Tr.SurePasteCommitMessage,
+		HandleConfirm: func() error {
+			self.SetMessageAndDescriptionInView(message)
 			return nil
 		},
 	})

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -582,6 +582,8 @@ type TranslationSet struct {
 	CommitHash                            string
 	CommitURL                             string
 	CopyCommitMessageToClipboard          string
+	PasteCommitMessageFromClipboard       string
+	SurePasteCommitMessage                string
 	CommitMessage                         string
 	CommitSubject                         string
 	CommitAuthor                          string
@@ -1553,6 +1555,8 @@ func EnglishTranslationSet() *TranslationSet {
 		CommitHash:                            "Commit hash",
 		CommitURL:                             "Commit URL",
 		CopyCommitMessageToClipboard:          "Copy commit message to clipboard",
+		PasteCommitMessageFromClipboard:       "Paste commit message from clipboard",
+		SurePasteCommitMessage:                "Pasting will overwrite the current commit message, continue?",
 		CommitMessage:                         "Commit message",
 		CommitSubject:                         "Commit subject",
 		CommitAuthor:                          "Commit author",

--- a/pkg/integration/tests/commit/paste_commit_message.go
+++ b/pkg/integration/tests/commit/paste_commit_message.go
@@ -1,0 +1,49 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var PasteCommitMessage = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Paste a commit message into the commit message panel",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.UserConfig.OS.CopyToClipboardCmd = "echo {{text}} > ../clipboard"
+		config.UserConfig.OS.ReadFromClipboardCmd = "cat ../clipboard"
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("subject\n\nbody 1st line\nbody 2nd line")
+		shell.CreateFileAndAdd("file", "file content")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			ContainsLines(
+				Contains("subject").IsSelected(),
+			).
+			Press(keys.Commits.CopyCommitAttributeToClipboard)
+
+		t.ExpectPopup().Menu().Title(Equals("Copy to clipboard")).
+			Select(Contains("Commit message")).Confirm()
+
+		t.ExpectToast(Equals("Commit message copied to clipboard"))
+
+		t.Views().Files().
+			Focus().
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			OpenCommitMenu()
+
+		t.ExpectPopup().Menu().Title(Equals("Commit Menu")).
+			Select(Contains("Paste commit message from clipboard")).
+			Confirm()
+
+		t.ExpectPopup().CommitMessagePanel().
+			Content(Equals("subject")).
+			SwitchToDescription().
+			Content(Equals("body 1st line\nbody 2nd line"))
+	},
+})

--- a/pkg/integration/tests/commit/paste_commit_message_over_existing.go
+++ b/pkg/integration/tests/commit/paste_commit_message_over_existing.go
@@ -1,0 +1,54 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var PasteCommitMessageOverExisting = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Paste a commit message into the commit message panel when there is already text in the panel, causing a confirmation",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.UserConfig.OS.CopyToClipboardCmd = "echo {{text}} > ../clipboard"
+		config.UserConfig.OS.ReadFromClipboardCmd = "cat ../clipboard"
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("subject\n\nbody 1st line\nbody 2nd line")
+		shell.CreateFileAndAdd("file", "file content")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			ContainsLines(
+				Contains("subject").IsSelected(),
+			).
+			Press(keys.Commits.CopyCommitAttributeToClipboard)
+
+		t.ExpectPopup().Menu().Title(Equals("Copy to clipboard")).
+			Select(Contains("Commit message")).Confirm()
+
+		t.ExpectToast(Equals("Commit message copied to clipboard"))
+
+		t.Views().Files().
+			Focus().
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			Type("existing message").
+			OpenCommitMenu()
+
+		t.ExpectPopup().Menu().Title(Equals("Commit Menu")).
+			Select(Contains("Paste commit message from clipboard")).
+			Confirm()
+
+		t.ExpectPopup().Alert().Title(Equals("Paste commit message from clipboard")).
+			Content(Equals("Pasting will overwrite the current commit message, continue?")).
+			Confirm()
+
+		t.ExpectPopup().CommitMessagePanel().
+			Content(Equals("subject")).
+			SwitchToDescription().
+			Content(Equals("body 1st line\nbody 2nd line"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -89,6 +89,8 @@ var tests = []*components.IntegrationTest{
 	commit.History,
 	commit.HistoryComplex,
 	commit.NewBranch,
+	commit.PasteCommitMessage,
+	commit.PasteCommitMessageOverExisting,
 	commit.PreserveCommitMessage,
 	commit.ResetAuthor,
 	commit.ResetAuthorRange,

--- a/schema/config.json
+++ b/schema/config.json
@@ -796,7 +796,11 @@
         },
         "copyToClipboardCmd": {
           "type": "string",
-          "description": "CopyToClipboardCmd is the command for copying to clipboard.\nSee https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-clipboard"
+          "description": "CopyToClipboardCmd is the command for copying to clipboard.\nSee https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard"
+        },
+        "readFromClipboardCmd": {
+          "type": "string",
+          "description": "ReadFromClipboardCmd is the command for reading the clipboard.\nSee https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
- **PR Description**

Resolves #3672

Added an entry to the commit message menu called "Paste commit message from clipboard",
which splits the clipboard into subject and description and pastes both into their respective fields.

Also found that the current `SplitCommitMessageAndDescription` function has a problem with lines ending in CRLF, fixed.

---

There should be some more tests here, but I'm not sure where to start. I'll do my best if anyone can tell me.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
