### PR TITLE
Filter binding label

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -174,7 +174,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | View commits |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Main panel (merging)
 
@@ -242,7 +242,7 @@ If you would instead like to start an interactive rebase from the selected commi
 |-----|--------|-------------|
 | `` <enter> `` | Execute |  |
 | `` <esc> `` | Close |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Reflog
 
@@ -259,7 +259,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | View commits |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Remote branches
 
@@ -277,7 +277,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | View commits |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Remotes
 
@@ -288,7 +288,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` d `` | Remove | Remove the selected remote. Any local branches tracking a remote branch from the remote will be unaffected. |
 | `` e `` | Edit | Edit the selected remote's name or URL. |
 | `` f `` | Fetch | Fetch updates from the remote repository. This retrieves new commits and branches without merging them into your local branches. |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Stash
 
@@ -301,7 +301,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` r `` | Rename stash |  |
 | `` <enter> `` | View files |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Status
 
@@ -342,7 +342,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` e `` | Update submodule URL |  |
 | `` i `` | Initialize | Initialize the selected submodule to prepare for fetching. You probably want to follow this up by invoking the 'update' action to fetch the submodule. |
 | `` b `` | View bulk submodule options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Tags
 
@@ -356,7 +356,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | View commits |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Worktrees
 
@@ -366,4 +366,4 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <space> `` | Switch | Switch to the selected worktree. |
 | `` o `` | Open in editor |  |
 | `` d `` | Remove | Remove the selected worktree. This will both delete the worktree's directory, as well as metadata about the worktree in the .git directory. |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -62,7 +62,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` r `` | Stashを変更 |  |
 | `` <enter> `` | View files |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Sub-commits
 
@@ -89,7 +89,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <space> `` | Switch | Switch to the selected worktree. |
 | `` o `` | Open in editor |  |
 | `` d `` | Remove | Remove the selected worktree. This will both delete the worktree's directory, as well as metadata about the worktree in the .git directory. |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## コミット
 
@@ -164,7 +164,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` e `` | サブモジュールのURLを更新 |  |
 | `` i `` | Initialize | サブモジュールを初期化 |
 | `` b `` | View bulk submodule options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## ステータス
 
@@ -188,7 +188,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | コミットを閲覧 |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## ファイル
 
@@ -245,7 +245,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | コミットを閲覧 |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## メインパネル (Merging)
 
@@ -313,7 +313,7 @@ If you would instead like to start an interactive rebase from the selected commi
 |-----|--------|-------------|
 | `` <enter> `` | 実行 |  |
 | `` <esc> `` | 閉じる |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## リモート
 
@@ -324,7 +324,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` d `` | Remove | Remove the selected remote. Any local branches tracking a remote branch from the remote will be unaffected. |
 | `` e `` | Edit | リモートを編集 |
 | `` f `` | Fetch | リモートをfetch |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## リモートブランチ
 
@@ -342,7 +342,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | コミットを閲覧 |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## 参照ログ
 
@@ -359,7 +359,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | コミットを閲覧 |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## 確認パネル
 

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -66,7 +66,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | 커밋 보기 |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Stash
 
@@ -79,7 +79,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` r `` | Rename stash |  |
 | `` <enter> `` | View selected item's files |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Sub-commits
 
@@ -106,7 +106,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <space> `` | Switch | Switch to the selected worktree. |
 | `` o `` | Open in editor |  |
 | `` d `` | Remove | Remove the selected worktree. This will both delete the worktree's directory, as well as metadata about the worktree in the .git directory. |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## 메뉴
 
@@ -114,7 +114,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 |-----|--------|-------------|
 | `` <enter> `` | 실행 |  |
 | `` <esc> `` | 닫기 |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## 메인 패널 (Merging)
 
@@ -201,7 +201,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | 커밋 보기 |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## 상태
 
@@ -225,7 +225,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` e `` | 서브모듈의 URL을 수정 |  |
 | `` i `` | Initialize | 서브모듈 초기화 |
 | `` b `` | View bulk submodule options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## 원격
 
@@ -236,7 +236,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` d `` | Remove | Remove the selected remote. Any local branches tracking a remote branch from the remote will be unaffected. |
 | `` e `` | Edit | Remote를 수정 |
 | `` f `` | Fetch | 원격을 업데이트 |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## 원격 브랜치
 
@@ -254,7 +254,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | 커밋 보기 |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## 커밋
 
@@ -329,7 +329,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | 커밋 보기 |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## 파일
 

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -113,7 +113,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | Bekijk commits |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Commit bericht
 
@@ -182,7 +182,7 @@ If you would instead like to start an interactive rebase from the selected commi
 |-----|--------|-------------|
 | `` <enter> `` | Uitvoeren |  |
 | `` <esc> `` | Sluiten |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Mergen
 
@@ -237,7 +237,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | Bekijk commits |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Remote branches
 
@@ -255,7 +255,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | Bekijk commits |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Remotes
 
@@ -266,7 +266,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` d `` | Remove | Remove the selected remote. Any local branches tracking a remote branch from the remote will be unaffected. |
 | `` e `` | Edit | Wijzig remote |
 | `` f `` | Fetch | Fetch remote |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Staging
 
@@ -301,7 +301,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` r `` | Rename stash |  |
 | `` <enter> `` | Bekijk gecommite bestanden |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Status
 
@@ -342,7 +342,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` e `` | Update submodule URL |  |
 | `` i `` | Initialize | Initialiseer submodule |
 | `` b `` | Bekijk bulk submodule opties |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Tags
 
@@ -356,7 +356,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | Bekijk commits |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Worktrees
 
@@ -366,4 +366,4 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <space> `` | Switch | Switch to the selected worktree. |
 | `` o `` | Open in editor |  |
 | `` d `` | Remove | Remove the selected worktree. This will both delete the worktree's directory, as well as metadata about the worktree in the .git directory. |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |

--- a/docs/keybindings/Keybindings_ru.md
+++ b/docs/keybindings/Keybindings_ru.md
@@ -59,7 +59,7 @@ _Связки клавиш_
 | `` <space> `` | Switch | Switch to the selected worktree. |
 | `` o `` | Open in editor |  |
 | `` d `` | Remove | Remove the selected worktree. This will both delete the worktree's directory, as well as metadata about the worktree in the .git directory. |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Главная панель (Индексирование)
 
@@ -136,7 +136,7 @@ _Связки клавиш_
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | Просмотреть коммиты |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Коммиты
 
@@ -201,7 +201,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | Просмотреть коммиты |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Меню
 
@@ -209,7 +209,7 @@ If you would instead like to start an interactive rebase from the selected commi
 |-----|--------|-------------|
 | `` <enter> `` | Выполнить |  |
 | `` <esc> `` | Закрыть |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Панель Подтверждения
 
@@ -247,7 +247,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` e `` | Обновить URL подмодуля |  |
 | `` i `` | Initialize | Инициализировать подмодуль |
 | `` b `` | Просмотреть параметры массового подмодуля |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Сводка коммита
 
@@ -294,7 +294,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | Просмотреть коммиты |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Удалённые ветки
 
@@ -312,7 +312,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` <enter> `` | Просмотреть коммиты |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Удалённые репозитории
 
@@ -323,7 +323,7 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` d `` | Remove | Remove the selected remote. Any local branches tracking a remote branch from the remote will be unaffected. |
 | `` e `` | Edit | Редактировать удалённый репозитории |
 | `` f `` | Получить изменения | Получение изменения из удалённого репозитория |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |
 
 ## Файлы
 
@@ -366,4 +366,4 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` r `` | Переименовать хранилище |  |
 | `` <enter> `` | Просмотреть файлы выбранного элемента |  |
 | `` w `` | View worktree options |  |
-| `` / `` | Filter the current view by text |  |
+| `` / `` | Filter |  |

--- a/pkg/gui/controllers/filter_controller.go
+++ b/pkg/gui/controllers/filter_controller.go
@@ -36,9 +36,10 @@ func (self *FilterController) Context() types.Context {
 func (self *FilterController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
 	return []*types.Binding{
 		{
-			Key:         opts.GetKey(opts.Config.Universal.StartSearch),
-			Handler:     self.OpenFilterPrompt,
-			Description: self.c.Tr.StartFilter,
+			Key:             opts.GetKey(opts.Config.Universal.StartSearch),
+			Handler:         self.OpenFilterPrompt,
+			Description:     self.c.Tr.StartFilter,
+			DisplayOnScreen: true,
 		},
 	}
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1522,7 +1522,7 @@ func EnglishTranslationSet() *TranslationSet {
 		NextScreenMode:                   "Next screen mode (normal/half/fullscreen)",
 		PrevScreenMode:                   "Prev screen mode",
 		StartSearch:                      "Search the current view by text",
-		StartFilter:                      "Filter the current view by text",
+		StartFilter:                      "Filter",
 		Panel:                            "Panel",
 		KeybindingsLegend:                "Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b",
 		RenameBranch:                     "Rename branch",


### PR DESCRIPTION
Update the controller (filter_controller.go) to set up the binding to be displayed. Additionally, update the translations for the binding name to be shorter, to make it more likely the text will fit at the bottom of the screen

The keybinding screen in particular (which is a filterable popup) seems frustrating for users. In #3141, @kadaan suggested that perhaps the keybindings page should display a message in the footer about the presence of this option as a way to increase discoverability.

I ran into this issue myself, and figured I'd see if anyone else had implemented some kind of fuzzy finding for the keybindings menu (somewhat like what `aerc` has). The issue I linked earlier seemed to describe the perfect solution, and it was easy enough to implement. Perhaps in the future the keybinding popup can have special functionality where typing automatically filters, but just having the filter option shown at the bottom seems to me a big improvement.

For reference, here's what the keybindings menu looks like with the change (notice the new "Filter" keybinding hint at the bottom):
![image](https://github.com/user-attachments/assets/13e39e2f-09ce-42f4-afd5-54fd141cec15)

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc