### PR TITLE
Fix merge conflict resolution when file doesn't end with a LF

### DIFF
--- a/pkg/integration/tests/conflicts/resolve_without_trailing_lf.go
+++ b/pkg/integration/tests/conflicts/resolve_without_trailing_lf.go
@@ -1,0 +1,60 @@
+package conflicts
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ResolveWithoutTrailingLf = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Regression test for resolving a merge conflict when the file doesn't have a trailing newline",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			NewBranch("branch1").
+			CreateFileAndAdd("file", "a\n\nno eol").
+			Commit("initial commit").
+			UpdateFileAndAdd("file", "a1\n\nno eol").
+			Commit("commit on branch1").
+			NewBranchFrom("branch2", "HEAD^").
+			UpdateFileAndAdd("file", "a2\n\nno eol").
+			Commit("commit on branch2").
+			Checkout("branch1").
+			RunCommandExpectError([]string{"git", "merge", "--no-edit", "branch2"})
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			IsFocused().
+			Lines(
+				Contains("UU file").IsSelected(),
+			).
+			PressEnter()
+
+		t.Views().MergeConflicts().
+			IsFocused().
+			SelectedLines(
+				Contains("<<<<<<< HEAD"),
+				Contains("a1"),
+				Contains("======="),
+			).
+			SelectNextItem().
+			PressPrimaryAction()
+
+		t.ExpectPopup().Alert().
+			Title(Equals("Continue")).
+			Content(Contains("All merge conflicts resolved. Continue?")).
+			Cancel()
+
+		t.Views().Files().
+			Focus().
+			Lines(
+				Contains("M  file").IsSelected(),
+			)
+
+		/* EXPECTED:
+		t.Views().Main().Content(Contains("-a1\n+a2\n").DoesNotContain("-no eol"))
+		ACTUAL: */
+		t.Views().Main().Content(Contains("-a1\n+a2\n").Contains("-no eol"))
+	},
+})

--- a/pkg/integration/tests/conflicts/resolve_without_trailing_lf.go
+++ b/pkg/integration/tests/conflicts/resolve_without_trailing_lf.go
@@ -52,9 +52,6 @@ var ResolveWithoutTrailingLf = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("M  file").IsSelected(),
 			)
 
-		/* EXPECTED:
 		t.Views().Main().Content(Contains("-a1\n+a2\n").DoesNotContain("-no eol"))
-		ACTUAL: */
-		t.Views().Main().Content(Contains("-a1\n+a2\n").Contains("-no eol"))
 	},
 })

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -123,6 +123,7 @@ var tests = []*components.IntegrationTest{
 	conflicts.ResolveExternally,
 	conflicts.ResolveMultipleFiles,
 	conflicts.ResolveNoAutoStage,
+	conflicts.ResolveWithoutTrailingLf,
 	conflicts.UndoChooseHunk,
 	custom_commands.AccessCommitProperties,
 	custom_commands.BasicCommand,

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bufio"
+	"io"
 	"os"
 )
 
@@ -12,14 +13,18 @@ func ForEachLineInFile(path string, f func(string, int)) error {
 	}
 	defer file.Close()
 
-	reader := bufio.NewReader(file)
+	forEachLineInStream(file, f)
+
+	return nil
+}
+
+func forEachLineInStream(reader io.Reader, f func(string, int)) {
+	bufferedReader := bufio.NewReader(reader)
 	for i := 0; true; i++ {
-		line, err := reader.ReadString('\n')
+		line, err := bufferedReader.ReadString('\n')
 		if err != nil {
 			break
 		}
 		f(line, i)
 	}
-
-	return nil
 }

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -21,8 +21,8 @@ func ForEachLineInFile(path string, f func(string, int)) error {
 func forEachLineInStream(reader io.Reader, f func(string, int)) {
 	bufferedReader := bufio.NewReader(reader)
 	for i := 0; true; i++ {
-		line, err := bufferedReader.ReadString('\n')
-		if err != nil {
+		line, _ := bufferedReader.ReadString('\n')
+		if len(line) == 0 {
 			break
 		}
 		f(line, i)

--- a/pkg/utils/io_test.go
+++ b/pkg/utils/io_test.go
@@ -26,10 +26,7 @@ func Test_forEachLineInStream(t *testing.T) {
 		{
 			name:          "single line without line feed",
 			input:         "abc",
-			/* EXPECTED:
 			expectedLines: []string{"abc"},
-			ACTUAL: */
-			expectedLines: []string{},
 		},
 		{
 			name:          "multiple lines",
@@ -44,10 +41,7 @@ func Test_forEachLineInStream(t *testing.T) {
 		{
 			name:          "multiple lines without linefeed at end of file",
 			input:         "abc\ndef\nghi",
-			/* EXPECTED:
 			expectedLines: []string{"abc\n", "def\n", "ghi"},
-			ACTUAL: */
-			expectedLines: []string{"abc\n", "def\n"},
 		},
 	}
 

--- a/pkg/utils/io_test.go
+++ b/pkg/utils/io_test.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_forEachLineInStream(t *testing.T) {
+	scenarios := []struct {
+		name          string
+		input         string
+		expectedLines []string
+	}{
+		{
+			name:          "empty input",
+			input:         "",
+			expectedLines: []string{},
+		},
+		{
+			name:          "single line",
+			input:         "abc\n",
+			expectedLines: []string{"abc\n"},
+		},
+		{
+			name:          "single line without line feed",
+			input:         "abc",
+			/* EXPECTED:
+			expectedLines: []string{"abc"},
+			ACTUAL: */
+			expectedLines: []string{},
+		},
+		{
+			name:          "multiple lines",
+			input:         "abc\ndef\n",
+			expectedLines: []string{"abc\n", "def\n"},
+		},
+		{
+			name:          "multiple lines including empty lines",
+			input:         "abc\n\ndef\n",
+			expectedLines: []string{"abc\n", "\n", "def\n"},
+		},
+		{
+			name:          "multiple lines without linefeed at end of file",
+			input:         "abc\ndef\nghi",
+			/* EXPECTED:
+			expectedLines: []string{"abc\n", "def\n", "ghi"},
+			ACTUAL: */
+			expectedLines: []string{"abc\n", "def\n"},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			lines := []string{}
+			forEachLineInStream(strings.NewReader(s.input), func(line string, i int) {
+				lines = append(lines, line)
+			})
+			assert.EqualValues(t, s.expectedLines, lines)
+		})
+	}
+}


### PR DESCRIPTION
- **PR Description**

When resolving conflicts using lazygit's merge conflicts view in a file that doesn't end with a trailing line feed, the last line would be lost.

Fixes #3444.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
