### PR TITLE
Fix copying commit author to clipboard

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -189,7 +189,7 @@ type Author struct {
 
 func (self *CommitCommands) GetCommitAuthor(commitHash string) (Author, error) {
 	cmdArgs := NewGitCmd("show").
-		Arg("--no-patch", "--pretty=format:'%an%x00%ae'", commitHash).
+		Arg("--no-patch", "--pretty=format:%an%x00%ae", commitHash).
 		ToArgv()
 
 	output, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()

--- a/pkg/integration/tests/commit/copy_author_to_clipboard.go
+++ b/pkg/integration/tests/commit/copy_author_to_clipboard.go
@@ -43,9 +43,6 @@ var CopyAuthorToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("clipboard").IsSelected(),
 			)
 
-		/* EXPECTED:
 		t.Views().Main().Content(Contains("/John Doe <john@doe.com>/"))
-		ACTUAL: */
-		t.Views().Main().Content(Contains("/'John Doe <john@doe.com'>/"))
 	},
 })

--- a/pkg/integration/tests/commit/copy_author_to_clipboard.go
+++ b/pkg/integration/tests/commit/copy_author_to_clipboard.go
@@ -1,0 +1,51 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+// We're emulating the clipboard by writing to a file called clipboard
+
+var CopyAuthorToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Copy a commit author name to the clipboard",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		// Include delimiters around the text so that we can assert on the entire content
+		config.GetUserConfig().OS.CopyToClipboardCmd = "echo /{{text}}/ > clipboard"
+	},
+
+	SetupRepo: func(shell *Shell) {
+		shell.SetAuthor("John Doe", "john@doe.com")
+		shell.EmptyCommit("commit")
+	},
+
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("commit").IsSelected(),
+			).
+			Press(keys.Commits.CopyCommitAttributeToClipboard)
+
+		t.ExpectPopup().Menu().
+			Title(Equals("Copy to clipboard")).
+			Select(Contains("Commit author")).
+			Confirm()
+
+		t.ExpectToast(Equals("Commit author copied to clipboard"))
+
+		t.Views().Files().
+			Focus().
+			Press(keys.Files.RefreshFiles).
+			Lines(
+				Contains("clipboard").IsSelected(),
+			)
+
+		/* EXPECTED:
+		t.Views().Main().Content(Contains("/John Doe <john@doe.com>/"))
+		ACTUAL: */
+		t.Views().Main().Content(Contains("/'John Doe <john@doe.com'>/"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -87,6 +87,7 @@ var tests = []*components.IntegrationTest{
 	commit.CommitWithGlobalPrefix,
 	commit.CommitWithNonMatchingBranchName,
 	commit.CommitWithPrefix,
+	commit.CopyAuthorToClipboard,
 	commit.CreateAmendCommit,
 	commit.CreateFixupCommitInBranchStack,
 	commit.CreateTag,


### PR DESCRIPTION
- **PR Description**

This included single quotes in strange places in the copied text.

Fixes #3933.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
