### PR TITLE
Reapply "Check for fixup commits on CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
       - name: "Checkout PR branch and all PR commits"
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,3 +219,25 @@ jobs:
           CODACY_PROJECT_TOKEN=${{ secrets.CODACY_PROJECT_TOKEN }} \
             bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
             --force-coverage-parser go -r coverage.out
+
+  check-for-fixups:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
+    steps:
+      # See https://github.com/actions/checkout/issues/552#issuecomment-1167086216
+      - name: "PR commits + 1"
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
+      - name: "Checkout PR branch and all PR commits"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+
+      - name: "Fetch the other branch with enough history for a common merge-base commit"
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+
+      - name: Check for fixups
+        run: |
+          ./scripts/check_for_fixups.sh ${{ github.event.pull_request.base.ref }}

--- a/scripts/check_for_fixups.sh
+++ b/scripts/check_for_fixups.sh
@@ -13,13 +13,13 @@ fi
 echo "Base commit: $base_commit"
 
 # Get commits with "fixup!" in the message from base_commit to HEAD
-commits=$(git log -i -E --grep "fixup\!" --format="%h %s" "$base_commit..HEAD")
+commits=$(git log -i -E --grep '^fixup!' --grep '^squash!' --grep '^amend!' --grep '^[^\n]*WIP' --grep '^[^\n]*DROPME' --format="%h %s" "$base_commit..HEAD")
 
 if [ -z "$commits" ]; then
     echo "No fixup commits found."
     exit 0
 else
-    echo "Fixup commits found:"
+    echo "Fixup or WIP commits found:"
     echo "$commits"
     exit 1
 fi

--- a/scripts/check_for_fixups.sh
+++ b/scripts/check_for_fixups.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+base_ref=$1
+
+# Determine the base commit
+base_commit=$(git merge-base HEAD origin/"$base_ref")
+
+# Check if base_commit is set correctly
+if [ -z "$base_commit" ]; then
+    echo "Failed to determine base commit."
+    exit 1
+fi
+echo "Base commit: $base_commit"
+
+# Get commits with "fixup!" in the message from base_commit to HEAD
+commits=$(git log -i -P --grep "fixup\!" --format="%h %s" "$base_commit..HEAD")
+
+if [ -z "$commits" ]; then
+    echo "No fixup commits found."
+    exit 0
+else
+    echo "Fixup commits found:"
+    echo "$commits"
+    exit 1
+fi

--- a/scripts/check_for_fixups.sh
+++ b/scripts/check_for_fixups.sh
@@ -13,7 +13,7 @@ fi
 echo "Base commit: $base_commit"
 
 # Get commits with "fixup!" in the message from base_commit to HEAD
-commits=$(git log -i -P --grep "fixup\!" --format="%h %s" "$base_commit..HEAD")
+commits=$(git log -i -E --grep "fixup\!" --format="%h %s" "$base_commit..HEAD")
 
 if [ -z "$commits" ]; then
     echo "No fixup commits found."


### PR DESCRIPTION
Re-enable the check for fixup commits (see #3742), make it work for forks, and extend it to "amend!" and "WIP" commits (and a few others).