### PR TITLE
Allow using `<`/`>` and `,`/`.` in sticky range select mode in patch explorer

### DIFF
--- a/pkg/gui/controllers/patch_explorer_controller.go
+++ b/pkg/gui/controllers/patch_explorer_controller.go
@@ -244,14 +244,12 @@ func (self *PatchExplorerController) HandleScrollRight() error {
 }
 
 func (self *PatchExplorerController) HandlePrevPage() error {
-	self.context.GetState().SetLineSelectMode()
 	self.context.GetState().AdjustSelectedLineIdx(-self.context.GetViewTrait().PageDelta())
 
 	return nil
 }
 
 func (self *PatchExplorerController) HandleNextPage() error {
-	self.context.GetState().SetLineSelectMode()
 	self.context.GetState().AdjustSelectedLineIdx(self.context.GetViewTrait().PageDelta())
 
 	return nil

--- a/pkg/gui/patch_exploring/state.go
+++ b/pkg/gui/patch_exploring/state.go
@@ -123,6 +123,12 @@ func (s *State) SetLineSelectMode() {
 	s.selectMode = LINE
 }
 
+func (s *State) DismissHunkSelectMode() {
+	if s.SelectingHunk() {
+		s.selectMode = LINE
+	}
+}
+
 // For when you move the cursor without holding shift (meaning if we're in
 // a non-sticky range select, we'll cancel it)
 func (s *State) SelectLine(newSelectedLineIdx int) {
@@ -239,7 +245,7 @@ func (s *State) CurrentLineNumber() int {
 }
 
 func (s *State) AdjustSelectedLineIdx(change int) {
-	s.SetLineSelectMode()
+	s.DismissHunkSelectMode()
 	s.SelectLine(s.selectedLineIdx + change)
 }
 
@@ -256,12 +262,12 @@ func (s *State) PlainRenderSelected() string {
 }
 
 func (s *State) SelectBottom() {
-	s.SetLineSelectMode()
+	s.DismissHunkSelectMode()
 	s.SelectLine(s.patch.LineCount() - 1)
 }
 
 func (s *State) SelectTop() {
-	s.SetLineSelectMode()
+	s.DismissHunkSelectMode()
 	s.SelectLine(0)
 }
 

--- a/pkg/gui/patch_exploring/state.go
+++ b/pkg/gui/patch_exploring/state.go
@@ -239,6 +239,7 @@ func (s *State) CurrentLineNumber() int {
 }
 
 func (s *State) AdjustSelectedLineIdx(change int) {
+	s.SetLineSelectMode()
 	s.SelectLine(s.selectedLineIdx + change)
 }
 

--- a/pkg/integration/tests/ui/range_select.go
+++ b/pkg/integration/tests/ui/range_select.go
@@ -14,6 +14,7 @@ import (
 // (sticky range, press 'v') -> no range
 // (sticky range, press 'escape') -> no range
 // (sticky range, press arrow) -> sticky range
+// (sticky range, press `<`/`>` or `,`/`.`) -> sticky range
 // (sticky range, press shift+arrow) -> nonsticky range
 // (nonsticky range, press 'v') -> no range
 // (nonsticky range, press 'escape') -> no range
@@ -138,19 +139,18 @@ var RangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 				SelectedLines(
 					Contains("line 8"),
 				).
+				// (sticky range, press '>') -> sticky range
 				Press(keys.Universal.ToggleRangeSelect).
-				SelectedLines(
-					Contains("line 8"),
-				).
-				SelectNextItem().
+				Press(keys.Universal.GotoBottom).
 				SelectedLines(
 					Contains("line 8"),
 					Contains("line 9"),
+					Contains("line 10"),
 				).
 				// (sticky range, press 'escape') -> no range
 				PressEscape().
 				SelectedLines(
-					Contains("line 9"),
+					Contains("line 10"),
 				)
 		}
 


### PR DESCRIPTION
- **PR Description**

Don't cancel sticky range select when pressing `<`/`>`, `,`/`.` in the patch explorer view. This was already working correctly in list views.

Fixes #3823.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
