### PR TITLE
Support hyperlinks from pagers

### DIFF
--- a/docs/Custom_Pagers.md
+++ b/docs/Custom_Pagers.md
@@ -26,6 +26,8 @@ git:
 
 ![](https://i.imgur.com/QJpQkF3.png)
 
+A cool feature of delta is --hyperlinks, which renders clickable links for the line numbers in the left margin, and lazygit supports these. To use them, set the `pager:` config to `delta --dark --paging=never --line-numbers --hyperlinks --hyperlinks-file-link-format="lazygit-edit://{path}:{line}`; this allows you to click on an underlined line number in the diff to jump right to that same line in your editor.
+
 ## Diff-so-fancy
 
 ```yaml

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/integrii/flaggy v1.4.0
 	github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68
 	github.com/jesseduffield/go-git/v5 v5.1.2-0.20221018185014-fdd53fef665d
-	github.com/jesseduffield/gocui v0.3.1-0.20240824081936-a3adeb73f602
+	github.com/jesseduffield/gocui v0.3.1-0.20240824083442-15b7fbca7ae9
 	github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10
 	github.com/jesseduffield/lazycore v0.0.0-20221012050358-03d2e40243c5
 	github.com/jesseduffield/minimal/gitignore v0.3.3-0.20211018110810-9cde264e6b1e

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68 h1:EQP2Tv8T
 github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68/go.mod h1:+LLj9/WUPAP8LqCchs7P+7X0R98HiFujVFANdNaxhGk=
 github.com/jesseduffield/go-git/v5 v5.1.2-0.20221018185014-fdd53fef665d h1:bO+OmbreIv91rCe8NmscRwhFSqkDJtzWCPV4Y+SQuXE=
 github.com/jesseduffield/go-git/v5 v5.1.2-0.20221018185014-fdd53fef665d/go.mod h1:nGNEErzf+NRznT+N2SWqmHnDnF9aLgANB1CUNEan09o=
-github.com/jesseduffield/gocui v0.3.1-0.20240824081936-a3adeb73f602 h1:nzGt/sRT0WCancALG5Q9e4DlQWGo7QUMc35rApdt+aM=
-github.com/jesseduffield/gocui v0.3.1-0.20240824081936-a3adeb73f602/go.mod h1:XtEbqCbn45keRXEu+OMZkjN5gw6AEob59afsgHjokZ8=
+github.com/jesseduffield/gocui v0.3.1-0.20240824083442-15b7fbca7ae9 h1:1muwCO0cmCGHpOvNz1qTOrCFPECnBAV87yDE9Fgwy6U=
+github.com/jesseduffield/gocui v0.3.1-0.20240824083442-15b7fbca7ae9/go.mod h1:XtEbqCbn45keRXEu+OMZkjN5gw6AEob59afsgHjokZ8=
 github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10 h1:jmpr7KpX2+2GRiE91zTgfq49QvgiqB0nbmlwZ8UnOx0=
 github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10/go.mod h1:aA97kHeNA+sj2Hbki0pvLslmE4CbDyhBeSSTUUnOuVo=
 github.com/jesseduffield/lazycore v0.0.0-20221012050358-03d2e40243c5 h1:CDuQmfOjAtb1Gms6a1p5L2P8RhbLUq5t8aL7PiQd2uY=

--- a/pkg/gui/controllers/helpers/confirmation_helper.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper.go
@@ -259,11 +259,7 @@ func underlineLinks(text string) string {
 		} else {
 			linkEnd += linkStart
 		}
-		underlinedLink := style.AttrUnderline.Sprint(remaining[linkStart:linkEnd])
-		if strings.HasSuffix(underlinedLink, "\x1b[0m") {
-			// Replace the "all styles off" code with "underline off" code
-			underlinedLink = underlinedLink[:len(underlinedLink)-2] + "24m"
-		}
+		underlinedLink := style.PrintSimpleHyperlink(remaining[linkStart:linkEnd])
 		result += remaining[:linkStart] + underlinedLink
 		remaining = remaining[linkEnd:]
 	}

--- a/pkg/gui/controllers/helpers/confirmation_helper_test.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper_test.go
@@ -27,27 +27,27 @@ func Test_underlineLinks(t *testing.T) {
 		{
 			name:           "entire string is a link",
 			text:           "https://example.com",
-			expectedResult: "\x1b[4mhttps://example.com\x1b[24m",
+			expectedResult: "\x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\",
 		},
 		{
 			name:           "link preceeded and followed by text",
 			text:           "bla https://example.com xyz",
-			expectedResult: "bla \x1b[4mhttps://example.com\x1b[24m xyz",
+			expectedResult: "bla \x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\ xyz",
 		},
 		{
 			name:           "more than one link",
 			text:           "bla https://link1 blubb https://link2 xyz",
-			expectedResult: "bla \x1b[4mhttps://link1\x1b[24m blubb \x1b[4mhttps://link2\x1b[24m xyz",
+			expectedResult: "bla \x1b]8;;https://link1\x1b\\https://link1\x1b]8;;\x1b\\ blubb \x1b]8;;https://link2\x1b\\https://link2\x1b]8;;\x1b\\ xyz",
 		},
 		{
 			name:           "link in angle brackets",
 			text:           "See <https://example.com> for details",
-			expectedResult: "See <\x1b[4mhttps://example.com\x1b[24m> for details",
+			expectedResult: "See <\x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\> for details",
 		},
 		{
 			name:           "link followed by newline",
 			text:           "URL: https://example.com\nNext line",
-			expectedResult: "URL: \x1b[4mhttps://example.com\x1b[24m\nNext line",
+			expectedResult: "URL: \x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\\nNext line",
 		},
 	}
 

--- a/pkg/gui/controllers/status_controller.go
+++ b/pkg/gui/controllers/status_controller.go
@@ -72,20 +72,11 @@ func (self *StatusController) GetKeybindings(opts types.KeybindingsOpts) []*type
 func (self *StatusController) GetMouseKeybindings(opts types.KeybindingsOpts) []*gocui.ViewMouseBinding {
 	return []*gocui.ViewMouseBinding{
 		{
-			ViewName: "main",
-			Key:      gocui.MouseLeft,
-			Handler:  self.onClickMain,
-		},
-		{
 			ViewName: self.Context().GetViewName(),
 			Key:      gocui.MouseLeft,
 			Handler:  self.onClick,
 		},
 	}
-}
-
-func (self *StatusController) onClickMain(opts gocui.ViewMouseBindingOpts) error {
-	return self.c.HandleGenericClick(self.c.Views().Main)
 }
 
 func (self *StatusController) GetOnRenderToMain() func() error {
@@ -219,12 +210,12 @@ func (self *StatusController) showDashboard() error {
 		[]string{
 			lazygitTitle(),
 			fmt.Sprintf("Copyright %d Jesse Duffield", time.Now().Year()),
-			fmt.Sprintf("Keybindings: %s", style.AttrUnderline.Sprint(fmt.Sprintf(constants.Links.Docs.Keybindings, versionStr))),
-			fmt.Sprintf("Config Options: %s", style.AttrUnderline.Sprint(fmt.Sprintf(constants.Links.Docs.Config, versionStr))),
-			fmt.Sprintf("Tutorial: %s", style.AttrUnderline.Sprint(constants.Links.Docs.Tutorial)),
-			fmt.Sprintf("Raise an Issue: %s", style.AttrUnderline.Sprint(constants.Links.Issues)),
-			fmt.Sprintf("Release Notes: %s", style.AttrUnderline.Sprint(constants.Links.Releases)),
-			style.FgMagenta.Sprintf("Become a sponsor: %s", style.AttrUnderline.Sprint(constants.Links.Donate)), // caffeine ain't free
+			fmt.Sprintf("Keybindings: %s", style.PrintSimpleHyperlink(fmt.Sprintf(constants.Links.Docs.Keybindings, versionStr))),
+			fmt.Sprintf("Config Options: %s", style.PrintSimpleHyperlink(fmt.Sprintf(constants.Links.Docs.Config, versionStr))),
+			fmt.Sprintf("Tutorial: %s", style.PrintSimpleHyperlink(constants.Links.Docs.Tutorial)),
+			fmt.Sprintf("Raise an Issue: %s", style.PrintSimpleHyperlink(constants.Links.Issues)),
+			fmt.Sprintf("Release Notes: %s", style.PrintSimpleHyperlink(constants.Links.Releases)),
+			style.FgMagenta.Sprintf("Become a sponsor: %s", style.PrintSimpleHyperlink(constants.Links.Donate)), // caffeine ain't free
 		}, "\n\n") + "\n"
 
 	return self.c.RenderToMainViews(types.RefreshMainOpts{

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -109,14 +109,6 @@ func (gui *Gui) scrollDownConfirmationPanel() error {
 	return nil
 }
 
-func (gui *Gui) handleConfirmationClick() error {
-	if gui.Views.Confirmation.Editable {
-		return nil
-	}
-
-	return gui.handleGenericClick(gui.Views.Confirmation)
-}
-
 func (gui *Gui) handleCopySelectedSideContextItemToClipboard() error {
 	return gui.handleCopySelectedSideContextItemToClipboardWithTruncation(-1)
 }

--- a/pkg/gui/gui_common.go
+++ b/pkg/gui/gui_common.go
@@ -33,10 +33,6 @@ func (self *guiCommon) PostRefreshUpdate(context types.Context) error {
 	return self.gui.postRefreshUpdate(context)
 }
 
-func (self *guiCommon) HandleGenericClick(view *gocui.View) error {
-	return self.gui.handleGenericClick(view)
-}
-
 func (self *guiCommon) RunSubprocessAndRefresh(cmdObj oscommands.ICmdObj) error {
 	return self.gui.runSubprocessWithSuspenseAndRefresh(cmdObj)
 }

--- a/pkg/gui/information_panel.go
+++ b/pkg/gui/information_panel.go
@@ -14,8 +14,8 @@ func (gui *Gui) informationStr() string {
 	}
 
 	if gui.g.Mouse {
-		donate := style.FgMagenta.SetUnderline().Sprint(gui.c.Tr.Donate)
-		askQuestion := style.FgYellow.SetUnderline().Sprint(gui.c.Tr.AskQuestion)
+		donate := style.FgMagenta.Sprint(style.PrintHyperlink(gui.c.Tr.Donate, constants.Links.Donate))
+		askQuestion := style.FgYellow.Sprint(style.PrintHyperlink(gui.c.Tr.AskQuestion, constants.Links.Discussions))
 		return fmt.Sprintf("%s %s %s", donate, askQuestion, gui.Config.GetVersion())
 	} else {
 		return gui.Config.GetVersion()
@@ -37,29 +37,6 @@ func (gui *Gui) handleInfoClick() error {
 			return nil
 		}
 		return activeMode.Reset()
-	}
-
-	var title, url string
-
-	// if we're not in an active mode we show the donate button
-	if cx <= utils.StringWidth(gui.c.Tr.Donate) {
-		url = constants.Links.Donate
-		title = gui.c.Tr.Donate
-	} else if cx <= utils.StringWidth(gui.c.Tr.Donate)+1+utils.StringWidth(gui.c.Tr.AskQuestion) {
-		url = constants.Links.Discussions
-		title = gui.c.Tr.AskQuestion
-	}
-	err := gui.os.OpenLink(url)
-	if err != nil {
-		// Opening the link via the OS failed for some reason. (For example, this
-		// can happen if the `os.openLink` config key references a command that
-		// doesn't exist, or that errors when called.)
-		//
-		// In that case, rather than crash the app, fall back to simply showing a
-		// dialog asking the user to visit the URL.
-		placeholders := map[string]string{"url": url}
-		message := utils.ResolvePlaceholderString(gui.c.Tr.PleaseGoToURL, placeholders)
-		return gui.c.Alert(title, message)
 	}
 
 	return nil

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -250,12 +250,6 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 		},
 		{
 			ViewName: "confirmation",
-			Key:      gocui.MouseLeft,
-			Modifier: gocui.ModNone,
-			Handler:  self.handleConfirmationClick,
-		},
-		{
-			ViewName: "confirmation",
 			Key:      gocui.MouseWheelUp,
 			Handler:  self.scrollUpConfirmationPanel,
 		},

--- a/pkg/gui/style/hyperlink.go
+++ b/pkg/gui/style/hyperlink.go
@@ -1,0 +1,13 @@
+package style
+
+import "fmt"
+
+// Render the given text as an OSC 8 hyperlink
+func PrintHyperlink(text string, link string) string {
+	return fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", link, text)
+}
+
+// Render a link where the text is the same as a link
+func PrintSimpleHyperlink(link string) string {
+	return fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", link, link)
+}

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -35,10 +35,6 @@ type IGuiCommon interface {
 	// case would be overkill, although refresh will internally call 'PostRefreshUpdate'
 	PostRefreshUpdate(Context) error
 
-	// a generic click handler that can be used for any view; it handles opening
-	// URLs in the browser when the user clicks on one
-	HandleGenericClick(view *gocui.View) error
-
 	// renders string to a view without resetting its origin
 	SetViewContent(view *gocui.View, content string)
 	// resets cursor and origin of view. Often used before calling SetViewContent

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -1,7 +1,6 @@
 package gui
 
 import (
-	"regexp"
 	"time"
 
 	"github.com/jesseduffield/gocui"
@@ -146,31 +145,6 @@ func (gui *Gui) postRefreshUpdate(c types.Context) error {
 			return err
 		}
 	}
-
-	return nil
-}
-
-// handleGenericClick is a generic click handler that can be used for any view.
-// It handles opening URLs in the browser when the user clicks on one.
-func (gui *Gui) handleGenericClick(view *gocui.View) error {
-	cx, cy := view.Cursor()
-	word, err := view.Word(cx, cy)
-	if err != nil {
-		return nil
-	}
-
-	// Allow URLs to be wrapped in angle brackets, and the closing bracket to
-	// be followed by punctuation:
-	re := regexp.MustCompile(`^<?(https://.+?)(>[,.;!]*)?$`)
-	matches := re.FindStringSubmatch(word)
-	if matches == nil {
-		return nil
-	}
-
-	// Ignore errors (opening the link via the OS can fail if the
-	// `os.openLink` config key references a command that doesn't exist, or
-	// that errors when called.)
-	_ = gui.c.OS().OpenLink(matches[1])
 
 	return nil
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -784,7 +784,9 @@ type TranslationSet struct {
 	MarkAsBaseCommit                         string
 	MarkAsBaseCommitTooltip                  string
 	MarkedCommitMarker                       string
+	FailedToOpenURL                          string
 	PleaseGoToURL                            string
+	InvalidLazygitEditURL                    string
 	NoCopiedCommits                          string
 	DisabledMenuItemPrefix                   string
 	QuickStartInteractiveRebase              string
@@ -1770,7 +1772,9 @@ func EnglishTranslationSet() *TranslationSet {
 		MarkAsBaseCommit:                         "Mark as base commit for rebase",
 		MarkAsBaseCommitTooltip:                  "Select a base commit for the next rebase. When you rebase onto a branch, only commits above the base commit will be brought across. This uses the `git rebase --onto` command.",
 		MarkedCommitMarker:                       "↑↑↑ Will rebase from here ↑↑↑",
+		FailedToOpenURL:                          "Failed to open URL %s\n\nError: %v",
 		PleaseGoToURL:                            "Please go to {{.url}}",
+		InvalidLazygitEditURL:                    "Invalid lazygit-edit URL format: %s",
 		DisabledMenuItemPrefix:                   "Disabled: ",
 		NoCopiedCommits:                          "No copied commits",
 		QuickStartInteractiveRebase:              "Start interactive rebase",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -785,7 +785,6 @@ type TranslationSet struct {
 	MarkAsBaseCommitTooltip                  string
 	MarkedCommitMarker                       string
 	FailedToOpenURL                          string
-	PleaseGoToURL                            string
 	InvalidLazygitEditURL                    string
 	NoCopiedCommits                          string
 	DisabledMenuItemPrefix                   string
@@ -1773,7 +1772,6 @@ func EnglishTranslationSet() *TranslationSet {
 		MarkAsBaseCommitTooltip:                  "Select a base commit for the next rebase. When you rebase onto a branch, only commits above the base commit will be brought across. This uses the `git rebase --onto` command.",
 		MarkedCommitMarker:                       "↑↑↑ Will rebase from here ↑↑↑",
 		FailedToOpenURL:                          "Failed to open URL %s\n\nError: %v",
-		PleaseGoToURL:                            "Please go to {{.url}}",
 		InvalidLazygitEditURL:                    "Invalid lazygit-edit URL format: %s",
 		DisabledMenuItemPrefix:                   "Disabled: ",
 		NoCopiedCommits:                          "No copied commits",

--- a/pkg/integration/tests/ui/open_link_failure.go
+++ b/pkg/integration/tests/ui/open_link_failure.go
@@ -17,8 +17,8 @@ var OpenLinkFailure = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Information().Click(0, 0)
 
 		t.ExpectPopup().Confirmation().
-			Title(Equals("Donate")).
-			Content(Equals("Please go to https://github.com/sponsors/jesseduffield")).
+			Title(Equals("Error")).
+			Content(Equals("Failed to open URL https://github.com/sponsors/jesseduffield\n\nError: exit status 42")).
 			Confirm()
 	},
 })

--- a/pkg/utils/color.go
+++ b/pkg/utils/color.go
@@ -25,7 +25,9 @@ func Decolorise(str string) string {
 	}
 
 	re := regexp.MustCompile(`\x1B\[([0-9]{1,3}(;[0-9]{1,3})*)?[mGK]`)
+	linkRe := regexp.MustCompile(`\x1B]8;[^;]*;(.*?)(\x1B.|\x07)`)
 	ret := re.ReplaceAllString(str, "")
+	ret = linkRe.ReplaceAllString(ret, "")
 
 	decoloriseMutex.Lock()
 	decoloriseCache[str] = ret

--- a/pkg/utils/color_test.go
+++ b/pkg/utils/color_test.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/gui/style"
 )
 
 func TestDecolorise(t *testing.T) {
@@ -188,6 +190,10 @@ func TestDecolorise(t *testing.T) {
 		{
 			input:  "\x1b[38;2;157;205;18mta\x1b[0m",
 			output: "ta",
+		},
+		{
+			input:  "a_" + style.PrintSimpleHyperlink("xyz") + "_b",
+			output: "a_xyz_b",
 		},
 	}
 

--- a/vendor/github.com/jesseduffield/gocui/tcell_driver.go
+++ b/vendor/github.com/jesseduffield/gocui/tcell_driver.go
@@ -363,6 +363,7 @@ func (g *Gui) pollEvent() GocuiEvent {
 				mouseKey = MouseRight
 			case tcell.ButtonMiddle:
 				mouseKey = MouseMiddle
+			default:
 			}
 		}
 
@@ -374,11 +375,13 @@ func (g *Gui) pollEvent() GocuiEvent {
 					dragState = NOT_DRAGGING
 				case tcell.ButtonSecondary:
 				case tcell.ButtonMiddle:
+				default:
 				}
 				mouseMod = Modifier(lastMouseMod)
 				lastMouseMod = tcell.ModNone
 				lastMouseKey = tcell.ButtonNone
 			}
+		default:
 		}
 
 		if !wheeling {

--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -378,6 +378,7 @@ type viewLine struct {
 type cell struct {
 	chr              rune
 	bgColor, fgColor Attribute
+	hyperlink        string
 }
 
 type lineType []cell
@@ -851,9 +852,10 @@ func (v *View) parseInput(ch rune, x int, _ int) (bool, []cell) {
 			repeatCount = tabStop - (x % tabStop)
 		}
 		c := cell{
-			fgColor: v.ei.curFgColor,
-			bgColor: v.ei.curBgColor,
-			chr:     ch,
+			fgColor:   v.ei.curFgColor,
+			bgColor:   v.ei.curBgColor,
+			hyperlink: v.ei.hyperlink,
+			chr:       ch,
 		}
 		for i := 0; i < repeatCount; i++ {
 			cells = append(cells, c)
@@ -1187,6 +1189,9 @@ func (v *View) draw() error {
 			bgColor := c.bgColor
 			if bgColor == ColorDefault {
 				bgColor = v.BgColor
+			}
+			if c.hyperlink != "" {
+				fgColor |= AttrUnderline
 			}
 
 			if err := v.setRune(x, y, c.chr, fgColor, bgColor); err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -172,7 +172,7 @@ github.com/jesseduffield/go-git/v5/utils/merkletrie/filesystem
 github.com/jesseduffield/go-git/v5/utils/merkletrie/index
 github.com/jesseduffield/go-git/v5/utils/merkletrie/internal/frame
 github.com/jesseduffield/go-git/v5/utils/merkletrie/noder
-# github.com/jesseduffield/gocui v0.3.1-0.20240824081936-a3adeb73f602
+# github.com/jesseduffield/gocui v0.3.1-0.20240824083442-15b7fbca7ae9
 ## explicit; go 1.12
 github.com/jesseduffield/gocui
 # github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10


### PR DESCRIPTION
- **PR Description**

Allows to use `delta --hyperlinks` as a pager, which turns line numbers in the diff into clickable links that take you to the respective file. For VS Code users, I recommend to combine this with `--hyperlinks-file-link-format="vscode://file/{path}:{line}"` so that it jumps to the right line.

In addition, I added a few commits that replaces our old, manual ad-hoc handling of links in various places (status view, confirmation panels, information view) with the new hyperlinks feature, which cleans up the code a bit.

Fixes #3817.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
