### PR TITLE
Delete range selection of branches

### DIFF
--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -109,10 +109,10 @@ func (self *BranchCommands) CurrentBranchName() (string, error) {
 }
 
 // LocalDelete delete branch locally
-func (self *BranchCommands) LocalDelete(branch string, force bool) error {
+func (self *BranchCommands) LocalDelete(branches []string, force bool) error {
 	cmdArgs := NewGitCmd("branch").
 		ArgIfElse(force, "-D", "-d").
-		Arg(branch).
+		Arg(branches...).
 		ToArgv()
 
 	return self.cmd.New(cmdArgs).Run()

--- a/pkg/commands/git_commands/branch_test.go
+++ b/pkg/commands/git_commands/branch_test.go
@@ -62,15 +62,17 @@ func TestBranchNewBranch(t *testing.T) {
 
 func TestBranchDeleteBranch(t *testing.T) {
 	type scenario struct {
-		testName string
-		force    bool
-		runner   *oscommands.FakeCmdObjRunner
-		test     func(error)
+		testName    string
+		branchNames []string
+		force       bool
+		runner      *oscommands.FakeCmdObjRunner
+		test        func(error)
 	}
 
 	scenarios := []scenario{
 		{
 			"Delete a branch",
+			[]string{"test"},
 			false,
 			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"branch", "-d", "test"}, "", nil),
 			func(err error) {
@@ -78,9 +80,28 @@ func TestBranchDeleteBranch(t *testing.T) {
 			},
 		},
 		{
+			"Delete multiple branches",
+			[]string{"test1", "test2", "test3"},
+			false,
+			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"branch", "-d", "test1", "test2", "test3"}, "", nil),
+			func(err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
 			"Force delete a branch",
+			[]string{"test"},
 			true,
 			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"branch", "-D", "test"}, "", nil),
+			func(err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			"Force delete multiple branches",
+			[]string{"test1", "test2", "test3"},
+			true,
+			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"branch", "-D", "test1", "test2", "test3"}, "", nil),
 			func(err error) {
 				assert.NoError(t, err)
 			},
@@ -91,7 +112,7 @@ func TestBranchDeleteBranch(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildBranchCommands(commonDeps{runner: s.runner})
 
-			s.test(instance.LocalDelete("test", s.force))
+			s.test(instance.LocalDelete(s.branchNames, s.force))
 			s.runner.CheckForMissingCalls()
 		})
 	}

--- a/pkg/commands/git_commands/remote.go
+++ b/pkg/commands/git_commands/remote.go
@@ -49,9 +49,10 @@ func (self *RemoteCommands) UpdateRemoteUrl(remoteName string, updatedUrl string
 	return self.cmd.New(cmdArgs).Run()
 }
 
-func (self *RemoteCommands) DeleteRemoteBranch(task gocui.Task, remoteName string, branchName string) error {
+func (self *RemoteCommands) DeleteRemoteBranch(task gocui.Task, remoteName string, branchNames []string) error {
 	cmdArgs := NewGitCmd("push").
-		Arg(remoteName, "--delete", branchName).
+		Arg(remoteName, "--delete").
+		Arg(branchNames...).
 		ToArgv()
 
 	return self.cmd.New(cmdArgs).PromptOnCredentialRequest(task).Run()

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -525,7 +525,8 @@ func (self *BranchesController) localDelete(branch *models.Branch) error {
 }
 
 func (self *BranchesController) remoteDelete(branch *models.Branch) error {
-	return self.c.Helpers().BranchesHelper.ConfirmDeleteRemote(branch.UpstreamRemote, branch.UpstreamBranch)
+	remoteBranch := &models.RemoteBranch{Name: branch.UpstreamBranch, RemoteName: branch.UpstreamRemote}
+	return self.c.Helpers().BranchesHelper.ConfirmDeleteRemote(remoteBranch)
 }
 
 func (self *BranchesController) localAndRemoteDelete(branch *models.Branch) error {

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -534,6 +534,8 @@ func (self *BranchesController) localAndRemoteDelete(branch *models.Branch) erro
 
 func (self *BranchesController) delete(branch *models.Branch) error {
 	checkedOutBranch := self.c.Helpers().Refs.GetCheckedOutRef()
+	isBranchCheckedOut := checkedOutBranch.Name == branch.Name
+	hasUpstream := branch.IsTrackingRemote() && !branch.UpstreamGone
 
 	localDeleteItem := &types.MenuItem{
 		Label: self.c.Tr.DeleteLocalBranch,
@@ -542,7 +544,7 @@ func (self *BranchesController) delete(branch *models.Branch) error {
 			return self.localDelete(branch)
 		},
 	}
-	if checkedOutBranch.Name == branch.Name {
+	if isBranchCheckedOut {
 		localDeleteItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.CantDeleteCheckOutBranch}
 	}
 
@@ -553,7 +555,7 @@ func (self *BranchesController) delete(branch *models.Branch) error {
 			return self.remoteDelete(branch)
 		},
 	}
-	if !branch.IsTrackingRemote() || branch.UpstreamGone {
+	if !hasUpstream {
 		remoteDeleteItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.UpstreamNotSetError}
 	}
 
@@ -564,9 +566,9 @@ func (self *BranchesController) delete(branch *models.Branch) error {
 			return self.localAndRemoteDelete(branch)
 		},
 	}
-	if checkedOutBranch.Name == branch.Name {
+	if isBranchCheckedOut {
 		deleteBothItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.CantDeleteCheckOutBranch}
-	} else if !branch.IsTrackingRemote() || branch.UpstreamGone {
+	} else if !hasUpstream {
 		deleteBothItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.UpstreamNotSetError}
 	}
 

--- a/pkg/gui/controllers/helpers/branches_helper.go
+++ b/pkg/gui/controllers/helpers/branches_helper.go
@@ -66,18 +66,18 @@ func (self *BranchesHelper) ConfirmLocalDelete(branch *models.Branch) error {
 	return nil
 }
 
-func (self *BranchesHelper) ConfirmDeleteRemote(remoteName string, branchName string) error {
+func (self *BranchesHelper) ConfirmDeleteRemote(remoteBranch *models.RemoteBranch) error {
 	title := utils.ResolvePlaceholderString(
 		self.c.Tr.DeleteBranchTitle,
 		map[string]string{
-			"selectedBranchName": branchName,
+			"selectedBranchName": remoteBranch.Name,
 		},
 	)
 	prompt := utils.ResolvePlaceholderString(
 		self.c.Tr.DeleteRemoteBranchPrompt,
 		map[string]string{
-			"selectedBranchName": branchName,
-			"upstream":           remoteName,
+			"selectedBranchName": remoteBranch.Name,
+			"upstream":           remoteBranch.RemoteName,
 		},
 	)
 	self.c.Confirm(types.ConfirmOpts{
@@ -86,7 +86,7 @@ func (self *BranchesHelper) ConfirmDeleteRemote(remoteName string, branchName st
 		HandleConfirm: func() error {
 			return self.c.WithWaitingStatus(self.c.Tr.DeletingStatus, func(task gocui.Task) error {
 				self.c.LogAction(self.c.Tr.Actions.DeleteRemoteBranch)
-				if err := self.c.Git().Remote.DeleteRemoteBranch(task, remoteName, branchName); err != nil {
+				if err := self.c.Git().Remote.DeleteRemoteBranch(task, remoteBranch.RemoteName, remoteBranch.Name); err != nil {
 					return err
 				}
 				return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.BRANCHES, types.REMOTES}})

--- a/pkg/gui/controllers/remote_branches_controller.go
+++ b/pkg/gui/controllers/remote_branches_controller.go
@@ -133,7 +133,7 @@ func (self *RemoteBranchesController) context() *context.RemoteBranchesContext {
 }
 
 func (self *RemoteBranchesController) delete(selectedBranch *models.RemoteBranch) error {
-	return self.c.Helpers().BranchesHelper.ConfirmDeleteRemote(selectedBranch.RemoteName, selectedBranch.Name)
+	return self.c.Helpers().BranchesHelper.ConfirmDeleteRemote(selectedBranch)
 }
 
 func (self *RemoteBranchesController) merge(selectedBranch *models.RemoteBranch) error {

--- a/pkg/gui/controllers/remote_branches_controller.go
+++ b/pkg/gui/controllers/remote_branches_controller.go
@@ -66,8 +66,8 @@ func (self *RemoteBranchesController) GetKeybindings(opts types.KeybindingsOpts)
 		},
 		{
 			Key:               opts.GetKey(opts.Config.Universal.Remove),
-			Handler:           self.withItem(self.delete),
-			GetDisabledReason: self.require(self.singleItemSelected()),
+			Handler:           self.withItems(self.delete),
+			GetDisabledReason: self.require(self.itemRangeSelected()),
 			Description:       self.c.Tr.Delete,
 			Tooltip:           self.c.Tr.DeleteRemoteBranchTooltip,
 			DisplayOnScreen:   true,
@@ -132,8 +132,8 @@ func (self *RemoteBranchesController) context() *context.RemoteBranchesContext {
 	return self.c.Contexts().RemoteBranches
 }
 
-func (self *RemoteBranchesController) delete(selectedBranch *models.RemoteBranch) error {
-	return self.c.Helpers().BranchesHelper.ConfirmDeleteRemote(selectedBranch)
+func (self *RemoteBranchesController) delete(selectedBranches []*models.RemoteBranch) error {
+	return self.c.Helpers().BranchesHelper.ConfirmDeleteRemote(selectedBranches)
 }
 
 func (self *RemoteBranchesController) merge(selectedBranch *models.RemoteBranch) error {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -105,12 +105,17 @@ type TranslationSet struct {
 	NewBranchNameBranchOff                string
 	CantDeleteCheckOutBranch              string
 	DeleteBranchTitle                     string
+	DeleteBranchesTitle                   string
 	DeleteLocalBranch                     string
+	DeleteLocalBranches                   string
 	DeleteRemoteBranchOption              string
 	DeleteRemoteBranchPrompt              string
+	DeleteRemoteBranchesPrompt            string
 	DeleteLocalAndRemoteBranchPrompt      string
+	DeleteLocalAndRemoteBranchesPrompt    string
 	ForceDeleteBranchTitle                string
 	ForceDeleteBranchMessage              string
+	ForceDeleteBranchesMessage            string
 	RebaseBranch                          string
 	RebaseBranchTooltip                   string
 	CantRebaseOntoSelf                    string
@@ -472,8 +477,10 @@ type TranslationSet struct {
 	RemoveRemoteTooltip                   string
 	RemoveRemotePrompt                    string
 	DeleteRemoteBranch                    string
+	DeleteRemoteBranches                  string
 	DeleteRemoteBranchTooltip             string
 	DeleteLocalAndRemoteBranch            string
+	DeleteLocalAndRemoteBranches          string
 	SetAsUpstream                         string
 	SetAsUpstreamTooltip                  string
 	SetUpstream                           string
@@ -542,6 +549,7 @@ type TranslationSet struct {
 	ViewBranchUpstreamOptions             string
 	ViewBranchUpstreamOptionsTooltip      string
 	UpstreamNotSetError                   string
+	UpstreamsNotSetError                  string
 	NewGitFlowBranchPrompt                string
 	RenameBranchWarning                   string
 	OpenKeybindingsMenu                   string
@@ -750,6 +758,7 @@ type TranslationSet struct {
 	SwitchToWorktreeTooltip                  string
 	AlreadyCheckedOutByWorktree              string
 	BranchCheckedOutByWorktree               string
+	SomeBranchesCheckedOutByWorktreeError    string
 	DetachWorktreeTooltip                    string
 	Switching                                string
 	RemoveWorktree                           string
@@ -1087,12 +1096,17 @@ func EnglishTranslationSet() *TranslationSet {
 		NewBranchNameBranchOff:               "New branch name (branch is off of '{{.branchName}}')",
 		CantDeleteCheckOutBranch:             "You cannot delete the checked out branch!",
 		DeleteBranchTitle:                    "Delete branch '{{.selectedBranchName}}'?",
+		DeleteBranchesTitle:                  "Delete selected branches?",
 		DeleteLocalBranch:                    "Delete local branch",
+		DeleteLocalBranches:                  "Delete local branches",
 		DeleteRemoteBranchOption:             "Delete remote branch",
 		DeleteRemoteBranchPrompt:             "Are you sure you want to delete the remote branch '{{.selectedBranchName}}' from '{{.upstream}}'?",
+		DeleteRemoteBranchesPrompt:           "Are you sure you want to delete the remote branches of the selected branches from their respective remotes?",
 		DeleteLocalAndRemoteBranchPrompt:     "Are you sure you want to delete both '{{.localBranchName}}' from your machine, and '{{.remoteBranchName}}' from '{{.remoteName}}'?",
+		DeleteLocalAndRemoteBranchesPrompt:   "Are you sure you want to delete both the selected branches from your machine, and their remote branches from their respective remotes?",
 		ForceDeleteBranchTitle:               "Force delete branch",
 		ForceDeleteBranchMessage:             "'{{.selectedBranchName}}' is not fully merged. Are you sure you want to delete it?",
+		ForceDeleteBranchesMessage:           "Some of the selected branches are not fully merged. Are you sure you want to delete them?",
 		RebaseBranch:                         "Rebase",
 		RebaseBranchTooltip:                  "Rebase the checked-out branch onto the selected branch.",
 		CantRebaseOntoSelf:                   "You cannot rebase a branch onto itself",
@@ -1464,8 +1478,10 @@ func EnglishTranslationSet() *TranslationSet {
 		RemoveRemoteTooltip:                  `Remove the selected remote. Any local branches tracking a remote branch from the remote will be unaffected.`,
 		RemoveRemotePrompt:                   "Are you sure you want to remove remote?",
 		DeleteRemoteBranch:                   "Delete remote branch",
+		DeleteRemoteBranches:                 "Delete remote branches",
 		DeleteRemoteBranchTooltip:            "Delete the remote branch from the remote.",
 		DeleteLocalAndRemoteBranch:           "Delete local and remote branch",
+		DeleteLocalAndRemoteBranches:         "Delete local and remote branches",
 		SetAsUpstream:                        "Set as upstream",
 		SetAsUpstreamTooltip:                 "Set the selected remote branch as the upstream of the checked-out branch.",
 		SetUpstream:                          "Set upstream of selected branch",
@@ -1530,6 +1546,7 @@ func EnglishTranslationSet() *TranslationSet {
 		ViewBranchUpstreamOptions:        "View upstream options",
 		ViewBranchUpstreamOptionsTooltip: "View options relating to the branch's upstream e.g. setting/unsetting the upstream and resetting to the upstream.",
 		UpstreamNotSetError:              "The selected branch has no upstream (or the upstream is not stored locally)",
+		UpstreamsNotSetError:             "Some of the selected branches have no upstream (or the upstream is not stored locally)",
 		Upstream:                         "Upstream",
 		UpstreamTooltip:                  "View upstream options for selected branch e.g. setting/unsetting the upstream and resetting to the upstream.",
 		NewBranchNamePrompt:              "Enter new branch name for branch",
@@ -1741,6 +1758,7 @@ func EnglishTranslationSet() *TranslationSet {
 		SwitchToWorktreeTooltip:                  "Switch to the selected worktree.",
 		AlreadyCheckedOutByWorktree:              "This branch is checked out by worktree {{.worktreeName}}. Do you want to switch to that worktree?",
 		BranchCheckedOutByWorktree:               "Branch {{.branchName}} is checked out by worktree {{.worktreeName}}",
+		SomeBranchesCheckedOutByWorktreeError:    "Some of the selected branches are checked out by other worktrees. Select them one by one to delete them.",
 		DetachWorktreeTooltip:                    "This will run `git checkout --detach` on the worktree so that it stops hogging the branch, but the worktree's working tree will be left alone.",
 		Switching:                                "Switching",
 		RemoveWorktree:                           "Remove worktree",

--- a/pkg/integration/tests/branch/delete.go
+++ b/pkg/integration/tests/branch/delete.go
@@ -150,24 +150,12 @@ var Delete = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			Tap(func() {
-				t.Views().Remotes().
-					Focus().
-					Lines(Contains("origin")).
-					PressEnter()
-
-				t.Views().
-					RemoteBranches().
-					Lines(
-						Equals("branch-five"),
-						Equals("branch-four"),
-						Equals("branch-six"),
-						Equals("branch-two"),
-					).
-					Press(keys.Universal.Return)
-
-				t.Views().
-					Branches().
-					Focus()
+				checkRemoteBranches(t, keys, "origin", []string{
+					"branch-five",
+					"branch-four",
+					"branch-six",
+					"branch-two",
+				})
 			}).
 			Lines(
 				Contains("current-head"),

--- a/pkg/integration/tests/branch/delete_multiple.go
+++ b/pkg/integration/tests/branch/delete_multiple.go
@@ -1,0 +1,186 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var DeleteMultiple = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Try some combinations of local and remote branch deletions with a range selection of branches",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetAppState().LocalBranchSortOrder = "alphabetic"
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			CloneIntoRemote("origin").
+			CloneIntoRemote("other-remote").
+			EmptyCommit("blah").
+			NewBranch("branch-01").
+			EmptyCommit("on branch-01 01").
+			PushBranchAndSetUpstream("origin", "branch-01").
+			EmptyCommit("on branch-01 02").
+			NewBranch("branch-02").
+			EmptyCommit("on branch-02 01").
+			PushBranchAndSetUpstream("origin", "branch-02").
+			NewBranchFrom("branch-03", "master").
+			EmptyCommit("on branch-03 01").
+			NewBranch("current-head").
+			EmptyCommit("on current-head").
+			NewBranchFrom("branch-04", "master").
+			EmptyCommit("on branch-04 01").
+			PushBranchAndSetUpstream("other-remote", "branch-04").
+			EmptyCommit("on branch-04 02").
+			NewBranchFrom("branch-05", "master").
+			EmptyCommit("on branch-05 01").
+			PushBranchAndSetUpstream("origin", "branch-05").
+			NewBranchFrom("branch-06", "master").
+			EmptyCommit("on branch-06 01").
+			PushBranch("origin", "branch-06").
+			PushBranchAndSetUpstream("other-remote", "branch-06").
+			EmptyCommit("on branch-06 02").
+			Checkout("current-head")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("current-head").IsSelected(),
+				Contains("branch-01 ↑1"),
+				Contains("branch-02 ✓"),
+				Contains("branch-03"),
+				Contains("branch-04 ↑1"),
+				Contains("branch-05 ✓"),
+				Contains("branch-06 ↑1"),
+				Contains("master"),
+			).
+			Press(keys.Universal.RangeSelectDown).
+
+			// Deleting a range that includes the current branch is not possible
+			Press(keys.Universal.Remove).
+			Tap(func() {
+				t.ExpectPopup().
+					Menu().
+					Tooltip(Contains("You cannot delete the checked out branch!")).
+					Title(Equals("Delete selected branches?")).
+					Select(Contains("Delete local branches")).
+					Confirm().
+					Tap(func() {
+						t.ExpectToast(Contains("You cannot delete the checked out branch!"))
+					}).
+					Cancel()
+			}).
+
+			// Delete branch-03 and branch-04. 04 is not fully merged, so we get
+			// a confirmation popup.
+			NavigateToLine(Contains("branch-03")).
+			Press(keys.Universal.RangeSelectDown).
+			Press(keys.Universal.Remove).
+			Tap(func() {
+				t.ExpectPopup().
+					Menu().
+					Title(Equals("Delete selected branches?")).
+					Select(Contains("Delete local branches")).
+					Confirm()
+				t.ExpectPopup().
+					Confirmation().
+					Title(Equals("Force delete branch")).
+					Content(Equals("Some of the selected branches are not fully merged. Are you sure you want to delete them?")).
+					Confirm()
+			}).
+			Lines(
+				Contains("current-head"),
+				Contains("branch-01 ↑1"),
+				Contains("branch-02 ✓"),
+				Contains("branch-05 ✓").IsSelected(),
+				Contains("branch-06 ↑1"),
+				Contains("master"),
+			).
+
+			// Delete remote branches of branch-05 and branch-06. They are on different remotes.
+			NavigateToLine(Contains("branch-05")).
+			Press(keys.Universal.RangeSelectDown).
+			Press(keys.Universal.Remove).
+			Tap(func() {
+				t.ExpectPopup().
+					Menu().
+					Title(Equals("Delete selected branches?")).
+					Select(Contains("Delete remote branches")).
+					Confirm()
+			}).
+			Tap(func() {
+				t.ExpectPopup().
+					Confirmation().
+					Title(Equals("Delete selected branches?")).
+					Content(Equals("Are you sure you want to delete the remote branches of the selected branches from their respective remotes?")).
+					Confirm()
+			}).
+			Tap(func() {
+				checkRemoteBranches(t, keys, "origin", []string{
+					"branch-01",
+					"branch-02",
+					"branch-06",
+				})
+				checkRemoteBranches(t, keys, "other-remote", []string{
+					"branch-04",
+				})
+			}).
+			Lines(
+				Contains("current-head"),
+				Contains("branch-01 ↑1"),
+				Contains("branch-02 ✓"),
+				Contains("branch-05 (upstream gone)").IsSelected(),
+				Contains("branch-06 (upstream gone)").IsSelected(),
+				Contains("master"),
+			).
+
+			// Try to delete both local and remote branches of branch-02 and
+			// branch-05; not possible because branch-05's upstream is gone
+			Press(keys.Universal.Remove).
+			Tap(func() {
+				t.ExpectPopup().
+					Menu().
+					Title(Equals("Delete selected branches?")).
+					Select(Contains("Delete local and remote branches")).
+					Confirm().
+					Tap(func() {
+						t.ExpectToast(Contains("Some of the selected branches have no upstream (or the upstream is not stored locally)"))
+					}).
+					Cancel()
+			}).
+
+			// Delete both local and remote branches of branch-01 and branch-02. We get
+			// the force-delete warning because branch-01 it is not fully merged.
+			NavigateToLine(Contains("branch-01")).
+			Press(keys.Universal.RangeSelectDown).
+			Press(keys.Universal.Remove).
+			Tap(func() {
+				t.ExpectPopup().
+					Menu().
+					Title(Equals("Delete selected branches?")).
+					Select(Contains("Delete local and remote branches")).
+					Confirm()
+				t.ExpectPopup().
+					Confirmation().
+					Title(Equals("Delete local and remote branch")).
+					Content(Contains("Are you sure you want to delete both the selected branches from your machine, and their remote branches from their respective remotes?").
+						Contains("Some of the selected branches are not fully merged. Are you sure you want to delete them?")).
+					Confirm()
+			}).
+			Lines(
+				Contains("current-head"),
+				Contains("branch-05 (upstream gone)").IsSelected(),
+				Contains("branch-06 (upstream gone)"),
+				Contains("master"),
+			).
+			Tap(func() {
+				checkRemoteBranches(t, keys, "origin", []string{
+					"branch-06",
+				})
+				checkRemoteBranches(t, keys, "other-remote", []string{
+					"branch-04",
+				})
+			})
+	},
+})

--- a/pkg/integration/tests/branch/shared.go
+++ b/pkg/integration/tests/branch/shared.go
@@ -1,0 +1,25 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+	"github.com/samber/lo"
+)
+
+func checkRemoteBranches(t *TestDriver, keys config.KeybindingConfig, remoteName string, expectedBranches []string) {
+	t.Views().Remotes().
+		Focus().
+		NavigateToLine(Contains(remoteName)).
+		PressEnter()
+
+	t.Views().
+		RemoteBranches().
+		Lines(
+			lo.Map(expectedBranches, func(branch string, _ int) *TextMatcher { return Equals(branch) })...,
+		).
+		Press(keys.Universal.Return)
+
+	t.Views().
+		Branches().
+		Focus()
+}

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -42,6 +42,7 @@ var tests = []*components.IntegrationTest{
 	branch.CheckoutByName,
 	branch.CreateTag,
 	branch.Delete,
+	branch.DeleteMultiple,
 	branch.DeleteRemoteBranchWithCredentialPrompt,
 	branch.DeleteRemoteBranchWithDifferentName,
 	branch.DetachedHead,


### PR DESCRIPTION
- **PR Description**

This allows range-selecting multiple branches and deleting them all at once. We allow deleting remote branches (or local and remote branches) as long as *all* selected branches have one.

We show the warning about force-deleting as soon as at least one of the selected branches is not fully merged.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
