### PR TITLE
Don't preserve commit message when it's unchanged from initial message

### DIFF
--- a/pkg/gui/context/commit_message_context.go
+++ b/pkg/gui/context/commit_message_context.go
@@ -30,6 +30,9 @@ type CommitMessageViewModel struct {
 	// if true, then upon escaping from the commit message panel, we will preserve
 	// the message so that it's still shown next time we open the panel
 	preserveMessage bool
+	// we remember the initial message so that we can tell whether we should preserve
+	// the message; if it's still identical to the initial message, we don't
+	initialMessage string
 	// the full preserved message (combined summary and description)
 	preservedMessage string
 	// invoked when pressing enter in the commit message panel
@@ -84,6 +87,10 @@ func (self *CommitMessageContext) SetPreservedMessage(message string) {
 	self.viewModel.preservedMessage = message
 }
 
+func (self *CommitMessageContext) GetInitialMessage() string {
+	return strings.TrimSpace(self.viewModel.initialMessage)
+}
+
 func (self *CommitMessageContext) GetHistoryMessage() string {
 	return self.viewModel.historyMessage
 }
@@ -101,11 +108,13 @@ func (self *CommitMessageContext) SetPanelState(
 	summaryTitle string,
 	descriptionTitle string,
 	preserveMessage bool,
+	initialMessage string,
 	onConfirm func(string, string) error,
 	onSwitchToEditor func(string) error,
 ) {
 	self.viewModel.selectedindex = index
 	self.viewModel.preserveMessage = preserveMessage
+	self.viewModel.initialMessage = initialMessage
 	self.viewModel.onConfirm = onConfirm
 	self.viewModel.onSwitchToEditor = onSwitchToEditor
 	self.GetView().Title = summaryTitle

--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -143,6 +143,7 @@ func (self *CommitsHelper) OpenCommitMessagePanel(opts *OpenCommitMessagePanelOp
 		opts.SummaryTitle,
 		opts.DescriptionTitle,
 		opts.PreserveMessage,
+		opts.InitialMessage,
 		onConfirm,
 		opts.OnSwitchToEditor,
 	)
@@ -177,8 +178,9 @@ func (self *CommitsHelper) HandleCommitConfirm() error {
 func (self *CommitsHelper) CloseCommitMessagePanel() {
 	if self.c.Contexts().CommitMessage.GetPreserveMessage() {
 		message := self.JoinCommitMessageAndUnwrappedDescription()
-
-		self.c.Contexts().CommitMessage.SetPreservedMessage(message)
+		if message != self.c.Contexts().CommitMessage.GetInitialMessage() {
+			self.c.Contexts().CommitMessage.SetPreservedMessage(message)
+		}
 	} else {
 		self.SetMessageAndDescriptionInView("")
 	}

--- a/pkg/integration/tests/commit/commit_with_prefix.go
+++ b/pkg/integration/tests/commit/commit_with_prefix.go
@@ -41,12 +41,8 @@ var CommitWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).
-			/* EXPECTED:
 			InitialText(Equals("[TEST-001]: ")).
 			Type("my commit message").
-			ACTUAL: */
-			InitialText(Equals("[TEST-001]:")).
-			Type(" my commit message").
 			Cancel()
 
 		t.Views().Files().

--- a/pkg/integration/tests/commit/commit_with_prefix.go
+++ b/pkg/integration/tests/commit/commit_with_prefix.go
@@ -10,7 +10,12 @@ var CommitWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(cfg *config.AppConfig) {
-		cfg.GetUserConfig().Git.CommitPrefixes = map[string]config.CommitPrefixConfig{"repo": {Pattern: "^\\w+\\/(\\w+-\\w+).*", Replace: "[$1]: "}}
+		cfg.GetUserConfig().Git.CommitPrefixes = map[string]config.CommitPrefixConfig{
+			"repo": {
+				Pattern: `^\w+/(\w+-\w+).*`,
+				Replace: "[$1]: ",
+			},
+		}
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.NewBranch("feature/TEST-001")

--- a/pkg/integration/tests/commit/commit_with_prefix.go
+++ b/pkg/integration/tests/commit/commit_with_prefix.go
@@ -33,7 +33,20 @@ var CommitWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).
 			InitialText(Equals("[TEST-001]: ")).
+			Cancel()
+
+		t.Views().Files().
+			IsFocused().
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			Title(Equals("Commit summary")).
+			/* EXPECTED:
+			InitialText(Equals("[TEST-001]: ")).
 			Type("my commit message").
+			ACTUAL: */
+			InitialText(Equals("[TEST-001]:")).
+			Type(" my commit message").
 			Cancel()
 
 		t.Views().Files().


### PR DESCRIPTION
- **PR Description**

Sometimes we populate the commit message panel with a pre-created commit
message. The two cases where this happens is:
- you type `w` to commit, in which case we put the skipHookPrefix in the subject
- you have a commitPrefix pattern, in which case we match it against the branch
  name and populate the subject with the replacement string if it matches

In either case, if you have a preserved commit message, we use that.

Now, when you use either of these and then cancel, we preserve that initial,
unchanged message and reuse it the next time you commit. This has two problems:
it strips spaces, which is a problem for the commitPrefix patterns, which often
end with a space. And also, when you change your config to experiment with
commitPrefix patterns, the change seemingly doesn't take effect, which can be
very confusing.

To fix both of these problems, only preserve the commit message when it is not
identical to the initial message.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
