### PR TITLE
Fix 'go generate ./...' on windows

### DIFF
--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 	"encoding/json"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/cloudfoundry/jibber_jabber"
@@ -83,7 +83,7 @@ func getSupportedLanguageCodes() ([]string, error) {
 }
 
 func readLanguageFile(languageCode string) (*TranslationSet, error) {
-	jsonData, err := embedFS.ReadFile(filepath.Join("translations", languageCode+".json"))
+	jsonData, err := embedFS.ReadFile(path.Join("translations", languageCode+".json"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When running the `go generate ./...` command, `pkg\cheatsheet\generate.go` panics because the embedded translation files cannot be found. Previously mentionned [here](https://github.com/jesseduffield/lazygit/pull/3691#discussion_r1659944389).

This is caused by the method `filepath.Join`, which uses the OS-specific path separator.

> Join joins any number of path elements into a single path, separating them with an OS-specific [Separator](https://pkg.go.dev/path/filepath@go1.22.4#Separator).

See [filepath.Join documentation](https://pkg.go.dev/path/filepath@go1.22.4#Join).

</br>

On Windows, it is `\` (backslash). However, `embed.FS.ReadFile` expects the path separator to be `/` (slash) regardless of the OS.

> The path separator is a forward slash, even on Windows systems.

See [embed documentation](https://pkg.go.dev/embed).

</br>

To fulfill the contract of `embed.FS.ReadFile`, the `path.Join` method should be used instead since it always uses slashes as the path separator.

> Join joins any number of path elements into a single path, separating them with slashes.

See [path.Join documentation](https://pkg.go.dev/path@go1.22.4#Join).

</br>

I have tried running `go generate ./...` on Ubuntu using WSL and the functionality seems unchanged.

**Note**
I also ran in another problem coming from `pkg\jsonschema\generate.go` where it panics because the string it is looking for terminates by `\n`.
``` go
DocumentationCommentStart    = "<!-- START CONFIG YAML: AUTOMATICALLY GENERATED with `go generate ./..., DO NOT UPDATE MANUALLY -->\n"
```
However on Windows the new line characters are `\r\n`.
The solution was to disable git autocrlf (`git config core.autocrlf false`) and to renomalize the files (`git add --renormalize .`) to have the new line character match the one in `DocumentationCommentStart`.
It might be worth including something in the doc about how to run `go generate ./...`.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
