### PR TITLE
Always reapply filters on filtered views when model changes, even inactive ones

### DIFF
--- a/pkg/gui/controllers/helpers/search_helper.go
+++ b/pkg/gui/controllers/helpers/search_helper.go
@@ -239,14 +239,14 @@ func (self *SearchHelper) OnPromptContentChanged(searchString string) {
 }
 
 func (self *SearchHelper) ReApplyFilter(context types.Context) {
-	state := self.searchState()
-	if context == state.Context {
-		filterableContext, ok := context.(types.IFilterableContext)
-		if ok {
+	filterableContext, ok := context.(types.IFilterableContext)
+	if ok {
+		state := self.searchState()
+		if context == state.Context {
 			filterableContext.SetSelection(0)
 			_ = filterableContext.GetView().SetOriginY(0)
-			filterableContext.ReApplyFilter(self.c.UserConfig.Gui.UseFuzzySearch())
 		}
+		filterableContext.ReApplyFilter(self.c.UserConfig.Gui.UseFuzzySearch())
 	}
 }
 

--- a/pkg/integration/tests/filter_and_search/filter_updates_when_model_changes.go
+++ b/pkg/integration/tests/filter_and_search/filter_updates_when_model_changes.go
@@ -56,9 +56,7 @@ var FilterUpdatesWhenModelChanges = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Branches().
 			Lines(
 				Contains("checked-out-branch").IsSelected(),
-				/* EXPECTED:
 				Contains("new-branch"),
-				*/
 			)
 
 		t.Views().Branches().

--- a/pkg/integration/tests/filter_and_search/filter_updates_when_model_changes.go
+++ b/pkg/integration/tests/filter_and_search/filter_updates_when_model_changes.go
@@ -41,13 +41,35 @@ var FilterUpdatesWhenModelChanges = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Lines(
 				Contains("checked-out-branch").IsSelected(),
-			).
+			)
+
+		// Verify that updating the filter works even if the view is not the active one
+		t.Views().Files().Focus()
+
+		// To do that, we use a custom command to create a new branch that matches the filter
+		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.ExpectPopup().Prompt().
+			Title(Equals("Custom command:")).
+			Type("git branch new-branch").
+			Confirm()
+
+		t.Views().Branches().
+			Lines(
+				Contains("checked-out-branch").IsSelected(),
+				/* EXPECTED:
+				Contains("new-branch"),
+				*/
+			)
+
+		t.Views().Branches().
+			Focus().
 			// cancel the filter
 			PressEscape().
 			Lines(
 				Contains("checked-out-branch").IsSelected(),
 				Contains("other"),
 				Contains("master"),
+				Contains("new-branch"),
 			)
 	},
 })


### PR DESCRIPTION
- **PR Description**

A filtered view would show stale data when the model changes but the view is inactive. I think this could only happen when changing some git state outside of lazygit; for example, when creating a new branch while the branches panel has a filter set, but doesn't have the focus. (See the added test for an example.)