### PR TITLE
Fix linter warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
-          version: v1.58
+          version: v1.60
       - name: errors
         run: golangci-lint run
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
         with:
           go-version: 1.22.x
       - name: Lint
-        uses: golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@v6.1.0
         with:
           version: v1.60
       - name: errors

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,10 @@
 linters:
-  disable:
-    - structcheck # gives false positives
   enable:
     - gofumpt
     - thelper
     - goimports
     - tparallel
     - wastedassign
-    - exportloopref
     - unparam
     - prealloc
     - unconvert

--- a/pkg/commands/git_config/cached_git_config.go
+++ b/pkg/commands/git_config/cached_git_config.go
@@ -69,7 +69,7 @@ func (self *CachedGitConfig) getGeneralAux(args string) string {
 	cmd := getGitConfigGeneralCmd(args)
 	value, err := self.runGitConfigCmd(cmd)
 	if err != nil {
-		self.log.Debugf("Error getting git config value for args: " + args + ". Error: " + err.Error())
+		self.log.Debugf("Error getting git config value for args: %s. Error: %v", args, err.Error())
 		return ""
 	}
 	return strings.TrimSpace(value)
@@ -79,7 +79,7 @@ func (self *CachedGitConfig) getAux(key string) string {
 	cmd := getGitConfigCmd(key)
 	value, err := self.runGitConfigCmd(cmd)
 	if err != nil {
-		self.log.Debugf("Error getting git config value for key: " + key + ". Error: " + err.Error())
+		self.log.Debugf("Error getting git config value for key: %s. Error: %v", key, err.Error())
 		return ""
 	}
 	return strings.TrimSpace(value)

--- a/pkg/commands/git_config/cached_git_config.go
+++ b/pkg/commands/git_config/cached_git_config.go
@@ -42,7 +42,7 @@ func (self *CachedGitConfig) Get(key string) string {
 	defer self.mutex.Unlock()
 
 	if value, ok := self.cache[key]; ok {
-		self.log.Debugf("using cache for key " + key)
+		self.log.Debug("using cache for key " + key)
 		return value
 	}
 
@@ -56,7 +56,7 @@ func (self *CachedGitConfig) GetGeneral(args string) string {
 	defer self.mutex.Unlock()
 
 	if value, ok := self.cache[args]; ok {
-		self.log.Debugf("using cache for args " + args)
+		self.log.Debug("using cache for args " + args)
 		return value
 	}
 

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -810,7 +810,7 @@ func (self *BranchesController) createPullRequestMenu(selectedBranch *models.Bra
 
 	menuItems = append(menuItems, menuItemsForBranch(selectedBranch)...)
 
-	return self.c.Menu(types.CreateMenuOptions{Title: fmt.Sprintf(self.c.Tr.CreatePullRequestOptions), Items: menuItems})
+	return self.c.Menu(types.CreateMenuOptions{Title: fmt.Sprint(self.c.Tr.CreatePullRequestOptions), Items: menuItems})
 }
 
 func (self *BranchesController) createPullRequest(from string, to string) error {

--- a/pkg/gui/controllers/helpers/confirmation_helper.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper.go
@@ -157,7 +157,7 @@ func (self *ConfirmationHelper) getPopupPanelWidth() int {
 
 func (self *ConfirmationHelper) prepareConfirmationPanel(
 	opts types.ConfirmOpts,
-) error {
+) {
 	self.c.Views().Confirmation.Title = opts.Title
 	// for now we do not support wrapping in our editor
 	self.c.Views().Confirmation.Wrap = !opts.Editable
@@ -176,8 +176,6 @@ func (self *ConfirmationHelper) prepareConfirmationPanel(
 		suggestionsView.Title = fmt.Sprintf(self.c.Tr.SuggestionsTitle, self.c.UserConfig().Keybinding.Universal.TogglePanel)
 		suggestionsView.Subtitle = ""
 	}
-
-	return nil
 }
 
 func runeForMask(mask bool) rune {
@@ -207,7 +205,7 @@ func (self *ConfirmationHelper) CreatePopupPanel(ctx goContext.Context, opts typ
 	// remove any previous keybindings
 	self.clearConfirmationViewKeyBindings()
 
-	err := self.prepareConfirmationPanel(
+	self.prepareConfirmationPanel(
 		types.ConfirmOpts{
 			Title:               opts.Title,
 			Prompt:              opts.Prompt,
@@ -215,10 +213,6 @@ func (self *ConfirmationHelper) CreatePopupPanel(ctx goContext.Context, opts typ
 			Editable:            opts.Editable,
 			Mask:                opts.Mask,
 		})
-	if err != nil {
-		cancel()
-		return err
-	}
 	confirmationView := self.c.Views().Confirmation
 	confirmationView.Editable = opts.Editable
 
@@ -232,10 +226,7 @@ func (self *ConfirmationHelper) CreatePopupPanel(ctx goContext.Context, opts typ
 		self.c.SetViewContent(confirmationView, style.AttrBold.Sprint(underlineLinks(opts.Prompt)))
 	}
 
-	if err := self.setKeyBindings(cancel, opts); err != nil {
-		cancel()
-		return err
-	}
+	self.setKeyBindings(cancel, opts)
 
 	self.c.Contexts().Suggestions.State.AllowEditSuggestion = opts.AllowEditSuggestion
 
@@ -266,7 +257,7 @@ func underlineLinks(text string) string {
 	return result + remaining
 }
 
-func (self *ConfirmationHelper) setKeyBindings(cancel goContext.CancelFunc, opts types.CreatePopupPanelOpts) error {
+func (self *ConfirmationHelper) setKeyBindings(cancel goContext.CancelFunc, opts types.CreatePopupPanelOpts) {
 	var onConfirm func() error
 	if opts.HandleConfirmPrompt != nil {
 		onConfirm = self.wrappedPromptConfirmationFunction(cancel, opts.HandleConfirmPrompt, func() string { return self.c.Views().Confirmation.TextArea.GetContent() })
@@ -296,8 +287,6 @@ func (self *ConfirmationHelper) setKeyBindings(cancel goContext.CancelFunc, opts
 	self.c.Contexts().Suggestions.State.OnConfirm = onSuggestionConfirm
 	self.c.Contexts().Suggestions.State.OnClose = onClose
 	self.c.Contexts().Suggestions.State.OnDeleteSuggestion = onDeleteSuggestion
-
-	return nil
 }
 
 func (self *ConfirmationHelper) clearConfirmationViewKeyBindings() {

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -1,7 +1,6 @@
 package helpers
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -60,7 +59,7 @@ func (self *RefreshHelper) Refresh(options types.RefreshOptions) error {
 
 	t := time.Now()
 	defer func() {
-		self.c.Log.Infof(fmt.Sprintf("Refresh took %s", time.Since(t)))
+		self.c.Log.Infof("Refresh took %s", time.Since(t))
 	}()
 
 	if options.Scope == nil {
@@ -114,7 +113,7 @@ func (self *RefreshHelper) Refresh(options types.RefreshOptions) error {
 					t := time.Now()
 					defer wg.Done()
 					f()
-					self.c.Log.Infof(fmt.Sprintf("refreshed %s in %s", name, time.Since(t)))
+					self.c.Log.Infof("refreshed %s in %s", name, time.Since(t))
 				})
 			}
 		}

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -970,7 +970,7 @@ func (gui *Gui) runSubprocess(cmdObj oscommands.ICmdObj) error { //nolint:unpara
 
 		// scan to buffer to prevent run unintentional operations when TUI resumes.
 		var buffer string
-		fmt.Scanln(&buffer) // wait for enter press
+		_, _ = fmt.Scanln(&buffer) // wait for enter press
 	}
 
 	return err

--- a/pkg/gui/services/custom_commands/handler_creator.go
+++ b/pkg/gui/services/custom_commands/handler_creator.go
@@ -131,11 +131,9 @@ func (self *HandlerCreator) inputPrompt(prompt *config.CustomCommandPrompt, wrap
 func (self *HandlerCreator) generateFindSuggestionsFunc(prompt *config.CustomCommandPrompt) (func(string) []*types.Suggestion, error) {
 	if prompt.Suggestions.Preset != "" && prompt.Suggestions.Command != "" {
 		return nil, fmt.Errorf(
-			fmt.Sprintf(
-				"Custom command prompt cannot have both a preset and a command for suggestions. Preset: '%s', Command: '%s'",
-				prompt.Suggestions.Preset,
-				prompt.Suggestions.Command,
-			),
+			"Custom command prompt cannot have both a preset and a command for suggestions. Preset: '%s', Command: '%s'",
+			prompt.Suggestions.Preset,
+			prompt.Suggestions.Command,
 		)
 	} else if prompt.Suggestions.Preset != "" {
 		return self.getPresetSuggestionsFn(prompt.Suggestions.Preset)

--- a/pkg/integration/clients/cli.go
+++ b/pkg/integration/clients/cli.go
@@ -49,7 +49,7 @@ func RunCLI(testNames []string, slow bool, sandbox bool, waitForDebugger bool, r
 
 func runAndPrintFatalError(test *components.IntegrationTest, f func() error) {
 	if err := f(); err != nil {
-		log.Fatalf(err.Error())
+		log.Fatal(err.Error())
 	}
 }
 

--- a/pkg/integration/clients/tui.go
+++ b/pkg/integration/clients/tui.go
@@ -292,7 +292,7 @@ func suspendAndRunTest(test *components.IntegrationTest, sandbox bool, waitForDe
 	runTuiTest(test, sandbox, waitForDebugger, raceDetector, inputDelay)
 
 	fmt.Fprintf(os.Stdout, "\n%s", style.FgGreen.Sprint("press enter to return"))
-	fmt.Scanln() // wait for enter press
+	_, _ = fmt.Scanln() // wait for enter press
 
 	if err := gocui.Screen.Resume(); err != nil {
 		panic(err)


### PR DESCRIPTION
- **PR Description**

Fix some linter warnings that I keep getting locally because I'm running a newer version of golangci-lint than the pinned version we use on CI.

Also, update the pinned version in CI to 1.60 so that we are in sync again.

Finally, upgrade the golangci-lint-action version to the latest, although I'm not sure what difference this makes. The linting step runs faster now, maybe because of better caching -- I noticed that previously, loading and saving the cache took a very long time, which often made the lint step the slowest of all.