### PR TITLE
Fix running lazygit with a language other than English on Windows

### DIFF
--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -3,8 +3,8 @@ package i18n
 import (
 	"embed"
 	"encoding/json"
+	"fmt"
 	"io/fs"
-	"path/filepath"
 	"strings"
 
 	"github.com/cloudfoundry/jibber_jabber"
@@ -83,7 +83,7 @@ func getSupportedLanguageCodes() ([]string, error) {
 }
 
 func readLanguageFile(languageCode string) (*TranslationSet, error) {
-	jsonData, err := embedFS.ReadFile(filepath.Join("translations", languageCode+".json"))
+	jsonData, err := embedFS.ReadFile(fmt.Sprintf("translations/%s.json", languageCode))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
On Windows, trying to use lazygit with a language other than English would result in the error message `open translations\ja.json: file does not exist`.
