### PR TITLE
Switch tabs with panel jump keys

### DIFF
--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -197,7 +197,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 	commandLogController := controllers.NewCommandLogController(common)
 	confirmationController := controllers.NewConfirmationController(common)
 	suggestionsController := controllers.NewSuggestionsController(common)
-	jumpToSideWindowController := controllers.NewJumpToSideWindowController(common)
+	jumpToSideWindowController := controllers.NewJumpToSideWindowController(common, gui.handleNextTab)
 
 	sideWindowControllerFactory := controllers.NewSideWindowControllerFactory(common)
 

--- a/pkg/gui/controllers/jump_to_side_window_controller.go
+++ b/pkg/gui/controllers/jump_to_side_window_controller.go
@@ -10,15 +10,18 @@ import (
 
 type JumpToSideWindowController struct {
 	baseController
-	c *ControllerCommon
+	c           *ControllerCommon
+	nextTabFunc func() error
 }
 
 func NewJumpToSideWindowController(
 	c *ControllerCommon,
+	nextTabFunc func() error,
 ) *JumpToSideWindowController {
 	return &JumpToSideWindowController{
 		baseController: baseController{},
 		c:              c,
+		nextTabFunc:    nextTabFunc,
 	}
 }
 
@@ -46,6 +49,10 @@ func (self *JumpToSideWindowController) GetKeybindings(opts types.KeybindingsOpt
 
 func (self *JumpToSideWindowController) goToSideWindow(window string) func() error {
 	return func() error {
+		if self.c.Helpers().Window.CurrentWindow() == window {
+			return self.nextTabFunc()
+		}
+
 		context := self.c.Helpers().Window.GetContextForWindow(window)
 
 		return self.c.PushContext(context)

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -338,6 +338,7 @@ var tests = []*components.IntegrationTest{
 	ui.OpenLinkFailure,
 	ui.RangeSelect,
 	ui.SwitchTabFromMenu,
+	ui.SwitchTabWithPanelJumpKeys,
 	undo.UndoCheckoutAndDrop,
 	undo.UndoDrop,
 	worktree.AddFromBranch,

--- a/pkg/integration/tests/ui/switch_tab_with_panel_jump_keys.go
+++ b/pkg/integration/tests/ui/switch_tab_with_panel_jump_keys.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var SwitchTabWithPanelJumpKeys = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Switch tab with the panel jump keys",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Worktrees().Focus().
+			Press(keys.Universal.JumpToBlock[2])
+
+		t.Views().Branches().IsFocused().
+			Press(keys.Universal.JumpToBlock[2])
+
+		t.Views().Remotes().IsFocused().
+			Press(keys.Universal.JumpToBlock[2])
+
+		t.Views().Tags().IsFocused().
+			Press(keys.Universal.JumpToBlock[2])
+
+		t.Views().Branches().IsFocused().
+			Press(keys.Universal.JumpToBlock[1])
+
+		// When jumping to a panel from a different one, keep its current tab:
+		t.Views().Worktrees().IsFocused()
+	},
+})


### PR DESCRIPTION
- **PR Description**

When using the panel jump keybindings (`1` through `5` by default), and the target panel is already the active one, go to the next tab instead.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
