### PR TITLE
Add "create fixup commit with message" option to "create fixup commit" menu

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -300,6 +300,16 @@ func (self *CommitCommands) CreateFixupCommit(hash string) error {
 	return self.cmd.New(cmdArgs).Run()
 }
 
+// CreateFixupCommit creates a commit that fixes up a previous commit including a message
+func (self *CommitCommands) CreateFixupCommitWithMessage(hash string, message string) error {
+	cmdArgs := NewGitCmd("commit").
+		Arg("--fixup="+hash).
+		Arg("-m", message).
+		ToArgv()
+
+	return self.cmd.New(cmdArgs).Run()
+}
+
 // CreateAmendCommit creates a commit that changes the commit message of a previous commit
 func (self *CommitCommands) CreateAmendCommit(originalSubject, newSubject, newDescription string, includeFileChanges bool) error {
 	description := newSubject

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -282,7 +282,9 @@ type TranslationSet struct {
 	MergeOptionsTitle                     string
 	RebaseOptionsTitle                    string
 	CommitSummaryTitle                    string
+	FixupCommitSummaryTitle               string
 	CommitDescriptionTitle                string
+	FixupCommitDescriptionTitle           string
 	CommitDescriptionSubTitle             string
 	LocalBranchesTitle                    string
 	SearchTitle                           string
@@ -407,7 +409,9 @@ type TranslationSet struct {
 	CreateFixupCommitTooltip              string
 	CreateAmendCommit                     string
 	FixupMenu_Fixup                       string
+	FixupMenu_FixupWithMessage            string
 	FixupMenu_FixupTooltip                string
+	FixupMenu_FixupWithMessageTooltip     string
 	FixupMenu_AmendWithChanges            string
 	FixupMenu_AmendWithChangesTooltip     string
 	FixupMenu_AmendWithoutChanges         string
@@ -1264,7 +1268,9 @@ func EnglishTranslationSet() *TranslationSet {
 		MergeOptionsTitle:                    "Merge options",
 		RebaseOptionsTitle:                   "Rebase options",
 		CommitSummaryTitle:                   "Commit summary",
+		FixupCommitSummaryTitle:              "Fixup commit summary",
 		CommitDescriptionTitle:               "Commit description",
+		FixupCommitDescriptionTitle:          "Fixup commit description",
 		CommitDescriptionSubTitle:            "Press {{.togglePanelKeyBinding}} to toggle focus, {{.commitMenuKeybinding}} to open menu",
 		LocalBranchesTitle:                   "Local branches",
 		SearchTitle:                          "Search",
@@ -1401,7 +1407,9 @@ func EnglishTranslationSet() *TranslationSet {
 		CreateFixupCommitTooltip:             "Create 'fixup!' commit for the selected commit. Later on, you can press `{{.squashAbove}}` on this same commit to apply all above fixup commits.",
 		CreateAmendCommit:                    `Create "amend!" commit`,
 		FixupMenu_Fixup:                      "fixup! commit",
+		FixupMenu_FixupWithMessage:           "fixup! commit with message",
 		FixupMenu_FixupTooltip:               "Lets you fixup another commit and keep the original commit's message.",
+		FixupMenu_FixupWithMessageTooltip:    "Lets you fixup another commit and keep the original commit's message while adding a fixup commit message.",
 		FixupMenu_AmendWithChanges:           "amend! commit with changes",
 		FixupMenu_AmendWithChangesTooltip:    "Lets you fixup another commit and also change its commit message.",
 		FixupMenu_AmendWithoutChanges:        "amend! commit without changes (pure reword)",


### PR DESCRIPTION
**PR Description**
Closes #3962 
Adds option to the "Create fixup commit" menu that allows user to add a message to their fixup commit. This will make it easier for PR reviewers to look at a specific fixup commit regarding their comments/feedback.

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/72b7a79e-e804-4261-8027-34daa1b16986">

When selecting the fixup! commit with message option, the "normal" commit message panel opens and promts user with commit message.

Refactoring/extracting functions is needed in the OnPress and help is gladly accepted as I am little familiar with the structure.

**Please check if the PR fulfills these requirements**
* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
