### PR TITLE
Add an option to delete both remote and local branch in one menu item

### DIFF
--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -472,6 +472,9 @@ type TranslationSet struct {
 	DeleteRemoteBranch                    string
 	DeleteRemoteBranchMessage             string
 	DeleteRemoteBranchTooltip             string
+	DeleteRemoteAndLocalBranch            string
+	DeleteRemoteAndLocalBranchMessage     string
+	DeleteRemoteAndLocalBranchTooltip     string
 	SetAsUpstream                         string
 	SetAsUpstreamTooltip                  string
 	SetUpstream                           string
@@ -910,6 +913,9 @@ type Actions struct {
 	MovePatchIntoIndex                string
 	MovePatchIntoNewCommit            string
 	DeleteRemoteBranch                string
+	DeleteRemoteAndLocalBranch        string
+	DeleteRemoteAndLocalBranchMessage string
+	DeleteRemoteAndLocalBranchTooltip string
 	SetBranchUpstream                 string
 	AddRemote                         string
 	RemoveRemote                      string
@@ -1455,6 +1461,9 @@ func EnglishTranslationSet() *TranslationSet {
 		DeleteRemoteBranch:                   "Delete remote branch",
 		DeleteRemoteBranchMessage:            "Are you sure you want to delete remote branch",
 		DeleteRemoteBranchTooltip:            "Delete the remote branch from the remote.",
+		DeleteRemoteAndLocalBranch:           "Delete remote and local branches",
+		DeleteRemoteAndLocalBranchMessage:    "Are you sure you want to delete both remote and local branches",
+		DeleteRemoteAndLocalBranchTooltip:    "First remote, then local branch will be deleted.",
 		SetAsUpstream:                        "Set as upstream",
 		SetAsUpstreamTooltip:                 "Set the selected remote branch as the upstream of the checked-out branch.",
 		SetUpstream:                          "Set upstream of selected branch",


### PR DESCRIPTION
- **PR Description**

Adds menu option to delete the branch on remote first, then locally.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
