### PR TITLE
Turn off the highlight of the suggestions panel when it loses focus

### DIFF
--- a/pkg/gui/controllers/suggestions_controller.go
+++ b/pkg/gui/controllers/suggestions_controller.go
@@ -71,6 +71,7 @@ func (self *SuggestionsController) GetKeybindings(opts types.KeybindingsOpts) []
 
 func (self *SuggestionsController) switchToConfirmation() error {
 	self.c.Views().Suggestions.Subtitle = ""
+	self.c.Views().Suggestions.Highlight = false
 	return self.c.ReplaceContext(self.c.Contexts().Confirmation)
 }
 

--- a/pkg/gui/controllers/suggestions_controller.go
+++ b/pkg/gui/controllers/suggestions_controller.go
@@ -40,11 +40,8 @@ func (self *SuggestionsController) GetKeybindings(opts types.KeybindingsOpts) []
 			Handler: func() error { return self.context().State.OnClose() },
 		},
 		{
-			Key: opts.GetKey(opts.Config.Universal.TogglePanel),
-			Handler: func() error {
-				self.c.Views().Suggestions.Subtitle = ""
-				return self.c.ReplaceContext(self.c.Contexts().Confirmation)
-			},
+			Key:     opts.GetKey(opts.Config.Universal.TogglePanel),
+			Handler: self.switchToConfirmation,
 		},
 		{
 			Key: opts.GetKey(opts.Config.Universal.Remove),
@@ -61,7 +58,7 @@ func (self *SuggestionsController) GetKeybindings(opts types.KeybindingsOpts) []
 						self.c.Contexts().Confirmation.GetView().TextArea.TypeString(selectedItem.Value)
 						self.c.Contexts().Confirmation.GetView().RenderTextArea()
 						self.c.Contexts().Suggestions.RefreshSuggestions()
-						return self.c.ReplaceContext(self.c.Contexts().Confirmation)
+						return self.switchToConfirmation()
 					}
 				}
 				return nil
@@ -70,6 +67,11 @@ func (self *SuggestionsController) GetKeybindings(opts types.KeybindingsOpts) []
 	}
 
 	return bindings
+}
+
+func (self *SuggestionsController) switchToConfirmation() error {
+	self.c.Views().Suggestions.Subtitle = ""
+	return self.c.ReplaceContext(self.c.Contexts().Confirmation)
 }
 
 func (self *SuggestionsController) GetOnFocusLost() func(types.OnFocusLostOpts) error {


### PR DESCRIPTION
- **PR Description**

The highlight is normally turned off in HandleFocusLost, but that's not called when using ReplaceContext (and changing this would be a lot of work, it seems), so turn it off manually for now.

For a moment I considered whether we want to show the new inactive highlight when switching from suggestions to the prompt (actually this did happen on master), but I decided against it for several reasons: 
- it's not quite the right concept (the suggestions view is not the "parent" context of the prompt), 
- there's no benefit from seeing one of the suggestions selected (and the selection would change arbitrarily when changing the filter string)
- there would be visual problems when the suggestions become empty, in which case we would still highlight the first empty row (which you can only see if you set the gui.theme.inactiveViewSelectedLineBgColor config to some color). Now this could be considered a bug in the focus management of the suggestions panel, but it doesn't seem worth fixing this; the problem goes away by turning off the highlight.