### PR TITLE
Adjust line number for working copy when editing a line

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/integrii/flaggy v1.4.0
 	github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68
 	github.com/jesseduffield/go-git/v5 v5.1.2-0.20221018185014-fdd53fef665d
-	github.com/jesseduffield/gocui v0.3.1-0.20250106080306-164661a92088
+	github.com/jesseduffield/gocui v0.3.1-0.20250107151125-716b1eb82fb4
 	github.com/jesseduffield/kill v0.0.0-20250101124109-e216ddbe133a
 	github.com/jesseduffield/lazycore v0.0.0-20221012050358-03d2e40243c5
 	github.com/jesseduffield/minimal/gitignore v0.3.3-0.20211018110810-9cde264e6b1e

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68 h1:EQP2Tv8T
 github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68/go.mod h1:+LLj9/WUPAP8LqCchs7P+7X0R98HiFujVFANdNaxhGk=
 github.com/jesseduffield/go-git/v5 v5.1.2-0.20221018185014-fdd53fef665d h1:bO+OmbreIv91rCe8NmscRwhFSqkDJtzWCPV4Y+SQuXE=
 github.com/jesseduffield/go-git/v5 v5.1.2-0.20221018185014-fdd53fef665d/go.mod h1:nGNEErzf+NRznT+N2SWqmHnDnF9aLgANB1CUNEan09o=
-github.com/jesseduffield/gocui v0.3.1-0.20250106080306-164661a92088 h1:yAJ+yFWcv1WRsbgoc4BrGxZVqdLiGVMkz+hEQ1ktgb0=
-github.com/jesseduffield/gocui v0.3.1-0.20250106080306-164661a92088/go.mod h1:XtEbqCbn45keRXEu+OMZkjN5gw6AEob59afsgHjokZ8=
+github.com/jesseduffield/gocui v0.3.1-0.20250107151125-716b1eb82fb4 h1:hSAimLVb4b5ktU3uJRtBsZW0P2dtXECReTcsHYfOy58=
+github.com/jesseduffield/gocui v0.3.1-0.20250107151125-716b1eb82fb4/go.mod h1:XtEbqCbn45keRXEu+OMZkjN5gw6AEob59afsgHjokZ8=
 github.com/jesseduffield/kill v0.0.0-20250101124109-e216ddbe133a h1:UDeJ3EBk04bXDLOPvuqM3on8HvyJfISw0+UMqW+0a4g=
 github.com/jesseduffield/kill v0.0.0-20250101124109-e216ddbe133a/go.mod h1:FSWDLKT0NQpntbDd1H3lbz51fhCVlMzy/J0S6nM727Q=
 github.com/jesseduffield/lazycore v0.0.0-20221012050358-03d2e40243c5 h1:CDuQmfOjAtb1Gms6a1p5L2P8RhbLUq5t8aL7PiQd2uY=

--- a/pkg/commands/git_commands/diff.go
+++ b/pkg/commands/git_commands/diff.go
@@ -16,6 +16,8 @@ func NewDiffCommands(gitCommon *GitCommon) *DiffCommands {
 	}
 }
 
+// This is for generating diffs to be shown in the UI (e.g. rendering a range
+// diff to the main view). It uses a custom pager if one is configured.
 func (self *DiffCommands) DiffCmdObj(diffArgs []string) oscommands.ICmdObj {
 	extDiffCmd := self.UserConfig().Git.Paging.ExternalDiffCommand
 	useExtDiff := extDiffCmd != ""
@@ -36,27 +38,21 @@ func (self *DiffCommands) DiffCmdObj(diffArgs []string) oscommands.ICmdObj {
 	)
 }
 
-func (self *DiffCommands) internalDiffCmdObj(diffArgs ...string) *GitCommandBuilder {
-	return NewGitCmd("diff").
-		Config("diff.noprefix=false").
-		Arg("--no-ext-diff", "--no-color").
-		Arg(diffArgs...).
-		Dir(self.repoPaths.worktreePath)
-}
-
-func (self *DiffCommands) GetPathDiff(path string, staged bool) (string, error) {
+// This is a basic generic diff command that can be used for any diff operation
+// (e.g. copying a diff to the clipboard). It will not use a custom pager, and
+// does not use user configs such as ignore whitespace.
+// If you want to diff specific refs (one or two), you need to add them yourself
+// in additionalArgs; it is recommended to also pass `--` after that. If you
+// want to restrict the diff to specific paths, pass them in additionalArgs
+// after the `--`.
+func (self *DiffCommands) GetDiff(staged bool, additionalArgs ...string) (string, error) {
 	return self.cmd.New(
-		self.internalDiffCmdObj().
+		NewGitCmd("diff").
+			Config("diff.noprefix=false").
+			Arg("--no-ext-diff", "--no-color").
 			ArgIf(staged, "--staged").
-			Arg(path).
-			ToArgv(),
-	).RunWithOutput()
-}
-
-func (self *DiffCommands) GetAllDiff(staged bool) (string, error) {
-	return self.cmd.New(
-		self.internalDiffCmdObj().
-			ArgIf(staged, "--staged").
+			Dir(self.repoPaths.worktreePath).
+			Arg(additionalArgs...).
 			ToArgv(),
 	).RunWithOutput()
 }

--- a/pkg/commands/patch/patch.go
+++ b/pkg/commands/patch/patch.go
@@ -154,3 +154,24 @@ func (self *Patch) LineCount() int {
 func (self *Patch) HunkCount() int {
 	return len(self.hunks)
 }
+
+// Adjust the given line number (one-based) according to the current patch. The
+// patch is supposed to be a diff of an old file state against the working
+// directory; the line number is a line number in that old file, and the
+// function returns the corresponding line number in the working directory file.
+func (self *Patch) AdjustLineNumber(lineNumber int) int {
+	adjustedLineNumber := lineNumber
+	for _, hunk := range self.hunks {
+		if hunk.oldStart >= lineNumber {
+			break
+		}
+
+		if hunk.oldStart+hunk.oldLength() > lineNumber {
+			return hunk.newStart
+		}
+
+		adjustedLineNumber += hunk.newLength() - hunk.oldLength()
+	}
+
+	return adjustedLineNumber
+}

--- a/pkg/commands/patch/patch_test.go
+++ b/pkg/commands/patch/patch_test.go
@@ -639,3 +639,59 @@ func TestGetNextStageableLineIndex(t *testing.T) {
 		})
 	}
 }
+
+func TestAdjustLineNumber(t *testing.T) {
+	type scenario struct {
+		oldLineNumbers  []int
+		expectedResults []int
+	}
+	scenarios := []scenario{
+		{
+			oldLineNumbers:  []int{1, 2, 3, 4, 5, 6, 7},
+			expectedResults: []int{1, 2, 2, 3, 4, 7, 8},
+		},
+	}
+
+	// The following diff was generated from old.txt:
+	//   1
+	//   2a
+	//   2b
+	//   3
+	//   4
+	//   7
+	//   8
+	// against new.txt:
+	//   1
+	//   2
+	//   3
+	//   4
+	//   5
+	//   6
+	//   7
+	//   8
+
+	// This test setup makes the test easy to understand, because the resulting
+	// adjusted line numbers are the same as the content of the lines in new.txt.
+
+	diff := `--- old.txt	2024-12-16 18:04:29
++++ new.txt	2024-12-16 18:04:27
+@@ -2,2 +2 @@
+-2a
+-2b
++2
+@@ -5,0 +5,2 @@
++5
++6
+`
+
+	patch := Parse(diff)
+
+	for _, s := range scenarios {
+		t.Run("TestAdjustLineNumber", func(t *testing.T) {
+			for idx, oldLineNumber := range s.oldLineNumbers {
+				result := patch.AdjustLineNumber(oldLineNumber)
+				assert.Equal(t, s.expectedResults[idx], result)
+			}
+		})
+	}
+}

--- a/pkg/gui/context/branches_context.go
+++ b/pkg/gui/context/branches_context.go
@@ -80,6 +80,14 @@ func (self *BranchesContext) GetDiffTerminals() []string {
 	return nil
 }
 
+func (self *BranchesContext) RefForAdjustingLineNumberInDiff() string {
+	branch := self.GetSelected()
+	if branch != nil {
+		return branch.ID()
+	}
+	return ""
+}
+
 func (self *BranchesContext) ShowBranchHeadsInSubCommits() bool {
 	return true
 }

--- a/pkg/gui/context/commit_files_context.go
+++ b/pkg/gui/context/commit_files_context.go
@@ -77,6 +77,13 @@ func (self *CommitFilesContext) GetDiffTerminals() []string {
 	return []string{self.GetRef().RefName()}
 }
 
+func (self *CommitFilesContext) RefForAdjustingLineNumberInDiff() string {
+	if refs := self.GetRefRange(); refs != nil {
+		return refs.To.RefName()
+	}
+	return self.GetRef().RefName()
+}
+
 func (self *CommitFilesContext) GetFromAndToForDiff() (string, string) {
 	if refs := self.GetRefRange(); refs != nil {
 		return refs.From.ParentRefName(), refs.To.RefName()

--- a/pkg/gui/context/local_commits_context.go
+++ b/pkg/gui/context/local_commits_context.go
@@ -170,6 +170,14 @@ func (self *LocalCommitsContext) GetDiffTerminals() []string {
 	return []string{itemId}
 }
 
+func (self *LocalCommitsContext) RefForAdjustingLineNumberInDiff() string {
+	commits, _, _ := self.GetSelectedItems()
+	if commits == nil {
+		return ""
+	}
+	return commits[0].Hash
+}
+
 func (self *LocalCommitsContext) ModelSearchResults(searchStr string, caseSensitive bool) []gocui.SearchPosition {
 	return searchModelCommits(caseSensitive, self.GetCommits(), self.ColumnPositions(), searchStr)
 }

--- a/pkg/gui/context/reflog_commits_context.go
+++ b/pkg/gui/context/reflog_commits_context.go
@@ -86,6 +86,10 @@ func (self *ReflogCommitsContext) GetDiffTerminals() []string {
 	return []string{itemId}
 }
 
+func (self *ReflogCommitsContext) RefForAdjustingLineNumberInDiff() string {
+	return self.GetSelectedItemId()
+}
+
 func (self *ReflogCommitsContext) ShowBranchHeadsInSubCommits() bool {
 	return false
 }

--- a/pkg/gui/context/remote_branches_context.go
+++ b/pkg/gui/context/remote_branches_context.go
@@ -78,6 +78,10 @@ func (self *RemoteBranchesContext) GetDiffTerminals() []string {
 	return []string{itemId}
 }
 
+func (self *RemoteBranchesContext) RefForAdjustingLineNumberInDiff() string {
+	return self.GetSelectedItemId()
+}
+
 func (self *RemoteBranchesContext) ShowBranchHeadsInSubCommits() bool {
 	return true
 }

--- a/pkg/gui/context/remotes_context.go
+++ b/pkg/gui/context/remotes_context.go
@@ -53,3 +53,7 @@ func (self *RemotesContext) GetDiffTerminals() []string {
 
 	return []string{itemId}
 }
+
+func (self *RemotesContext) RefForAdjustingLineNumberInDiff() string {
+	return ""
+}

--- a/pkg/gui/context/stash_context.go
+++ b/pkg/gui/context/stash_context.go
@@ -71,3 +71,7 @@ func (self *StashContext) GetDiffTerminals() []string {
 
 	return []string{itemId}
 }
+
+func (self *StashContext) RefForAdjustingLineNumberInDiff() string {
+	return self.GetSelectedItemId()
+}

--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -217,6 +217,14 @@ func (self *SubCommitsContext) GetDiffTerminals() []string {
 	return []string{itemId}
 }
 
+func (self *SubCommitsContext) RefForAdjustingLineNumberInDiff() string {
+	commits, _, _ := self.GetSelectedItems()
+	if commits == nil {
+		return ""
+	}
+	return commits[0].Hash
+}
+
 func (self *SubCommitsContext) ModelSearchResults(searchStr string, caseSensitive bool) []gocui.SearchPosition {
 	return searchModelCommits(caseSensitive, self.GetCommits(), self.ColumnPositions(), searchStr)
 }

--- a/pkg/gui/context/tags_context.go
+++ b/pkg/gui/context/tags_context.go
@@ -66,6 +66,10 @@ func (self *TagsContext) GetDiffTerminals() []string {
 	return []string{itemId}
 }
 
+func (self *TagsContext) RefForAdjustingLineNumberInDiff() string {
+	return self.GetSelectedItemId()
+}
+
 func (self *TagsContext) ShowBranchHeadsInSubCommits() bool {
 	return true
 }

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -869,7 +869,7 @@ func (self *FilesController) openCopyMenu() error {
 		OnPress: func() error {
 			path := self.context().GetSelectedPath()
 			hasStaged := self.hasPathStagedChanges(node)
-			diff, err := self.c.Git().Diff.GetPathDiff(path, hasStaged)
+			diff, err := self.c.Git().Diff.GetDiff(hasStaged, "--", path)
 			if err != nil {
 				return err
 			}
@@ -894,7 +894,7 @@ func (self *FilesController) openCopyMenu() error {
 		Tooltip: self.c.Tr.CopyFileDiffTooltip,
 		OnPress: func() error {
 			hasStaged := self.c.Helpers().WorkingTree.AnyStagedFiles()
-			diff, err := self.c.Git().Diff.GetAllDiff(hasStaged)
+			diff, err := self.c.Git().Diff.GetDiff(hasStaged, "--")
 			if err != nil {
 				return err
 			}

--- a/pkg/gui/controllers/patch_building_controller.go
+++ b/pkg/gui/controllers/patch_building_controller.go
@@ -107,6 +107,7 @@ func (self *PatchBuildingController) EditFile() error {
 	}
 
 	lineNumber := self.context().GetState().CurrentLineNumber()
+	lineNumber = self.c.Helpers().Diff.AdjustLineNumber(path, lineNumber, self.context().GetViewName())
 	return self.c.Helpers().Files.EditFileAtLine(path, lineNumber)
 }
 

--- a/pkg/gui/controllers/staging_controller.go
+++ b/pkg/gui/controllers/staging_controller.go
@@ -161,6 +161,7 @@ func (self *StagingController) EditFile() error {
 	}
 
 	lineNumber := self.context.GetState().CurrentLineNumber()
+	lineNumber = self.c.Helpers().Diff.AdjustLineNumber(path, lineNumber, self.context.GetViewName())
 	return self.c.Helpers().Files.EditFileAtLine(path, lineNumber)
 }
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -358,7 +358,7 @@ func (gui *Gui) onNewRepo(startArgs appTypes.StartArgs, contextKey types.Context
 		return nil
 	})
 
-	gui.g.SetOpenHyperlinkFunc(func(url string) error {
+	gui.g.SetOpenHyperlinkFunc(func(url string, viewname string) error {
 		if strings.HasPrefix(url, "lazygit-edit:") {
 			re := regexp.MustCompile(`^lazygit-edit://(.+?)(?::(\d+))?$`)
 			matches := re.FindStringSubmatch(url)

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -368,6 +368,7 @@ func (gui *Gui) onNewRepo(startArgs appTypes.StartArgs, contextKey types.Context
 			filepath := matches[1]
 			if matches[2] != "" {
 				lineNumber := utils.MustConvertToInt(matches[2])
+				lineNumber = gui.helpers.Diff.AdjustLineNumber(filepath, lineNumber, viewname)
 				return gui.helpers.Files.EditFileAtLine(filepath, lineNumber)
 			}
 			return gui.helpers.Files.EditFiles([]string{filepath})

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -152,6 +152,14 @@ type DiffableContext interface {
 	// which becomes an option when you bring up the diff menu, but when you're just
 	// flicking through branches it will be using the local branch name.
 	GetDiffTerminals() []string
+
+	// Returns the ref that should be used for creating a diff of what's
+	// currently shown in the main view against the working directory, in order
+	// to adjust line numbers in the diff to match the current state of the
+	// shown file. For example, if the main view shows a range diff of commits,
+	// we need to pass the first commit of the range. This is used by
+	// DiffHelper.AdjustLineNumber.
+	RefForAdjustingLineNumberInDiff() string
 }
 
 type IListContext interface {

--- a/pkg/integration/tests/patch_building/edit_line_in_patch_building_panel.go
+++ b/pkg/integration/tests/patch_building/edit_line_in_patch_building_panel.go
@@ -42,9 +42,6 @@ var EditLineInPatchBuildingPanel = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("+5")).
 			Press(keys.Universal.Edit)
 
-		/* EXPECTED:
 		t.FileSystem().FileContent("edit-command", Contains("file.txt:5\n"))
-		ACTUAL: */
-		t.FileSystem().FileContent("edit-command", Contains("file.txt:2\n"))
 	},
 })

--- a/pkg/integration/tests/patch_building/edit_line_in_patch_building_panel.go
+++ b/pkg/integration/tests/patch_building/edit_line_in_patch_building_panel.go
@@ -1,0 +1,50 @@
+package patch_building
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var EditLineInPatchBuildingPanel = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Edit a line in the patch building panel; make sure we end up on the right line",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().OS.EditAtLine = "echo {{filename}}:{{line}} > edit-command"
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file.txt", "4\n5\n6\n")
+		shell.Commit("01")
+		shell.UpdateFileAndAdd("file.txt", "1\n2a\n2b\n3\n4\n5\n6\n")
+		shell.Commit("02")
+		shell.UpdateFile("file.txt", "1\n2\n3\n4\n5\n6\n")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("02").IsSelected(),
+				Contains("01"),
+			).
+			Press(keys.Universal.NextItem).
+			PressEnter()
+
+		t.Views().CommitFiles().
+			IsFocused().
+			Lines(
+				Contains("A file.txt").IsSelected(),
+			).
+			PressEnter()
+
+		t.Views().PatchBuilding().
+			IsFocused().
+			Content(Contains("+4\n+5\n+6")).
+			NavigateToLine(Contains("+5")).
+			Press(keys.Universal.Edit)
+
+		/* EXPECTED:
+		t.FileSystem().FileContent("edit-command", Contains("file.txt:5\n"))
+		ACTUAL: */
+		t.FileSystem().FileContent("edit-command", Contains("file.txt:2\n"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -257,6 +257,7 @@ var tests = []*components.IntegrationTest{
 	patch_building.Apply,
 	patch_building.ApplyInReverse,
 	patch_building.ApplyInReverseWithConflict,
+	patch_building.EditLineInPatchBuildingPanel,
 	patch_building.MoveRangeToIndex,
 	patch_building.MoveToEarlierCommit,
 	patch_building.MoveToEarlierCommitFromAddedFile,

--- a/vendor/github.com/jesseduffield/gocui/gui.go
+++ b/vendor/github.com/jesseduffield/gocui/gui.go
@@ -130,7 +130,7 @@ type Gui struct {
 	managers          []Manager
 	keybindings       []*keybinding
 	focusHandler      func(bool) error
-	openHyperlink     func(string) error
+	openHyperlink     func(string, string) error
 	maxX, maxY        int
 	outputMode        OutputMode
 	stop              chan struct{}
@@ -627,7 +627,7 @@ func (g *Gui) SetFocusHandler(handler func(bool) error) {
 	g.focusHandler = handler
 }
 
-func (g *Gui) SetOpenHyperlinkFunc(openHyperlinkFunc func(string) error) {
+func (g *Gui) SetOpenHyperlinkFunc(openHyperlinkFunc func(string, string) error) {
 	g.openHyperlink = openHyperlinkFunc
 }
 
@@ -1371,7 +1371,7 @@ func (g *Gui) onKey(ev *GocuiEvent) error {
 		if ev.Key == MouseLeft && !v.Editable && g.openHyperlink != nil {
 			if newY >= 0 && newY <= len(v.viewLines)-1 && newX >= 0 && newX <= len(v.viewLines[newY].line)-1 {
 				if link := v.viewLines[newY].line[newX].hyperlink; link != "" {
-					return g.openHyperlink(link)
+					return g.openHyperlink(link, v.name)
 				}
 			}
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -172,7 +172,7 @@ github.com/jesseduffield/go-git/v5/utils/merkletrie/filesystem
 github.com/jesseduffield/go-git/v5/utils/merkletrie/index
 github.com/jesseduffield/go-git/v5/utils/merkletrie/internal/frame
 github.com/jesseduffield/go-git/v5/utils/merkletrie/noder
-# github.com/jesseduffield/gocui v0.3.1-0.20250106080306-164661a92088
+# github.com/jesseduffield/gocui v0.3.1-0.20250107151125-716b1eb82fb4
 ## explicit; go 1.12
 github.com/jesseduffield/gocui
 # github.com/jesseduffield/kill v0.0.0-20250101124109-e216ddbe133a


### PR DESCRIPTION
- **PR Description**

There are two ways to jump to the editor on a specific line: pressing `e` in the
staging or patch building panels, or clicking on a hyperlink in a delta diff. In
both cases, this works perfectly in the unstaged changes view, but in other
views (either staged changes, or an older commit) it can often jump to the wrong
line; this happens when there are further changes to the file being viewed in
later commits or in unstaged changes.

This commit fixes this so that you end up on the right line in these cases.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
