### PR TITLE
Fixes to lazygit Ubuntu install instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ sudo eopkg install lazygit
 ### Ubuntu
 
 ```sh
-LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-curl -Lo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz"
+LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | \grep -Po '"tag_name": *"v\K[^"]*')
+curl -Lo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz"
 tar xf lazygit.tar.gz lazygit
 sudo install lazygit -D -t /usr/local/bin/
 ```


### PR DESCRIPTION
- **PR Description**
Found that the method to pull the latest tarball for the project was incorrect. This pull request fixes the instructions in the Ubuntu section of the Readme.

Simple fix to README.md