### PR TITLE
Fix lack of icon assignation when extension don't match capitalization (lowercase)

### DIFF
--- a/pkg/gui/presentation/icons/file_icons.go
+++ b/pkg/gui/presentation/icons/file_icons.go
@@ -2,6 +2,7 @@ package icons
 
 import (
 	"path/filepath"
+	"strings"
 )
 
 // NOTE: Visit next links for inspiration:
@@ -728,7 +729,7 @@ func IconForFile(name string, isSubmodule bool, isLinkedWorktree bool, isDirecto
 		return icon
 	}
 
-	ext := filepath.Ext(name)
+	ext := strings.ToLower(filepath.Ext(name))
 	if icon, ok := extIconMap[ext]; ok {
 		return icon
 	}


### PR DESCRIPTION
- **PR Description**
The extension icon map contain all extensions on lowercase, when a file don't have extension on lowercase the string don't match and icon is not assigned.

#### Before
![image](https://github.com/user-attachments/assets/c6efb6f5-1095-4a1a-9422-32c199b4cc51)

#### After
![image](https://github.com/user-attachments/assets/83a453e0-cf83-4ff2-bf7e-f9fcf9e77db3)


- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [X] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
