### PR TITLE
Fix scroll position when entering staging view by clicking in the main view

### DIFF
--- a/pkg/gui/context/patch_explorer_context.go
+++ b/pkg/gui/context/patch_explorer_context.go
@@ -53,7 +53,7 @@ func NewPatchExplorerContext(
 		func(selectedLineIdx int) error {
 			ctx.GetMutex().Lock()
 			defer ctx.GetMutex().Unlock()
-			ctx.NavigateTo(ctx.c.Context().IsCurrent(ctx), selectedLineIdx)
+			ctx.NavigateTo(selectedLineIdx)
 			return nil
 		}),
 	)
@@ -79,15 +79,15 @@ func (self *PatchExplorerContext) GetIncludedLineIndices() []int {
 	return self.getIncludedLineIndices()
 }
 
-func (self *PatchExplorerContext) RenderAndFocus(isFocused bool) {
-	self.setContent(isFocused)
+func (self *PatchExplorerContext) RenderAndFocus() {
+	self.setContent()
 
 	self.FocusSelection()
 	self.c.Render()
 }
 
-func (self *PatchExplorerContext) Render(isFocused bool) {
-	self.setContent(isFocused)
+func (self *PatchExplorerContext) Render() {
+	self.setContent()
 
 	self.c.Render()
 }
@@ -97,8 +97,8 @@ func (self *PatchExplorerContext) Focus() {
 	self.c.Render()
 }
 
-func (self *PatchExplorerContext) setContent(isFocused bool) {
-	self.GetView().SetContent(self.GetContentToRender(isFocused))
+func (self *PatchExplorerContext) setContent() {
+	self.GetView().SetContent(self.GetContentToRender())
 }
 
 func (self *PatchExplorerContext) FocusSelection() {
@@ -119,19 +119,19 @@ func (self *PatchExplorerContext) FocusSelection() {
 	view.SetCursorY(endIdx - newOriginY)
 }
 
-func (self *PatchExplorerContext) GetContentToRender(isFocused bool) string {
+func (self *PatchExplorerContext) GetContentToRender() string {
 	if self.GetState() == nil {
 		return ""
 	}
 
-	return self.GetState().RenderForLineIndices(isFocused, self.GetIncludedLineIndices())
+	return self.GetState().RenderForLineIndices(self.GetIncludedLineIndices())
 }
 
-func (self *PatchExplorerContext) NavigateTo(isFocused bool, selectedLineIdx int) {
+func (self *PatchExplorerContext) NavigateTo(selectedLineIdx int) {
 	self.GetState().SetLineSelectMode()
 	self.GetState().SelectLine(selectedLineIdx)
 
-	self.RenderAndFocus(isFocused)
+	self.RenderAndFocus()
 }
 
 func (self *PatchExplorerContext) GetMutex() *deadlock.Mutex {

--- a/pkg/gui/controllers/helpers/patch_building_helper.go
+++ b/pkg/gui/controllers/helpers/patch_building_helper.go
@@ -98,7 +98,7 @@ func (self *PatchBuildingHelper) RefreshPatchBuildingPanel(opts types.OnFocusOpt
 		return
 	}
 
-	mainContent := context.GetContentToRender(true)
+	mainContent := context.GetContentToRender()
 
 	self.c.Contexts().CustomPatchBuilder.FocusSelection()
 

--- a/pkg/gui/controllers/helpers/staging_helper.go
+++ b/pkg/gui/controllers/helpers/staging_helper.go
@@ -73,8 +73,8 @@ func (self *StagingHelper) RefreshStagingPanel(focusOpts types.OnFocusOpts) {
 	mainState := mainContext.GetState()
 	secondaryState := secondaryContext.GetState()
 
-	mainContent := mainContext.GetContentToRender(!secondaryFocused)
-	secondaryContent := secondaryContext.GetContentToRender(secondaryFocused)
+	mainContent := mainContext.GetContentToRender()
+	secondaryContent := secondaryContext.GetContentToRender()
 
 	mainContext.GetMutex().Unlock()
 	secondaryContext.GetMutex().Unlock()

--- a/pkg/gui/controllers/patch_explorer_controller.go
+++ b/pkg/gui/controllers/patch_explorer_controller.go
@@ -302,7 +302,7 @@ func (self *PatchExplorerController) withRenderAndFocus(f func() error) func() e
 			return err
 		}
 
-		self.context.RenderAndFocus(self.isFocused())
+		self.context.RenderAndFocus()
 		return nil
 	})
 }

--- a/pkg/gui/controllers/staging_controller.go
+++ b/pkg/gui/controllers/staging_controller.go
@@ -132,8 +132,6 @@ func (self *StagingController) GetOnFocusLost() func(types.OnFocusLostOpts) {
 		if opts.NewContextKey != self.otherContext.GetKey() {
 			self.c.Views().Staging.Wrap = true
 			self.c.Views().StagingSecondary.Wrap = true
-			self.c.Contexts().Staging.Render(false)
-			self.c.Contexts().StagingSecondary.Render(false)
 		}
 	}
 }

--- a/pkg/gui/patch_exploring/state.go
+++ b/pkg/gui/patch_exploring/state.go
@@ -249,7 +249,7 @@ func (s *State) AdjustSelectedLineIdx(change int) {
 	s.SelectLine(s.selectedLineIdx + change)
 }
 
-func (s *State) RenderForLineIndices(isFocused bool, includedLineIndices []int) string {
+func (s *State) RenderForLineIndices(includedLineIndices []int) string {
 	includedLineIndicesSet := set.NewFromSlice(includedLineIndices)
 	return s.patch.FormatView(patch.FormatViewOpts{
 		IncLineIndices: includedLineIndicesSet,

--- a/pkg/gui/tasks_adapter.go
+++ b/pkg/gui/tasks_adapter.go
@@ -53,9 +53,7 @@ func (gui *Gui) newStringTaskWithoutScroll(view *gocui.View, str string) error {
 		return nil
 	}
 
-	// Using empty key so that on subsequent calls we won't reset the view's origin.
-	// Note this means that we will be scrolling back to the top if we're switching from a different key
-	if err := manager.NewTask(f, ""); err != nil {
+	if err := manager.NewTask(f, manager.GetTaskKey()); err != nil {
 		return err
 	}
 
@@ -71,7 +69,7 @@ func (gui *Gui) newStringTaskWithScroll(view *gocui.View, str string, originX in
 		return nil
 	}
 
-	if err := manager.NewTask(f, ""); err != nil {
+	if err := manager.NewTask(f, manager.GetTaskKey()); err != nil {
 		return err
 	}
 

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -177,11 +177,11 @@ type IPatchExplorerContext interface {
 	GetState() *patch_exploring.State
 	SetState(*patch_exploring.State)
 	GetIncludedLineIndices() []int
-	RenderAndFocus(isFocused bool)
-	Render(isFocused bool)
+	RenderAndFocus()
+	Render()
 	Focus()
-	GetContentToRender(isFocused bool) string
-	NavigateTo(isFocused bool, selectedLineIdx int)
+	GetContentToRender() string
+	NavigateTo(selectedLineIdx int)
 	GetMutex() *deadlock.Mutex
 	IsPatchExplorerContext() // used for type switch
 }


### PR DESCRIPTION
This is both a bug fix and a behavior change:

- The bug fix is that when entering the staging view for a selected file by clicking in the main view, and the main view was scrolled down, then it would scroll to the top and show an ugly range selection from the line that was clicked to the line that is now under the mouse after scrolling up.
- The behavior change is that when leaving the staging view by pressing escape, it now retains its scroll position rather than scrolling back up to the top.

In addition, this fixes a minor flickering issue when leaving the staging view.

Note that maintaining the scroll position when going into and out of the staging view is not always perfect for two reasons:
- the focused staging view does not wrap long lines, but the unfocused one does
- a pager like delta might change the number of lines e.g. of the diff hunks

For the second problem there's little we can do, but the first one will be improved once we wrap lines in the focused staging view (see #1384 and #3558), which I'm currently working on.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
