### PR TITLE
commits panel: add missing default sort order

### DIFF
--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -1272,6 +1272,11 @@ func (self *LocalCommitsController) handleOpenLogMenu() error {
 								OnPress: onPress("author-date-order"),
 								Widget:  types.MakeMenuRadioButton(currentValue == "author-date-order"),
 							},
+							{
+								Label:   "default",
+								OnPress: onPress("default"),
+								Widget:  types.MakeMenuRadioButton(currentValue == "default"),
+							},
 						},
 					})
 				},


### PR DESCRIPTION
- **PR Description**

In the commits panel, <c-l> menu has only 3 sort orders, but previously `git.log.order` had 4 accepted values. `default` is missing in the new menu.

with `default` selected, I can see `gitlogorder: default` in state.yml and it function as expected in `lazygit --logs`

```bash
git log HEAD --oneline --pretty=format:%H%x00%at%x00%aN%x00%ae%x00%D%x00%p%x00%m%x00%s --abbrev=40 -300 --no-show-signature -- (145.062786ms)
```

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
