### PR TITLE
Add new filter to only show tracked files in Files panel

### DIFF
--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -696,6 +696,13 @@ func (self *FilesController) handleStatusFilterPressed() error {
 				Key: 'u',
 			},
 			{
+				Label: self.c.Tr.FilterTrackedFiles,
+				OnPress: func() error {
+					return self.setStatusFiltering(filetree.DisplayTracked)
+				},
+				Key: 't',
+			},
+			{
 				Label: self.c.Tr.ResetFilter,
 				OnPress: func() error {
 					return self.setStatusFiltering(filetree.DisplayAll)

--- a/pkg/gui/filetree/file_tree.go
+++ b/pkg/gui/filetree/file_tree.go
@@ -15,6 +15,7 @@ const (
 	DisplayAll FileTreeDisplayFilter = iota
 	DisplayStaged
 	DisplayUnstaged
+	DisplayTracked
 	// this shows files with merge conflicts
 	DisplayConflicted
 )
@@ -82,6 +83,8 @@ func (self *FileTree) getFilesForDisplay() []*models.File {
 		return self.FilterFiles(func(file *models.File) bool { return file.HasStagedChanges })
 	case DisplayUnstaged:
 		return self.FilterFiles(func(file *models.File) bool { return file.HasUnstagedChanges })
+	case DisplayTracked:
+		return self.FilterFiles(func(file *models.File) bool { return file.Tracked })
 	case DisplayConflicted:
 		return self.FilterFiles(func(file *models.File) bool { return file.HasMergeConflicts })
 	default:

--- a/pkg/gui/filetree/file_tree_test.go
+++ b/pkg/gui/filetree/file_tree_test.go
@@ -41,6 +41,19 @@ func TestFilterAction(t *testing.T) {
 			},
 		},
 		{
+			name:   "filter files that are tracked",
+			filter: DisplayTracked,
+			files: []*models.File{
+				{Name: "dir2/dir2/file4", ShortStatus: "M ", Tracked: true},
+				{Name: "dir2/file5", ShortStatus: "M ", Tracked: false},
+				{Name: "file1", ShortStatus: "M ", Tracked: true},
+			},
+			expected: []*models.File{
+				{Name: "dir2/dir2/file4", ShortStatus: "M ", Tracked: true},
+				{Name: "file1", ShortStatus: "M ", Tracked: true},
+			},
+		},
+		{
 			name:   "filter all files",
 			filter: DisplayAll,
 			files: []*models.File{

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -87,6 +87,7 @@ type TranslationSet struct {
 	AllFilesDiffCopiedToast               string
 	FilterStagedFiles                     string
 	FilterUnstagedFiles                   string
+	FilterTrackedFiles                    string
 	ResetFilter                           string
 	MergeConflictsTitle                   string
 	Checkout                              string
@@ -1075,6 +1076,7 @@ func EnglishTranslationSet() *TranslationSet {
 		AllFilesDiffCopiedToast:              "All files diff copied to clipboard",
 		FilterStagedFiles:                    "Show only staged files",
 		FilterUnstagedFiles:                  "Show only unstaged files",
+		FilterTrackedFiles:                   "Show only tracked files",
 		ResetFilter:                          "Reset filter",
 		NoChangedFiles:                       "No changed files",
 		SoftReset:                            "Soft reset",


### PR DESCRIPTION
- **PR Description**

Added new filter to only show tracked files in Files panel. This allows to hide all non-tracked files on large repos.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->

FYI This is my first PR in this repo.