### PR TITLE
Improve mouse support for commit message panel

### DIFF
--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -354,6 +354,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 
 	controllers.AttachControllers(gui.State.Contexts.CommitDescription,
 		commitDescriptionController,
+		verticalScrollControllerFactory.Create(gui.State.Contexts.CommitDescription),
 	)
 
 	controllers.AttachControllers(gui.State.Contexts.RemoteBranches,

--- a/pkg/gui/controllers/commit_description_controller.go
+++ b/pkg/gui/controllers/commit_description_controller.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 )
 
@@ -45,11 +44,7 @@ func (self *CommitDescriptionController) GetKeybindings(opts types.KeybindingsOp
 }
 
 func (self *CommitDescriptionController) Context() types.Context {
-	return self.context()
-}
-
-func (self *CommitDescriptionController) context() *context.CommitMessageContext {
-	return self.c.Contexts().CommitMessage
+	return self.c.Contexts().CommitDescription
 }
 
 func (self *CommitDescriptionController) switchToCommitMessage() error {

--- a/pkg/gui/controllers/commit_description_controller.go
+++ b/pkg/gui/controllers/commit_description_controller.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 )
 
@@ -47,6 +49,16 @@ func (self *CommitDescriptionController) Context() types.Context {
 	return self.c.Contexts().CommitDescription
 }
 
+func (self *CommitDescriptionController) GetMouseKeybindings(opts types.KeybindingsOpts) []*gocui.ViewMouseBinding {
+	return []*gocui.ViewMouseBinding{
+		{
+			ViewName: self.Context().GetViewName(),
+			Key:      gocui.MouseLeft,
+			Handler:  self.onClick,
+		},
+	}
+}
+
 func (self *CommitDescriptionController) switchToCommitMessage() error {
 	return self.c.Context().Replace(self.c.Contexts().CommitMessage)
 }
@@ -62,4 +74,13 @@ func (self *CommitDescriptionController) confirm() error {
 func (self *CommitDescriptionController) openCommitMenu() error {
 	authorSuggestion := self.c.Helpers().Suggestions.GetAuthorsSuggestionsFunc()
 	return self.c.Helpers().Commits.OpenCommitMenu(authorSuggestion)
+}
+
+func (self *CommitDescriptionController) onClick(opts gocui.ViewMouseBindingOpts) error {
+	// Activate the description panel when the commit message panel is currently active
+	if self.c.Context().Current().GetKey() == context.COMMIT_MESSAGE_CONTEXT_KEY {
+		return self.c.Context().Replace(self.c.Contexts().CommitDescription)
+	}
+
+	return nil
 }

--- a/pkg/gui/controllers/commit_message_controller.go
+++ b/pkg/gui/controllers/commit_message_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"errors"
 
+	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/controllers/helpers"
@@ -56,6 +57,16 @@ func (self *CommitMessageController) GetKeybindings(opts types.KeybindingsOpts) 
 	}
 
 	return bindings
+}
+
+func (self *CommitMessageController) GetMouseKeybindings(opts types.KeybindingsOpts) []*gocui.ViewMouseBinding {
+	return []*gocui.ViewMouseBinding{
+		{
+			ViewName: self.Context().GetViewName(),
+			Key:      gocui.MouseLeft,
+			Handler:  self.onClick,
+		},
+	}
 }
 
 func (self *CommitMessageController) GetOnFocusLost() func(types.OnFocusLostOpts) error {
@@ -136,4 +147,13 @@ func (self *CommitMessageController) close() error {
 func (self *CommitMessageController) openCommitMenu() error {
 	authorSuggestion := self.c.Helpers().Suggestions.GetAuthorsSuggestionsFunc()
 	return self.c.Helpers().Commits.OpenCommitMenu(authorSuggestion)
+}
+
+func (self *CommitMessageController) onClick(opts gocui.ViewMouseBindingOpts) error {
+	// Activate the commit message panel when the commit description panel is currently active
+	if self.c.Context().Current().GetKey() == context.COMMIT_DESCRIPTION_CONTEXT_KEY {
+		return self.c.Context().Replace(self.c.Contexts().CommitMessage)
+	}
+
+	return nil
 }

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -424,8 +424,14 @@ func (gui *Gui) SetKeybinding(binding *types.Binding) error {
 func (gui *Gui) SetMouseKeybinding(binding *gocui.ViewMouseBinding) error {
 	baseHandler := binding.Handler
 	newHandler := func(opts gocui.ViewMouseBindingOpts) error {
-		// we ignore click events on views that aren't popup panels, when a popup panel is focused
-		if gui.helpers.Confirmation.IsPopupPanelFocused() && gui.currentViewName() != binding.ViewName {
+		// we ignore click events on views that aren't popup panels, when a popup panel is focused.
+		// Unless both the current view and the clicked-on view are either commit message or commit
+		// description, because we want to allow switching between those two views by clicking.
+		isCommitMessageView := func(viewName string) bool {
+			return viewName == "commitMessage" || viewName == "commitDescription"
+		}
+		if gui.helpers.Confirmation.IsPopupPanelFocused() && gui.currentViewName() != binding.ViewName &&
+			(!isCommitMessageView(gui.currentViewName()) || !isCommitMessageView(binding.ViewName)) {
 			return nil
 		}
 

--- a/vendor/github.com/jesseduffield/gocui/gui.go
+++ b/vendor/github.com/jesseduffield/gocui/gui.go
@@ -1356,6 +1356,15 @@ func (g *Gui) onKey(ev *GocuiEvent) error {
 			if err := v.SetCursor(newCx, newCy); err != nil {
 				return err
 			}
+			if v.Editable {
+				v.TextArea.SetCursor2D(newX, newY)
+
+				// SetCursor2D might have adjusted the text area's cursor to the
+				// left to move left from a soft line break, so we need to
+				// update the view's cursor to match the text area's cursor.
+				cX, _ := v.TextArea.GetCursorXY()
+				v.SetCursorX(cX)
+			}
 		}
 
 		if IsMouseKey(ev.Key) {

--- a/vendor/github.com/jesseduffield/gocui/gui.go
+++ b/vendor/github.com/jesseduffield/gocui/gui.go
@@ -1344,6 +1344,9 @@ func (g *Gui) onKey(ev *GocuiEvent) error {
 			}
 
 			lastCharForLine := len(v.lines[newY])
+			for lastCharForLine > 0 && v.lines[newY][lastCharForLine-1].chr == 0 {
+				lastCharForLine--
+			}
 			if lastCharForLine < newX {
 				newX = lastCharForLine
 				newCx = lastCharForLine - v.ox

--- a/vendor/github.com/jesseduffield/gocui/text_area.go
+++ b/vendor/github.com/jesseduffield/gocui/text_area.go
@@ -282,13 +282,7 @@ func (self *TextArea) GoToEndOfLine() {
 
 	self.cursor = self.closestNewlineOnRight()
 
-	// If the end of line is a soft line break, we need to move left by one so
-	// that we end up at the last whitespace before the line break. Otherwise
-	// we'd be at the start of the next line, since the newline character
-	// doesn't really exist in the real content.
-	if self.cursor < len(self.content) && self.content[self.cursor] != '\n' {
-		self.cursor--
-	}
+	self.moveLeftFromSoftLineBreak()
 }
 
 func (self *TextArea) closestNewlineOnRight() int {
@@ -301,6 +295,16 @@ func (self *TextArea) closestNewlineOnRight() int {
 	}
 
 	return len(self.content)
+}
+
+func (self *TextArea) moveLeftFromSoftLineBreak() {
+	// If the end of line is a soft line break, we need to move left by one so
+	// that we end up at the last whitespace before the line break. Otherwise
+	// we'd be at the start of the next line, since the newline character
+	// doesn't really exist in the real content.
+	if self.cursor < len(self.content) && self.content[self.cursor] != '\n' {
+		self.cursor--
+	}
 }
 
 func (self *TextArea) atLineStart() bool {

--- a/vendor/github.com/jesseduffield/gocui/text_area.go
+++ b/vendor/github.com/jesseduffield/gocui/text_area.go
@@ -424,12 +424,16 @@ func (self *TextArea) SetCursor2D(x int, y int) {
 	for _, r := range self.wrappedContent {
 		if x <= 0 && y == 0 {
 			self.cursor = self.wrappedCursorToOrigCursor(newCursor)
+			if self.wrappedContent[newCursor] == '\n' {
+				self.moveLeftFromSoftLineBreak()
+			}
 			return
 		}
 
 		if r == '\n' {
 			if y == 0 {
 				self.cursor = self.wrappedCursorToOrigCursor(newCursor)
+				self.moveLeftFromSoftLineBreak()
 				return
 			}
 			y--


### PR DESCRIPTION
#### PR Description

* Fix some minor problems related to cursor movement in an auto-wrapped commit message
* Allow clicking in an editable view to set the cursor (most useful in longer commit descriptions)
* Allow switching between commit message and description by clicking

#### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
