### PR TITLE
Make commit author length configurable, take 2

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -185,6 +185,12 @@ gui:
   # If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.
   showFileIcons: true
 
+  # Length of author name in (non-expanded) commits view. 2 means show initials only.
+  commitAuthorShortLength: 2
+
+  # Length of author name in expanded commits view. 2 means show initials only.
+  commitAuthorLongLength: 17
+
   # Length of commit hash in commits view. 0 shows '*' if NF icons aren't on.
   commitHashLength: 8
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -185,11 +185,6 @@ gui:
   # If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.
   showFileIcons: true
 
-  # Whether to show full author names or their shortened form in the commit graph.
-  # One of 'auto' (default) | 'full' | 'short'
-  # If 'auto', initials will be shown in small windows, and full names - in larger ones.
-  commitAuthorFormat: auto
-
   # Length of commit hash in commits view. 0 shows '*' if NF icons aren't on.
   commitHashLength: 8
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -125,6 +125,10 @@ type GuiConfig struct {
 	NerdFontsVersion string `yaml:"nerdFontsVersion" jsonschema:"enum=2,enum=3,enum="`
 	// If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.
 	ShowFileIcons bool `yaml:"showFileIcons"`
+	// Length of author name in (non-expanded) commits view. 2 means show initials only.
+	CommitAuthorShortLength int `yaml:"commitAuthorShortLength"`
+	// Length of author name in expanded commits view. 2 means show initials only.
+	CommitAuthorLongLength int `yaml:"commitAuthorLongLength"`
 	// Length of commit hash in commits view. 0 shows '*' if NF icons aren't on.
 	CommitHashLength int `yaml:"commitHashLength" jsonschema:"minimum=0"`
 	// If true, show commit hashes alongside branch names in the branches view.
@@ -694,6 +698,8 @@ func GetDefaultConfig() *UserConfig {
 			ShowIcons:                    false,
 			NerdFontsVersion:             "",
 			ShowFileIcons:                true,
+			CommitAuthorShortLength:      2,
+			CommitAuthorLongLength:       17,
 			CommitHashLength:             8,
 			ShowBranchCommitHash:         false,
 			ShowDivergenceFromBaseBranch: "none",

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -125,10 +125,6 @@ type GuiConfig struct {
 	NerdFontsVersion string `yaml:"nerdFontsVersion" jsonschema:"enum=2,enum=3,enum="`
 	// If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.
 	ShowFileIcons bool `yaml:"showFileIcons"`
-	// Whether to show full author names or their shortened form in the commit graph.
-	// One of 'auto' (default) | 'full' | 'short'
-	// If 'auto', initials will be shown in small windows, and full names - in larger ones.
-	CommitAuthorFormat string `yaml:"commitAuthorFormat" jsonschema:"enum=auto,enum=short,enum=full"`
 	// Length of commit hash in commits view. 0 shows '*' if NF icons aren't on.
 	CommitHashLength int `yaml:"commitHashLength" jsonschema:"minimum=0"`
 	// If true, show commit hashes alongside branch names in the branches view.
@@ -687,7 +683,6 @@ func GetDefaultConfig() *UserConfig {
 				UnstagedChangesColor:            []string{"red"},
 				DefaultFgColor:                  []string{"default"},
 			},
-			CommitAuthorFormat:           "auto",
 			CommitLength:                 CommitLengthConfig{Show: true},
 			SkipNoStagedFilesWarning:     false,
 			ShowListFooter:               true,

--- a/pkg/config/user_config_validation.go
+++ b/pkg/config/user_config_validation.go
@@ -7,11 +7,6 @@ import (
 )
 
 func (config *UserConfig) Validate() error {
-	if err := validateEnum("gui.commitAuthorFormat", config.Gui.CommitAuthorFormat,
-		[]string{"auto", "short", "full"}); err != nil {
-		return err
-	}
-
 	if err := validateEnum("gui.statusPanelView", config.Gui.StatusPanelView,
 		[]string{"dashboard", "allBranchesLog"}); err != nil {
 		return err

--- a/pkg/gui/presentation/authors/authors.go
+++ b/pkg/gui/presentation/authors/authors.go
@@ -11,11 +11,16 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
+type authorNameCacheKey struct {
+	authorName string
+	truncateTo int
+}
+
 // if these being global variables causes trouble we can wrap them in a struct
 // attached to the gui state.
 var (
 	authorInitialCache = make(map[string]string)
-	authorNameCache    = make(map[string]string)
+	authorNameCache    = make(map[authorNameCacheKey]string)
 	authorStyleCache   = make(map[string]style.TextStyle)
 )
 
@@ -37,17 +42,35 @@ func ShortAuthor(authorName string) string {
 	return value
 }
 
-func LongAuthor(authorName string) string {
-	if value, ok := authorNameCache[authorName]; ok {
+func LongAuthor(authorName string, length int) string {
+	cacheKey := authorNameCacheKey{authorName: authorName, truncateTo: length}
+	if value, ok := authorNameCache[cacheKey]; ok {
 		return value
 	}
 
-	paddedAuthorName := utils.WithPadding(authorName, 17, utils.AlignLeft)
-	truncatedName := utils.TruncateWithEllipsis(paddedAuthorName, 17)
+	paddedAuthorName := utils.WithPadding(authorName, length, utils.AlignLeft)
+	truncatedName := utils.TruncateWithEllipsis(paddedAuthorName, length)
 	value := AuthorStyle(authorName).Sprint(truncatedName)
-	authorNameCache[authorName] = value
+	authorNameCache[cacheKey] = value
 
 	return value
+}
+
+// AuthorWithLength returns a representation of the author that fits into a
+// given maximum length:
+// - if the length is less than 2, it returns an empty string
+// - if the length is 2, it returns the initials
+// - otherwise, it returns the author name truncated to the maximum length
+func AuthorWithLength(authorName string, length int) string {
+	if length < 2 {
+		return ""
+	}
+
+	if length == 2 {
+		return ShortAuthor(authorName)
+	}
+
+	return LongAuthor(authorName, length)
 }
 
 func AuthorStyle(authorName string) style.TextStyle {

--- a/pkg/gui/presentation/authors/authors_test.go
+++ b/pkg/gui/presentation/authors/authors_test.go
@@ -1,6 +1,11 @@
 package authors
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestGetInitials(t *testing.T) {
 	for input, expectedOutput := range map[string]string{
@@ -16,5 +21,23 @@ func TestGetInitials(t *testing.T) {
 		if output != expectedOutput {
 			t.Errorf("Expected %s to be %s", output, expectedOutput)
 		}
+	}
+}
+
+func TestAuthorWithLength(t *testing.T) {
+	scenarios := []struct {
+		authorName     string
+		length         int
+		expectedOutput string
+	}{
+		{"Jesse Duffield", 0, ""},
+		{"Jesse Duffield", 1, ""},
+		{"Jesse Duffield", 2, "JD"},
+		{"Jesse Duffield", 3, "Je…"},
+		{"Jesse Duffield", 10, "Jesse Duf…"},
+		{"Jesse Duffield", 14, "Jesse Duffield"},
+	}
+	for _, s := range scenarios {
+		assert.Equal(t, s.expectedOutput, utils.Decolorise(AuthorWithLength(s.authorName, s.length)))
 	}
 }

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -440,14 +440,9 @@ func displayCommit(
 		mark = fmt.Sprintf("%s ", willBeRebased)
 	}
 
-	var authorFunc func(string) string
-	switch common.UserConfig.Gui.CommitAuthorFormat {
-	case "short":
-		authorFunc = authors.ShortAuthor
-	case "full":
+	authorFunc := authors.ShortAuthor
+	if fullDescription {
 		authorFunc = authors.LongAuthor
-	default:
-		authorFunc = lo.Ternary(fullDescription, authors.LongAuthor, authors.ShortAuthor)
 	}
 
 	cols := make([]string, 0, 7)

--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -440,10 +440,11 @@ func displayCommit(
 		mark = fmt.Sprintf("%s ", willBeRebased)
 	}
 
-	authorFunc := authors.ShortAuthor
+	authorLength := common.UserConfig.Gui.CommitAuthorShortLength
 	if fullDescription {
-		authorFunc = authors.LongAuthor
+		authorLength = common.UserConfig.Gui.CommitAuthorLongLength
 	}
+	author := authors.AuthorWithLength(commit.AuthorName, authorLength)
 
 	cols := make([]string, 0, 7)
 	cols = append(
@@ -453,7 +454,7 @@ func displayCommit(
 		bisectString,
 		descriptionString,
 		actionString,
-		authorFunc(commit.AuthorName),
+		author,
 		graphLine+mark+tagString+theme.DefaultTextColor.Sprint(name),
 	)
 

--- a/schema/config.json
+++ b/schema/config.json
@@ -332,16 +332,6 @@
           "description": "If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.",
           "default": true
         },
-        "commitAuthorFormat": {
-          "type": "string",
-          "enum": [
-            "auto",
-            "short",
-            "full"
-          ],
-          "description": "Whether to show full author names or their shortened form in the commit graph.\nOne of 'auto' (default) | 'full' | 'short'\nIf 'auto', initials will be shown in small windows, and full names - in larger ones.",
-          "default": "auto"
-        },
         "commitHashLength": {
           "type": "integer",
           "minimum": 0,

--- a/schema/config.json
+++ b/schema/config.json
@@ -332,6 +332,16 @@
           "description": "If true (default), file icons are shown in the file views. Only relevant if NerdFontsVersion is not empty.",
           "default": true
         },
+        "commitAuthorShortLength": {
+          "type": "integer",
+          "description": "Length of author name in (non-expanded) commits view. 2 means show initials only.",
+          "default": 2
+        },
+        "commitAuthorLongLength": {
+          "type": "integer",
+          "description": "Length of author name in expanded commits view. 2 means show initials only.",
+          "default": 17
+        },
         "commitHashLength": {
           "type": "integer",
           "minimum": 0,


### PR DESCRIPTION
- **PR Description**

This reverts #3625, and instead adds two new config keys `commitAuthorShortLength` and `commitAuthorLongLength` for achieving the same thing, but with more flexibility.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
