### PR TITLE
Add support for ~/.config/lazygit without setting XDG_CONFIG_HOME on macOS

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -3,7 +3,7 @@
 Default path for the global config file:
 
 - Linux: `~/.config/lazygit/config.yml`
-- MacOS: `~/Library/Application\ Support/lazygit/config.yml`
+- MacOS: `~/.config/lazygit/config.yml` (previously `~/Library/Application\ Support/lazygit/config.yml`)
 - Windows: `%LOCALAPPDATA%\lazygit\config.yml` (default location, but it will also be found in `%APPDATA%\lazygit\config.yml`
 
 For old installations (slightly embarrassing: I didn't realise at the time that you didn't need to supply a vendor name to the path so I just used my name):
@@ -11,10 +11,6 @@ For old installations (slightly embarrassing: I didn't realise at the time that 
 - Linux: `~/.config/jesseduffield/lazygit/config.yml`
 - MacOS: `~/Library/Application\ Support/jesseduffield/lazygit/config.yml`
 - Windows: `%APPDATA%\jesseduffield\lazygit\config.yml`
-
-If you want to change the config directory:
-
-- MacOS: `export XDG_CONFIG_HOME="$HOME/.config"`
 
 In addition to the global config file you can create repo-specific config files in `<repo>/.git/lazygit.yml`. Settings in these files override settings in the global config file. In addition, files called `.lazygit.yml` in any of the parent directories of a repo will also be loaded; this can be useful if you have settings that you want to apply to a group of repositories.
 

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -417,13 +417,34 @@ func findConfigFile(filename string) (exists bool, path string) {
 		return true, legacyConfigPath
 	}
 
+	// if on macOs, default to looking in ~/.config/lazygit first since that's
+	// the most common location for CLI apps to store configuration when
+	// `XDG_CONFIG_HOME` is not set. The `xdg` package uses `~/Library/Application\ Support`
+	// as the default directory for macOS, so we have to handle this case manually.
+	if overrideXdgConfigHome && os.Getenv("XDG_CONFIG_HOME") == "" {
+		homeConfigFilePath, err := findHomeConfigFile(filename)
+		if err == nil {
+			return true, homeConfigFilePath
+		}
+	}
+
 	// look for lazygit/filename in XDG_CONFIG_HOME and XDG_CONFIG_DIRS
 	configFilepath, err := xdg.SearchConfigFile(filepath.Join("lazygit", filename))
 	if err == nil {
 		return true, configFilepath
 	}
 
-	return false, filepath.Join(xdg.ConfigHome, "lazygit", filename)
+	configHome := xdg.ConfigHome
+	// If we're on macOS and XDG_CONFIG_HOME is not set, we use
+	// ~/.config/lazygit instead of the default `~/Library/Application\ Support`
+	// directory the `xdg` package uses.
+	if overrideXdgConfigHome && os.Getenv("XDG_CONFIG_HOME") == "" {
+		if homeDir, err := os.UserHomeDir(); err == nil {
+			return false, filepath.Join(homeDir, ".config", "lazygit", filename)
+		}
+	}
+
+	return false, filepath.Join(configHome, "lazygit", filename)
 }
 
 var ConfigFilename = "config.yml"
@@ -561,4 +582,18 @@ func LogPath() (string, error) {
 	}
 
 	return stateFilePath("development.log")
+}
+
+func findHomeConfigFile(filename string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(home, ".config", "lazygit", filename)
+	if _, err = os.Stat(path); err != nil {
+		return "", err
+	}
+
+	return path, nil
 }

--- a/pkg/config/xdg.go
+++ b/pkg/config/xdg.go
@@ -1,0 +1,5 @@
+//go:build !darwin
+
+package config
+
+const overrideXdgConfigHome = false

--- a/pkg/config/xdg_darwin.go
+++ b/pkg/config/xdg_darwin.go
@@ -1,0 +1,5 @@
+//go:build darwin
+
+package config
+
+const overrideXdgConfigHome = true


### PR DESCRIPTION
Currently lazygit looks for its config file in `XDG_CONFIG_HOME` if it's available, but if not it falls back to the defaults defined by the [xdg](https://github.com/adrg/xdg) package. Unfortunately the defaults the package falls back to isn't what CLI applications commonly fall back to on macOS. Specifically, it looks in `~/Library/Application Support` instead of `~/.config`.

This updates the app config logic to:

- Look for `~/.config/lazygit` first if `XDG_CONFIG_HOME` is not set and we're on macOS.
- Fallback to the existing `xdg` package location if the configuration file exists there.
- Default to `~/.config/lazygit/config.yml` if `XDG_CONFIG_HOME` is not set, we're on macOS, and there is no existing configuration file.

This change did feel a bit like having to thread a needle and I didn't see any existing tests for this behavior (which is reasonable, since it's complicated and OS dependent) so I did test a few variations of the configuration locally by building with this change included and comparing against a `brew` installed lazygit.

It seemed to work properly, falling back to the existing location when `XDG_CONFIG_HOME` isn't set, using `~/.config/lazygit` when `config.yml` is present, and creating `~/.config/lazygit/config.yml` when it's not.

I think this should resolve https://github.com/jesseduffield/lazygit/issues/1341

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
