### PR TITLE
Don't exit app when GetRepoPaths call fails during startup

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -118,11 +118,11 @@ func NewApp(config config.AppConfigurer, test integrationTypes.IntegrationTest, 
 		return app, err
 	}
 
-	// If we're not in a repo, repoPaths will be nil. The error is moot for us
+	// If we're not in a repo, GetRepoPaths will return an error. The error is moot for us
 	// at this stage, since we'll try to init a new repo in setupRepo(), below
 	repoPaths, err := git_commands.GetRepoPaths(app.OSCommand.Cmd, gitVersion)
 	if err != nil {
-		return app, err
+		common.Log.Infof("Error getting repo paths: %v", err)
 	}
 
 	showRecentRepos, err := app.setupRepo(repoPaths)


### PR DESCRIPTION
- **PR Description**
Fixes #3740 

As explained in the issue, 7a67096 moved some code around that caused a call to `GetRepoPaths` to occur before `setupApp`, which usually handles the scenario where we are not in a git directory. `GetRepoPaths` returns an error if the path isn't a git repository, which caused the app to exit before we reached `setupApp`.

When starting up lazygit, we ignore (and log) the error returned by `GetRepoPaths`, and continue instead of exiting early. This allows us to reach the step where we follow the user's `notARepository` config entry.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
