### PR TITLE
Add ability to configure branch color patterns using regex

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -832,13 +832,16 @@ gui:
 
 ## Custom Branch Color
 
-You can customize the color of branches based on the branch prefix:
+You can customize the color of branches based on branch patterns (regular expressions):
 
 ```yaml
 gui:
-  branchColors:
-    'docs': '#11aaff' # use a light blue for branches beginning with 'docs/'
+  branchColorPatterns:
+    '^docs/': '#11aaff' # use a light blue for branches beginning with 'docs/'
+    'ISSUE-\d+': '#ff5733' # use a bright orange for branches containing 'ISSUE-<some-number>'
 ```
+
+Note that the regular expressions are not implicitly anchored to the beginning/end of the branch name. If you want to do that, add leading `^` and/or trailing `$` as needed.
 
 ## Example Coloring
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -52,7 +52,10 @@ type GuiConfig struct {
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-author-color
 	AuthorColors map[string]string `yaml:"authorColors"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-branch-color
+	// Deprecated: use branchColorPatterns instead
 	BranchColors map[string]string `yaml:"branchColors"`
+	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-branch-color
+	BranchColorPatterns map[string]string `yaml:"branchColorPatterns"`
 	// The number of lines you scroll by when scrolling the main window
 	ScrollHeight int `yaml:"scrollHeight" jsonschema:"minimum=1"`
 	// If true, allow scrolling past the bottom of the content in the main window

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -455,7 +455,13 @@ func (gui *Gui) onUserConfigLoaded() error {
 	} else if userConfig.Gui.ShowIcons {
 		icons.SetNerdFontsVersion("2")
 	}
-	presentation.SetCustomBranches(userConfig.Gui.BranchColors)
+
+	if len(userConfig.Gui.BranchColorPatterns) > 0 {
+		presentation.SetCustomBranches(userConfig.Gui.BranchColorPatterns, true)
+	} else {
+		// Fall back to the deprecated branchColors config
+		presentation.SetCustomBranches(userConfig.Gui.BranchColors, false)
+	}
 
 	return nil
 }

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -131,16 +131,7 @@ func GetBranchTextStyle(name string) style.TextStyle {
 		return value
 	}
 
-	switch branchType {
-	case "feature":
-		return style.FgGreen
-	case "bugfix":
-		return style.FgYellow
-	case "hotfix":
-		return style.FgRed
-	default:
-		return theme.DefaultTextColor
-	}
+	return theme.DefaultTextColor
 }
 
 func BranchStatus(

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -2,6 +2,7 @@ package presentation
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -18,7 +19,12 @@ import (
 	"github.com/samber/lo"
 )
 
-var branchPrefixColorCache = make(map[string]style.TextStyle)
+type colorMatcher struct {
+	patterns map[string]style.TextStyle
+	isRegex  bool // NOTE: this value is needed only until the deprecated branchColors config is removed and only regex color patterns are used
+}
+
+var colorPatterns *colorMatcher
 
 func GetBranchListDisplayStrings(
 	branches []*models.Branch,
@@ -125,13 +131,29 @@ func getBranchDisplayStrings(
 
 // GetBranchTextStyle branch color
 func GetBranchTextStyle(name string) style.TextStyle {
-	branchType := strings.Split(name, "/")[0]
-
-	if value, ok := branchPrefixColorCache[branchType]; ok {
-		return value
+	if style, ok := colorPatterns.match(name); ok {
+		return *style
 	}
 
 	return theme.DefaultTextColor
+}
+
+func (m *colorMatcher) match(name string) (*style.TextStyle, bool) {
+	if m.isRegex {
+		for pattern, style := range m.patterns {
+			if matched, _ := regexp.MatchString(pattern, name); matched {
+				return &style, true
+			}
+		}
+	} else {
+		// old behavior using the deprecated branchColors behavior matching on branch type
+		branchType := strings.Split(name, "/")[0]
+		if value, ok := m.patterns[branchType]; ok {
+			return &value, true
+		}
+	}
+
+	return nil, false
 }
 
 func BranchStatus(
@@ -180,6 +202,9 @@ func BranchStatus(
 	return result
 }
 
-func SetCustomBranches(customBranchColors map[string]string) {
-	branchPrefixColorCache = utils.SetCustomColors(customBranchColors)
+func SetCustomBranches(customBranchColors map[string]string, isRegex bool) {
+	colorPatterns = &colorMatcher{
+		patterns: utils.SetCustomColors(customBranchColors),
+		isRegex:  isRegex,
+	}
 }

--- a/pkg/gui/presentation/branches_test.go
+++ b/pkg/gui/presentation/branches_test.go
@@ -321,6 +321,7 @@ func Test_getBranchDisplayStrings(t *testing.T) {
 	defer color.ForceSetColorLevel(oldColorLevel)
 
 	c := utils.NewDummyCommon()
+	SetCustomBranches(c.UserConfig().Gui.BranchColorPatterns, true)
 
 	for i, s := range scenarios {
 		icons.SetNerdFontsVersion(lo.Ternary(s.useIcons, "3", ""))

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -2006,6 +2006,8 @@ keybinding:
 gui:
   filterMode: 'fuzzy'
 	  `,
+			"0.44.0": `- The gui.branchColors config option is deprecated; it will be removed in a future version. Please use gui.branchColorPatterns instead.
+- The automatic coloring of branches starting with "feature/", "bugfix/", or "hotfix/" has been removed; if you want this, it's easy to set up using the new gui.branchColorPatterns option.`,
 		},
 	}
 }

--- a/schema/config.json
+++ b/schema/config.json
@@ -16,6 +16,13 @@
             "type": "string"
           },
           "type": "object",
+          "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-branch-color\nDeprecated: use branchColorPatterns instead"
+        },
+        "branchColorPatterns": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
           "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-branch-color"
         },
         "scrollHeight": {


### PR DESCRIPTION
- **PR Description**

Add ability to specify color patterns in the `branchColorPatterns` config using regex, ex. `JIRA-\d+` would match all branch names in the form `JIRA-456`.

Example config:
```yaml
gui:
  branchColorPatterns:
    'docs/.+': 'black' # make all branches prefixed with docs/ have a black color
    'feature/collapse-all': 'red' # make a specfic branch name red
    'IDEA-\d+': 'blue' # make all branches with the prefix `IDEA-` followed by a digit, blue

```

<img width="452" alt="Screenshot 2025-01-05 at 3 57 54 PM" src="https://github.com/user-attachments/assets/d6b056e0-357b-44d9-8a4e-7e42d6165453" />



- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
