### PR TITLE
Always show the "Discard unchanged changes" menu item

### DIFF
--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -175,6 +175,7 @@ type TranslationSet struct {
 	UndoMergeResolveTooltip               string
 	DiscardAllTooltip                     string
 	DiscardUnstagedTooltip                string
+	DiscardUnstagedDisabled               string
 	Pop                                   string
 	StashPopTooltip                       string
 	Drop                                  string
@@ -1143,6 +1144,7 @@ func EnglishTranslationSet() TranslationSet {
 		UndoMergeResolveTooltip:              "Undo last merge conflict resolution.",
 		DiscardAllTooltip:                    "Discard both staged and unstaged changes in '{{.path}}'.",
 		DiscardUnstagedTooltip:               "Discard unstaged changes in '{{.path}}'.",
+		DiscardUnstagedDisabled:              "The selected items don't have both staged and unstaged changes.",
 		Pop:                                  "Pop",
 		StashPopTooltip:                      "Apply the stash entry to your working directory and remove the stash entry.",
 		Drop:                                 "Drop",


### PR DESCRIPTION
Always show the "Discard unchanged changes" menu item in the Discard menu, just strike it through if not applicable. This will hopefully help with confusion about the meaning of "all" in the "Discard all changes" entry; some people misunderstand this to mean all changes in the working copy. Seeing the "Discard unstaged changes" item next to it hopefully makes it clearer that "all" is meant in contrast to that.
