### PR TITLE
Prompt for PIN on tpm-backed ssh keys

### DIFF
--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -376,8 +376,11 @@ func (self *cmdObjRunner) getCheckForCredentialRequestFunc() func([]byte) (Crede
 		`Password\s*for\s*'.+':`:                 Password,
 		`Username\s*for\s*'.+':`:                 Username,
 		`Enter\s*passphrase\s*for\s*key\s*'.+':`: Passphrase,
-		`Enter\s*PIN\s*for\s*.+\s*key\s*.+:`:     PIN,
-		`.*2FA Token.*`:                          Token,
+		// With a tpm, ssh prompts:
+		// Enter PIN for '%s':
+		// https://github.com/openssh/libopenssh/blob/05dfdd5f54d9a1bae5544141a7ee65baa3313ecd/ssh/ssh-pkcs11.c#L251
+		`Enter\s*PIN\s*for\s*.+\s*(key\s*.+|'.+'):`: PIN,
+		`.*2FA Token.*`: Token,
 	}
 
 	compiledPrompts := map[*regexp.Regexp]CredentialType{}

--- a/pkg/commands/oscommands/cmd_obj_runner_test.go
+++ b/pkg/commands/oscommands/cmd_obj_runner_test.go
@@ -95,6 +95,12 @@ func TestProcessOutput(t *testing.T) {
 			expectedToWrite:         "pin",
 		},
 		{
+			name:                    "tpm pin prompt",
+			promptUserForCredential: defaultPromptUserForCredential,
+			output:                  "Enter PIN for 'label':", // https://github.com/tpm2-software/tpm2-pkcs11/blob/d7fd660dd3ad2b8382afc57a768872032bd71d64/docs/SSH.md?plain=1#L86S
+			expectedToWrite:         "pin",
+		},
+		{
 			name:                    "2FA token prompt",
 			promptUserForCredential: defaultPromptUserForCredential,
 			output:                  "testuser 2FA Token (citadel)",


### PR DESCRIPTION
- **PR Description**

Prompt for PIN on tpm-backed ssh keys.

Typical prompt:
```
Enter PIN for 'label':
```

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] You've read through your own file changes for silly mistakes etc
