### PR TITLE
Fix moving a commit across a branch boundary in a stack of branches

### DIFF
--- a/pkg/app/daemon/daemon.go
+++ b/pkg/app/daemon/daemon.go
@@ -325,7 +325,7 @@ func (self *MoveTodosUpInstruction) run(common *common.Common) error {
 	})
 
 	return handleInteractiveRebase(common, func(path string) error {
-		return utils.MoveTodosUp(path, todosToMove, getCommentChar())
+		return utils.MoveTodosUp(path, todosToMove, false, getCommentChar())
 	})
 }
 
@@ -355,7 +355,7 @@ func (self *MoveTodosDownInstruction) run(common *common.Common) error {
 	})
 
 	return handleInteractiveRebase(common, func(path string) error {
-		return utils.MoveTodosDown(path, todosToMove, getCommentChar())
+		return utils.MoveTodosDown(path, todosToMove, false, getCommentChar())
 	})
 }
 

--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -369,7 +369,7 @@ func (self *RebaseCommands) MoveTodosDown(commits []*models.Commit) error {
 		return todoFromCommit(commit)
 	})
 
-	return utils.MoveTodosDown(fileName, todosToMove, self.config.GetCoreCommentChar())
+	return utils.MoveTodosDown(fileName, todosToMove, true, self.config.GetCoreCommentChar())
 }
 
 func (self *RebaseCommands) MoveTodosUp(commits []*models.Commit) error {
@@ -378,7 +378,7 @@ func (self *RebaseCommands) MoveTodosUp(commits []*models.Commit) error {
 		return todoFromCommit(commit)
 	})
 
-	return utils.MoveTodosUp(fileName, todosToMove, self.config.GetCoreCommentChar())
+	return utils.MoveTodosUp(fileName, todosToMove, true, self.config.GetCoreCommentChar())
 }
 
 // SquashAllAboveFixupCommits squashes all fixup! commits above the given one

--- a/pkg/integration/tests/interactive_rebase/move_across_branch_boundary_outside_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/move_across_branch_boundary_outside_rebase.go
@@ -37,16 +37,9 @@ var MoveAcrossBranchBoundaryOutsideRebase = NewIntegrationTest(NewIntegrationTes
 			NavigateToLine(Contains("commit 04")).
 			Press(keys.Commits.MoveDownCommit).
 			Lines(
-				/* EXPECTED:
 				Contains("CI commit 05"),
 				Contains("CI * commit 03"),
 				Contains("CI commit 04").IsSelected(),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
-				ACTUAL: */
-				Contains("CI commit 05"),
-				Contains("CI * commit 04"),
-				Contains("CI commit 03").IsSelected(),
 				Contains("CI commit 02"),
 				Contains("CI commit 01"),
 			)

--- a/pkg/integration/tests/interactive_rebase/move_across_branch_boundary_outside_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/move_across_branch_boundary_outside_rebase.go
@@ -1,0 +1,54 @@
+package interactive_rebase
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var MoveAcrossBranchBoundaryOutsideRebase = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Move a commit across a branch boundary in a stack of branches",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	GitVersion:   AtLeast("2.38.0"),
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Git.MainBranches = []string{"master"}
+		config.GetAppState().GitLogShowGraph = "never"
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			CreateNCommits(1).
+			NewBranch("branch1").
+			CreateNCommitsStartingAt(2, 2).
+			NewBranch("branch2").
+			CreateNCommitsStartingAt(2, 4)
+
+		shell.SetConfig("rebase.updateRefs", "true")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("CI commit 05").IsSelected(),
+				Contains("CI commit 04"),
+				Contains("CI * commit 03"),
+				Contains("CI commit 02"),
+				Contains("CI commit 01"),
+			).
+			NavigateToLine(Contains("commit 04")).
+			Press(keys.Commits.MoveDownCommit).
+			Lines(
+				/* EXPECTED:
+				Contains("CI commit 05"),
+				Contains("CI * commit 03"),
+				Contains("CI commit 04").IsSelected(),
+				Contains("CI commit 02"),
+				Contains("CI commit 01"),
+				ACTUAL: */
+				Contains("CI commit 05"),
+				Contains("CI * commit 04"),
+				Contains("CI commit 03").IsSelected(),
+				Contains("CI commit 02"),
+				Contains("CI commit 01"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -223,6 +223,7 @@ var tests = []*components.IntegrationTest{
 	interactive_rebase.InteractiveRebaseOfCopiedBranch,
 	interactive_rebase.MidRebaseRangeSelect,
 	interactive_rebase.Move,
+	interactive_rebase.MoveAcrossBranchBoundaryOutsideRebase,
 	interactive_rebase.MoveInRebase,
 	interactive_rebase.MoveUpdateRefTodo,
 	interactive_rebase.MoveWithCustomCommentChar,

--- a/pkg/utils/rebase_todo.go
+++ b/pkg/utils/rebase_todo.go
@@ -286,9 +286,9 @@ func RemoveUpdateRefsForCopiedBranch(fileName string, commentChar byte) error {
 }
 
 // We render a todo in the commits view if it's a commit or if it's an
-// update-ref. We don't render label, reset, or comment lines.
+// update-ref or exec. We don't render label, reset, or comment lines.
 func isRenderedTodo(t todo.Todo) bool {
-	return t.Commit != "" || t.Command == todo.UpdateRef
+	return t.Commit != "" || t.Command == todo.UpdateRef || t.Command == todo.Exec
 }
 
 func DropMergeCommit(fileName string, hash string, commentChar byte) error {

--- a/pkg/utils/rebase_todo_test.go
+++ b/pkg/utils/rebase_todo_test.go
@@ -89,12 +89,8 @@ func TestRebaseCommands_moveTodoDown(t *testing.T) {
 			todoToMoveDown: Todo{Hash: "5678"},
 			expectedErr:    "",
 			expectedTodos: []todo.Todo{
-				/* EXPECTED:
 				{Command: todo.Pick, Commit: "1234"},
 				{Command: todo.Pick, Commit: "5678"},
-				ACTUAL: */
-				{Command: todo.Pick, Commit: "5678"},
-				{Command: todo.Pick, Commit: "1234"},
 				{Command: todo.Exec, ExecCommand: "make test"},
 			},
 		},
@@ -250,12 +246,8 @@ func TestRebaseCommands_moveTodoUp(t *testing.T) {
 			expectedErr:  "",
 			expectedTodos: []todo.Todo{
 				{Command: todo.Exec, ExecCommand: "make test"},
-				/* EXPECTED:
 				{Command: todo.Pick, Commit: "1234"},
 				{Command: todo.Pick, Commit: "5678"},
-				ACTUAL: */
-				{Command: todo.Pick, Commit: "5678"},
-				{Command: todo.Pick, Commit: "1234"},
 			},
 		},
 		{

--- a/pkg/utils/rebase_todo_test.go
+++ b/pkg/utils/rebase_todo_test.go
@@ -65,6 +65,21 @@ func TestRebaseCommands_moveTodoDown(t *testing.T) {
 			},
 		},
 		{
+			testName: "move across update-ref todo",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.UpdateRef, Ref: "refs/heads/some_branch"},
+				{Command: todo.Pick, Commit: "5678"},
+			},
+			todoToMoveDown: Todo{Hash: "5678"},
+			expectedErr:    "",
+			expectedTodos: []todo.Todo{
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.Pick, Commit: "5678"},
+				{Command: todo.UpdateRef, Ref: "refs/heads/some_branch"},
+			},
+		},
+		{
 			testName: "skip an invisible todo",
 			todos: []todo.Todo{
 				{Command: todo.Pick, Commit: "1234"},
@@ -188,6 +203,21 @@ func TestRebaseCommands_moveTodoUp(t *testing.T) {
 				{Command: todo.Pick, Commit: "1234"},
 				{Command: todo.Pick, Commit: "5678"},
 				{Command: todo.UpdateRef, Ref: "refs/heads/some_branch"},
+			},
+		},
+		{
+			testName: "move across update-ref todo",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.UpdateRef, Ref: "refs/heads/some_branch"},
+				{Command: todo.Pick, Commit: "5678"},
+			},
+			todoToMoveUp: Todo{Hash: "1234"},
+			expectedErr:  "",
+			expectedTodos: []todo.Todo{
+				{Command: todo.UpdateRef, Ref: "refs/heads/some_branch"},
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.Pick, Commit: "5678"},
 			},
 		},
 		{

--- a/pkg/utils/rebase_todo_test.go
+++ b/pkg/utils/rebase_todo_test.go
@@ -80,6 +80,25 @@ func TestRebaseCommands_moveTodoDown(t *testing.T) {
 			},
 		},
 		{
+			testName: "move across exec todo",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.Exec, ExecCommand: "make test"},
+				{Command: todo.Pick, Commit: "5678"},
+			},
+			todoToMoveDown: Todo{Hash: "5678"},
+			expectedErr:    "",
+			expectedTodos: []todo.Todo{
+				/* EXPECTED:
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.Pick, Commit: "5678"},
+				ACTUAL: */
+				{Command: todo.Pick, Commit: "5678"},
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.Exec, ExecCommand: "make test"},
+			},
+		},
+		{
 			testName: "skip an invisible todo",
 			todos: []todo.Todo{
 				{Command: todo.Pick, Commit: "1234"},
@@ -218,6 +237,25 @@ func TestRebaseCommands_moveTodoUp(t *testing.T) {
 				{Command: todo.UpdateRef, Ref: "refs/heads/some_branch"},
 				{Command: todo.Pick, Commit: "1234"},
 				{Command: todo.Pick, Commit: "5678"},
+			},
+		},
+		{
+			testName: "move across exec todo",
+			todos: []todo.Todo{
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.Exec, ExecCommand: "make test"},
+				{Command: todo.Pick, Commit: "5678"},
+			},
+			todoToMoveUp: Todo{Hash: "1234"},
+			expectedErr:  "",
+			expectedTodos: []todo.Todo{
+				{Command: todo.Exec, ExecCommand: "make test"},
+				/* EXPECTED:
+				{Command: todo.Pick, Commit: "1234"},
+				{Command: todo.Pick, Commit: "5678"},
+				ACTUAL: */
+				{Command: todo.Pick, Commit: "5678"},
+				{Command: todo.Pick, Commit: "1234"},
 			},
 		},
 		{


### PR DESCRIPTION
- **PR Description**

When moving the first commit of the second branch in a stack down by one (across the branch head of the first branch), the current behavior is broken: we move the commit only past the update-ref todo of branch1, which means the order of commits stays the same and only the branch head icon moves up by one. However, we move the selection down by one, so the wrong commit is selected now. This is especially bad if you type a bunch of ctrl-j quickly in a row, because now you are moving the wrong commit.

There would be two possible ways to fix this:
1) keep the moving behavior the same, but don't change the selection
2) change the behavior so that we move the commit not only past the update-ref, but also past the next real commit.

You could argue that 1) is the more desirable fix, as it gives you more control over where exactly the moved commit goes; however, it is much trickier to implement, so we go with 2) for now. If users need more fine-grained control, they can always enter an interactive rebase first.

While we're at it, also fix moving a commit across an exec todo in an interactive rebase, which is currently broken (it moves the commit one too far).

Fixes #4040.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
