### PR TITLE
Fix language auto detection

### DIFF
--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -24,7 +24,7 @@ func NewTranslationSetFromConfig(log *logrus.Entry, configLanguage string) (*Tra
 		language := detectLanguage(jibber_jabber.DetectIETF)
 		for _, languageCode := range languageCodes {
 			if strings.HasPrefix(language, languageCode) {
-				return newTranslationSet(log, language)
+				return newTranslationSet(log, languageCode)
 			}
 		}
 

--- a/pkg/i18n/i18n_test.go
+++ b/pkg/i18n/i18n_test.go
@@ -2,8 +2,11 @@ package i18n
 
 import (
 	"fmt"
+	"io"
+	"runtime"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,5 +34,86 @@ func TestDetectLanguage(t *testing.T) {
 
 	for _, s := range scenarios {
 		assert.EqualValues(t, s.expected, detectLanguage(s.langDetector))
+	}
+}
+
+// Can't use utils.NewDummyLog() because of a cyclic dependency
+func newDummyLog() *logrus.Entry {
+	log := logrus.New()
+	log.Out = io.Discard
+	return log.WithField("test", "test")
+}
+
+func TestNewTranslationSetFromConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// These tests are based on setting the LANG environment variable, which
+		// isn't respected on Windows.
+		t.Skip("Skipping test on Windows")
+	}
+
+	scenarios := []struct {
+		name           string
+		configLanguage string
+		envLanguage    string
+		expected       string
+		expectedErr    bool
+	}{
+		{
+			name:           "configLanguage is nl",
+			configLanguage: "nl",
+			envLanguage:    "en_US",
+			expected:       "nl",
+			expectedErr:    false,
+		},
+		{
+			name:           "configLanguage is an unsupported language",
+			configLanguage: "xy",
+			envLanguage:    "en_US",
+			expectedErr:    true,
+		},
+		{
+			name:           "auto-detection without LANG set",
+			configLanguage: "auto",
+			envLanguage:    "",
+			expected:       "en",
+			expectedErr:    false,
+		},
+		{
+			name:           "auto-detection with LANG set to nl_NL",
+			configLanguage: "auto",
+			envLanguage:    "nl_NL",
+			expected:       "nl",
+			expectedErr:    true, // Demonstrates the bug, this should be false
+		},
+		{
+			name:           "auto-detection with LANG set to zh-CN",
+			configLanguage: "auto",
+			envLanguage:    "zh-CN",
+			expected:       "zh-CN",
+			expectedErr:    false,
+		},
+		{
+			name:           "auto-detection with LANG set to an unsupported language",
+			configLanguage: "auto",
+			envLanguage:    "xy_XY",
+			expected:       "en",
+			expectedErr:    false,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			log := newDummyLog()
+			t.Setenv("LANG", s.envLanguage)
+			actualTranslationSet, err := NewTranslationSetFromConfig(log, s.configLanguage)
+			if s.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				expectedTranslationSet, _ := newTranslationSet(log, s.expected)
+				assert.Equal(t, expectedTranslationSet, actualTranslationSet)
+			}
+		})
 	}
 }

--- a/pkg/i18n/i18n_test.go
+++ b/pkg/i18n/i18n_test.go
@@ -83,7 +83,7 @@ func TestNewTranslationSetFromConfig(t *testing.T) {
 			configLanguage: "auto",
 			envLanguage:    "nl_NL",
 			expected:       "nl",
-			expectedErr:    true, // Demonstrates the bug, this should be false
+			expectedErr:    false,
 		},
 		{
 			name:           "auto-detection with LANG set to zh-CN",


### PR DESCRIPTION
- **PR Description**

Fix a regression (introduced with #3649) that broke language auto-detection. When starting lazygit with the `gui.language` config set to "auto" (which is the default), lazygit would fail to start if the LANG environment is set to one of our supported languages.

For example:
```
$ export LANG=nl_NL
$ lazygit
2024/07/13 11:43:03 open translations/nl-NL.json: file does not exist
```

Fixes #3743