### PR TITLE
Add screen-mode command line argument

### DIFF
--- a/pkg/app/entry_point.go
+++ b/pkg/app/entry_point.go
@@ -29,16 +29,17 @@ type cliArgs struct {
 	RepoPath           string
 	FilterPath         string
 	GitArg             string
+	UseConfigDir       string
+	WorkTree           string
+	GitDir             string
+	CustomConfigFile   string
+	ScreenMode         string
 	PrintVersionInfo   bool
 	Debug              bool
 	TailLogs           bool
 	Profile            bool
 	PrintDefaultConfig bool
 	PrintConfigDir     bool
-	UseConfigDir       string
-	WorkTree           string
-	GitDir             string
-	CustomConfigFile   string
 }
 
 type BuildInfo struct {
@@ -164,7 +165,7 @@ func Start(buildInfo *BuildInfo, integrationTest integrationTypes.IntegrationTes
 
 	parsedGitArg := parseGitArg(cliArgs.GitArg)
 
-	Run(appConfig, common, appTypes.NewStartArgs(cliArgs.FilterPath, parsedGitArg, integrationTest))
+	Run(appConfig, common, appTypes.NewStartArgs(cliArgs.FilterPath, parsedGitArg, cliArgs.ScreenMode, integrationTest))
 }
 
 func parseCliArgsAndEnvVars() *cliArgs {
@@ -209,6 +210,9 @@ func parseCliArgsAndEnvVars() *cliArgs {
 	customConfigFile := ""
 	flaggy.String(&customConfigFile, "ucf", "use-config-file", "Comma separated list to custom config file(s)")
 
+	screenMode := ""
+	flaggy.String(&screenMode, "sm", "screen-mode", "The initial screen-mode, which determines the size of the focused panel. Valid options: 'normal' (default), 'half', 'full'")
+
 	flaggy.Parse()
 
 	if os.Getenv("DEBUG") == "TRUE" {
@@ -229,6 +233,7 @@ func parseCliArgsAndEnvVars() *cliArgs {
 		WorkTree:           workTree,
 		GitDir:             gitDir,
 		CustomConfigFile:   customConfigFile,
+		ScreenMode:         screenMode,
 	}
 }
 

--- a/pkg/app/types/types.go
+++ b/pkg/app/types/types.go
@@ -6,12 +6,14 @@ import (
 
 // StartArgs is the struct that represents some things we want to do on program start
 type StartArgs struct {
-	// FilterPath determines which path we're going to filter on so that we only see commits from that file.
-	FilterPath string
 	// GitArg determines what context we open in
 	GitArg GitArg
 	// integration test (only relevant when invoking lazygit in the context of an integration test)
 	IntegrationTest integrationTypes.IntegrationTest
+	// FilterPath determines which path we're going to filter on so that we only see commits from that file.
+	FilterPath string
+	// ScreenMode determines the initial Screen Mode (normal, half or full) to use
+	ScreenMode string
 }
 
 type GitArg string
@@ -24,10 +26,11 @@ const (
 	GitArgStash  GitArg = "stash"
 )
 
-func NewStartArgs(filterPath string, gitArg GitArg, test integrationTypes.IntegrationTest) StartArgs {
+func NewStartArgs(filterPath string, gitArg GitArg, screenMode string, test integrationTypes.IntegrationTest) StartArgs {
 	return StartArgs{
 		FilterPath:      filterPath,
 		GitArg:          gitArg,
+		ScreenMode:      screenMode,
 		IntegrationTest: test,
 	}
 }

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -580,19 +580,23 @@ func initialWindowViewNameMap(contextTree *context.ContextTree) *utils.ThreadSaf
 }
 
 func initialScreenMode(startArgs appTypes.StartArgs, config config.AppConfigurer) types.WindowMaximisation {
-	if startArgs.FilterPath != "" || startArgs.GitArg != appTypes.GitArgNone {
+	if startArgs.ScreenMode != "" {
+		return getWindowMaximisation(startArgs.ScreenMode)
+	} else if startArgs.FilterPath != "" || startArgs.GitArg != appTypes.GitArgNone {
 		return types.SCREEN_FULL
 	} else {
-		defaultWindowSize := config.GetUserConfig().Gui.WindowSize
+		return getWindowMaximisation(config.GetUserConfig().Gui.WindowSize)
+	}
+}
 
-		switch defaultWindowSize {
-		case "half":
-			return types.SCREEN_HALF
-		case "full":
-			return types.SCREEN_FULL
-		default:
-			return types.SCREEN_NORMAL
-		}
+func getWindowMaximisation(modeString string) types.WindowMaximisation {
+	switch modeString {
+	case "half":
+		return types.SCREEN_HALF
+	case "full":
+		return types.SCREEN_FULL
+	default:
+		return types.SCREEN_NORMAL
 	}
 }
 


### PR DESCRIPTION
Introduce a new "screen-mode" command line argument (`-sm normal|half|full` / `--screen-mode normal|half|full`) that allows a user to specify which screen mode (normal, half or full) Lazygit should use when it runs.

This argument will take precedence over a default Window Size specified in user config.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
