### PR TITLE
Add a comment about base branches on mainBranches config

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -288,7 +288,7 @@ git:
     # The commit message to use for a squash merge commit. Can contain "{{selectedRef}}" and "{{currentBranch}}" placeholders.
     squashMergeMessage: Squash merge {{selectedRef}} into {{currentBranch}}
 
-  # list of branches that are considered 'main' branches, used when displaying commits
+  # list of branches that are considered 'main' branches (base branches), used when displaying commits
   mainBranches:
     - master
     - main

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -214,7 +214,7 @@ type GitConfig struct {
 	Commit CommitConfig `yaml:"commit"`
 	// Config relating to merging
 	Merging MergingConfig `yaml:"merging"`
-	// list of branches that are considered 'main' branches, used when displaying commits
+	// list of branches that are considered 'main' branches (base branches), used when displaying commits
 	MainBranches []string `yaml:"mainBranches" jsonschema:"uniqueItems=true"`
 	// Prefix to use when skipping hooks. E.g. if set to 'WIP', then pre-commit hooks will be skipped when the commit message starts with 'WIP'
 	SkipHookPrefix string `yaml:"skipHookPrefix"`

--- a/schema/config.json
+++ b/schema/config.json
@@ -547,7 +547,7 @@
           },
           "type": "array",
           "uniqueItems": true,
-          "description": "list of branches that are considered 'main' branches, used when displaying commits",
+          "description": "list of branches that are considered 'main' branches (base branches), used when displaying commits",
           "default": [
             "master",
             "main"


### PR DESCRIPTION
- **PR Description**

It took a while to find where to set up the base branch used for quick rebasing and viewing divergence, because it is no such thing as *base branch* in config.

Now it's easy to find a list of base branch names.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
