### PR TITLE
Clarify commit message prefix mechanics

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -940,6 +940,14 @@ git:
       replace: '[$1] '
 ```
 
+> [!IMPORTANT]
+> The way golang regex works is when you use `$n` in the replacement string, where `n` is a number, it puts the nth captured subgroup at that place. If `n` is out of range because there aren't that many capture groups in the regex, it puts an empty string there.
+>
+> So make sure you are capturing group or groups in your regex.
+>
+> For example `^[A-Z]+-\d+$` won't work on branch name like BRANCH-1111
+> But `^([A-Z]+-\d+)$` will
+
 ## Predefined branch name prefix
 
 In situations where certain naming pattern is used for branches, this can be used to populate new branch creation with a static prefix.


### PR DESCRIPTION
- **PR Description**
Added quote that qlarifies that users should use subgroups instead of regular match when configuring commit message prefixes

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
