### PR TITLE
Prepare remote url for specific branch

### DIFF
--- a/pkg/commands/git_commands/remote.go
+++ b/pkg/commands/git_commands/remote.go
@@ -76,6 +76,16 @@ func (self *RemoteCommands) CheckRemoteBranchExists(branchName string) bool {
 	return err == nil
 }
 
+// Returns remote name for branch
+func (self *RemoteCommands) GetRemoteName(branchName string) (string, error) {
+	cmdArgs := NewGitCmd("config").
+		Arg(fmt.Sprintf("branch.%s.remote", branchName)).
+		ToArgv()
+
+	remote, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
+	return strings.TrimSpace(remote), err
+}
+
 // Resolve what might be a aliased URL into a full URL
 // SEE: `man -P 'less +/--get-url +n' git-ls-remote`
 func (self *RemoteCommands) GetRemoteURL(remoteName string) (string, error) {

--- a/pkg/gui/controllers/helpers/host_helper.go
+++ b/pkg/gui/controllers/helpers/host_helper.go
@@ -42,7 +42,12 @@ func (self *HostHelper) GetCommitURL(commitHash string) (string, error) {
 // getting this on every request rather than storing it in state in case our remoteURL changes
 // from one invocation to the next.
 func (self *HostHelper) getHostingServiceMgr() (*hosting_service.HostingServiceMgr, error) {
-	remoteUrl, err := self.c.Git().Remote.GetRemoteURL("origin")
+	branch := self.c.IGetContexts.Contexts().Branches.GetSelected().Name
+	remoteName, err := self.c.Git().Remote.GetRemoteName(branch)
+	if err != nil {
+		return nil, err
+	}
+	remoteUrl, err := self.c.Git().Remote.GetRemoteURL(remoteName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- **PR Description**
Before we always use "origin". Now I modified the operation to check the remote for a given branch, and based on the remote name, a remote URL is created. Fixed #3997 

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
