### PR TITLE
Add return-alt1 to allow for a secondary Return key

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -449,6 +449,8 @@ keybinding:
     quit: q
     quit-alt1: <c-c>
     return: <esc>
+    # When set to a printable character, this will work for returning from non-prompt panels
+    return-alt1: null
     quitWithoutChangingDirectory: Q
     togglePanel: <tab>
     prevItem: <up>

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -344,6 +344,7 @@ type KeybindingUniversalConfig struct {
 	Quit                              string   `yaml:"quit"`
 	QuitAlt1                          string   `yaml:"quit-alt1"`
 	Return                            string   `yaml:"return"`
+	ReturnAlt1                        string   `yaml:"return-alt1"`
 	QuitWithoutChangingDirectory      string   `yaml:"quitWithoutChangingDirectory"`
 	TogglePanel                       string   `yaml:"togglePanel"`
 	PrevItem                          string   `yaml:"prevItem"`

--- a/pkg/gui/controllers/commit_description_controller.go
+++ b/pkg/gui/controllers/commit_description_controller.go
@@ -32,6 +32,10 @@ func (self *CommitDescriptionController) GetKeybindings(opts types.KeybindingsOp
 			Handler: self.close,
 		},
 		{
+			Key:     opts.GetKey(opts.Config.Universal.ReturnAlt1),
+			Handler: self.close,
+		},
+		{
 			Key:     opts.GetKey(opts.Config.Universal.ConfirmInEditor),
 			Handler: self.confirm,
 		},

--- a/pkg/gui/controllers/confirmation_controller.go
+++ b/pkg/gui/controllers/confirmation_controller.go
@@ -38,6 +38,10 @@ func (self *ConfirmationController) GetKeybindings(opts types.KeybindingsOpts) [
 			DisplayOnScreen: true,
 		},
 		{
+			Key:     opts.GetKey(opts.Config.Universal.ReturnAlt1),
+			Handler: func() error { return self.context().State.OnClose() },
+		},
+		{
 			Key: opts.GetKey(opts.Config.Universal.TogglePanel),
 			Handler: func() error {
 				if len(self.c.Contexts().Suggestions.State.Suggestions) > 0 {

--- a/pkg/gui/controllers/global_controller.go
+++ b/pkg/gui/controllers/global_controller.go
@@ -120,6 +120,11 @@ func (self *GlobalController) GetKeybindings(opts types.KeybindingsOpts) []*type
 			DisplayOnScreen: true,
 		},
 		{
+			Key:      opts.GetKey(opts.Config.Universal.ReturnAlt1),
+			Modifier: gocui.ModNone,
+			Handler:  self.escape,
+		},
+		{
 			Key:         opts.GetKey(opts.Config.Universal.ToggleWhitespaceInDiffView),
 			Handler:     self.toggleWhitespace,
 			Description: self.c.Tr.ToggleWhitespaceInDiffView,

--- a/pkg/gui/controllers/menu_controller.go
+++ b/pkg/gui/controllers/menu_controller.go
@@ -50,6 +50,10 @@ func (self *MenuController) GetKeybindings(opts types.KeybindingsOpts) []*types.
 			Description:     self.c.Tr.Close,
 			DisplayOnScreen: true,
 		},
+		{
+			Key:     opts.GetKey(opts.Config.Universal.ReturnAlt1),
+			Handler: self.close,
+		},
 	}
 
 	return bindings

--- a/pkg/gui/controllers/merge_conflicts_controller.go
+++ b/pkg/gui/controllers/merge_conflicts_controller.go
@@ -123,6 +123,10 @@ func (self *MergeConflictsController) GetKeybindings(opts types.KeybindingsOpts)
 			Handler:     self.Escape,
 			Description: self.c.Tr.ReturnToFilesPanel,
 		},
+		{
+			Key:     opts.GetKey(opts.Config.Universal.ReturnAlt1),
+			Handler: self.Escape,
+		},
 	}
 
 	return bindings

--- a/pkg/gui/controllers/patch_building_controller.go
+++ b/pkg/gui/controllers/patch_building_controller.go
@@ -47,6 +47,10 @@ func (self *PatchBuildingController) GetKeybindings(opts types.KeybindingsOpts) 
 			Handler:     self.Escape,
 			Description: self.c.Tr.ExitCustomPatchBuilder,
 		},
+		{
+			Key:     opts.GetKey(opts.Config.Universal.ReturnAlt1),
+			Handler: self.Escape,
+		},
 	}
 }
 

--- a/pkg/gui/controllers/search_prompt_controller.go
+++ b/pkg/gui/controllers/search_prompt_controller.go
@@ -34,6 +34,11 @@ func (self *SearchPromptController) GetKeybindings(opts types.KeybindingsOpts) [
 			Handler:  self.cancel,
 		},
 		{
+			Key:      opts.GetKey(opts.Config.Universal.ReturnAlt1),
+			Modifier: gocui.ModNone,
+			Handler:  self.cancel,
+		},
+		{
 			Key:      opts.GetKey(opts.Config.Universal.PrevItem),
 			Modifier: gocui.ModNone,
 			Handler:  self.prevHistory,

--- a/pkg/gui/controllers/snake_controller.go
+++ b/pkg/gui/controllers/snake_controller.go
@@ -43,6 +43,10 @@ func (self *SnakeController) GetKeybindings(opts types.KeybindingsOpts) []*types
 			Key:     opts.GetKey(opts.Config.Universal.Return),
 			Handler: self.Escape,
 		},
+		{
+			Key:     opts.GetKey(opts.Config.Universal.ReturnAlt1),
+			Handler: self.Escape,
+		},
 	}
 
 	return bindings

--- a/pkg/gui/controllers/staging_controller.go
+++ b/pkg/gui/controllers/staging_controller.go
@@ -71,6 +71,10 @@ func (self *StagingController) GetKeybindings(opts types.KeybindingsOpts) []*typ
 			Description: self.c.Tr.ReturnToFilesPanel,
 		},
 		{
+			Key:     opts.GetKey(opts.Config.Universal.ReturnAlt1),
+			Handler: self.Escape,
+		},
+		{
 			Key:             opts.GetKey(opts.Config.Universal.TogglePanel),
 			Handler:         self.TogglePanel,
 			Description:     self.c.Tr.ToggleStagingView,

--- a/pkg/gui/controllers/suggestions_controller.go
+++ b/pkg/gui/controllers/suggestions_controller.go
@@ -40,6 +40,10 @@ func (self *SuggestionsController) GetKeybindings(opts types.KeybindingsOpts) []
 			Handler: func() error { return self.context().State.OnClose() },
 		},
 		{
+			Key:     opts.GetKey(opts.Config.Universal.ReturnAlt1),
+			Handler: func() error { return self.context().State.OnClose() },
+		},
+		{
 			Key:     opts.GetKey(opts.Config.Universal.TogglePanel),
 			Handler: self.switchToConfirmation,
 		},


### PR DESCRIPTION
- **PR Description**

This partially adds the feature back that was removed in #2495. This
allows specifing a secondary Return keybinding. In my personal setup I
use the `q` for this (and remove it as the default for Quit). Returning
is a very common operation in lazygit, and having to reach for the
Escape key all the time is annoying. There are cases where it's not
possible to use a regular letter as the Return keybinding, such as the
commit prompt.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
