### PR TITLE
feat(custom command): support multiple contexts within one command

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -87,6 +87,11 @@ The permitted contexts are:
 | stash          | The 'Stash' tab                                                                                          |
 | global         | This keybinding will take affect everywhere                                                              |
 
+> **Bonus**
+>
+> You can use a comma-separated string, such as `context: 'commits, subCommits'`, to make it effective in multiple contexts.
+
+
 ## Prompts
 
 ### Common fields

--- a/pkg/gui/services/custom_commands/client.go
+++ b/pkg/gui/services/custom_commands/client.go
@@ -39,11 +39,11 @@ func (self *Client) GetCustomCommandKeybindings() ([]*types.Binding, error) {
 	bindings := []*types.Binding{}
 	for _, customCommand := range self.customCommands {
 		handler := self.handlerCreator.call(customCommand)
-		binding, err := self.keybindingCreator.call(customCommand, handler)
+		compoundBindings, err := self.keybindingCreator.call(customCommand, handler)
 		if err != nil {
 			return nil, err
 		}
-		bindings = append(bindings, binding)
+		bindings = append(bindings, compoundBindings...)
 	}
 
 	return bindings, nil

--- a/pkg/integration/tests/custom_commands/global_context.go
+++ b/pkg/integration/tests/custom_commands/global_context.go
@@ -1,0 +1,61 @@
+package custom_commands
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var GlobalContext = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Ensure global context works",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("my change")
+	},
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.UserConfig.CustomCommands = []config.CustomCommand{
+			{
+				Key:        "X",
+				Context:    "global",
+				Command:    "touch myfile",
+				ShowOutput: false,
+			},
+		}
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		// commits
+		t.Views().Commits().
+			Focus().
+			Press("X")
+
+		t.Views().Files().
+			Focus().
+			Lines(Contains("myfile"))
+
+		t.Shell().DeleteFile("myfile")
+		t.GlobalPress(keys.Files.RefreshFiles)
+
+		// branches
+		t.Views().Branches().
+			Focus().
+			Press("X")
+
+		t.Views().Files().
+			Focus().
+			Lines(Contains("myfile"))
+
+		t.Shell().DeleteFile("myfile")
+		t.GlobalPress(keys.Files.RefreshFiles)
+
+		// files
+		t.Views().Files().
+			Focus().
+			Press("X")
+
+		t.Views().Files().
+			Focus().
+			Lines(Contains("myfile"))
+
+		t.Shell().DeleteFile("myfile")
+	},
+})

--- a/pkg/integration/tests/custom_commands/multiple_contexts.go
+++ b/pkg/integration/tests/custom_commands/multiple_contexts.go
@@ -1,0 +1,58 @@
+package custom_commands
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var MultipleContexts = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Test that multiple contexts works",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("my change")
+	},
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.UserConfig.CustomCommands = []config.CustomCommand{
+			{
+				Key:        "X",
+				Context:    "commits, reflogCommits",
+				Command:    "touch myfile",
+				ShowOutput: false,
+			},
+		}
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		// commits
+		t.Views().Commits().
+			Focus().
+			Press("X")
+
+		t.Views().Files().
+			Focus().
+			Lines(Contains("myfile"))
+
+		t.Shell().DeleteFile("myfile")
+		t.GlobalPress(keys.Files.RefreshFiles)
+
+		// branches
+		t.Views().Branches().
+			Focus().
+			Press("X")
+
+		t.Views().Files().
+			Focus().
+			IsEmpty()
+
+		// files
+		t.Views().ReflogCommits().
+			Focus().
+			Press("X")
+
+		t.Views().Files().
+			Focus().
+			Lines(Contains("myfile"))
+
+		t.Shell().DeleteFile("myfile")
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -122,6 +122,7 @@ var tests = []*components.IntegrationTest{
 	custom_commands.DeleteFromHistory,
 	custom_commands.EditHistory,
 	custom_commands.FormPrompts,
+	custom_commands.GlobalContext,
 	custom_commands.History,
 	custom_commands.MenuFromCommand,
 	custom_commands.MenuFromCommandsOutput,

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -126,6 +126,7 @@ var tests = []*components.IntegrationTest{
 	custom_commands.History,
 	custom_commands.MenuFromCommand,
 	custom_commands.MenuFromCommandsOutput,
+	custom_commands.MultipleContexts,
 	custom_commands.MultiplePrompts,
 	custom_commands.OmitFromHistory,
 	custom_commands.ShowOutputInPanel,


### PR DESCRIPTION
- **PR Description**

For some custom commands, they can be used in multiple contexts. But for now, if we want to do this, we should copy and paste the same config times and times with just a different **context**. 

Related issue: #3759 

This PR changes the `context` of `customCommand` to `contexts`.

There are at least 3 solutions for this:
**1**: make a **breaking** change to `context` completely.
**2**: keep the `context` and add a new `contexts` key, only one of them can be configured at the same command. `contexts` has a higher priority if both are present.
**3**: keep the `context` key but support both `string` and `array` types.

The current implementation is 1. Maybe 3 is better? Any advice is appreciated.



- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
