### PR TITLE
Fix crash when viewing the divergence of a branch which is up to date with its upstream

### DIFF
--- a/pkg/gui/context/list_renderer.go
+++ b/pkg/gui/context/list_renderer.go
@@ -121,7 +121,10 @@ func (self *ListRenderer) insertNonModelItems(
 			break
 		}
 		if item.Index+offset >= startIdx {
-			padding := strings.Repeat(" ", columnPositions[item.Column])
+			padding := ""
+			if columnPositions != nil {
+				padding = strings.Repeat(" ", columnPositions[item.Column])
+			}
 			lines = slices.Insert(lines, item.Index+offset-startIdx, padding+item.Content)
 		}
 		offset++

--- a/pkg/integration/tests/branch/show_divergence_from_upstream_no_divergence.go
+++ b/pkg/integration/tests/branch/show_divergence_from_upstream_no_divergence.go
@@ -1,0 +1,34 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ShowDivergenceFromUpstreamNoDivergence = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Show divergence from upstream when the divergence view is empty",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("commit1")
+		shell.CloneIntoRemote("origin")
+		shell.SetBranchUpstream("master", "origin/master")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Lines(Contains("master")).
+			Press(keys.Branches.SetUpstream)
+
+		t.ExpectPopup().Menu().Title(Contains("Upstream")).Select(Contains("View divergence from upstream")).Confirm()
+
+		t.Views().SubCommits().
+			IsFocused().
+			Title(Contains("Commits (master <-> origin/master)")).
+			Lines(
+				Contains("--- Remote ---"),
+				Contains("--- Local ---"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -65,6 +65,7 @@ var tests = []*components.IntegrationTest{
 	branch.SetUpstream,
 	branch.ShowDivergenceFromBaseBranch,
 	branch.ShowDivergenceFromUpstream,
+	branch.ShowDivergenceFromUpstreamNoDivergence,
 	branch.SortLocalBranches,
 	branch.SortRemoteBranches,
 	branch.SquashMerge,


### PR DESCRIPTION
This was introduced by #3838, specifically by commit e675025411.

Fixes #3900 and #3917.