### PR TITLE
Add config option to disable switching tabs with panel jump keys

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -252,6 +252,9 @@ gui:
   # If true, jump to the Files panel after applying a stash
   switchToFilesAfterStashApply: true
 
+  # If true, when using the panel jump keys (default 1 through 5) and target panel is already active, go to next tab instead
+  switchTabsWithPanelJumpKeys: false
+
 # Config relating to git
 git:
   # See https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Pagers.md

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -165,6 +165,8 @@ type GuiConfig struct {
 	SwitchToFilesAfterStashPop bool `yaml:"switchToFilesAfterStashPop"`
 	// If true, jump to the Files panel after applying a stash
 	SwitchToFilesAfterStashApply bool `yaml:"switchToFilesAfterStashApply"`
+	// If true, when using the panel jump keys (default 1 through 5) and target panel is already active, go to next tab instead
+	SwitchTabsWithPanelJumpKeys bool `yaml:"switchTabsWithPanelJumpKeys"`
 }
 
 func (c *GuiConfig) UseFuzzySearch() bool {
@@ -736,6 +738,7 @@ func GetDefaultConfig() *UserConfig {
 			StatusPanelView:              "dashboard",
 			SwitchToFilesAfterStashPop:   true,
 			SwitchToFilesAfterStashApply: true,
+			SwitchTabsWithPanelJumpKeys:  false,
 		},
 		Git: GitConfig{
 			Paging: PagingConfig{

--- a/pkg/gui/controllers/jump_to_side_window_controller.go
+++ b/pkg/gui/controllers/jump_to_side_window_controller.go
@@ -49,7 +49,8 @@ func (self *JumpToSideWindowController) GetKeybindings(opts types.KeybindingsOpt
 
 func (self *JumpToSideWindowController) goToSideWindow(window string) func() error {
 	return func() error {
-		if self.c.Helpers().Window.CurrentWindow() == window {
+		sideWindowAlreadyActive := self.c.Helpers().Window.CurrentWindow() == window
+		if sideWindowAlreadyActive && self.c.UserConfig().Gui.SwitchTabsWithPanelJumpKeys {
 			return self.nextTabFunc()
 		}
 

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -346,6 +346,7 @@ var tests = []*components.IntegrationTest{
 	tag.ForceTagLightweight,
 	tag.Reset,
 	ui.Accordion,
+	ui.DisableSwitchTabWithPanelJumpKeys,
 	ui.DoublePopup,
 	ui.EmptyMenu,
 	ui.KeybindingSuggestionsWhenSwitchingRepos,

--- a/pkg/integration/tests/ui/disable_switch_tab_with_panel_jump_keys.go
+++ b/pkg/integration/tests/ui/disable_switch_tab_with_panel_jump_keys.go
@@ -1,0 +1,26 @@
+package ui
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var DisableSwitchTabWithPanelJumpKeys = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Verify that the tab does not change by default when jumping to an already focused panel",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+	},
+	SetupRepo: func(shell *Shell) {
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Status().Focus().
+			Press(keys.Universal.JumpToBlock[1])
+		t.Views().Files().IsFocused().
+			Press(keys.Universal.JumpToBlock[1])
+
+		// Despite jumping to an already focused panel,
+		// the tab should not change from the base files view
+		t.Views().Files().IsFocused()
+	},
+})

--- a/pkg/integration/tests/ui/switch_tab_with_panel_jump_keys.go
+++ b/pkg/integration/tests/ui/switch_tab_with_panel_jump_keys.go
@@ -6,10 +6,12 @@ import (
 )
 
 var SwitchTabWithPanelJumpKeys = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Switch tab with the panel jump keys",
+	Description:  "Switch tab with the panel jump keys after enabling the feature",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
-	SetupConfig:  func(config *config.AppConfig) {},
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Gui.SwitchTabsWithPanelJumpKeys = true
+	},
 	SetupRepo: func(shell *Shell) {
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {

--- a/schema/config.json
+++ b/schema/config.json
@@ -462,6 +462,11 @@
           "type": "boolean",
           "description": "If true, jump to the Files panel after applying a stash",
           "default": true
+        },
+        "switchTabsWithPanelJumpKeys": {
+          "type": "boolean",
+          "description": "If true, when using the panel jump keys (default 1 through 5) and target panel is already active, go to next tab instead",
+          "default": false
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
# **PR Description**

## Problem this PR attempts to solve

I really appreciate the feature added in #3794 that allows switching tabs using panel jump keys when the side panel is already active and see how it is convenient for many users. However, after using lazygit for quite some time, I've developed muscle memory where I rely on pressing a number key to instantly switch to a panel and perform an action, regardless of which panel is currently active. I have found myself several times in the past few days clicking '2' and going to hit 'a' + 'c' to commit all and find I was already had window 2 active and my tab was instead switched to 'Worktrees' and the keybindings no longer apply to stage or commit. 

## Solution

- Add a config `SwitchTabsWithPanelJumpKeys` as a gui boolean that is true by default, keeping the current new behavior added by #3794 
- When `SwitchTabsWithPanelJumpKeys` is set to false in the user's config, the old behavior is returned which does not switch tabs using the side panel jump keys. 
- This is behavior is verified with an integration test with ``SwitchTabsWithPanelJumpKeys` set to false that shows the expected behavior that jumping to window 2 while window 2 is already active does not switch tabs within window 2

To disable switching tabs with panel jump keys, add the following to your config.yml:
```yaml
gui:
  # If true, when using the panel jump keys (default 1 through 5) and target panel is already active, go to next tab instead
  switchTabsWithPanelJumpKeys: false
```

### P.S. 
This is my first contribution to lazygit and while I absolutely strived to read all documentation and follow all standards, I accept that this PR may not be perfect and am very open to feedback and suggestions to improve both this code and any future contributions. I absolutely love lazygit, I use it everyday and swear by it as the most powerful and efficient tool for managing git, I love and appreciate all the work all the maintainers do to constantly improve it. So thank you to all who are reading this and I look forward to contributing more to make lazygit even more of the best git tool available!

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] No text rendered to user -> Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
