### PR TITLE
Highlight (reverse) hyperlinks on mouse hover

### DIFF
--- a/pkg/gui/controllers/helpers/confirmation_helper.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper.go
@@ -259,7 +259,7 @@ func underlineLinks(text string) string {
 		} else {
 			linkEnd += linkStart
 		}
-		underlinedLink := style.PrintSimpleHyperlink(remaining[linkStart:linkEnd])
+		underlinedLink := style.PrintSimpleHyperlink(remaining[linkStart:linkEnd], true)
 		result += remaining[:linkStart] + underlinedLink
 		remaining = remaining[linkEnd:]
 	}

--- a/pkg/gui/controllers/status_controller.go
+++ b/pkg/gui/controllers/status_controller.go
@@ -210,12 +210,12 @@ func (self *StatusController) showDashboard() error {
 		[]string{
 			lazygitTitle(),
 			fmt.Sprintf("Copyright %d Jesse Duffield", time.Now().Year()),
-			fmt.Sprintf("Keybindings: %s", style.PrintSimpleHyperlink(fmt.Sprintf(constants.Links.Docs.Keybindings, versionStr))),
-			fmt.Sprintf("Config Options: %s", style.PrintSimpleHyperlink(fmt.Sprintf(constants.Links.Docs.Config, versionStr))),
-			fmt.Sprintf("Tutorial: %s", style.PrintSimpleHyperlink(constants.Links.Docs.Tutorial)),
-			fmt.Sprintf("Raise an Issue: %s", style.PrintSimpleHyperlink(constants.Links.Issues)),
-			fmt.Sprintf("Release Notes: %s", style.PrintSimpleHyperlink(constants.Links.Releases)),
-			style.FgMagenta.Sprintf("Become a sponsor: %s", style.PrintSimpleHyperlink(constants.Links.Donate)), // caffeine ain't free
+			fmt.Sprintf("Keybindings: %s", style.PrintSimpleHyperlink(fmt.Sprintf(constants.Links.Docs.Keybindings, versionStr), true)),
+			fmt.Sprintf("Config Options: %s", style.PrintSimpleHyperlink(fmt.Sprintf(constants.Links.Docs.Config, versionStr), true)),
+			fmt.Sprintf("Tutorial: %s", style.PrintSimpleHyperlink(constants.Links.Docs.Tutorial, true)),
+			fmt.Sprintf("Raise an Issue: %s", style.PrintSimpleHyperlink(constants.Links.Issues, true)),
+			fmt.Sprintf("Release Notes: %s", style.PrintSimpleHyperlink(constants.Links.Releases, true)),
+			style.FgMagenta.Sprintf("Become a sponsor: %s", style.PrintSimpleHyperlink(constants.Links.Donate, true)), // caffeine ain't free
 		}, "\n\n") + "\n"
 
 	return self.c.RenderToMainViews(types.RefreshMainOpts{

--- a/pkg/gui/information_panel.go
+++ b/pkg/gui/information_panel.go
@@ -14,8 +14,8 @@ func (gui *Gui) informationStr() string {
 	}
 
 	if gui.g.Mouse {
-		donate := style.FgMagenta.Sprint(style.PrintHyperlink(gui.c.Tr.Donate, constants.Links.Donate))
-		askQuestion := style.FgYellow.Sprint(style.PrintHyperlink(gui.c.Tr.AskQuestion, constants.Links.Discussions))
+		donate := style.FgMagenta.Sprint(style.PrintHyperlink(gui.c.Tr.Donate, constants.Links.Donate, true))
+		askQuestion := style.FgYellow.Sprint(style.PrintHyperlink(gui.c.Tr.AskQuestion, constants.Links.Discussions, true))
 		return fmt.Sprintf("%s %s %s", donate, askQuestion, gui.Config.GetVersion())
 	} else {
 		return gui.Config.GetVersion()

--- a/pkg/gui/style/hyperlink.go
+++ b/pkg/gui/style/hyperlink.go
@@ -3,11 +3,19 @@ package style
 import "fmt"
 
 // Render the given text as an OSC 8 hyperlink
-func PrintHyperlink(text string, link string) string {
-	return fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", link, text)
+func PrintHyperlink(text string, link string, underline bool) string {
+	result := fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", link, text)
+	if underline {
+		return AttrUnderline.Sprint(result)
+	}
+	return result
 }
 
 // Render a link where the text is the same as a link
-func PrintSimpleHyperlink(link string) string {
-	return fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", link, link)
+func PrintSimpleHyperlink(link string, underline bool) string {
+	result := fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", link, link)
+	if underline {
+		return AttrUnderline.Sprint(result)
+	}
+	return result
 }

--- a/pkg/utils/color_test.go
+++ b/pkg/utils/color_test.go
@@ -192,7 +192,11 @@ func TestDecolorise(t *testing.T) {
 			output: "ta",
 		},
 		{
-			input:  "a_" + style.PrintSimpleHyperlink("xyz") + "_b",
+			input:  "a_" + style.PrintSimpleHyperlink("xyz", true) + "_b",
+			output: "a_xyz_b",
+		},
+		{
+			input:  "a_" + style.PrintSimpleHyperlink("xyz", false) + "_b",
 			output: "a_xyz_b",
 		},
 	}

--- a/vendor/github.com/jesseduffield/gocui/gui.go
+++ b/vendor/github.com/jesseduffield/gocui/gui.go
@@ -180,6 +180,8 @@ type Gui struct {
 	suspended      bool
 
 	taskManager *TaskManager
+
+	lastHoverView *View
 }
 
 type NewGuiOpts struct {
@@ -836,7 +838,7 @@ func (g *Gui) processRemainingEvents() error {
 // etc.)
 func (g *Gui) handleEvent(ev *GocuiEvent) error {
 	switch ev.Type {
-	case eventKey, eventMouse:
+	case eventKey, eventMouse, eventMouseMove:
 		return g.onKey(ev)
 	case eventError:
 		return ev.Err
@@ -1394,6 +1396,19 @@ func (g *Gui) onKey(ev *GocuiEvent) error {
 		if err := g.execKeybindings(v, ev); err != nil {
 			return err
 		}
+
+	case eventMouseMove:
+		mx, my := ev.MouseX, ev.MouseY
+		v, err := g.VisibleViewByPosition(mx, my)
+		if err != nil {
+			break
+		}
+		if g.lastHoverView != nil && g.lastHoverView != v {
+			g.lastHoverView.lastHoverPosition = nil
+			g.lastHoverView.hoveredHyperlink = nil
+		}
+		g.lastHoverView = v
+		v.onMouseMove(mx, my)
 
 	default:
 	}

--- a/vendor/github.com/jesseduffield/gocui/tcell_driver.go
+++ b/vendor/github.com/jesseduffield/gocui/tcell_driver.go
@@ -176,6 +176,7 @@ const (
 	eventKey
 	eventResize
 	eventMouse
+	eventMouseMove // only used when no button is down, otherwise it's eventMouse
 	eventFocus
 	eventInterrupt
 	eventError
@@ -387,7 +388,11 @@ func (g *Gui) pollEvent() GocuiEvent {
 		if !wheeling {
 			switch dragState {
 			case NOT_DRAGGING:
-				return GocuiEvent{Type: eventNone}
+				return GocuiEvent{
+					Type:   eventMouseMove,
+					MouseX: x,
+					MouseY: y,
+				}
 			// if we haven't released the left mouse button and we've moved the cursor then we're dragging
 			case MAYBE_DRAGGING:
 				if x != lastX || y != lastY {


### PR DESCRIPTION
- **PR Description**

This is an alternative to #3856: here we change gocui so that it doesn't underline links at all, ever (if clients want that, they need to add the underline attribute themselves). Instead, we highlight links on hover by using the reverse attribute.

I prefer this to #3856: it looks better, at least for the line numbers in delta diffs, and it is much easier to see.