### PR TITLE
Fix truncation of branch names containing non-ASCII characters

### DIFF
--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -79,10 +79,10 @@ func getBranchDisplayStrings(
 	}
 
 	// Don't bother shortening branch names that are already 3 characters or less
-	if len(displayName) > max(availableWidth, 3) {
+	if runewidth.StringWidth(displayName) > max(availableWidth, 3) {
 		// Never shorten the branch name to less then 3 characters
 		len := max(availableWidth, 4)
-		displayName = displayName[:len-1] + "…"
+		displayName = runewidth.Truncate(displayName, len, "…")
 	}
 	coloredName := nameTextStyle.Sprint(displayName)
 	if checkedOutByWorkTree {

--- a/pkg/gui/presentation/branches_test.go
+++ b/pkg/gui/presentation/branches_test.go
@@ -51,7 +51,7 @@ func Test_getBranchDisplayStrings(t *testing.T) {
 			useIcons:             false,
 			checkedOutByWorktree: false,
 			showDivergenceCfg:    "none",
-			expected:             []string{"1m", "🍉_special_c…"}, // truncated, but shouldn't
+			expected:             []string{"1m", "🍉_special_char"},
 		},
 		{
 			branch:               &models.Branch{Name: "branch_name", Recency: "1m"},
@@ -202,7 +202,7 @@ func Test_getBranchDisplayStrings(t *testing.T) {
 			useIcons:             false,
 			checkedOutByWorktree: false,
 			showDivergenceCfg:    "none",
-			expected:             []string{"1m", "🍉_special_…"}, // truncated two runes too much
+			expected:             []string{"1m", "🍉_special_ch…"},
 		},
 		{
 			branch:               &models.Branch{Name: "branch_name", Recency: "1m"},

--- a/pkg/gui/presentation/branches_test.go
+++ b/pkg/gui/presentation/branches_test.go
@@ -44,6 +44,16 @@ func Test_getBranchDisplayStrings(t *testing.T) {
 			expected:             []string{"1m", "branch_name"},
 		},
 		{
+			branch:               &models.Branch{Name: "🍉_special_char", Recency: "1m"},
+			itemOperation:        types.ItemOperationNone,
+			fullDescription:      false,
+			viewWidth:            19,
+			useIcons:             false,
+			checkedOutByWorktree: false,
+			showDivergenceCfg:    "none",
+			expected:             []string{"1m", "🍉_special_c…"}, // truncated, but shouldn't
+		},
+		{
 			branch:               &models.Branch{Name: "branch_name", Recency: "1m"},
 			itemOperation:        types.ItemOperationNone,
 			fullDescription:      false,
@@ -183,6 +193,16 @@ func Test_getBranchDisplayStrings(t *testing.T) {
 			checkedOutByWorktree: false,
 			showDivergenceCfg:    "none",
 			expected:             []string{"1m", "branch_na…"},
+		},
+		{
+			branch:               &models.Branch{Name: "🍉_special_char", Recency: "1m"},
+			itemOperation:        types.ItemOperationNone,
+			fullDescription:      false,
+			viewWidth:            18,
+			useIcons:             false,
+			checkedOutByWorktree: false,
+			showDivergenceCfg:    "none",
+			expected:             []string{"1m", "🍉_special_…"}, // truncated two runes too much
 		},
 		{
 			branch:               &models.Branch{Name: "branch_name", Recency: "1m"},

--- a/pkg/utils/formatting.go
+++ b/pkg/utils/formatting.go
@@ -161,10 +161,10 @@ func MaxFn[T any](items []T, fn func(T) int) int {
 
 // TruncateWithEllipsis returns a string, truncated to a certain length, with an ellipsis
 func TruncateWithEllipsis(str string, limit int) string {
-	if runewidth.StringWidth(str) > limit && limit <= 3 {
+	if runewidth.StringWidth(str) > limit && limit <= 2 {
 		return strings.Repeat(".", limit)
 	}
-	return runewidth.Truncate(str, limit, "...")
+	return runewidth.Truncate(str, limit, "…")
 }
 
 func SafeTruncate(str string, limit int) string {

--- a/pkg/utils/formatting_test.go
+++ b/pkg/utils/formatting_test.go
@@ -107,22 +107,22 @@ func TestTruncateWithEllipsis(t *testing.T) {
 		{
 			"hello world !",
 			3,
-			"...",
+			"he…",
 		},
 		{
 			"hello world !",
 			4,
-			"h...",
+			"hel…",
 		},
 		{
 			"hello world !",
 			5,
-			"he...",
+			"hell…",
 		},
 		{
 			"hello world !",
 			12,
-			"hello wor...",
+			"hello world…",
 		},
 		{
 			"hello world !",
@@ -137,12 +137,17 @@ func TestTruncateWithEllipsis(t *testing.T) {
 		{
 			"大大大大",
 			5,
-			"大...",
+			"大大…",
 		},
 		{
 			"大大大大",
 			2,
 			"..",
+		},
+		{
+			"大大大大",
+			1,
+			".",
 		},
 		{
 			"大大大大",


### PR DESCRIPTION
- **PR Description**

Fix truncating long branch names containing non-ASCII characters.

Before:
<img width="569" alt="image" src="https://github.com/jesseduffield/lazygit/assets/1225667/9cf4ad21-e7d0-4085-bc16-9f175285c023">

After:
<img width="569" alt="image" src="https://github.com/jesseduffield/lazygit/assets/1225667/4047e8b5-f3f1-4c4e-807f-7a9cd86a2fa7">
