### PR TITLE
Add hosting service definition for Azure DevOps Server

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -879,7 +879,7 @@ services:
 Where:
 
 - `gitDomain` stands for the domain used by git itself (i.e. the one present on clone URLs), e.g. `git.work.com`
-- `provider` is one of `github`, `bitbucket`, `bitbucketServer`, `azuredevops`, `gitlab` or `gitea`
+- `provider` is one of `github`, `bitbucket`, `bitbucketServer`, `azuredevops`, `azuredevopsServer`, `gitlab` or `gitea`
 - `webDomain` is the URL where your git service exposes a web interface and APIs, e.g. `gitservice.work.com`
 
 ## Predefined commit message prefix

--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -52,6 +52,18 @@ var azdoServiceDef = ServiceDefinition{
 	repoURLTemplate: "https://{{.webDomain}}/{{.org}}/{{.project}}/_git/{{.repo}}",
 }
 
+var azdoServerServiceDef = ServiceDefinition{
+	provider:                        "azuredevopsServer",
+	pullRequestURLIntoDefaultBranch: "/pullrequestcreate?sourceRef={{.From}}",
+	pullRequestURLIntoTargetBranch:  "/pullrequestcreate?sourceRef={{.From}}&targetRef={{.To}}",
+	commitURL:                       "/commit/{{.CommitHash}}",
+	regexStrings: []string{
+		`^(?:ssh://)?(?:git@)?[^:/]+(?::\d+)?[:/](?P<collection>[^/]+)/(?P<project>[^/]+)/(?P<repo>.+)$`,
+		`^https://[^/]+/(?P<collection>[^/]+)/(?P<project>[^/]+)/_git/(?P<repo>.+)$`,
+	},
+	repoURLTemplate: "https://{{.webDomain}}/{{.collection}}/{{.project}}/_git/{{.repo}}",
+}
+
 var bitbucketServerServiceDef = ServiceDefinition{
 	provider:                        "bitbucketServer",
 	pullRequestURLIntoDefaultBranch: "/pull-requests?create&sourceBranch={{.From}}",
@@ -78,6 +90,7 @@ var serviceDefinitions = []ServiceDefinition{
 	bitbucketServiceDef,
 	gitLabServiceDef,
 	azdoServiceDef,
+	azdoServerServiceDef,
 	bitbucketServerServiceDef,
 	giteaServiceDef,
 }

--- a/pkg/commands/hosting_service/hosting_service_test.go
+++ b/pkg/commands/hosting_service/hosting_service_test.go
@@ -211,6 +211,68 @@ func TestGetPullRequestURL(t *testing.T) {
 			},
 		},
 		{
+			testName:  "Opens a link to new pull request on Azure DevOps Server (SSH with scheme)",
+			from:      "feature/new",
+			remoteUrl: "ssh://my.server:22/DefaultCollection/myproject/myrepo",
+			configServiceDomains: map[string]string{
+				"my.server": "azuredevopsServer:my.server",
+			},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://my.server/DefaultCollection/myproject/_git/myrepo/pullrequestcreate?sourceRef=feature%2Fnew", url)
+			},
+		},
+		{
+			testName:  "Opens a link to new pull request on Azure DevOps Server (SSH without scheme)",
+			from:      "feature/new",
+			remoteUrl: "git@my.server:DefaultCollection/myproject/myrepo",
+			configServiceDomains: map[string]string{
+				"my.server": "azuredevopsServer:my.server",
+			},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://my.server/DefaultCollection/myproject/_git/myrepo/pullrequestcreate?sourceRef=feature%2Fnew", url)
+			},
+		},
+		{
+			testName:  "Opens a link to new pull request on Azure DevOps Server (SSH) with specific target",
+			from:      "feature/new",
+			to:        "dev",
+			remoteUrl: "git@my.server:DefaultCollection/myproject/myrepo",
+			configServiceDomains: map[string]string{
+				"my.server": "azuredevopsServer:my.server",
+			},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://my.server/DefaultCollection/myproject/_git/myrepo/pullrequestcreate?sourceRef=feature%2Fnew&targetRef=dev", url)
+			},
+		},
+		{
+			testName:  "Opens a link to new pull request on Azure DevOps Server (HTTP)",
+			from:      "feature/new",
+			remoteUrl: "https://my.server/DefaultCollection/myproject/_git/myrepo",
+			configServiceDomains: map[string]string{
+				"my.server": "azuredevopsServer:my.server",
+			},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://my.server/DefaultCollection/myproject/_git/myrepo/pullrequestcreate?sourceRef=feature%2Fnew", url)
+			},
+		},
+		{
+			testName:  "Opens a link to new pull request on Azure DevOps Server (HTTP) with specific target",
+			from:      "feature/new",
+			to:        "dev",
+			remoteUrl: "https://my.server/DefaultCollection/myproject/_git/myrepo",
+			configServiceDomains: map[string]string{
+				"my.server": "azuredevopsServer:my.server",
+			},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://my.server/DefaultCollection/myproject/_git/myrepo/pullrequestcreate?sourceRef=feature%2Fnew&targetRef=dev", url)
+			},
+		},
+		{
 			testName:  "Opens a link to new pull request on Bitbucket Server (SSH)",
 			from:      "feature/new",
 			remoteUrl: "ssh://git@mycompany.bitbucket.com/myproject/myrepo.git",
@@ -388,7 +450,7 @@ func TestGetPullRequestURL(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, "https://bitbucket.org/johndoe/social_network/pull-requests/new?source=feature%2Fprofile-page&t=1", url)
 			},
-			expectedLoggedErrors: []string{"Unknown git service type: 'noservice'. Expected one of github, bitbucket, gitlab, azuredevops, bitbucketServer, gitea"},
+			expectedLoggedErrors: []string{"Unknown git service type: 'noservice'. Expected one of github, bitbucket, gitlab, azuredevops, azuredevopsServer, bitbucketServer, gitea"},
 		},
 		{
 			testName:  "Escapes reserved URL characters in from branch name",


### PR DESCRIPTION
- **PR Description**

This adds a new service definition for Azure DevOps Server (the on-prem version of Azure DevOps Service). The service definition URLs are also slightly different from its cloud-hosted sibling.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [X] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc
