### PR TITLE
Add worktree option to fast forwarding operation

### DIFF
--- a/pkg/commands/git_commands/git_command_builder.go
+++ b/pkg/commands/git_commands/git_command_builder.go
@@ -76,6 +76,14 @@ func (self *GitCommandBuilder) Worktree(path string) *GitCommandBuilder {
 	return self
 }
 
+func (self *GitCommandBuilder) WorktreePathIf(condition bool, path string) *GitCommandBuilder {
+	if condition {
+		return self.Worktree(path)
+	}
+
+	return self
+}
+
 // Note, you may prefer to use the Dir method instead of this one
 func (self *GitCommandBuilder) GitDir(path string) *GitCommandBuilder {
 	// git dir arg comes before the command

--- a/pkg/commands/git_commands/sync.go
+++ b/pkg/commands/git_commands/sync.go
@@ -88,6 +88,7 @@ type PullOptions struct {
 	BranchName      string
 	FastForwardOnly bool
 	WorktreeGitDir  string
+	WorktreePath    string
 }
 
 func (self *SyncCommands) Pull(task gocui.Task, opts PullOptions) error {
@@ -97,6 +98,7 @@ func (self *SyncCommands) Pull(task gocui.Task, opts PullOptions) error {
 		ArgIf(opts.RemoteName != "", opts.RemoteName).
 		ArgIf(opts.BranchName != "", "refs/heads/"+opts.BranchName).
 		GitDirIf(opts.WorktreeGitDir != "", opts.WorktreeGitDir).
+		WorktreePathIf(opts.WorktreePath != "", opts.WorktreePath).
 		ToArgv()
 
 	// setting GIT_SEQUENCE_EDITOR to ':' as a way of skipping it, in case the user

--- a/pkg/commands/git_commands/sync.go
+++ b/pkg/commands/git_commands/sync.go
@@ -101,7 +101,7 @@ func (self *SyncCommands) Pull(task gocui.Task, opts PullOptions) error {
 		WorktreePathIf(opts.WorktreePath != "", opts.WorktreePath).
 		ToArgv()
 
-	// setting GIT_SEQUENCE_EDITOR to ':' as a way of skipping if, in case the user
+	// setting GIT_SEQUENCE_EDITOR to ':' as a way of skipping it, in case the user
 	// has 'pull.rebase = interactive' configured.
 	return self.cmd.New(cmdArgs).AddEnvVars("GIT_SEQUENCE_EDITOR=:").PromptOnCredentialRequest(task).Run()
 }

--- a/pkg/commands/git_commands/sync.go
+++ b/pkg/commands/git_commands/sync.go
@@ -101,7 +101,7 @@ func (self *SyncCommands) Pull(task gocui.Task, opts PullOptions) error {
 		WorktreePathIf(opts.WorktreePath != "", opts.WorktreePath).
 		ToArgv()
 
-	// setting GIT_SEQUENCE_EDITOR to ':' as a way of skipping it, in case the user
+	// setting GIT_SEQUENCE_EDITOR to ':' as a way of skipping if, in case the user
 	// has 'pull.rebase = interactive' configured.
 	return self.cmd.New(cmdArgs).AddEnvVars("GIT_SEQUENCE_EDITOR=:").PromptOnCredentialRequest(task).Run()
 }

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -629,9 +629,11 @@ func (self *BranchesController) fastForward(branch *models.Branch) error {
 			self.c.LogAction(action)
 
 			worktreeGitDir := ""
+			worktreePath := ""
 			// if it is the current worktree path, no need to specify the path
 			if !worktree.IsCurrent {
 				worktreeGitDir = worktree.GitDir
+				worktreePath = worktree.Path
 			}
 
 			err := self.c.Git().Sync.Pull(
@@ -641,6 +643,7 @@ func (self *BranchesController) fastForward(branch *models.Branch) error {
 					BranchName:      branch.UpstreamBranch,
 					FastForwardOnly: true,
 					WorktreeGitDir:  worktreeGitDir,
+					WorktreePath: worktreePath,
 				},
 			)
 			_ = self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -643,7 +643,7 @@ func (self *BranchesController) fastForward(branch *models.Branch) error {
 					BranchName:      branch.UpstreamBranch,
 					FastForwardOnly: true,
 					WorktreeGitDir:  worktreeGitDir,
-					WorktreePath: worktreePath,
+					WorktreePath:    worktreePath,
 				},
 			)
 			_ = self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -380,6 +380,7 @@ var tests = []*components.IntegrationTest{
 	worktree.DoubleNestedLinkedSubmodule,
 	worktree.ExcludeFileInWorktree,
 	worktree.FastForwardWorktreeBranch,
+	worktree.FastForwardWorktreeBranchShouldNotPolluteCurrentWorktree,
 	worktree.ForceRemoveWorktree,
 	worktree.RemoveWorktreeFromBranch,
 	worktree.ResetWindowTabs,

--- a/pkg/integration/tests/worktree/fast_forward_worktree_branch_should_not_pollute_current_worktree.go
+++ b/pkg/integration/tests/worktree/fast_forward_worktree_branch_should_not_pollute_current_worktree.go
@@ -1,0 +1,59 @@
+package worktree
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var FastForwardWorktreeBranchShouldNotPolluteCurrentWorktree = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Fast-forward a linked worktree branch from another worktree",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		// both main and linked worktree will have changed to fast-forward
+		shell.NewBranch("mybranch")
+		shell.CreateFileAndAdd("README.md", "hello world")
+		shell.Commit("initial commit")
+		shell.EmptyCommit("two")
+		shell.EmptyCommit("three")
+		shell.NewBranch("newbranch")
+
+		shell.CloneIntoRemote("origin")
+		shell.SetBranchUpstream("mybranch", "origin/mybranch")
+		shell.SetBranchUpstream("newbranch", "origin/newbranch")
+
+		// remove the 'three' commit so that we have something to pull from the remote
+		shell.HardReset("HEAD^")
+		shell.Checkout("mybranch")
+		shell.HardReset("HEAD^")
+
+		shell.AddWorktreeCheckout("newbranch", "../linked-worktree")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("mybranch").Contains("↓1").IsSelected(),
+				Contains("newbranch (worktree)").Contains("↓1"),
+			).
+			Press(keys.Branches.FastForward).
+			Lines(
+				Contains("mybranch").Contains("✓").IsSelected(),
+				Contains("newbranch (worktree)").Contains("↓1"),
+			).
+			NavigateToLine(Contains("newbranch (worktree)")).
+			Press(keys.Branches.FastForward).
+			Lines(
+				Contains("mybranch").Contains("✓"),
+				Contains("newbranch (worktree)").Contains("✓").IsSelected(),
+			).
+			NavigateToLine(Contains("mybranch"))
+
+		// check the current worktree that it has no lines in the File changes pane
+		t.Views().Files().
+			Focus().
+			Press(keys.Files.RefreshFiles).
+			LineCount(EqualsInt(0))
+	},
+})


### PR DESCRIPTION
- **PR Description**

Fix a reported issue regarding Fast-forwarding a branch that is checked out in a different worktree. It's reported, and I could [repro](https://github.com/jesseduffield/lazygit/issues/2957#issuecomment-2462872838), that whenever such an action is taken, the current worktree is polluted with unwanted File changes related to the Fast-forward operation.

A solution is suggested – and tested to produce expected results – that adding `--work-tree` option to the generated command should fix the issue.

[Issue: 2957](https://github.com/jesseduffield/lazygit/issues/2957)

I'm proposing to merge these changes as it produces expected results:
<img width="1722" alt="Screenshot 2024-11-08 at 19 55 31" src="https://github.com/user-attachments/assets/89ac1c8d-7a64-4d88-afd9-3ec3d41705f1">



- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
