### PR TITLE
Fix pressing escape after clicking in diff view

### DIFF
--- a/pkg/gui/patch_exploring/state.go
+++ b/pkg/gui/patch_exploring/state.go
@@ -112,7 +112,7 @@ func (s *State) SelectingHunk() bool {
 }
 
 func (s *State) SelectingRange() bool {
-	return s.selectMode == RANGE
+	return s.selectMode == RANGE && (s.rangeIsSticky || s.rangeStartLineIdx != s.selectedLineIdx)
 }
 
 func (s *State) SelectingLine() bool {


### PR DESCRIPTION
- **PR Description**

When clicking in a single-file diff view to enter staging (or custom patch editing, when coming from the commit files panel), you needed to press escape twice to exit, where the first press would seemingly do nothing.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
