### PR TITLE
Make auto-staging resolved conflicts optional

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -305,6 +305,12 @@ git:
   # If true, pass the --all arg to git fetch
   fetchAll: true
 
+  # If true, lazygit will automatically stage files that used to have merge
+  # conflicts but no longer do; and it will also ask you if you want to
+  # continue a merge or rebase if you've resolved all conflicts. If false, it
+  # won't do either of these things.
+  autoStageResolvedConflicts: true
+
   # Command used when displaying the current branch git log in the main window
   branchLogCmd: git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -224,6 +224,11 @@ type GitConfig struct {
 	AutoRefresh bool `yaml:"autoRefresh"`
 	// If true, pass the --all arg to git fetch
 	FetchAll bool `yaml:"fetchAll"`
+	// If true, lazygit will automatically stage files that used to have merge
+	// conflicts but no longer do; and it will also ask you if you want to
+	// continue a merge or rebase if you've resolved all conflicts. If false, it
+	// won't do either of these things.
+	AutoStageResolvedConflicts bool `yaml:"autoStageResolvedConflicts"`
 	// Command used when displaying the current branch git log in the main window
 	BranchLogCmd string `yaml:"branchLogCmd"`
 	// Command used to display git log of all branches in the main window.
@@ -753,6 +758,7 @@ func GetDefaultConfig() *UserConfig {
 			AutoFetch:                    true,
 			AutoRefresh:                  true,
 			FetchAll:                     true,
+			AutoStageResolvedConflicts:   true,
 			BranchLogCmd:                 "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",
 			AllBranchesLogCmd:            "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium",
 			DisableForcePushing:          false,

--- a/pkg/gui/filetree/file_node.go
+++ b/pkg/gui/filetree/file_node.go
@@ -1,6 +1,9 @@
 package filetree
 
-import "github.com/jesseduffield/lazygit/pkg/commands/models"
+import (
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/jesseduffield/lazygit/pkg/gui/mergeconflicts"
+)
 
 // FileNode wraps a node and provides some file-specific methods for it.
 type FileNode struct {
@@ -44,7 +47,13 @@ func (self *FileNode) GetHasStagedChanges() bool {
 }
 
 func (self *FileNode) GetHasInlineMergeConflicts() bool {
-	return self.SomeFile(func(file *models.File) bool { return file.HasInlineMergeConflicts })
+	return self.SomeFile(func(file *models.File) bool {
+		if !file.HasInlineMergeConflicts {
+			return false
+		}
+		hasConflicts, _ := mergeconflicts.FileHasConflictMarkers(file.Name)
+		return hasConflicts
+	})
 }
 
 func (self *FileNode) GetIsTracked() bool {

--- a/pkg/integration/tests/conflicts/resolve_no_auto_stage.go
+++ b/pkg/integration/tests/conflicts/resolve_no_auto_stage.go
@@ -1,0 +1,81 @@
+package conflicts
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+	"github.com/jesseduffield/lazygit/pkg/integration/tests/shared"
+)
+
+var ResolveNoAutoStage = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Resolving conflicts without auto-staging",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Git.AutoStageResolvedConflicts = false
+	},
+	SetupRepo: func(shell *Shell) {
+		shared.CreateMergeConflictFiles(shell)
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			IsFocused().
+			Lines(
+				Contains("UU").Contains("file1").IsSelected(),
+				Contains("UU").Contains("file2"),
+			).
+			PressEnter()
+
+		t.Views().MergeConflicts().
+			IsFocused().
+			SelectedLines(
+				Contains("<<<<<<< HEAD"),
+				Contains("First Change"),
+				Contains("======="),
+			).
+			PressPrimaryAction()
+
+		t.Views().Files().
+			IsFocused().
+			// Resolving the conflict didn't auto-stage it
+			Lines(
+				Contains("UU").Contains("file1").IsSelected(),
+				Contains("UU").Contains("file2"),
+			).
+			// So do that manually
+			PressPrimaryAction().
+			Lines(
+				Contains("UU").Contains("file2").IsSelected(),
+			).
+			// Trying to stage a file that still has conflicts is not allowed:
+			PressPrimaryAction().
+			Tap(func() {
+				t.ExpectPopup().Alert().
+					Title(Equals("Error")).
+					Content(Contains("Cannot stage/unstage directory containing files with inline merge conflicts.")).
+					Confirm()
+			}).
+			PressEnter()
+
+		// coincidentally these files have the same conflict
+		t.Views().MergeConflicts().
+			IsFocused().
+			SelectedLines(
+				Contains("<<<<<<< HEAD"),
+				Contains("First Change"),
+				Contains("======="),
+			).
+			PressPrimaryAction()
+
+		t.Views().Files().
+			IsFocused().
+			// Again, resolving the conflict didn't auto-stage it
+			Lines(
+				Contains("UU").Contains("file2").IsSelected(),
+			).
+			// Doing that manually now works:
+			PressPrimaryAction().
+			Lines(
+				Contains("A").Contains("file3").IsSelected(),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -115,6 +115,7 @@ var tests = []*components.IntegrationTest{
 	conflicts.Filter,
 	conflicts.ResolveExternally,
 	conflicts.ResolveMultipleFiles,
+	conflicts.ResolveNoAutoStage,
 	conflicts.UndoChooseHunk,
 	custom_commands.AccessCommitProperties,
 	custom_commands.BasicCommand,

--- a/schema/config.json
+++ b/schema/config.json
@@ -573,6 +573,11 @@
           "description": "If true, pass the --all arg to git fetch",
           "default": true
         },
+        "autoStageResolvedConflicts": {
+          "type": "boolean",
+          "description": "If true, lazygit will automatically stage files that used to have merge\nconflicts but no longer do; and it will also ask you if you want to\ncontinue a merge or rebase if you've resolved all conflicts. If false, it\nwon't do either of these things.",
+          "default": true
+        },
         "branchLogCmd": {
           "type": "string",
           "description": "Command used when displaying the current branch git log in the main window",


### PR DESCRIPTION
- **PR Description**

Add user config `git.autoStageResolvedConflicts` (default true). When set to false, users need to stage their conflicted files manually after resolving conflicts, and also continue a merge/rebase manually when all conflicted files are resolved.

Fixes #3111.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
