### PR TITLE
Improve fixup commits script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,8 +225,8 @@ jobs:
     if: github.ref != 'refs/heads/master'
     steps:
       # See https://github.com/actions/checkout/issues/552#issuecomment-1167086216
-      - name: "PR commits + 1"
-        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+      - name: "PR commits"
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} ))" >> "${GITHUB_ENV}"
 
       - name: "Checkout PR branch and all PR commits"
         uses: actions/checkout@v4
@@ -234,10 +234,6 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
-
-      - name: "Fetch the other branch with enough history for a common merge-base commit"
-        run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}
 
       - name: Check for fixups
         run: |

--- a/scripts/check_for_fixups.sh
+++ b/scripts/check_for_fixups.sh
@@ -1,19 +1,8 @@
 #!/bin/sh
 
-base_ref=$1
-
-# Determine the base commit
-base_commit=$(git merge-base HEAD origin/"$base_ref")
-
-# Check if base_commit is set correctly
-if [ -z "$base_commit" ]; then
-    echo "Failed to determine base commit."
-    exit 1
-fi
-echo "Base commit: $base_commit"
-
-# Get commits with "fixup!" in the message from base_commit to HEAD
-commits=$(git log -i -E --grep '^fixup!' --grep '^squash!' --grep '^amend!' --grep '^[^\n]*WIP' --grep '^[^\n]*DROPME' --format="%h %s" "$base_commit..HEAD")
+# We will have only done a shallow clone, so the git log will consist only of
+# commits on the current PR
+commits=$(git log --grep='^fixup!' --grep='^squash!' --grep='^amend!' --grep='^[^\n]*WIP' --grep='^[^\n]*DROPME' --format="%h %s")
 
 if [ -z "$commits" ]; then
     echo "No fixup commits found."


### PR DESCRIPTION
This script is failing currently on
https://github.com/jesseduffield/lazygit/pull/3631 because that fork's master branch is 300 commits behind our own, but the feature branch is up to date.

The thing is, we don't actually need to involve the master branch. All we care about is the feature branch's own commits, so this commit simply fetches those commits and checks them.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
