### PR TITLE
Graph highlight color depends on userconfig property

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -152,6 +152,10 @@ gui:
     defaultFgColor:
       - default
 
+    # Color for commit tree graph
+    commitTreeGraphHighlightColor:
+      - lightwhite
+
   # Config relating to the commit length indicator
   commitLength:
     # If true, show an indicator of commit message length

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -197,6 +197,8 @@ type ThemeConfig struct {
 	UnstagedChangesColor []string `yaml:"unstagedChangesColor" jsonschema:"minItems=1,uniqueItems=true"`
 	// Default text color
 	DefaultFgColor []string `yaml:"defaultFgColor" jsonschema:"minItems=1,uniqueItems=true"`
+	// Color for commit tree graph
+	CommitTreeGraphHighlightColor []string `yaml:"commitTreeGraphHighlightColor" jsonschema:"minItems=1,uniqueItems=true"`
 }
 
 type CommitLengthConfig struct {
@@ -704,6 +706,7 @@ func GetDefaultConfig() *UserConfig {
 				MarkedBaseCommitFgColor:         []string{"blue"},
 				UnstagedChangesColor:            []string{"red"},
 				DefaultFgColor:                  []string{"default"},
+				CommitTreeGraphHighlightColor:   []string{"lightwhite"},
 			},
 			CommitLength:                 CommitLengthConfig{Show: true},
 			SkipNoStagedFilesWarning:     false,

--- a/pkg/gui/presentation/graph/graph.go
+++ b/pkg/gui/presentation/graph/graph.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jesseduffield/generics/set"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
+	"github.com/jesseduffield/lazygit/pkg/theme"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
@@ -30,7 +31,7 @@ type Pipe struct {
 	style    style.TextStyle
 }
 
-var highlightStyle = style.FgLightWhite.SetBold()
+var highlightStyle = theme.CommitTreeGraphHighlightColor.SetBold()
 
 func ContainsCommitHash(pipes []*Pipe, hash string) bool {
 	for _, pipe := range pipes {

--- a/pkg/gui/style/basic_styles.go
+++ b/pkg/gui/style/basic_styles.go
@@ -48,6 +48,7 @@ var (
 		"magenta": {FgMagenta, BgMagenta},
 		"cyan":    {FgCyan, BgCyan},
 		"white":   {FgWhite, BgWhite},
+		"lightwhite": {FgLightWhite, BgWhite},
 	}
 )
 

--- a/pkg/theme/theme.go
+++ b/pkg/theme/theme.go
@@ -45,6 +45,8 @@ var (
 	DiffTerminalColor = style.FgMagenta
 
 	UnstagedChangesColor = style.New()
+
+	CommitTreeGraphHighlightColor = style.New()
 )
 
 // UpdateTheme updates all theme variables
@@ -73,4 +75,6 @@ func UpdateTheme(themeConfig config.ThemeConfig) {
 
 	DefaultTextColor = GetTextStyle(themeConfig.DefaultFgColor, false)
 	GocuiDefaultTextColor = GetGocuiStyle(themeConfig.DefaultFgColor)
+
+  CommitTreeGraphHighlightColor = GetTextStyle(themeConfig.CommitTreeGraphHighlightColor, false)
 }

--- a/schema/config.json
+++ b/schema/config.json
@@ -265,6 +265,18 @@
               "default": [
                 "default"
               ]
+            },
+            "commitTreeGraphHighlightColor": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "description": "Color for commit tree graph",
+              "default": [
+                "lightwhite"
+              ]
             }
           },
           "additionalProperties": false,


### PR DESCRIPTION
- **PR Description**
Added to config CommitTreeGraphHighlightColor property Fix #3627 
- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
