### PR TITLE
Fix hang when returning from shell command

### DIFF
--- a/pkg/commands/oscommands/cmd_obj_builder.go
+++ b/pkg/commands/oscommands/cmd_obj_builder.go
@@ -52,7 +52,7 @@ func (self *CmdObjBuilder) NewShell(commandStr string) ICmdObj {
 }
 
 func (self *CmdObjBuilder) NewInteractiveShell(commandStr string) ICmdObj {
-	quotedCommand := self.quotedCommandString(commandStr)
+	quotedCommand := self.quotedCommandString(commandStr + self.platform.InteractiveShellExit)
 	cmdArgs := str.ToArgv(fmt.Sprintf("%s %s %s %s", self.platform.InteractiveShell, self.platform.InteractiveShellArg, self.platform.ShellArg, quotedCommand))
 
 	return self.New(cmdArgs)

--- a/pkg/commands/oscommands/dummies.go
+++ b/pkg/commands/oscommands/dummies.go
@@ -51,13 +51,14 @@ func NewDummyCmdObjBuilder(runner ICmdObjRunner) *CmdObjBuilder {
 }
 
 var dummyPlatform = &Platform{
-	OS:                  "darwin",
-	Shell:               "bash",
-	InteractiveShell:    "bash",
-	ShellArg:            "-c",
-	InteractiveShellArg: "-i",
-	OpenCommand:         "open {{filename}}",
-	OpenLinkCommand:     "open {{link}}",
+	OS:                   "darwin",
+	Shell:                "bash",
+	InteractiveShell:     "bash",
+	ShellArg:             "-c",
+	InteractiveShellArg:  "-i",
+	InteractiveShellExit: "; exit $?",
+	OpenCommand:          "open {{filename}}",
+	OpenLinkCommand:      "open {{link}}",
 }
 
 func NewDummyOSCommandWithRunner(runner *FakeCmdObjRunner) *OSCommand {

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -35,13 +35,14 @@ type OSCommand struct {
 
 // Platform stores the os state
 type Platform struct {
-	OS                  string
-	Shell               string
-	InteractiveShell    string
-	ShellArg            string
-	InteractiveShellArg string
-	OpenCommand         string
-	OpenLinkCommand     string
+	OS                   string
+	Shell                string
+	InteractiveShell     string
+	ShellArg             string
+	InteractiveShellArg  string
+	InteractiveShellExit string
+	OpenCommand          string
+	OpenLinkCommand      string
 }
 
 // NewOSCommand os command runner

--- a/pkg/commands/oscommands/os_default_platform.go
+++ b/pkg/commands/oscommands/os_default_platform.go
@@ -10,13 +10,14 @@ import (
 
 func GetPlatform() *Platform {
 	return &Platform{
-		OS:                  runtime.GOOS,
-		Shell:               "bash",
-		InteractiveShell:    getUserShell(),
-		ShellArg:            "-c",
-		InteractiveShellArg: "-i",
-		OpenCommand:         "open {{filename}}",
-		OpenLinkCommand:     "open {{link}}",
+		OS:                   runtime.GOOS,
+		Shell:                "bash",
+		InteractiveShell:     getUserShell(),
+		ShellArg:             "-c",
+		InteractiveShellArg:  "-i",
+		InteractiveShellExit: "; exit $?",
+		OpenCommand:          "open {{filename}}",
+		OpenLinkCommand:      "open {{link}}",
 	}
 }
 

--- a/pkg/commands/oscommands/os_windows.go
+++ b/pkg/commands/oscommands/os_windows.go
@@ -2,10 +2,11 @@ package oscommands
 
 func GetPlatform() *Platform {
 	return &Platform{
-		OS:                  "windows",
-		Shell:               "cmd",
-		InteractiveShell:    "cmd",
-		ShellArg:            "/c",
-		InteractiveShellArg: "",
+		OS:                   "windows",
+		Shell:                "cmd",
+		InteractiveShell:     "cmd",
+		ShellArg:             "/c",
+		InteractiveShellArg:  "",
+		InteractiveShellExit: "",
 	}
 }


### PR DESCRIPTION
- **PR Description**

In #3793 we changed the execution of shell commands to use an interactive shell (-i), because this allows users to use aliases or shell functions, which is a nice convenience.

Since then, however, many users have reported problems with lazygit not coming back to the foreground after executing a shell command. Some users report that appending "; exit" to the end of the command line solves this. I don't really understand what the cause of this problem was, or why appending "; exit" solves it, but if it helps, let's do it.

Fixes #3903, #3923, #3937.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
