### PR TITLE
Cleanup background fetch

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -108,8 +108,6 @@ type Gui struct {
 
 	PopupHandler types.IPopupHandler
 
-	IsNewRepo bool
-
 	IsRefreshingFiles bool
 
 	// we use this to decide whether we'll return to the original directory that

--- a/pkg/gui/recent_repos_panel.go
+++ b/pkg/gui/recent_repos_panel.go
@@ -21,8 +21,7 @@ func (gui *Gui) updateRecentRepoList() error {
 	if err != nil {
 		return err
 	}
-	known, recentRepos := newRecentReposList(recentRepos, currentRepo)
-	gui.IsNewRepo = known
+	recentRepos = newRecentReposList(recentRepos, currentRepo)
 	// TODO: migrate this file to use forward slashes on all OSes for consistency
 	// (windows uses backslashes at the moment)
 	gui.c.GetAppState().RecentRepos = recentRepos
@@ -30,8 +29,7 @@ func (gui *Gui) updateRecentRepoList() error {
 }
 
 // newRecentReposList returns a new repo list with a new entry but only when it doesn't exist yet
-func newRecentReposList(recentRepos []string, currentRepo string) (bool, []string) {
-	isNew := true
+func newRecentReposList(recentRepos []string, currentRepo string) []string {
 	newRepos := []string{currentRepo}
 	for _, repo := range recentRepos {
 		if repo != currentRepo {
@@ -39,9 +37,7 @@ func newRecentReposList(recentRepos []string, currentRepo string) (bool, []strin
 				continue
 			}
 			newRepos = append(newRepos, repo)
-		} else {
-			isNew = false
 		}
 	}
-	return isNew, newRepos
+	return newRepos
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -249,8 +249,6 @@ type TranslationSet struct {
 	NoBranchOnRemote                      string
 	Fetch                                 string
 	FetchTooltip                          string
-	NoAutomaticGitFetchTitle              string
-	NoAutomaticGitFetchBody               string
 	FileEnter                             string
 	FileEnterTooltip                      string
 	FileStagingRequirements               string
@@ -1235,8 +1233,6 @@ func EnglishTranslationSet() *TranslationSet {
 		NoBranchOnRemote:                     `This branch doesn't exist on remote. You need to push it to remote first.`,
 		Fetch:                                `Fetch`,
 		FetchTooltip:                         "Fetch changes from remote.",
-		NoAutomaticGitFetchTitle:             `No automatic git fetch`,
-		NoAutomaticGitFetchBody:              `Lazygit can't use "git fetch" in a private repo; use 'f' in the files panel to run "git fetch" manually`,
 		FileEnter:                            `Stage lines / Collapse directory`,
 		FileEnterTooltip:                     "If the selected item is a file, focus the staging view so you can stage individual hunks/lines. If the selected item is a directory, collapse/expand it.",
 		FileStagingRequirements:              `Can only stage individual lines for tracked files`,


### PR DESCRIPTION
- **PR Description**

Simplify startBackgroundFetch

This code had a lot of logic that (fortunately) didn't work because it was buggy:

- it was supposed to wait for the auto-fetch delay before fetching for the first
  time in case we start with a repo that we had open in a previous session (i.e.
  that appears in the recent repos list). This code actually ran always, not
  just for known repos, because the IsNewRepo flag is only set later, after this
  function runs. Fortunately, the code didn't work, because time.After starts a
  timer but doesn't wait for it (to do that, it would have to be
  `<-time.After`).
- if the first fetch fails with error 128, it was supposed to show an error
  message and not start the background fetch loop. Fortunately, this didn't work
  because 1) it was guarded by isNew which is always false here, and 2) because
  git's error message in this case is actually "exit code: 128", not "exit
  status 128" (maybe this has changed in git at some point).

I find both of these undesirable. Whenever I open a repo I want an auto-fetch to
be triggered immediately to get my branch information up to date as quickly as
possible. And if the initial fetch fails (e.g. because one of my remotes is
offline or doesn't exist any more), then that's no reason not to start the
auto-fetch loop anyway.

So let's simplify the code to do what it did before, but with much fewer lines
of code.

See #4083.
