### PR TITLE
remove duplicate secondary MouseWheelUp keybind

### DIFF
--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -195,12 +195,6 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 		},
 		{
 			ViewName: "secondary",
-			Key:      gocui.MouseWheelUp,
-			Modifier: gocui.ModNone,
-			Handler:  self.scrollUpSecondary,
-		},
-		{
-			ViewName: "secondary",
 			Key:      gocui.MouseWheelDown,
 			Modifier: gocui.ModNone,
 			Handler:  self.scrollDownSecondary,

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -194,12 +194,6 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 			OpensMenu:   true,
 		},
 		{
-			ViewName: "secondary",
-			Key:      gocui.MouseWheelDown,
-			Modifier: gocui.ModNone,
-			Handler:  self.scrollDownSecondary,
-		},
-		{
 			ViewName:    "main",
 			Key:         gocui.MouseWheelDown,
 			Handler:     self.scrollDownMain,
@@ -212,6 +206,12 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 			Handler:     self.scrollUpMain,
 			Description: self.c.Tr.ScrollUp,
 			Alternative: "fn+down",
+		},
+		{
+			ViewName: "secondary",
+			Key:      gocui.MouseWheelDown,
+			Modifier: gocui.ModNone,
+			Handler:  self.scrollDownSecondary,
 		},
 		{
 			ViewName: "secondary",


### PR DESCRIPTION
- **Remove duplicate secondary view MouseWheelUp keybinding**

The `MouseWheelUp` keybind for the secondary view was duplicated in the array.

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
