### PR TITLE
Rename "Custom Command" to "Shell Command"

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -495,7 +495,7 @@ keybinding:
     scrollDownMain-alt1: J
     scrollUpMain-alt2: <c-u>
     scrollDownMain-alt2: <c-d>
-    executeCustomCommand: ':'
+    executeShellCommand: ':'
     createRebaseOptionsMenu: m
 
     # 'Files' appended for legacy reasons

--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -18,7 +18,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename. |
 | `` } `` | Increase diff context size | Increase the amount of the context shown around changes in the diff view. |
 | `` { `` | Decrease diff context size | Decrease the amount of the context shown around changes in the diff view. |
-| `` : `` | Execute custom command | Bring up a prompt where you can enter a shell command to execute. Not to be confused with pre-configured custom commands. |
+| `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | View custom patch options |  |
 | `` m `` | View merge/rebase options | View options to abort/continue/skip the current merge/rebase. |
 | `` R `` | Refresh | Refresh the git state (i.e. run `git status`, `git branch`, etc in background to update the contents of panels). This does not run `git fetch`. |

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -18,7 +18,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename. |
 | `` } `` | Increase diff context size | Increase the amount of the context shown around changes in the diff view. |
 | `` { `` | Decrease diff context size | Decrease the amount of the context shown around changes in the diff view. |
-| `` : `` | カスタムコマンドを実行 | Bring up a prompt where you can enter a shell command to execute. Not to be confused with pre-configured custom commands. |
+| `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | View custom patch options |  |
 | `` m `` | View merge/rebase options | View options to abort/continue/skip the current merge/rebase. |
 | `` R `` | リフレッシュ | Refresh the git state (i.e. run `git status`, `git branch`, etc in background to update the contents of panels). This does not run `git fetch`. |

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -18,7 +18,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename. |
 | `` } `` | Diff 보기의 변경 사항 주위에 표시되는 컨텍스트의 크기를 늘리기 | Increase the amount of the context shown around changes in the diff view. |
 | `` { `` | Diff 보기의 변경 사항 주위에 표시되는 컨텍스트 크기 줄이기 | Decrease the amount of the context shown around changes in the diff view. |
-| `` : `` | Execute custom command | Bring up a prompt where you can enter a shell command to execute. Not to be confused with pre-configured custom commands. |
+| `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | 커스텀 Patch 옵션 보기 |  |
 | `` m `` | View merge/rebase options | View options to abort/continue/skip the current merge/rebase. |
 | `` R `` | 새로고침 | Refresh the git state (i.e. run `git status`, `git branch`, etc in background to update the contents of panels). This does not run `git fetch`. |

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -18,7 +18,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename. |
 | `` } `` | Increase diff context size | Increase the amount of the context shown around changes in the diff view. |
 | `` { `` | Decrease diff context size | Decrease the amount of the context shown around changes in the diff view. |
-| `` : `` | Voer aangepaste commando uit | Bring up a prompt where you can enter a shell command to execute. Not to be confused with pre-configured custom commands. |
+| `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | Bekijk aangepaste patch opties |  |
 | `` m `` | Bekijk merge/rebase opties | View options to abort/continue/skip the current merge/rebase. |
 | `` R `` | Verversen | Refresh the git state (i.e. run `git status`, `git branch`, etc in background to update the contents of panels). This does not run `git fetch`. |

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -18,7 +18,7 @@ _Legenda: `<c-b>` oznacza ctrl+b, `<a-b>` oznacza alt+b, `B` oznacza shift+b_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename. |
 | `` } `` | Zwiększ rozmiar kontekstu w widoku różnic | Zwiększ ilość kontekstu pokazywanego wokół zmian w widoku różnic. |
 | `` { `` | Zmniejsz rozmiar kontekstu w widoku różnic | Zmniejsz ilość kontekstu pokazywanego wokół zmian w widoku różnic. |
-| `` : `` | Wykonaj polecenie niestandardowe | Wyświetl monit, w którym możesz wprowadzić polecenie powłoki do wykonania. Nie należy mylić z wcześniej skonfigurowanymi poleceniami niestandardowymi. |
+| `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | Wyświetl opcje niestandardowej łatki |  |
 | `` m `` | Pokaż opcje scalania/rebase | Pokaż opcje do przerwania/kontynuowania/pominięcia bieżącego scalania/rebase. |
 | `` R `` | Odśwież | Odśwież stan git (tj. uruchom `git status`, `git branch`, itp. w tle, aby zaktualizować zawartość paneli). To nie uruchamia `git fetch`. |

--- a/docs/keybindings/Keybindings_ru.md
+++ b/docs/keybindings/Keybindings_ru.md
@@ -18,7 +18,7 @@ _Связки клавиш_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename. |
 | `` } `` | Увеличить размер контекста, отображаемого вокруг изменений в просмотрщике сравнении | Increase the amount of the context shown around changes in the diff view. |
 | `` { `` | Уменьшите размер контекста, отображаемого вокруг изменений в просмотрщике сравнении | Decrease the amount of the context shown around changes in the diff view. |
-| `` : `` | Выполнить пользовательскую команду | Bring up a prompt where you can enter a shell command to execute. Not to be confused with pre-configured custom commands. |
+| `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | Просмотреть пользовательские параметры патча |  |
 | `` m `` | Просмотреть параметры слияния/перебазирования | View options to abort/continue/skip the current merge/rebase. |
 | `` R `` | Обновить | Refresh the git state (i.e. run `git status`, `git branch`, etc in background to update the contents of panels). This does not run `git fetch`. |

--- a/docs/keybindings/Keybindings_zh-CN.md
+++ b/docs/keybindings/Keybindings_zh-CN.md
@@ -18,7 +18,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename. |
 | `` } `` | 扩大差异视图中显示的上下文范围 | Increase the amount of the context shown around changes in the diff view. |
 | `` { `` | 缩小差异视图中显示的上下文范围 | Decrease the amount of the context shown around changes in the diff view. |
-| `` : `` | 执行自定义命令 | Bring up a prompt where you can enter a shell command to execute. Not to be confused with pre-configured custom commands. |
+| `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | 查看自定义补丁选项 |  |
 | `` m `` | 查看 合并/变基 选项 | View options to abort/continue/skip the current merge/rebase. |
 | `` R `` | 刷新 | Refresh the git state (i.e. run `git status`, `git branch`, etc in background to update the contents of panels). This does not run `git fetch`. |

--- a/docs/keybindings/Keybindings_zh-TW.md
+++ b/docs/keybindings/Keybindings_zh-TW.md
@@ -18,7 +18,7 @@ _說明：`<c-b>` 表示 Ctrl＋B、`<a-b>` 表示 Alt＋B，`B`表示 Shift＋B
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename. |
 | `` } `` | 增加差異檢視中顯示變更周圍上下文的大小 | Increase the amount of the context shown around changes in the diff view. |
 | `` { `` | 減小差異檢視中顯示變更周圍上下文的大小 | Decrease the amount of the context shown around changes in the diff view. |
-| `` : `` | 執行自訂命令 | Bring up a prompt where you can enter a shell command to execute. Not to be confused with pre-configured custom commands. |
+| `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | 檢視自訂補丁選項 |  |
 | `` m `` | 查看合併/變基選項 | View options to abort/continue/skip the current merge/rebase. |
 | `` R `` | 重新整理 | Refresh the git state (i.e. run `git status`, `git branch`, etc in background to update the contents of panels). This does not run `git fetch`. |

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -184,6 +184,12 @@ func migrateUserConfig(path string, content []byte) ([]byte, error) {
 		return nil, fmt.Errorf("Couldn't migrate config file at `%s`: %s", path, err)
 	}
 
+	changedContent, err = yaml_utils.RenameYamlKey(changedContent, []string{"keybinding", "universal", "executeCustomCommand"},
+		"executeShellCommand")
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't migrate config file at `%s`: %s", path, err)
+	}
+
 	changedContent, err = changeNullKeybindingsToDisabled(changedContent)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't migrate config file at `%s`: %s", path, err)
@@ -365,8 +371,10 @@ type AppState struct {
 	StartupPopupVersion int
 	LastVersion         string // this is the last version the user was using, for the purpose of showing release notes
 
-	// these are for custom commands typed in directly, not for custom commands in the lazygit config
-	CustomCommandsHistory      []string
+	// these are for shell commands typed in directly, not for custom commands in the lazygit config.
+	// For backwards compatibility we keep the old name in yaml files.
+	ShellCommandsHistory []string `yaml:"customcommandshistory"`
+
 	HideCommandLog             bool
 	IgnoreWhitespaceInDiffView bool
 	DiffContextSize            int

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -385,7 +385,7 @@ type KeybindingUniversalConfig struct {
 	ScrollDownMainAlt1                string   `yaml:"scrollDownMain-alt1"`
 	ScrollUpMainAlt2                  string   `yaml:"scrollUpMain-alt2"`
 	ScrollDownMainAlt2                string   `yaml:"scrollDownMain-alt2"`
-	ExecuteCustomCommand              string   `yaml:"executeCustomCommand"`
+	ExecuteShellCommand               string   `yaml:"executeShellCommand"`
 	CreateRebaseOptionsMenu           string   `yaml:"createRebaseOptionsMenu"`
 	Push                              string   `yaml:"pushFiles"` // 'Files' appended for legacy reasons
 	Pull                              string   `yaml:"pullFiles"` // 'Files' appended for legacy reasons
@@ -824,7 +824,7 @@ func GetDefaultConfig() *UserConfig {
 				ScrollDownMainAlt1:                "J",
 				ScrollUpMainAlt2:                  "<c-u>",
 				ScrollDownMainAlt2:                "<c-d>",
-				ExecuteCustomCommand:              ":",
+				ExecuteShellCommand:               ":",
 				CreateRebaseOptionsMenu:           "m",
 				Push:                              "P",
 				Pull:                              "p",

--- a/pkg/gui/controllers/global_controller.go
+++ b/pkg/gui/controllers/global_controller.go
@@ -22,10 +22,10 @@ func NewGlobalController(
 func (self *GlobalController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
 	return []*types.Binding{
 		{
-			Key:         opts.GetKey(opts.Config.Universal.ExecuteCustomCommand),
-			Handler:     self.customCommand,
-			Description: self.c.Tr.ExecuteCustomCommand,
-			Tooltip:     self.c.Tr.ExecuteCustomCommandTooltip,
+			Key:         opts.GetKey(opts.Config.Universal.ExecuteShellCommand),
+			Handler:     self.shellCommand,
+			Description: self.c.Tr.ExecuteShellCommand,
+			Tooltip:     self.c.Tr.ExecuteShellCommandTooltip,
 			OpensMenu:   true,
 		},
 		{
@@ -132,8 +132,8 @@ func (self *GlobalController) Context() types.Context {
 	return nil
 }
 
-func (self *GlobalController) customCommand() error {
-	return (&CustomCommandAction{c: self.c}).Call()
+func (self *GlobalController) shellCommand() error {
+	return (&ShellCommandAction{c: self.c}).Call()
 }
 
 func (self *GlobalController) createCustomPatchOptionsMenu() error {

--- a/pkg/gui/controllers/shell_command_action.go
+++ b/pkg/gui/controllers/shell_command_action.go
@@ -10,19 +10,19 @@ import (
 	"github.com/samber/lo"
 )
 
-type CustomCommandAction struct {
+type ShellCommandAction struct {
 	c *ControllerCommon
 }
 
-func (self *CustomCommandAction) Call() error {
+func (self *ShellCommandAction) Call() error {
 	return self.c.Prompt(types.PromptOpts{
-		Title:               self.c.Tr.CustomCommand,
-		FindSuggestionsFunc: self.GetCustomCommandsHistorySuggestionsFunc(),
+		Title:               self.c.Tr.ShellCommand,
+		FindSuggestionsFunc: self.GetShellCommandsHistorySuggestionsFunc(),
 		AllowEditSuggestion: true,
 		HandleConfirm: func(command string) error {
 			if self.shouldSaveCommand(command) {
-				self.c.GetAppState().CustomCommandsHistory = utils.Limit(
-					lo.Uniq(append([]string{command}, self.c.GetAppState().CustomCommandsHistory...)),
+				self.c.GetAppState().ShellCommandsHistory = utils.Limit(
+					lo.Uniq(append([]string{command}, self.c.GetAppState().ShellCommandsHistory...)),
 					1000,
 				)
 			}
@@ -38,17 +38,17 @@ func (self *CustomCommandAction) Call() error {
 			// index is the index in the _filtered_ list of suggestions, so we
 			// need to map it back to the full list. There's no really good way
 			// to do this, but fortunately we keep the items in the
-			// CustomCommandsHistory unique, which allows us to simply search
+			// ShellCommandsHistory unique, which allows us to simply search
 			// for it by string.
 			item := self.c.Contexts().Suggestions.GetItems()[index].Value
-			fullIndex := lo.IndexOf(self.c.GetAppState().CustomCommandsHistory, item)
+			fullIndex := lo.IndexOf(self.c.GetAppState().ShellCommandsHistory, item)
 			if fullIndex == -1 {
 				// Should never happen, but better be safe
 				return nil
 			}
 
-			self.c.GetAppState().CustomCommandsHistory = slices.Delete(
-				self.c.GetAppState().CustomCommandsHistory, fullIndex, fullIndex+1)
+			self.c.GetAppState().ShellCommandsHistory = slices.Delete(
+				self.c.GetAppState().ShellCommandsHistory, fullIndex, fullIndex+1)
 			self.c.SaveAppStateAndLogError()
 			self.c.Contexts().Suggestions.RefreshSuggestions()
 			return nil
@@ -56,9 +56,9 @@ func (self *CustomCommandAction) Call() error {
 	})
 }
 
-func (self *CustomCommandAction) GetCustomCommandsHistorySuggestionsFunc() func(string) []*types.Suggestion {
+func (self *ShellCommandAction) GetShellCommandsHistorySuggestionsFunc() func(string) []*types.Suggestion {
 	return func(input string) []*types.Suggestion {
-		history := self.c.GetAppState().CustomCommandsHistory
+		history := self.c.GetAppState().ShellCommandsHistory
 
 		return helpers.FilterFunc(history, self.c.UserConfig.Gui.UseFuzzySearch())(input)
 	}
@@ -66,6 +66,6 @@ func (self *CustomCommandAction) GetCustomCommandsHistorySuggestionsFunc() func(
 
 // this mimics the shell functionality `ignorespace`
 // which doesn't save a command to history if it starts with a space
-func (self *CustomCommandAction) shouldSaveCommand(command string) bool {
+func (self *ShellCommandAction) shouldSaveCommand(command string) bool {
 	return !strings.HasPrefix(command, " ")
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -415,9 +415,9 @@ type TranslationSet struct {
 	SquashCommitsInCurrentBranch          string
 	SquashCommitsAboveSelectedCommit      string
 	CannotSquashCommitsInCurrentBranch    string
-	ExecuteCustomCommand                  string
-	ExecuteCustomCommandTooltip           string
-	CustomCommand                         string
+	ExecuteShellCommand                   string
+	ExecuteShellCommandTooltip            string
+	ShellCommand                          string
 	CommitChangesWithoutHook              string
 	SkipHookPrefixNotConfigured           string
 	ResetTo                               string
@@ -1401,9 +1401,9 @@ func EnglishTranslationSet() *TranslationSet {
 		SquashCommitsInCurrentBranch:         "In current branch",
 		SquashCommitsAboveSelectedCommit:     "Above the selected commit",
 		CannotSquashCommitsInCurrentBranch:   "Cannot squash commits in current branch: the HEAD commit is a merge commit or is present on the main branch.",
-		ExecuteCustomCommand:                 "Execute custom command",
-		ExecuteCustomCommandTooltip:          "Bring up a prompt where you can enter a shell command to execute. Not to be confused with pre-configured custom commands.",
-		CustomCommand:                        "Custom command:",
+		ExecuteShellCommand:                  "Execute shell command",
+		ExecuteShellCommandTooltip:           "Bring up a prompt where you can enter a shell command to execute.",
+		ShellCommand:                         "Shell command:",
 		CommitChangesWithoutHook:             "Commit changes without pre-commit hook",
 		SkipHookPrefixNotConfigured:          "You have not configured a commit message prefix for skipping hooks. Set `git.skipHookPrefix = 'WIP'` in your config",
 		ResetTo:                              `Reset to`,

--- a/pkg/integration/tests/custom_commands/basic_command.go
+++ b/pkg/integration/tests/custom_commands/basic_command.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
-var BasicCmdFromConfig = NewIntegrationTest(NewIntegrationTestArgs{
+var BasicCommand = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Using a custom command to create a new file",
 	ExtraCmdArgs: []string{},
 	Skip:         false,

--- a/pkg/integration/tests/filter_and_search/filter_updates_when_model_changes.go
+++ b/pkg/integration/tests/filter_and_search/filter_updates_when_model_changes.go
@@ -47,9 +47,9 @@ var FilterUpdatesWhenModelChanges = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().Focus()
 
 		// To do that, we use a custom command to create a new branch that matches the filter
-		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			Type("git branch new-branch").
 			Confirm()
 

--- a/pkg/integration/tests/shell_commands/basic_shell_command.go
+++ b/pkg/integration/tests/shell_commands/basic_shell_command.go
@@ -17,10 +17,10 @@ var BasicShellCommand = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().
 			IsEmpty().
 			IsFocused().
-			Press(keys.Universal.ExecuteCustomCommand)
+			Press(keys.Universal.ExecuteShellCommand)
 
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			Type("touch file.txt").
 			Confirm()
 

--- a/pkg/integration/tests/shell_commands/basic_shell_command.go
+++ b/pkg/integration/tests/shell_commands/basic_shell_command.go
@@ -1,12 +1,12 @@
-package custom_commands
+package shell_commands
 
 import (
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
-var ComplexCmdAtRuntime = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Using a custom command provided at runtime to create a new file, via a shell command. We invoke custom commands through a shell already. This test proves that we can run a shell within a shell, which requires complex escaping.",
+var BasicShellCommand = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Using a custom command provided at runtime to create a new file",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
@@ -21,7 +21,7 @@ var ComplexCmdAtRuntime = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().Prompt().
 			Title(Equals("Custom command:")).
-			Type("sh -c \"touch file.txt\"").
+			Type("touch file.txt").
 			Confirm()
 
 		t.GlobalPress(keys.Files.RefreshFiles)

--- a/pkg/integration/tests/shell_commands/complex_shell_command.go
+++ b/pkg/integration/tests/shell_commands/complex_shell_command.go
@@ -17,10 +17,10 @@ var ComplexShellCommand = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().
 			IsEmpty().
 			IsFocused().
-			Press(keys.Universal.ExecuteCustomCommand)
+			Press(keys.Universal.ExecuteShellCommand)
 
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			Type("sh -c \"touch file.txt\"").
 			Confirm()
 

--- a/pkg/integration/tests/shell_commands/complex_shell_command.go
+++ b/pkg/integration/tests/shell_commands/complex_shell_command.go
@@ -1,12 +1,12 @@
-package custom_commands
+package shell_commands
 
 import (
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
-var BasicCmdAtRuntime = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Using a custom command provided at runtime to create a new file",
+var ComplexShellCommand = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Using a custom command provided at runtime to create a new file, via a shell command. We invoke custom commands through a shell already. This test proves that we can run a shell within a shell, which requires complex escaping.",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupRepo: func(shell *Shell) {
@@ -21,7 +21,7 @@ var BasicCmdAtRuntime = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().Prompt().
 			Title(Equals("Custom command:")).
-			Type("touch file.txt").
+			Type("sh -c \"touch file.txt\"").
 			Confirm()
 
 		t.GlobalPress(keys.Files.RefreshFiles)

--- a/pkg/integration/tests/shell_commands/delete_from_history.go
+++ b/pkg/integration/tests/shell_commands/delete_from_history.go
@@ -13,9 +13,9 @@ var DeleteFromHistory = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupConfig:  func(cfg *config.AppConfig) {},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		createCustomCommand := func(command string) {
-			t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+			t.GlobalPress(keys.Universal.ExecuteShellCommand)
 			t.ExpectPopup().Prompt().
-				Title(Equals("Custom command:")).
+				Title(Equals("Shell command:")).
 				Type(command).
 				Confirm()
 		}
@@ -24,9 +24,9 @@ var DeleteFromHistory = NewIntegrationTest(NewIntegrationTestArgs{
 		createCustomCommand("echo 2")
 		createCustomCommand("echo 3")
 
-		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			SuggestionLines(
 				Contains("3"),
 				Contains("2"),

--- a/pkg/integration/tests/shell_commands/delete_from_history.go
+++ b/pkg/integration/tests/shell_commands/delete_from_history.go
@@ -1,4 +1,4 @@
-package custom_commands
+package shell_commands
 
 import (
 	"github.com/jesseduffield/lazygit/pkg/config"

--- a/pkg/integration/tests/shell_commands/edit_history.go
+++ b/pkg/integration/tests/shell_commands/edit_history.go
@@ -12,15 +12,15 @@ var EditHistory = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupRepo:    func(shell *Shell) {},
 	SetupConfig:  func(cfg *config.AppConfig) {},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
-		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			Type("echo x").
 			Confirm()
 
-		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			Type("ec").
 			SuggestionLines(
 				Equals("echo x"),

--- a/pkg/integration/tests/shell_commands/edit_history.go
+++ b/pkg/integration/tests/shell_commands/edit_history.go
@@ -1,4 +1,4 @@
-package custom_commands
+package shell_commands
 
 import (
 	"github.com/jesseduffield/lazygit/pkg/config"

--- a/pkg/integration/tests/shell_commands/history.go
+++ b/pkg/integration/tests/shell_commands/history.go
@@ -12,22 +12,22 @@ var History = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupRepo:    func(shell *Shell) {},
 	SetupConfig:  func(cfg *config.AppConfig) {},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
-		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			Type("echo 1").
 			Confirm()
 
-		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			SuggestionLines(Contains("1")).
 			Type("echo 2").
 			Confirm()
 
-		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			SuggestionLines(
 				// "echo 2" was typed last, so it should come first
 				Contains("2"),
@@ -36,9 +36,9 @@ var History = NewIntegrationTest(NewIntegrationTestArgs{
 			Type("echo 3").
 			Confirm()
 
-		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			SuggestionLines(
 				Contains("3"),
 				Contains("2"),
@@ -48,9 +48,9 @@ var History = NewIntegrationTest(NewIntegrationTestArgs{
 			Confirm()
 
 		// Executing a command again should move it to the front:
-		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			SuggestionLines(
 				Contains("1"),
 				Contains("3"),

--- a/pkg/integration/tests/shell_commands/history.go
+++ b/pkg/integration/tests/shell_commands/history.go
@@ -1,4 +1,4 @@
-package custom_commands
+package shell_commands
 
 import (
 	"github.com/jesseduffield/lazygit/pkg/config"

--- a/pkg/integration/tests/shell_commands/omit_from_history.go
+++ b/pkg/integration/tests/shell_commands/omit_from_history.go
@@ -14,23 +14,23 @@ var OmitFromHistory = NewIntegrationTest(NewIntegrationTestArgs{
 	},
 	SetupConfig: func(cfg *config.AppConfig) {},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
-		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			Type("echo aubergine").
 			Confirm()
 
-		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			SuggestionLines(Contains("aubergine")).
 			SuggestionLines(DoesNotContain("tangerine")).
 			Type(" echo tangerine").
 			Confirm()
 
-		t.GlobalPress(keys.Universal.ExecuteCustomCommand)
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
 		t.ExpectPopup().Prompt().
-			Title(Equals("Custom command:")).
+			Title(Equals("Shell command:")).
 			SuggestionLines(Contains("aubergine")).
 			SuggestionLines(DoesNotContain("tangerine")).
 			Cancel()

--- a/pkg/integration/tests/shell_commands/omit_from_history.go
+++ b/pkg/integration/tests/shell_commands/omit_from_history.go
@@ -1,4 +1,4 @@
-package custom_commands
+package shell_commands
 
 import (
 	"github.com/jesseduffield/lazygit/pkg/config"

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/misc"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/patch_building"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/reflog"
+	"github.com/jesseduffield/lazygit/pkg/integration/tests/shell_commands"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/staging"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/stash"
 	"github.com/jesseduffield/lazygit/pkg/integration/tests/status"
@@ -115,20 +116,14 @@ var tests = []*components.IntegrationTest{
 	conflicts.ResolveMultipleFiles,
 	conflicts.UndoChooseHunk,
 	custom_commands.AccessCommitProperties,
-	custom_commands.BasicCmdAtRuntime,
-	custom_commands.BasicCmdFromConfig,
+	custom_commands.BasicCommand,
 	custom_commands.CheckForConflicts,
-	custom_commands.ComplexCmdAtRuntime,
-	custom_commands.DeleteFromHistory,
-	custom_commands.EditHistory,
 	custom_commands.FormPrompts,
 	custom_commands.GlobalContext,
-	custom_commands.History,
 	custom_commands.MenuFromCommand,
 	custom_commands.MenuFromCommandsOutput,
 	custom_commands.MultipleContexts,
 	custom_commands.MultiplePrompts,
-	custom_commands.OmitFromHistory,
 	custom_commands.ShowOutputInPanel,
 	custom_commands.SuggestionsCommand,
 	custom_commands.SuggestionsPreset,
@@ -267,6 +262,12 @@ var tests = []*components.IntegrationTest{
 	reflog.DoNotShowBranchMarkersInReflogSubcommits,
 	reflog.Patch,
 	reflog.Reset,
+	shell_commands.BasicShellCommand,
+	shell_commands.ComplexShellCommand,
+	shell_commands.DeleteFromHistory,
+	shell_commands.EditHistory,
+	shell_commands.History,
+	shell_commands.OmitFromHistory,
 	staging.DiffChangeScreenMode,
 	staging.DiffContextChange,
 	staging.DiscardAllChanges,

--- a/schema/config.json
+++ b/schema/config.json
@@ -1232,7 +1232,7 @@
               "type": "string",
               "default": "\u003cc-d\u003e"
             },
-            "executeCustomCommand": {
+            "executeShellCommand": {
               "type": "string",
               "default": ":"
             },


### PR DESCRIPTION
- **PR Description**

The double use of the term "Custom Command" for both shell commands and user-configured keybindings was confusing.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
