### PR TITLE
Add status line info to the submodule list view

### DIFF
--- a/pkg/commands/models/submodule_config.go
+++ b/pkg/commands/models/submodule_config.go
@@ -3,9 +3,13 @@ package models
 import "path/filepath"
 
 type SubmoduleConfig struct {
-	Name string
-	Path string
-	Url  string
+	Name                string
+	Path                string
+	Url                 string
+	Head                string
+	NumStagedFiles      int
+	NumUnstagedChanges  int
+	NumUntrackedChanges int
 
 	ParentModule *SubmoduleConfig // nil if top-level
 }

--- a/pkg/gui/presentation/submodules.go
+++ b/pkg/gui/presentation/submodules.go
@@ -1,6 +1,8 @@
 package presentation
 
 import (
+	"fmt"
+
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/theme"
 	"github.com/samber/lo"
@@ -13,7 +15,11 @@ func GetSubmoduleListDisplayStrings(submodules []*models.SubmoduleConfig) [][]st
 }
 
 func getSubmoduleDisplayStrings(s *models.SubmoduleConfig) []string {
-	name := s.Name
+	// Pad right with some spaces to the end of the HEAD so that it (hopefully) aligns well.
+	// Put the HEAD first because those are more likely to be similar lengths than the repo name.
+	name := fmt.Sprintf("%-20s %s", s.Head,
+		s.Name,
+	)
 	if s.ParentModule != nil {
 		indentation := ""
 		for p := s.ParentModule; p != nil; p = p.ParentModule {
@@ -21,6 +27,30 @@ func getSubmoduleDisplayStrings(s *models.SubmoduleConfig) []string {
 		}
 
 		name = indentation + "- " + s.Name
+	}
+
+	if s.NumStagedFiles != 0 {
+		name = fmt.Sprintf(
+			"%s +%d",
+			name,
+			s.NumStagedFiles,
+		)
+	}
+
+	if s.NumUnstagedChanges != 0 {
+		name = fmt.Sprintf(
+			"%s !%d",
+			name,
+			s.NumUnstagedChanges,
+		)
+	}
+
+	if s.NumUntrackedChanges != 0 {
+		name = fmt.Sprintf(
+			"%s ?%d ",
+			name,
+			s.NumUntrackedChanges,
+		)
 	}
 
 	return []string{theme.DefaultTextColor.Sprint(name)}


### PR DESCRIPTION
**Add status line info to the submodule list view**

Adds a QOL status line to the git submodules feature, inspired by the default power level 10k status [line](https://github.com/romkatv/powerlevel10k?tab=readme-ov-file#what-do-different-symbols-in-git-status-mean). This is a pretty basic first pass that only includes 3 values snagged from running `git status --porcelain` but I think it could be extended to include all of the values in the table (potentially). See the list view on the left in the `submodules` pane for the changes

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->


![lazygitscreenshot](https://github.com/user-attachments/assets/5b319228-08c9-425c-b3b6-f6f6c2555da3)
