### PR TITLE
Fix typos

### DIFF
--- a/docs/dev/Busy.md
+++ b/docs/dev/Busy.md
@@ -2,7 +2,7 @@
 
 ## The use-case
 
-This topic deserves its own doc because there there are a few touch points for it. We have a use-case for knowing when Lazygit is idle or busy because integration tests follow the following process:
+This topic deserves its own doc because there are a few touch points for it. We have a use-case for knowing when Lazygit is idle or busy because integration tests follow the following process:
 1) press a key
 2) wait until Lazygit is idle
 3) run assertion / press another key

--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -348,7 +348,7 @@ If you would instead like to start an interactive rebase from the selected commi
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` <space> `` | Checkout | Checkout the selected tag tag as a detached HEAD. |
+| `` <space> `` | Checkout | Checkout the selected tag as a detached HEAD. |
 | `` n `` | New tag | Create new tag from current commit. You'll be prompted to enter a tag name and optional description. |
 | `` d `` | Delete | View delete options for local/remote tag. |
 | `` P `` | Push tag | Push the selected tag to a remote. You'll be prompted to select a remote. |

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -180,7 +180,7 @@ If you would instead like to start an interactive rebase from the selected commi
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` <space> `` | チェックアウト | Checkout the selected tag tag as a detached HEAD. |
+| `` <space> `` | チェックアウト | Checkout the selected tag as a detached HEAD. |
 | `` n `` | タグを作成 | Create new tag from current commit. You'll be prompted to enter a tag name and optional description. |
 | `` d `` | Delete | View delete options for local/remote tag. |
 | `` P `` | タグをpush | Push the selected tag to a remote. You'll be prompted to select a remote. |

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -321,7 +321,7 @@ If you would instead like to start an interactive rebase from the selected commi
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` <space> `` | 체크아웃 | Checkout the selected tag tag as a detached HEAD. |
+| `` <space> `` | 체크아웃 | Checkout the selected tag as a detached HEAD. |
 | `` n `` | 태그를 생성 | Create new tag from current commit. You'll be prompted to enter a tag name and optional description. |
 | `` d `` | Delete | View delete options for local/remote tag. |
 | `` P `` | 태그를 push | Push the selected tag to a remote. You'll be prompted to select a remote. |

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -348,7 +348,7 @@ If you would instead like to start an interactive rebase from the selected commi
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` <space> `` | Uitchecken | Checkout the selected tag tag as a detached HEAD. |
+| `` <space> `` | Uitchecken | Checkout the selected tag as a detached HEAD. |
 | `` n `` | Creëer tag | Create new tag from current commit. You'll be prompted to enter a tag name and optional description. |
 | `` d `` | Delete | View delete options for local/remote tag. |
 | `` P `` | Push tag | Push the selected tag to a remote. You'll be prompted to select a remote. |

--- a/docs/keybindings/Keybindings_ru.md
+++ b/docs/keybindings/Keybindings_ru.md
@@ -286,7 +286,7 @@ If you would instead like to start an interactive rebase from the selected commi
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` <space> `` | Переключить | Checkout the selected tag tag as a detached HEAD. |
+| `` <space> `` | Переключить | Checkout the selected tag as a detached HEAD. |
 | `` n `` | Создать тег | Create new tag from current commit. You'll be prompted to enter a tag name and optional description. |
 | `` d `` | Delete | View delete options for local/remote tag. |
 | `` P `` | Отправить тег | Push the selected tag to a remote. You'll be prompted to select a remote. |

--- a/docs/keybindings/Keybindings_zh-TW.md
+++ b/docs/keybindings/Keybindings_zh-TW.md
@@ -282,7 +282,7 @@ If you would instead like to start an interactive rebase from the selected commi
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` <space> `` | 檢出 | Checkout the selected tag tag as a detached HEAD. |
+| `` <space> `` | 檢出 | Checkout the selected tag as a detached HEAD. |
 | `` n `` | 建立標籤 | Create new tag from current commit. You'll be prompted to enter a tag name and optional description. |
 | `` d `` | 刪除 | View delete options for local/remote tag. |
 | `` P `` | 推送標籤 | Push the selected tag to a remote. You'll be prompted to select a remote. |

--- a/pkg/commands/oscommands/os_test.go
+++ b/pkg/commands/oscommands/os_test.go
@@ -122,7 +122,7 @@ func TestOSCommandFileType(t *testing.T) {
 			},
 		},
 		{
-			"nonExistant",
+			"nonExistent",
 			func() {},
 			func(output string) {
 				assert.EqualValues(t, "other", output)

--- a/pkg/gui/context/list_context_trait.go
+++ b/pkg/gui/context/list_context_trait.go
@@ -131,7 +131,7 @@ func (self *ListContextTrait) IsItemVisible(item types.HasUrn) bool {
 	return false
 }
 
-// By default, list contexts supporta range select
+// By default, list contexts supports range select
 func (self *ListContextTrait) RangeSelectEnabled() bool {
 	return true
 }

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -664,7 +664,7 @@ func (self *FilesController) handleAmendCommitPress() error {
 		Title:  self.c.Tr.AmendLastCommitTitle,
 		Prompt: self.c.Tr.SureToAmend,
 		HandleConfirm: func() error {
-			return self.c.Helpers().WorkingTree.WithEnsureCommitableFiles(func() error {
+			return self.c.Helpers().WorkingTree.WithEnsureCommittableFiles(func() error {
 				if len(self.c.Model().Commits) == 0 {
 					return errors.New(self.c.Tr.NoCommitToAmend)
 				}

--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -75,7 +75,7 @@ func (self *RefsHelper) CheckoutRef(ref string, options types.CheckoutRefOptions
 				return options.OnRefNotFound(ref)
 			}
 
-			if IsSwitchBranchUncommitedChangesError(err) {
+			if IsSwitchBranchUncommittedChangesError(err) {
 				// offer to autostash changes
 				self.c.OnUIThread(func() error {
 					// (Before showing the prompt, render again to remove the inline status)
@@ -353,7 +353,7 @@ func (self *RefsHelper) NewBranch(from string, fromFormattedName string, suggest
 				newBranchFunc = self.c.Git().Branch.NewWithoutTracking
 			}
 			if err := newBranchFunc(newBranchName, from); err != nil {
-				if IsSwitchBranchUncommitedChangesError(err) {
+				if IsSwitchBranchUncommittedChangesError(err) {
 					// offer to autostash changes
 					self.c.Confirm(types.ConfirmOpts{
 						Title:  self.c.Tr.AutoStashTitle,
@@ -413,6 +413,6 @@ func (self *RefsHelper) ParseRemoteBranchName(fullBranchName string) (string, st
 	return remoteName, branchName, true
 }
 
-func IsSwitchBranchUncommitedChangesError(err error) bool {
+func IsSwitchBranchUncommittedChangesError(err error) bool {
 	return strings.Contains(err.Error(), "Please commit your changes or stash them before you switch branch")
 }

--- a/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
@@ -422,7 +422,7 @@ func renderLayout(windows map[string]boxlayout.Dimensions) string {
 		return dimensionsA.X0 < dimensionsB.X0
 	})
 
-	// Uniquefy windows by dimensions (so perfectly overlapping windows are de-duped). This prevents getting 'fileshes' as a label where the files and branches windows overlap.
+	// Uniquify windows by dimensions (so perfectly overlapping windows are de-duped). This prevents getting 'fileshes' as a label where the files and branches windows overlap.
 	// branches windows overlap.
 	windowNames = lo.UniqBy(windowNames, func(windowName string) boxlayout.Dimensions {
 		return windows[windowName]

--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -87,7 +87,7 @@ func (self *WorkingTreeHelper) OpenMergeTool() error {
 }
 
 func (self *WorkingTreeHelper) HandleCommitPressWithMessage(initialMessage string) error {
-	return self.WithEnsureCommitableFiles(func() error {
+	return self.WithEnsureCommittableFiles(func() error {
 		self.commitsHelper.OpenCommitMessagePanel(
 			&OpenCommitMessagePanelOpts{
 				CommitIndex:      context.NoCommitIndex,
@@ -131,7 +131,7 @@ func (self *WorkingTreeHelper) switchFromCommitMessagePanelToEditor(filepath str
 // HandleCommitEditorPress - handle when the user wants to commit changes via
 // their editor rather than via the popup panel
 func (self *WorkingTreeHelper) HandleCommitEditorPress() error {
-	return self.WithEnsureCommitableFiles(func() error {
+	return self.WithEnsureCommittableFiles(func() error {
 		self.c.LogAction(self.c.Tr.Actions.Commit)
 		return self.c.RunSubprocessAndRefresh(
 			self.c.Git().Commit.CommitEditorCmdObj(),
@@ -172,7 +172,7 @@ func (self *WorkingTreeHelper) HandleCommitPress() error {
 	return self.HandleCommitPressWithMessage(message)
 }
 
-func (self *WorkingTreeHelper) WithEnsureCommitableFiles(handler func() error) error {
+func (self *WorkingTreeHelper) WithEnsureCommittableFiles(handler func() error) error {
 	if err := self.prepareFilesForCommit(); err != nil {
 		return err
 	}

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -736,7 +736,7 @@ func (self *LocalCommitsController) amendTo(commit *models.Commit) error {
 			Title:  self.c.Tr.AmendCommitTitle,
 			Prompt: self.c.Tr.AmendCommitPrompt,
 			HandleConfirm: func() error {
-				return self.c.Helpers().WorkingTree.WithEnsureCommitableFiles(func() error {
+				return self.c.Helpers().WorkingTree.WithEnsureCommittableFiles(func() error {
 					if err := self.c.Helpers().AmendHelper.AmendHead(); err != nil {
 						return err
 					}
@@ -752,7 +752,7 @@ func (self *LocalCommitsController) amendTo(commit *models.Commit) error {
 		Title:  self.c.Tr.AmendCommitTitle,
 		Prompt: self.c.Tr.AmendCommitPrompt,
 		HandleConfirm: func() error {
-			return self.c.Helpers().WorkingTree.WithEnsureCommitableFiles(func() error {
+			return self.c.Helpers().WorkingTree.WithEnsureCommittableFiles(func() error {
 				return self.c.WithWaitingStatus(self.c.Tr.AmendingStatus, func(gocui.Task) error {
 					self.c.LogAction(self.c.Tr.Actions.AmendCommit)
 					err := self.c.Git().Rebase.AmendTo(self.c.Model().Commits, self.context().GetView().SelectedLineIdx())
@@ -928,7 +928,7 @@ func (self *LocalCommitsController) createFixupCommit(commit *models.Commit) err
 				Label: self.c.Tr.FixupMenu_Fixup,
 				Key:   'f',
 				OnPress: func() error {
-					return self.c.Helpers().WorkingTree.WithEnsureCommitableFiles(func() error {
+					return self.c.Helpers().WorkingTree.WithEnsureCommittableFiles(func() error {
 						self.c.LogAction(self.c.Tr.Actions.CreateFixupCommit)
 						return self.c.WithWaitingStatusSync(self.c.Tr.CreatingFixupCommitStatus, func() error {
 							if err := self.c.Git().Commit.CreateFixupCommit(commit.Hash); err != nil {
@@ -951,7 +951,7 @@ func (self *LocalCommitsController) createFixupCommit(commit *models.Commit) err
 				Label: self.c.Tr.FixupMenu_AmendWithChanges,
 				Key:   'a',
 				OnPress: func() error {
-					return self.c.Helpers().WorkingTree.WithEnsureCommitableFiles(func() error {
+					return self.c.Helpers().WorkingTree.WithEnsureCommittableFiles(func() error {
 						return self.createAmendCommit(commit, true)
 					})
 				},

--- a/pkg/gui/patch_exploring/state.go
+++ b/pkg/gui/patch_exploring/state.go
@@ -41,7 +41,7 @@ const (
 func NewState(diff string, selectedLineIdx int, view *gocui.View, oldState *State) *State {
 	if oldState != nil && diff == oldState.diff && selectedLineIdx == -1 {
 		// if we're here then we can return the old state. If selectedLineIdx was not -1
-		// then that would mean we were trying to click and potentiall drag a range, which
+		// then that would mean we were trying to click and potentially drag a range, which
 		// is why in that case we continue below
 		return oldState
 	}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1076,7 +1076,7 @@ func EnglishTranslationSet() *TranslationSet {
 		Checkout:                             "Checkout",
 		CheckoutTooltip:                      "Checkout selected item.",
 		CantCheckoutBranchWhilePulling:       "You cannot checkout another branch while pulling the current branch",
-		TagCheckoutTooltip:                   "Checkout the selected tag tag as a detached HEAD.",
+		TagCheckoutTooltip:                   "Checkout the selected tag as a detached HEAD.",
 		RemoteBranchCheckoutTooltip:          "Checkout a new local branch based on the selected remote branch, or the remote branch as a detached head.",
 		CantPullOrPushSameBranchTwice:        "You cannot push or pull a branch while it is already being pushed or pulled",
 		FileFilter:                           "Filter files by status",

--- a/pkg/integration/clients/go_test.go
+++ b/pkg/integration/clients/go_test.go
@@ -4,7 +4,7 @@
 package clients
 
 // This file allows you to use `go test` to run integration tests.
-// See See pkg/integration/README.md for more info.
+// See pkg/integration/README.md for more info.
 
 import (
 	"bytes"

--- a/pkg/integration/components/env.go
+++ b/pkg/integration/components/env.go
@@ -19,7 +19,7 @@ const (
 	// which is good to test for.
 	PWD = "PWD"
 
-	// We set $HOME and $GIT_CONFIG_NOGLOBAL during integrationt tests so
+	// We set $HOME and $GIT_CONFIG_NOGLOBAL during integration tests so
 	// that older versions of git that don't respect $GIT_CONFIG_GLOBAL
 	// will find the correct global config file for testing
 	HOME                = "HOME"

--- a/pkg/integration/tests/demo/shared.go
+++ b/pkg/integration/tests/demo/shared.go
@@ -14,6 +14,6 @@ func setGeneratedAuthorColours(config *config.AppConfig) {
 }
 
 func setDefaultDemoConfig(config *config.AppConfig) {
-	// demos look much nicers with icons shown
+	// demos look much nicer with icons shown
 	config.GetUserConfig().Gui.NerdFontsVersion = "3"
 }

--- a/pkg/integration/tests/sync/fetch_prune.go
+++ b/pkg/integration/tests/sync/fetch_prune.go
@@ -23,7 +23,7 @@ var FetchPrune = NewIntegrationTest(NewIntegrationTestArgs{
 		shell.SetBranchUpstream("master", "origin/master")
 		shell.SetBranchUpstream("branch_to_remove", "origin/branch_to_remove")
 
-		// # unbenownst to our test repo we're removing the branch on the remote, so upon
+		// # unbeknownst to our test repo we're removing the branch on the remote, so upon
 		// # fetching with prune: true we expect git to realise the remote branch is gone
 		shell.RemoveRemoteBranch("origin", "branch_to_remove")
 	},

--- a/pkg/integration/tests/test_list_generator.go
+++ b/pkg/integration/tests/test_list_generator.go
@@ -33,7 +33,7 @@ func main() {
 }
 
 func generateCode() []byte {
-	// traverse parent directory to get all subling directories
+	// traverse parent directory to get all sibling directories
 	directories, err := os.ReadDir("../tests")
 	if err != nil {
 		panic(err)

--- a/pkg/integration/tests/ui/accordion.go
+++ b/pkg/integration/tests/ui/accordion.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
-// When in acccordion mode, Lazygit looks like this:
+// When in accordion mode, Lazygit looks like this:
 //
 // ╶─Status─────────────────────────╴┌─Patch──────────────────────────────────────────────────────────┐
 // ╶─Files - Submodules──────0 of 0─╴│commit 6e56dd04b70e548976f7f2928c4d9c359574e2bc                 ▲

--- a/pkg/integration/tests/worktree/bare_repo_worktree_config.go
+++ b/pkg/integration/tests/worktree/bare_repo_worktree_config.go
@@ -8,7 +8,7 @@ import (
 // This case is identical to dotfile_bare_repo.go, except
 // that it invokes lazygit with $GIT_DIR set but not
 // $GIT_WORK_TREE. Instead, the repo uses the core.worktree
-// config to identify the main worktre.
+// config to identify the main worktree.
 
 var BareRepoWorktreeConfig = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Open lazygit in the worktree of a vcsh-style bare repo and add a file and commit",


### PR DESCRIPTION
Just thought I'd contribute some typo fixes that I stumbled on. Nothing controversial (hopefully).

Use the following command to quickly review the corrections made:
```shell
git diff HEAD^! --word-diff-regex='\w+' -U0 \
  | grep -E '\[\-.*\-\]\{\+.*\+\}' \
  | sed -r 's/.*\[\-(.*)\-\]\{\+(.*)\+\}.*/\1 \2/' \
  | sort | uniq -c | sort -n
```

FWIW, the typos are:
* commitable -> committable (x8)
* uncommited -> uncommitted (x3)
* uniquefy -> uniquify
* acccordion -> accordion
* integrationt -> integration
* nicers -> nicer
* existant -> existent
* potentiall -> potentially
* subling -> sibling
* supporta -> supports
* unbenownst -> unbeknownst
* worktre -> worktree