### PR TITLE
Add missing dependency to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-<div align="center">
+url' not found, but can be installed with:
+sudo snap install curl  # ve<div align="center">
 <sup>Special thanks to:</sup>
 <br>
 <br>
@@ -306,6 +307,11 @@ sudo eopkg install lazygit
 ### Ubuntu
 
 ```sh
+if ! command -v curl &> /dev/null
+then
+    sudo apt update
+    sudo apt install -y curl
+fi
 LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
 curl -Lo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz"
 tar xf lazygit.tar.gz lazygit


### PR DESCRIPTION
- **PR Description**
The installation instructions did not check if `curl` is installed, which is not the case out of the box. 
- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
