### PR TITLE
Add options for disabling switching to the Files panel after popping or applying a stash

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -246,6 +246,12 @@ gui:
   # One of 'dashboard' (default) | 'allBranchesLog'
   statusPanelView: dashboard
 
+  # If true, jump to the Files panel after popping a stash
+  switchToFilesAfterStashPop: true
+
+  # If true, jump to the Files panel after applying a stash
+  switchToFilesAfterStashApply: true
+
 # Config relating to git
 git:
   # See https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Pagers.md

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -161,6 +161,10 @@ type GuiConfig struct {
 	// Status panel view.
 	// One of 'dashboard' (default) | 'allBranchesLog'
 	StatusPanelView string `yaml:"statusPanelView" jsonschema:"enum=dashboard,enum=allBranchesLog"`
+	// If true, jump to the Files panel after popping a stash
+	SwitchToFilesAfterStashPop bool `yaml:"switchToFilesAfterStashPop"`
+	// If true, jump to the Files panel after applying a stash
+	SwitchToFilesAfterStashApply bool `yaml:"switchToFilesAfterStashApply"`
 }
 
 func (c *GuiConfig) UseFuzzySearch() bool {
@@ -729,7 +733,9 @@ func GetDefaultConfig() *UserConfig {
 				Frames: []string{"|", "/", "-", "\\"},
 				Rate:   50,
 			},
-			StatusPanelView: "dashboard",
+			StatusPanelView:              "dashboard",
+			SwitchToFilesAfterStashPop:   true,
+			SwitchToFilesAfterStashApply: true,
 		},
 		Git: GitConfig{
 			Paging: PagingConfig{

--- a/pkg/gui/controllers/stash_controller.go
+++ b/pkg/gui/controllers/stash_controller.go
@@ -111,7 +111,9 @@ func (self *StashController) handleStashApply(stashEntry *models.StashEntry) err
 		if err != nil {
 			return err
 		}
-		self.c.Context().Push(self.c.Contexts().Files)
+		if self.c.UserConfig().Gui.SwitchToFilesAfterStashApply {
+			self.c.Context().Push(self.c.Contexts().Files)
+		}
 		return nil
 	}
 
@@ -138,7 +140,9 @@ func (self *StashController) handleStashPop(stashEntry *models.StashEntry) error
 		if err != nil {
 			return err
 		}
-		self.c.Context().Push(self.c.Contexts().Files)
+		if self.c.UserConfig().Gui.SwitchToFilesAfterStashPop {
+			self.c.Context().Push(self.c.Contexts().Files)
+		}
 		return nil
 	}
 

--- a/schema/config.json
+++ b/schema/config.json
@@ -452,6 +452,16 @@
           ],
           "description": "Status panel view.\nOne of 'dashboard' (default) | 'allBranchesLog'",
           "default": "dashboard"
+        },
+        "switchToFilesAfterStashPop": {
+          "type": "boolean",
+          "description": "If true, jump to the Files panel after popping a stash",
+          "default": true
+        },
+        "switchToFilesAfterStashApply": {
+          "type": "boolean",
+          "description": "If true, jump to the Files panel after applying a stash",
+          "default": true
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
- **PR Description**

In v0.44.0 we added a small QoL improvement to auto-switch to the Files panel after popping or applying a stash. While this should be an improvement for most people, it turns out to be in the way of some people's workflows, so make it configurable. See [here](https://github.com/jesseduffield/lazygit/pull/3888#issuecomment-2350853602) for more discussion.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
