### PR TITLE
Pass --verbose command to commit in editor

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -110,6 +110,7 @@ func (self *CommitCommands) RewordLastCommitInEditorWithMessageFileCmdObj(tmpMes
 
 func (self *CommitCommands) CommitInEditorWithMessageFileCmdObj(tmpMessageFile string) oscommands.ICmdObj {
 	return self.cmd.New(NewGitCmd("commit").
+		Arg("--verbose").
 		Arg("--edit").
 		Arg("--file="+tmpMessageFile).
 		ArgIf(self.signoffFlag() != "", self.signoffFlag()).
@@ -141,6 +142,7 @@ func (self *CommitCommands) commitMessageArgs(summary string, description string
 // runs git commit without the -m argument meaning it will invoke the user's editor
 func (self *CommitCommands) CommitEditorCmdObj() oscommands.ICmdObj {
 	cmdArgs := NewGitCmd("commit").
+		Arg("--verbose").
 		ArgIf(self.signoffFlag() != "", self.signoffFlag()).
 		ToArgv()
 

--- a/pkg/commands/git_commands/commit_test.go
+++ b/pkg/commands/git_commands/commit_test.go
@@ -124,12 +124,12 @@ func TestCommitCommitEditorCmdObj(t *testing.T) {
 		{
 			testName:      "Commit using editor",
 			configSignoff: false,
-			expected:      []string{"commit"},
+			expected:      []string{"commit", "--verbose"},
 		},
 		{
 			testName:      "Commit with --signoff",
 			configSignoff: true,
-			expected:      []string{"commit", "--signoff"},
+			expected:      []string{"commit", "--verbose", "--signoff"},
 		},
 	}
 


### PR DESCRIPTION
👋 _Thank you building this awesome tool_

What
---
Pass the `--verbose` flag when committing via the editor.

> --verbose
> Show unified diff between the HEAD commit and what would be committed
> at the bottom of the commit message template to help the user describe
> the commit by reminding what changes the commit has...
>
> [source](https://git-scm.com/docs/git-commit)

Why
---
To make it easier for the user to describe the commit by showing them the diff in the editor.


- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc


