### PR TITLE
Fix non-sticky range select after clicking in staging view

### DIFF
--- a/pkg/gui/gui_driver.go
+++ b/pkg/gui/gui_driver.go
@@ -57,6 +57,11 @@ func (self *GuiDriver) Click(x, y int) {
 		0,
 	)
 	self.waitTillIdle()
+	self.gui.g.ReplayedEvents.MouseEvents <- gocui.NewTcellMouseEventWrapper(
+		tcell.NewEventMouse(x, y, tcell.ButtonNone, 0),
+		0,
+	)
+	self.waitTillIdle()
 }
 
 // wait until lazygit is idle (i.e. all processing is done) before continuing

--- a/pkg/gui/patch_exploring/state.go
+++ b/pkg/gui/patch_exploring/state.go
@@ -94,7 +94,7 @@ func (s *State) ToggleStickySelectRange() {
 }
 
 func (s *State) ToggleSelectRange(sticky bool) {
-	if s.selectMode == RANGE {
+	if s.SelectingRange() {
 		s.selectMode = LINE
 	} else {
 		s.selectMode = RANGE

--- a/pkg/integration/tests/ui/range_select.go
+++ b/pkg/integration/tests/ui/range_select.go
@@ -50,7 +50,7 @@ var RangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 		shell.CreateFile("file1", fileContent)
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
-		assertRangeSelectBehaviour := func(v *ViewDriver) {
+		assertRangeSelectBehaviour := func(v *ViewDriver, otherView *ViewDriver, lineIdxOfFirstItem int) {
 			v.
 				SelectedLines(
 					Contains("line 1"),
@@ -152,9 +152,29 @@ var RangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 				SelectedLines(
 					Contains("line 10"),
 				)
+
+			// Click in view, press shift+arrow -> nonsticky range
+			otherView.Focus()
+			v.Click(1, lineIdxOfFirstItem).
+				SelectedLines(
+					Contains("line 1"),
+				).
+				Press(keys.Universal.RangeSelectDown)
+			if lineIdxOfFirstItem == 6 {
+				v.SelectedLines(
+					// bug: it moved to line 2 instead of selecting both line 1 and line 2
+					Contains("line 2"),
+				)
+			} else {
+				// works correctly in list views though
+				v.SelectedLines(
+					Contains("line 1"),
+					Contains("line 2"),
+				)
+			}
 		}
 
-		assertRangeSelectBehaviour(t.Views().Commits().Focus())
+		assertRangeSelectBehaviour(t.Views().Commits().Focus(), t.Views().Branches(), 0)
 
 		t.Views().Files().
 			Focus().
@@ -163,6 +183,6 @@ var RangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			PressEnter()
 
-		assertRangeSelectBehaviour(t.Views().Staging().IsFocused())
+		assertRangeSelectBehaviour(t.Views().Staging().IsFocused(), t.Views().Files(), 6)
 	},
 })

--- a/pkg/integration/tests/ui/range_select.go
+++ b/pkg/integration/tests/ui/range_select.go
@@ -159,19 +159,11 @@ var RangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 				SelectedLines(
 					Contains("line 1"),
 				).
-				Press(keys.Universal.RangeSelectDown)
-			if lineIdxOfFirstItem == 6 {
-				v.SelectedLines(
-					// bug: it moved to line 2 instead of selecting both line 1 and line 2
-					Contains("line 2"),
-				)
-			} else {
-				// works correctly in list views though
-				v.SelectedLines(
+				Press(keys.Universal.RangeSelectDown).
+				SelectedLines(
 					Contains("line 1"),
 					Contains("line 2"),
 				)
-			}
 		}
 
 		assertRangeSelectBehaviour(t.Views().Commits().Focus(), t.Views().Branches(), 0)


### PR DESCRIPTION
- **PR Description**

When clicking in a single-file diff view to enter staging (or custom patch editing, when coming from the commit files panel), and then pressing shift-down or shift-up to select a range, it would move the selected line rather than creating a range. Only on the next press would it start to select a range from there.

This is very similar to the fix we made for pressing escape in #3828.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
