### PR TITLE
Add user config `git.preferRemotes` to `OpenInBrowser` on specified remotes

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -305,6 +305,10 @@ git:
     - master
     - main
 
+  # Prefer to specified remote repositories, E.g. when `OpenInBrowser`
+  preferRemotes:
+    - origin
+
   # Prefix to use when skipping hooks. E.g. if set to 'WIP', then pre-commit hooks will be skipped when the commit message starts with 'WIP'
   skipHookPrefix: WIP
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -224,6 +224,8 @@ type GitConfig struct {
 	Merging MergingConfig `yaml:"merging"`
 	// list of branches that are considered 'main' branches, used when displaying commits
 	MainBranches []string `yaml:"mainBranches" jsonschema:"uniqueItems=true"`
+	// Prefer to specified remote repositories, E.g. when `OpenInBrowser`
+	PreferRemotes []string `yaml:"preferRemotes" jsonschema:"uniqueItems=true"`
 	// Prefix to use when skipping hooks. E.g. if set to 'WIP', then pre-commit hooks will be skipped when the commit message starts with 'WIP'
 	SkipHookPrefix string `yaml:"skipHookPrefix"`
 	// If true, periodically fetch from remote
@@ -765,6 +767,7 @@ func GetDefaultConfig() *UserConfig {
 				ShowGraph:      "always",
 				ShowWholeGraph: false,
 			},
+			PreferRemotes:                []string{"origin"},
 			SkipHookPrefix:               "WIP",
 			MainBranches:                 []string{"master", "main"},
 			AutoFetch:                    true,

--- a/pkg/gui/controllers/helpers/host_helper.go
+++ b/pkg/gui/controllers/helpers/host_helper.go
@@ -42,10 +42,15 @@ func (self *HostHelper) GetCommitURL(commitHash string) (string, error) {
 // getting this on every request rather than storing it in state in case our remoteURL changes
 // from one invocation to the next.
 func (self *HostHelper) getHostingServiceMgr() (*hosting_service.HostingServiceMgr, error) {
-	remoteUrl, err := self.c.Git().Remote.GetRemoteURL("origin")
-	if err != nil {
-		return nil, err
+	remotes := self.c.UserConfig().Git.PreferRemotes
+	var err error
+	var remoteUrl string
+	for _, remote := range remotes {
+		remoteUrl, err = self.c.Git().Remote.GetRemoteURL(remote)
+		if err == nil {
+			configServices := self.c.UserConfig().Services
+			return hosting_service.NewHostingServiceMgr(self.c.Log, self.c.Tr, remoteUrl, configServices), nil
+		}
 	}
-	configServices := self.c.UserConfig().Services
-	return hosting_service.NewHostingServiceMgr(self.c.Log, self.c.Tr, remoteUrl, configServices), nil
+	return nil, err
 }

--- a/schema/config.json
+++ b/schema/config.json
@@ -573,6 +573,17 @@
             "main"
           ]
         },
+        "preferRemotes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Prefer to specified remote repositories, E.g. when `OpenInBrowser`",
+          "default": [
+            "origin"
+          ]
+        },
         "skipHookPrefix": {
           "type": "string",
           "description": "Prefix to use when skipping hooks. E.g. if set to 'WIP', then pre-commit hooks will be skipped when the commit message starts with 'WIP'",


### PR DESCRIPTION
- **PR Description**

When I clone a new repo, after `gh repo fork`, `origin` will be renamed to `upstream`.
In this case, I hope `OpenInBrowser` to try `upstream` first.

With this `git.preferRemotes` option, this behavior can be implemented by:
```yaml
git:
  preferRemotes:
  - upstream
  - origin
```

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
