### PR TITLE
Add cleaner dubious ownership error

### DIFF
--- a/pkg/app/errors.go
+++ b/pkg/app/errors.go
@@ -31,6 +31,10 @@ func knownError(tr *i18n.TranslationSet, err error) (string, bool) {
 			originalError: "getwd: no such file or directory",
 			newError:      tr.WorkingDirectoryDoesNotExist,
 		},
+		{
+			originalError: "fatal: detected dubious ownership in repository",
+			newError:      tr.UnsafeOrNetworkDirectoryError,
+		},
 	}
 
 	if mapping, ok := lo.Find(mappings, func(mapping errorMapping) bool {

--- a/pkg/commands/git_commands/repo_paths.go
+++ b/pkg/commands/git_commands/repo_paths.go
@@ -143,6 +143,10 @@ func callGitRevParseWithDir(
 	gitCmd := cmd.New(gitRevParse.ToArgv()).DontLog()
 	res, err := gitCmd.RunWithOutput()
 	if err != nil {
+		if strings.Contains(err.Error(), "fatal: detected dubious ownership in repository") {
+			err = errors.New("fatal: detected dubious ownership in repository")
+			return "", err
+		}
 		return "", errors.Errorf("'%s' failed: %v", gitCmd.ToString(), err)
 	}
 	return strings.TrimSpace(res), nil

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -801,6 +801,7 @@ type TranslationSet struct {
 	RangeSelectNotSupportedForSubmodules     string
 	OldCherryPickKeyWarning                  string
 	CommandDoesNotSupportOpeningInEditor     string
+	UnsafeOrNetworkDirectoryError            string
 	Actions                                  Actions
 	Bisect                                   Bisect
 	Log                                      Log
@@ -1787,6 +1788,14 @@ func EnglishTranslationSet() *TranslationSet {
 		RangeSelectNotSupportedForSubmodules:     "Range select not supported for submodules",
 		OldCherryPickKeyWarning:                  "The 'c' key is no longer the default key for copying commits to cherry pick. Please use `{{.copy}}` instead (and `{{.paste}}` to paste). The reason for this change is that the 'v' key for selecting a range of lines when staging is now also used for selecting a range of lines in any list view, meaning that we needed to find a new key for pasting commits, and if we're going to now use `{{.paste}}` for pasting commits, we may as well use `{{.copy}}` for copying them. If you want to configure the keybindings to get the old behaviour, set the following in your config:\n\nkeybinding:\n  universal:\n    toggleRangeSelect: <something other than v>\n  commits:\n    cherryPickCopy: 'c'\n    pasteCommits: 'v'",
 		CommandDoesNotSupportOpeningInEditor:     "This command doesn't support switching to the editor",
+		UnsafeOrNetworkDirectoryError: `Git detected unsafe/dubious ownership of the repository's root directory
+
+Whilst there is a solution/workaround, please understand the relevant risks and purpose of this warning!
+See 'https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9' for background information on said risks
+
+This error is unrelated to lazygit
+For more information, see 'https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory'
+`,
 
 		Actions: Actions{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)


### PR DESCRIPTION
- **PR Description**
  Resolves #3303, resolves #3757

Whilst the above issues expect lazygit to prompt the user to prompt whether it should modify their global Git configuration, I believe it is more pertinent that the user instead inform themselves of what's actually going on.

This PR adds a new known error message covering "dubious ownership". Rather than panicking when Git throws such an error, the below error message will be displayed:

> Git detected unsafe/dubious ownership of the repository's root directory
>
> Whilst there is a solution/workaround, please understand the relevant risks and purpose of this warning!
> 
> See 'https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9' for background information on said risks
>
> This error is unrelated to lazygit
> For more information, see 'https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory'

Whilst I'm not against contributing to the implementation of the expected behaviour in the aforementioned issues, I think informing users of the risks involved is a necessary starting point.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
