### PR TITLE
With stacked branches, create fixup commit at the end of the branch it belongs to

### DIFF
--- a/pkg/app/daemon/daemon.go
+++ b/pkg/app/daemon/daemon.go
@@ -246,16 +246,18 @@ func (self *ChangeTodoActionsInstruction) run(common *common.Common) error {
 
 // Takes the hash of some commit, and the hash of a fixup commit that was created
 // at the end of the branch, then moves the fixup commit down to right after the
-// original commit, changing its type to "fixup"
+// original commit, changing its type to "fixup" (only if ChangeToFixup is true)
 type MoveFixupCommitDownInstruction struct {
-	OriginalHash string
-	FixupHash    string
+	OriginalHash  string
+	FixupHash     string
+	ChangeToFixup bool
 }
 
-func NewMoveFixupCommitDownInstruction(originalHash string, fixupHash string) Instruction {
+func NewMoveFixupCommitDownInstruction(originalHash string, fixupHash string, changeToFixup bool) Instruction {
 	return &MoveFixupCommitDownInstruction{
-		OriginalHash: originalHash,
-		FixupHash:    fixupHash,
+		OriginalHash:  originalHash,
+		FixupHash:     fixupHash,
+		ChangeToFixup: changeToFixup,
 	}
 }
 
@@ -269,7 +271,7 @@ func (self *MoveFixupCommitDownInstruction) SerializedInstructions() string {
 
 func (self *MoveFixupCommitDownInstruction) run(common *common.Common) error {
 	return handleInteractiveRebase(common, func(path string) error {
-		return utils.MoveFixupCommitDown(path, self.OriginalHash, self.FixupHash, getCommentChar())
+		return utils.MoveFixupCommitDown(path, self.OriginalHash, self.FixupHash, self.ChangeToFixup, getCommentChar())
 	})
 }
 

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -284,6 +284,11 @@ func (self *RebaseCommands) GitRebaseEditTodo(todosFileContent []byte) error {
 	return cmdObj.Run()
 }
 
+func (self *RebaseCommands) getHashOfLastCommitMade() (string, error) {
+	cmdArgs := NewGitCmd("rev-parse").Arg("--verify", "HEAD").ToArgv()
+	return self.cmd.New(cmdArgs).RunWithOutput()
+}
+
 // AmendTo amends the given commit with whatever files are staged
 func (self *RebaseCommands) AmendTo(commits []*models.Commit, commitIndex int) error {
 	commit := commits[commitIndex]
@@ -292,9 +297,7 @@ func (self *RebaseCommands) AmendTo(commits []*models.Commit, commitIndex int) e
 		return err
 	}
 
-	// Get the hash of the commit we just created
-	cmdArgs := NewGitCmd("rev-parse").Arg("--verify", "HEAD").ToArgv()
-	fixupHash, err := self.cmd.New(cmdArgs).RunWithOutput()
+	fixupHash, err := self.getHashOfLastCommitMade()
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -302,7 +302,7 @@ func (self *RebaseCommands) AmendTo(commits []*models.Commit, commitIndex int) e
 	return self.PrepareInteractiveRebaseCommand(PrepareInteractiveRebaseCommandOpts{
 		baseHashOrRoot: getBaseHashOrRoot(commits, commitIndex+1),
 		overrideEditor: true,
-		instruction:    daemon.NewMoveFixupCommitDownInstruction(commit.Hash, fixupHash),
+		instruction:    daemon.NewMoveFixupCommitDownInstruction(commit.Hash, fixupHash, true),
 	}).Run()
 }
 

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -309,6 +309,19 @@ func (self *RebaseCommands) AmendTo(commits []*models.Commit, commitIndex int) e
 	}).Run()
 }
 
+func (self *RebaseCommands) MoveFixupCommitDown(commits []*models.Commit, targetCommitIndex int) error {
+	fixupHash, err := self.getHashOfLastCommitMade()
+	if err != nil {
+		return err
+	}
+
+	return self.PrepareInteractiveRebaseCommand(PrepareInteractiveRebaseCommandOpts{
+		baseHashOrRoot: getBaseHashOrRoot(commits, targetCommitIndex+1),
+		overrideEditor: true,
+		instruction:    daemon.NewMoveFixupCommitDownInstruction(commits[targetCommitIndex].Hash, fixupHash, false),
+	}).Run()
+}
+
 func todoFromCommit(commit *models.Commit) utils.Todo {
 	if commit.Action == todo.UpdateRef {
 		return utils.Todo{Ref: commit.Name, Action: commit.Action}

--- a/pkg/integration/tests/commit/create_fixup_commit_in_branch_stack.go
+++ b/pkg/integration/tests/commit/create_fixup_commit_in_branch_stack.go
@@ -1,0 +1,53 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CreateFixupCommitInBranchStack = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Create a fixup commit in a stack of branches, verify that it is created at the end of the branch it belongs to",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	GitVersion:   AtLeast("2.38.0"),
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.NewBranch("branch1")
+		shell.EmptyCommit("branch1 commit 1")
+		shell.EmptyCommit("branch1 commit 2")
+		shell.EmptyCommit("branch1 commit 3")
+		shell.NewBranch("branch2")
+		shell.EmptyCommit("branch2 commit 1")
+		shell.EmptyCommit("branch2 commit 2")
+		shell.CreateFileAndAdd("fixup-file", "fixup content")
+
+		shell.SetConfig("rebase.updateRefs", "true")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("CI ◯ branch2 commit 2"),
+				Contains("CI ◯ branch2 commit 1"),
+				Contains("CI ◯ * branch1 commit 3"),
+				Contains("CI ◯ branch1 commit 2"),
+				Contains("CI ◯ branch1 commit 1"),
+			).
+			NavigateToLine(Contains("branch1 commit 2")).
+			Press(keys.Commits.CreateFixupCommit).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Create fixup commit")).
+					Select(Contains("fixup! commit")).
+					Confirm()
+			}).
+			Lines(
+				Contains("CI ◯ branch2 commit 2"),
+				Contains("CI ◯ branch2 commit 1"),
+				Contains("CI ◯ * fixup! branch1 commit 2"),
+				Contains("CI ◯ branch1 commit 3"),
+				Contains("CI ◯ branch1 commit 2"),
+				Contains("CI ◯ branch1 commit 1"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -87,6 +87,7 @@ var tests = []*components.IntegrationTest{
 	commit.CommitWithNonMatchingBranchName,
 	commit.CommitWithPrefix,
 	commit.CreateAmendCommit,
+	commit.CreateFixupCommitInBranchStack,
 	commit.CreateTag,
 	commit.DiscardOldFileChanges,
 	commit.FindBaseCommitForFixup,

--- a/pkg/utils/rebase_todo.go
+++ b/pkg/utils/rebase_todo.go
@@ -221,13 +221,13 @@ func moveTodosUp(todos []todo.Todo, todosToMove []Todo) ([]todo.Todo, error) {
 	return todos, nil
 }
 
-func MoveFixupCommitDown(fileName string, originalHash string, fixupHash string, commentChar byte) error {
+func MoveFixupCommitDown(fileName string, originalHash string, fixupHash string, changeToFixup bool, commentChar byte) error {
 	todos, err := ReadRebaseTodoFile(fileName, commentChar)
 	if err != nil {
 		return err
 	}
 
-	newTodos, err := moveFixupCommitDown(todos, originalHash, fixupHash)
+	newTodos, err := moveFixupCommitDown(todos, originalHash, fixupHash, changeToFixup)
 	if err != nil {
 		return err
 	}
@@ -235,7 +235,7 @@ func MoveFixupCommitDown(fileName string, originalHash string, fixupHash string,
 	return WriteRebaseTodoFile(fileName, newTodos, commentChar)
 }
 
-func moveFixupCommitDown(todos []todo.Todo, originalHash string, fixupHash string) ([]todo.Todo, error) {
+func moveFixupCommitDown(todos []todo.Todo, originalHash string, fixupHash string, changeToFixup bool) ([]todo.Todo, error) {
 	isOriginal := func(t todo.Todo) bool {
 		return (t.Command == todo.Pick || t.Command == todo.Merge) && equalHash(t.Commit, originalHash)
 	}
@@ -259,7 +259,9 @@ func moveFixupCommitDown(todos []todo.Todo, originalHash string, fixupHash strin
 
 	newTodos := MoveElement(todos, fixupIndex, originalIndex+1)
 
-	newTodos[originalIndex+1].Command = todo.Fixup
+	if changeToFixup {
+		newTodos[originalIndex+1].Command = todo.Fixup
+	}
 
 	return newTodos, nil
 }

--- a/pkg/utils/rebase_todo_test.go
+++ b/pkg/utils/rebase_todo_test.go
@@ -266,20 +266,37 @@ func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
 		todos         []todo.Todo
 		originalHash  string
 		fixupHash     string
+		changeToFixup bool
 		expectedTodos []todo.Todo
 		expectedErr   error
 	}{
 		{
-			name: "fixup commit is the last commit",
+			name: "fixup commit is the last commit (change to fixup)",
 			todos: []todo.Todo{
 				{Command: todo.Pick, Commit: "original"},
 				{Command: todo.Pick, Commit: "fixup"},
 			},
-			originalHash: "original",
-			fixupHash:    "fixup",
+			originalHash:  "original",
+			fixupHash:     "fixup",
+			changeToFixup: true,
 			expectedTodos: []todo.Todo{
 				{Command: todo.Pick, Commit: "original"},
 				{Command: todo.Fixup, Commit: "fixup"},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "fixup commit is the last commit (don't change to fixup)",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "original"},
+				{Command: todo.Pick, Commit: "fixup"},
+			},
+			originalHash:  "original",
+			fixupHash:     "fixup",
+			changeToFixup: false,
+			expectedTodos: []todo.Todo{
+				{Command: todo.Pick, Commit: "original"},
+				{Command: todo.Pick, Commit: "fixup"},
 			},
 			expectedErr: nil,
 		},
@@ -290,8 +307,9 @@ func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
 				{Command: todo.Pick, Commit: "other"},
 				{Command: todo.Pick, Commit: "fixup"},
 			},
-			originalHash: "original",
-			fixupHash:    "fixup",
+			originalHash:  "original",
+			fixupHash:     "fixup",
+			changeToFixup: true,
 			expectedTodos: []todo.Todo{
 				{Command: todo.Pick, Commit: "original"},
 				{Command: todo.Fixup, Commit: "fixup"},
@@ -306,8 +324,9 @@ func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
 				{Command: todo.Pick, Commit: "other"},
 				{Command: todo.Pick, Commit: "fixup"},
 			},
-			originalHash: "original",
-			fixupHash:    "fixup",
+			originalHash:  "original",
+			fixupHash:     "fixup",
+			changeToFixup: true,
 			expectedTodos: []todo.Todo{
 				{Command: todo.Merge, Commit: "original"},
 				{Command: todo.Fixup, Commit: "fixup"},
@@ -324,6 +343,7 @@ func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
 			},
 			originalHash:  "original",
 			fixupHash:     "fixup",
+			changeToFixup: true,
 			expectedTodos: nil,
 			expectedErr:   errors.New("Expected exactly one original hash, found 2"),
 		},
@@ -336,6 +356,7 @@ func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
 			},
 			originalHash:  "original",
 			fixupHash:     "fixup",
+			changeToFixup: true,
 			expectedTodos: nil,
 			expectedErr:   errors.New("Expected exactly one fixup hash, found 2"),
 		},
@@ -346,6 +367,7 @@ func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
 			},
 			originalHash:  "original",
 			fixupHash:     "fixup",
+			changeToFixup: true,
 			expectedTodos: nil,
 			expectedErr:   errors.New("Expected exactly one fixup hash, found 0"),
 		},
@@ -356,6 +378,7 @@ func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
 			},
 			originalHash:  "original",
 			fixupHash:     "fixup",
+			changeToFixup: true,
 			expectedTodos: nil,
 			expectedErr:   errors.New("Expected exactly one original hash, found 0"),
 		},
@@ -363,7 +386,7 @@ func TestRebaseCommands_moveFixupCommitDown(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
-			actualTodos, actualErr := moveFixupCommitDown(scenario.todos, scenario.originalHash, scenario.fixupHash)
+			actualTodos, actualErr := moveFixupCommitDown(scenario.todos, scenario.originalHash, scenario.fixupHash, scenario.changeToFixup)
 
 			if scenario.expectedErr == nil {
 				assert.NoError(t, actualErr)


### PR DESCRIPTION
- **PR Description**

When working with stacked branches, and creating a fixup commit for a commit in one of the lower branches of the stack, the fixup was created at the top of the stack and the user needed to move it down to the right branch manually. This is unnecessary extra work; create it at the end of the right branch automatically.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
