### PR TITLE
Switch to Files panel after popping a stash

### DIFF
--- a/pkg/gui/controllers/stash_controller.go
+++ b/pkg/gui/controllers/stash_controller.go
@@ -111,6 +111,7 @@ func (self *StashController) handleStashApply(stashEntry *models.StashEntry) err
 		if err != nil {
 			return err
 		}
+		self.c.Context().Push(self.c.Contexts().Files)
 		return nil
 	}
 
@@ -137,6 +138,7 @@ func (self *StashController) handleStashPop(stashEntry *models.StashEntry) error
 		if err != nil {
 			return err
 		}
+		self.c.Context().Push(self.c.Contexts().Files)
 		return nil
 	}
 

--- a/pkg/integration/tests/stash/apply.go
+++ b/pkg/integration/tests/stash/apply.go
@@ -36,6 +36,7 @@ var Apply = NewIntegrationTest(NewIntegrationTestArgs{
 			)
 
 		t.Views().Files().
+			IsFocused().
 			Lines(
 				Contains("file"),
 			)

--- a/pkg/integration/tests/stash/pop.go
+++ b/pkg/integration/tests/stash/pop.go
@@ -34,6 +34,7 @@ var Pop = NewIntegrationTest(NewIntegrationTestArgs{
 			IsEmpty()
 
 		t.Views().Files().
+			IsFocused().
 			Lines(
 				Contains("file"),
 			)


### PR DESCRIPTION
#### PR Description

I find myself always switching to the Files panel after popping a stash, 100% of the time, so it makes sense that lazygit does this for me. Do it for apply as well, for consistency.

#### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
