### PR TITLE
feat: add confirmation menu when hard reset

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -76,6 +76,7 @@ func AddCoAuthorToDescription(description string, author string) string {
 // ResetToCommit reset to commit
 func (self *CommitCommands) ResetToCommit(hash string, strength string, envVars []string) error {
 	cmdArgs := NewGitCmd("reset").Arg("--"+strength, hash).ToArgv()
+	self.Log.Warn("Here")
 
 	return self.cmd.New(cmdArgs).
 		// prevents git from prompting us for input which would freeze the program

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -391,6 +391,8 @@ type TranslationSet struct {
 	DiscardUntrackedFiles                 string
 	DiscardStagedChanges                  string
 	HardReset                             string
+	HardResetTitle                        string
+	HardResetPrompt                       string
 	BranchDeleteTooltip                   string
 	TagDeleteTooltip                      string
 	Delete                                string
@@ -1367,6 +1369,8 @@ func EnglishTranslationSet() *TranslationSet {
 		DiscardUntrackedFiles:                "Discard untracked files",
 		DiscardStagedChanges:                 "Discard staged changes",
 		HardReset:                            "Hard reset",
+		HardResetTitle:                       "Hard reset",
+		HardResetPrompt:                      "This will also reset the uncommited files",
 		BranchDeleteTooltip:                  "View delete options for local/remote branch.",
 		TagDeleteTooltip:                     "View delete options for local/remote tag.",
 		Delete:                               "Delete",


### PR DESCRIPTION
- **PR Description**

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->

This PR aims to solve this feature request : https://github.com/jesseduffield/lazygit/issues/3709

The problem I face is that the reset aren't done in `pkg/gui/controllers/workspace_reset_controller.go` as I though but directly in `pkg/commands/git_commands/commit.go` where we don't have access to the state of the working directory. If someone have an idea to solve this issue I would happy to make it the merge