### PR TITLE
Basic Subtree support

### DIFF
--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -284,3 +284,12 @@ func (self *BranchCommands) IsBranchMerged(branch *models.Branch, mainBranches *
 
 	return stdout == "", nil
 }
+
+// Creates a Subtree from the selected branch
+func (self *BranchCommands) CreateSubtree(remoteName string, branch string) error {
+	cmdArgs := NewGitCmd("subtree").
+		Arg("add", fmt.Sprintf("--prefix=%s", remoteName), remoteName, branch).
+		ToArgv()
+
+	return self.cmd.New(cmdArgs).Run()
+}

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -465,6 +465,7 @@ type KeybindingBranchesConfig struct {
 	SetUpstream            string `yaml:"setUpstream"`
 	FetchRemote            string `yaml:"fetchRemote"`
 	SortOrder              string `yaml:"sortOrder"`
+	CreateSubtree          string `yaml:"createSubtree"`
 }
 
 type KeybindingWorktreesConfig struct {
@@ -904,6 +905,7 @@ func GetDefaultConfig() *UserConfig {
 				SetUpstream:            "u",
 				FetchRemote:            "f",
 				SortOrder:              "s",
+				CreateSubtree:          "S",
 			},
 			Worktrees: KeybindingWorktreesConfig{
 				ViewWorktreeOptions: "w",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -248,6 +248,7 @@ type TranslationSet struct {
 	CopyPullRequestURL                    string
 	NoBranchOnRemote                      string
 	Fetch                                 string
+	Subtree                               string
 	FetchTooltip                          string
 	NoAutomaticGitFetchTitle              string
 	NoAutomaticGitFetchBody               string
@@ -515,6 +516,7 @@ type TranslationSet struct {
 	ForceTag                              string
 	ForceTagPrompt                        string
 	FetchRemoteTooltip                    string
+	SubtreeToolTip                        string
 	FetchingRemoteStatus                  string
 	CheckoutCommit                        string
 	CheckoutCommitTooltip                 string
@@ -918,6 +920,7 @@ type Actions struct {
 	SetBranchUpstream                 string
 	AddRemote                         string
 	RemoveRemote                      string
+	CreateSubtree                     string
 	UpdateRemote                      string
 	ApplyPatch                        string
 	Stash                             string
@@ -1232,6 +1235,7 @@ func EnglishTranslationSet() *TranslationSet {
 		CopyPullRequestURL:                   `Copy pull request URL to clipboard`,
 		NoBranchOnRemote:                     `This branch doesn't exist on remote. You need to push it to remote first.`,
 		Fetch:                                `Fetch`,
+		Subtree:                              "Subtree",
 		FetchTooltip:                         "Fetch changes from remote.",
 		NoAutomaticGitFetchTitle:             `No automatic git fetch`,
 		NoAutomaticGitFetchBody:              `Lazygit can't use "git fetch" in a private repo; use 'f' in the files panel to run "git fetch" manually`,
@@ -1508,6 +1512,7 @@ func EnglishTranslationSet() *TranslationSet {
 		ForceTag:               "Force Tag",
 		ForceTagPrompt:         "The tag '{{.tagName}}' exists already. Press {{.cancelKey}} to cancel, or {{.confirmKey}} to overwrite.",
 		FetchRemoteTooltip:     "Fetch updates from the remote repository. This retrieves new commits and branches without merging them into your local branches.",
+		SubtreeToolTip:         "Create a subtree from the selected branch.",
 		FetchingRemoteStatus:   "Fetching remote",
 		CheckoutCommit:         "Checkout commit",
 		CheckoutCommitTooltip:  "Checkout the selected commit as a detached HEAD.",


### PR DESCRIPTION
- **PR Description**
This PR allows the user to create a subtree from a selected remote branch. User can only create a Subtree at the moment.
- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc