### PR TITLE
Fix issues with opening links and files using WSL

### DIFF
--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -22,7 +22,7 @@ func GetPlatformDefaultConfig() OSConfig {
 	if isWSL() && !isContainer() {
 		return OSConfig{
 			Open:     `powershell.exe start explorer.exe "$(wslpath -w {{filename}})" >/dev/null`,
-			OpenLink: `powershell.exe start {{link}} >/dev/null`,
+			OpenLink: `powershell.exe start '{{link}}' >/dev/null`,
 		}
 	}
 

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -21,7 +21,7 @@ func isContainer() bool {
 func GetPlatformDefaultConfig() OSConfig {
 	if isWSL() && !isContainer() {
 		return OSConfig{
-			Open:     `powershell.exe start explorer.exe {{filename}} >/dev/null`,
+			Open:     `powershell.exe start explorer.exe "$(wslpath -w {{filename}})" >/dev/null`,
 			OpenLink: `powershell.exe start {{link}} >/dev/null`,
 		}
 	}


### PR DESCRIPTION
- **PR Description**

This PR fixes to issues with the current implementation of the OSConfig for WSL:

**File explorer**
When using the file explorer from WSL, for instance by pressing "o" in the "Files" menu, the explorer always opens on the default landing page. This is caused by the filepath being expressed in WSL format instead of the expected Windows format. For instance:
- "/home/myuser/path/to/my/file" should be "\\wsl$\MyDistroName\home\myuser\path\to\my\file"
- "/mnt/c/path/to/my/file" should be "C:\path\to\my\file"

There's a utility to do that in WSL, `wslpath`. We use it in the Open to format the filename before passing it to the Powershell command

**Link URLs**
Opening links containing ampersands inside lazygit (a pull-request creation page in BitBucket Server, for instance) returns the following Powershell error:
> The ampersand (&) character is not allowed. The & operator is reserved
> for future use; wrap an ampersand in double quotation marks ("&") to
> pass it as part of a string.

We fix it by enclosing the URL in single quotes.

**Notes on this PR**
This is my first PR on this repo, please tell me if something is needed. I read the contributing guide.
The OS-specific logic doesn't appear to be tested in integration and unit tests, so I didn't add tests.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
