### PR TITLE
Update tracking behaviour for branches created from remote branches

### DIFF
--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -28,6 +28,15 @@ func (self *BranchCommands) New(name string, base string) error {
 	return self.cmd.New(cmdArgs).Run()
 }
 
+func (self *BranchCommands) NewWithoutTracking(name string, base string) error {
+	cmdArgs := NewGitCmd("checkout").
+		Arg("-b", name, base).
+		Arg("--no-track").
+		ToArgv()
+
+	return self.cmd.New(cmdArgs).Run()
+}
+
 // CreateWithUpstream creates a new branch with a given upstream, but without
 // checking it out
 func (self *BranchCommands) CreateWithUpstream(name string, upstream string) error {

--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -279,7 +279,12 @@ func (self *RefsHelper) NewBranch(from string, fromFormattedName string, suggest
 		InitialContent: suggestedBranchName,
 		HandleConfirm: func(response string) error {
 			self.c.LogAction(self.c.Tr.Actions.CreateBranch)
-			if err := self.c.Git().Branch.New(SanitizedBranchName(response), from); err != nil {
+			newBranchName := SanitizedBranchName(response)
+			newBranchFunc := self.c.Git().Branch.New
+			if newBranchName != suggestedBranchName {
+				newBranchFunc = self.c.Git().Branch.NewWithoutTracking
+			}
+			if err := newBranchFunc(newBranchName, from); err != nil {
 				return err
 			}
 

--- a/pkg/integration/tests/branch/new_branch_from_remote_tracking_different_name.go
+++ b/pkg/integration/tests/branch/new_branch_from_remote_tracking_different_name.go
@@ -1,0 +1,50 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var NewBranchFromRemoteTrackingDifferentName = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Set tracking information when creating a new branch from a remote branch",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("commit")
+		shell.NewBranch("other_branch")
+		shell.CloneIntoRemote("origin")
+		shell.Checkout("master")
+		shell.RunCommand([]string{"git", "branch", "-D", "other_branch"})
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Remotes().
+			Focus().
+			Lines(
+				Contains("origin").IsSelected(),
+			).
+			PressEnter()
+
+		t.Views().RemoteBranches().
+			IsFocused().
+			Lines(
+				Contains("master").IsSelected(),
+				Contains("other_branch"),
+			).
+			SelectNextItem().
+			Press(keys.Universal.New)
+
+		t.ExpectPopup().Prompt().
+			Title(Equals("New branch name (branch is off of 'origin/other_branch')")).
+			Clear().
+			Type("different_name").
+			Confirm()
+
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("different_name").DoesNotContain("✓"),
+				Contains("master"),
+			)
+	},
+})

--- a/pkg/integration/tests/branch/new_branch_from_remote_tracking_same_name.go
+++ b/pkg/integration/tests/branch/new_branch_from_remote_tracking_same_name.go
@@ -1,0 +1,48 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var NewBranchFromRemoteTrackingSameName = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Set tracking information when creating a new branch from a remote branch",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("commit")
+		shell.NewBranch("other_branch")
+		shell.CloneIntoRemote("origin")
+		shell.Checkout("master")
+		shell.RunCommand([]string{"git", "branch", "-D", "other_branch"})
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Remotes().
+			Focus().
+			Lines(
+				Contains("origin").IsSelected(),
+			).
+			PressEnter()
+
+		t.Views().RemoteBranches().
+			IsFocused().
+			Lines(
+				Contains("master").IsSelected(),
+				Contains("other_branch"),
+			).
+			SelectNextItem().
+			Press(keys.Universal.New)
+
+		t.ExpectPopup().Prompt().
+			Title(Equals("New branch name (branch is off of 'origin/other_branch')")).
+			Confirm()
+
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("other_branch").Contains("✓"),
+				Contains("master"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -42,6 +42,8 @@ var tests = []*components.IntegrationTest{
 	branch.Delete,
 	branch.DeleteRemoteBranchWithCredentialPrompt,
 	branch.DetachedHead,
+	branch.NewBranchFromRemoteTrackingDifferentName,
+	branch.NewBranchFromRemoteTrackingSameName,
 	branch.OpenPullRequestNoUpstream,
 	branch.OpenWithCliArg,
 	branch.Rebase,


### PR DESCRIPTION
### Overview

| Current Behaviour | New Behaviour |
|--|--|
| Local branches will **always** track the remote branches they were created from. | Local branches will track the remote branches they were created from **only if their names match**. |

### Description

The current behaviour when creating a new branch off of a remote branch is to always track the branch it was created from.

For example, if a branch 'my_branch' is created off of the remote branch 'fix_crash_13', then 'my_branch' will be tracking the remote 'fix_crash_13' branch.
It is common practice to have both the local and remote branches named the same when the local is tracking the remote one. Therefore, it is reasonable to expect that 'my_branch' should not track the remote 'fix_crash_13' branch.

The new behaviour when creating a new branch off of a remote branch is to track the branch it was created from only if the branch names match. If the branch names DO NOT match then the newly created branch will not track the remote branch it was created from.

For example, if a user creates a new branch 'fix_crash_13' off of the remote branch 'fix_crash_13', then the local 'fix_crash_13' branch will track the remote 'fix_crash_13' branch.
However, if the user creates a new branch called 'other_branch_name' off of the remote branch 'fix_crash_13', then the local 'other_branch_name' branch will NOT track the remote 'fix_crash_13' branch.


- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc