### PR TITLE
Fix loading customCommands from per-repo config file

### DIFF
--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -196,9 +196,13 @@ func loadUserConfig(configFiles []*ConfigFile, base *UserConfig) (*UserConfig, e
 			return nil, err
 		}
 
+		existingCustomCommands := base.CustomCommands
+
 		if err := yaml.Unmarshal(content, base); err != nil {
 			return nil, fmt.Errorf("The config at `%s` couldn't be parsed, please inspect it before opening up an issue.\n%w", path, err)
 		}
+
+		base.CustomCommands = append(base.CustomCommands, existingCustomCommands...)
 
 		if err := base.Validate(); err != nil {
 			return nil, fmt.Errorf("The config at `%s` has a validation error.\n%w", path, err)

--- a/pkg/integration/components/file_system.go
+++ b/pkg/integration/components/file_system.go
@@ -30,7 +30,7 @@ func (self *FileSystem) FileContent(path string, matcher *TextMatcher) {
 	self.assertWithRetries(func() (bool, string) {
 		_, err := os.Stat(path)
 		if os.IsNotExist(err) {
-			return false, fmt.Sprintf("Expected path '%s' to not exist, but it does", path)
+			return false, fmt.Sprintf("Expected path '%s' to exist, but it does not", path)
 		}
 
 		output, err := os.ReadFile(path)

--- a/pkg/integration/tests/config/custom_commands_in_per_repo_config.go
+++ b/pkg/integration/tests/config/custom_commands_in_per_repo_config.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"path/filepath"
+
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CustomCommandsInPerRepoConfig = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Custom commands in per-repo config add to the global ones instead of replacing them",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(cfg *config.AppConfig) {
+		otherRepo, _ := filepath.Abs("../other")
+		cfg.GetAppState().RecentRepos = []string{otherRepo}
+
+		cfg.GetUserConfig().CustomCommands = []config.CustomCommand{
+			{
+				Key:     "X",
+				Context: "global",
+				Command: "printf 'global X' > file.txt",
+			},
+			{
+				Key:     "Y",
+				Context: "global",
+				Command: "printf 'global Y' > file.txt",
+			},
+		}
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.CloneNonBare("other")
+		shell.CreateFile("../other/.git/lazygit.yml", `
+customCommands:
+  - key: Y
+    context: global
+    command: printf 'local Y' > file.txt
+  - key: Z
+    context: global
+    command: printf 'local Z' > file.txt`)
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.GlobalPress(keys.Universal.OpenRecentRepos)
+		t.ExpectPopup().Menu().Title(Equals("Recent repositories")).
+			Lines(
+				Contains("other").IsSelected(),
+				Contains("Cancel"),
+			).Confirm()
+		t.Views().Status().Content(Contains("other → master"))
+
+		t.GlobalPress("X")
+		/* EXPECTED:
+		t.FileSystem().FileContent("../other/file.txt", Equals("global X"))
+		ACTUAL: */
+		t.FileSystem().PathNotPresent("../other/file.txt")
+
+		t.GlobalPress("Y")
+		t.FileSystem().FileContent("../other/file.txt", Equals("local Y"))
+
+		t.GlobalPress("Z")
+		t.FileSystem().FileContent("../other/file.txt", Equals("local Z"))
+	},
+})

--- a/pkg/integration/tests/config/custom_commands_in_per_repo_config.go
+++ b/pkg/integration/tests/config/custom_commands_in_per_repo_config.go
@@ -49,10 +49,7 @@ customCommands:
 		t.Views().Status().Content(Contains("other → master"))
 
 		t.GlobalPress("X")
-		/* EXPECTED:
 		t.FileSystem().FileContent("../other/file.txt", Equals("global X"))
-		ACTUAL: */
-		t.FileSystem().PathNotPresent("../other/file.txt")
 
 		t.GlobalPress("Y")
 		t.FileSystem().FileContent("../other/file.txt", Equals("local Y"))

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -110,6 +110,7 @@ var tests = []*components.IntegrationTest{
 	commit.Staged,
 	commit.StagedWithoutHooks,
 	commit.Unstaged,
+	config.CustomCommandsInPerRepoConfig,
 	config.RemoteNamedStar,
 	conflicts.Filter,
 	conflicts.ResolveExternally,


### PR DESCRIPTION
- **PR Description**

Any newly loaded custom command coming from the per-repo config file should add
to the global ones (or override an existing one in the global one), rather than
replace all global ones.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
