### PR TITLE
Don't allow opening a menu while the search or filter prompt is open

### DIFF
--- a/pkg/gui/controllers/helpers/search_helper.go
+++ b/pkg/gui/controllers/helpers/search_helper.go
@@ -45,7 +45,7 @@ func (self *SearchHelper) OpenFilterPrompt(context types.IFilterableContext) err
 		return err
 	}
 
-	return nil
+	return self.c.ResetKeybindings()
 }
 
 func (self *SearchHelper) OpenSearchPrompt(context types.ISearchableContext) error {
@@ -64,7 +64,7 @@ func (self *SearchHelper) OpenSearchPrompt(context types.ISearchableContext) err
 		return err
 	}
 
-	return nil
+	return self.c.ResetKeybindings()
 }
 
 func (self *SearchHelper) DisplayFilterStatus(context types.IFilterableContext) {
@@ -112,16 +112,21 @@ func (self *SearchHelper) Confirm() error {
 		return self.CancelPrompt()
 	}
 
+	var err error
 	switch state.SearchType() {
 	case types.SearchTypeFilter:
-		return self.ConfirmFilter()
+		err = self.ConfirmFilter()
 	case types.SearchTypeSearch:
-		return self.ConfirmSearch()
+		err = self.ConfirmSearch()
 	case types.SearchTypeNone:
-		return self.c.Context().Pop()
+		err = self.c.Context().Pop()
 	}
 
-	return nil
+	if err != nil {
+		return err
+	}
+
+	return self.c.ResetKeybindings()
 }
 
 func (self *SearchHelper) ConfirmFilter() error {
@@ -183,7 +188,11 @@ func modelSearchResults(context types.ISearchableContext) []gocui.SearchPosition
 func (self *SearchHelper) CancelPrompt() error {
 	self.Cancel()
 
-	return self.c.Context().Pop()
+	if err := self.c.Context().Pop(); err != nil {
+		return err
+	}
+
+	return self.c.ResetKeybindings()
 }
 
 func (self *SearchHelper) ScrollHistory(scrollIncrement int) {

--- a/pkg/gui/gui_common.go
+++ b/pkg/gui/gui_common.go
@@ -140,6 +140,10 @@ func (self *guiCommon) CallKeybindingHandler(binding *types.Binding) error {
 	return self.gui.callKeybindingHandler(binding)
 }
 
+func (self *guiCommon) ResetKeybindings() error {
+	return self.gui.resetKeybindings()
+}
+
 func (self *guiCommon) IsAnyModeActive() bool {
 	return self.gui.helpers.Mode.IsAnyModeActive()
 }

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/controllers/helpers"
 	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
@@ -345,6 +346,18 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 }
 
 func (self *Gui) GetInitialKeybindingsWithCustomCommands() ([]*types.Binding, []*gocui.ViewMouseBinding) {
+	// if the search or filter prompt is open, we only want the keybindings for
+	// that context. It shouldn't be possible, for example, to open a menu while
+	// the prompt is showing; you first need to confirm or cancel the search/filter.
+	if currentContext := self.State.ContextMgr.Current(); currentContext.GetKey() == context.SEARCH_CONTEXT_KEY {
+		bindings := currentContext.GetKeybindings(self.c.KeybindingsOpts())
+		viewName := currentContext.GetViewName()
+		for _, binding := range bindings {
+			binding.ViewName = viewName
+		}
+		return bindings, nil
+	}
+
 	bindings, mouseBindings := self.GetInitialKeybindings()
 	customBindings, err := self.CustomCommandsClient.GetCustomCommandKeybindings()
 	if err != nil {

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -98,6 +98,8 @@ type IGuiCommon interface {
 	KeybindingsOpts() KeybindingsOpts
 	CallKeybindingHandler(binding *Binding) error
 
+	ResetKeybindings() error
+
 	// hopefully we can remove this once we've moved all our keybinding stuff out of the gui god struct.
 	GetInitialKeybindingsWithCustomCommands() ([]*Binding, []*gocui.ViewMouseBinding)
 


### PR DESCRIPTION
- **PR Description**

This solves several problems that arise from opening a menu while the prompt is open. We might try to solve these in a different way, e.g. by dismissing the search prompt before opening a menu, but restricting what you can do while the prompt is open seems like the more robust fix.

To achieve this, we
- call resetKeyBindings both when opening and when closing the search/filter prompt
- change the keybindings to only contain the ones for the search prompt when that context is active.

Fixes #3875.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
