### PR TITLE
Collapse/uncollapse all files in tree

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -571,6 +571,8 @@ keybinding:
     openMergeTool: M
     openStatusFilter: <c-b>
     copyFileInfoToClipboard: "y"
+    collapseAll: '-'
+    expandAll: =
   branches:
     createPullRequest: o
     viewPullRequestOptions: O

--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -65,6 +65,8 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` a `` | Toggle all files | Add/remove all commit's files to custom patch. See https://github.com/jesseduffield/lazygit#rebase-magic-custom-patches. |
 | `` <enter> `` | Enter file / Toggle directory collapsed | If a file is selected, enter the file so that you can add/remove individual lines to the custom patch. If a directory is selected, toggle the directory. |
 | `` ` `` | Toggle file tree view | Toggle file view between flat and tree layout. Flat layout shows all file paths in a single list, tree layout groups files by directory. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | Search the current view by text |  |
 
 ## Commit summary
@@ -147,6 +149,8 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` M `` | Open external merge tool | Run `git mergetool`. |
 | `` f `` | Fetch | Fetch changes from remote. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | Search the current view by text |  |
 
 ## Local branches

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -143,6 +143,8 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` a `` | Toggle all files | Add/remove all commit's files to custom patch. See https://github.com/jesseduffield/lazygit#rebase-magic-custom-patches. |
 | `` <enter> `` | Enter file / Toggle directory collapsed | If a file is selected, enter the file so that you can add/remove individual lines to the custom patch. If a directory is selected, toggle the directory. |
 | `` ` `` | ファイルツリーの表示を切り替え | Toggle file view between flat and tree layout. Flat layout shows all file paths in a single list, tree layout groups files by directory. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | 検索を開始 |  |
 
 ## コミットメッセージ
@@ -218,6 +220,8 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` M `` | Git mergetoolを開く | Run `git mergetool`. |
 | `` f `` | Fetch | Fetch changes from remote. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | 検索を開始 |  |
 
 ## ブランチ

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -308,6 +308,8 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` a `` | Toggle all files included in patch | Add/remove all commit's files to custom patch. See https://github.com/jesseduffield/lazygit#rebase-magic-custom-patches. |
 | `` <enter> `` | Enter file to add selected lines to the patch (or toggle directory collapsed) | If a file is selected, enter the file so that you can add/remove individual lines to the custom patch. If a directory is selected, toggle the directory. |
 | `` ` `` | 파일 트리뷰로 전환 | Toggle file view between flat and tree layout. Flat layout shows all file paths in a single list, tree layout groups files by directory. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | 검색 시작 |  |
 
 ## 커밋메시지
@@ -359,6 +361,8 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` M `` | Git mergetool를 열기 | Run `git mergetool`. |
 | `` f `` | Fetch | Fetch changes from remote. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | 검색 시작 |  |
 
 ## 확인 패널

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -79,6 +79,8 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` M `` | Open external merge tool | Run `git mergetool`. |
 | `` f `` | Fetch | Fetch changes from remote. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | Start met zoeken |  |
 
 ## Bevestigingspaneel
@@ -136,6 +138,8 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` a `` | Toggle all files | Add/remove all commit's files to custom patch. See https://github.com/jesseduffield/lazygit#rebase-magic-custom-patches. |
 | `` <enter> `` | Enter bestand om geselecteerde regels toe te voegen aan de patch | If a file is selected, enter the file so that you can add/remove individual lines to the custom patch. If a directory is selected, toggle the directory. |
 | `` ` `` | Toggle bestandsboom weergave | Toggle file view between flat and tree layout. Flat layout shows all file paths in a single list, tree layout groups files by directory. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | Start met zoeken |  |
 
 ## Commits

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -229,6 +229,8 @@ Jeśli chcesz zamiast tego rozpocząć interaktywny rebase od wybranego commita,
 | `` <c-t> `` | Otwórz zewnętrzne narzędzie różnic (git difftool) |  |
 | `` M `` | Otwórz zewnętrzne narzędzie scalania | Uruchom `git mergetool`. |
 | `` f `` | Pobierz | Pobierz zmiany ze zdalnego serwera. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | Szukaj w bieżącym widoku po tekście |  |
 
 ## Pliki commita
@@ -245,6 +247,8 @@ Jeśli chcesz zamiast tego rozpocząć interaktywny rebase od wybranego commita,
 | `` a `` | Przełącz wszystkie pliki | Dodaj/usuń wszystkie pliki commita do niestandardowej łatki. Zobacz https://github.com/jesseduffield/lazygit#rebase-magic-custom-patches. |
 | `` <enter> `` | Wejdź do pliku / Przełącz zwiń katalog | Jeśli plik jest wybrany, wejdź do pliku, aby móc dodawać/usuwać poszczególne linie do niestandardowej łatki. Jeśli wybrany jest katalog, przełącz katalog. |
 | `` ` `` | Przełącz widok drzewa plików | Przełącz widok plików między płaskim a drzewem. Płaski układ pokazuje wszystkie ścieżki plików na jednej liście, układ drzewa grupuje pliki według katalogów. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | Szukaj w bieżącym widoku po tekście |  |
 
 ## Podsumowanie commita

--- a/docs/keybindings/Keybindings_ru.md
+++ b/docs/keybindings/Keybindings_ru.md
@@ -270,6 +270,8 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` a `` | Переключить все файлы, включённые в патч | Add/remove all commit's files to custom patch. See https://github.com/jesseduffield/lazygit#rebase-magic-custom-patches. |
 | `` <enter> `` | Введите файл, чтобы добавить выбранные строки в патч (или свернуть каталог переключения) | If a file is selected, enter the file so that you can add/remove individual lines to the custom patch. If a directory is selected, toggle the directory. |
 | `` ` `` | Переключить вид дерева файлов | Toggle file view between flat and tree layout. Flat layout shows all file paths in a single list, tree layout groups files by directory. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | Найти |  |
 
 ## Статус
@@ -353,6 +355,8 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | Open external diff tool (git difftool) |  |
 | `` M `` | Открыть внешний инструмент слияния (git mergetool) | Run `git mergetool`. |
 | `` f `` | Получить изменения | Fetch changes from remote. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | Найти |  |
 
 ## Хранилище

--- a/docs/keybindings/Keybindings_zh-CN.md
+++ b/docs/keybindings/Keybindings_zh-CN.md
@@ -195,6 +195,8 @@ _图例：`<c-b>` 意味着ctrl+b, `<a-b>意味着Alt+b, `B` 意味着shift+b_
 | `` a `` | 操作所有文件 | 添加或删除所有提交中的文件到自定义的补丁中。请参阅 https://github.com/jesseduffield/lazygit#rebase-magic-custom-patches。 |
 | `` <enter> `` | 输入文件以将所选行添加到补丁中(或切换目录折叠) | 如果已选择一个文件，则Enter进入该文件，以便您可以向自定义补丁添加/删除单独的行。如果选择了目录，则切换目录。 |
 | `` ` `` | 切换文件树视图 | 在平铺部署与树布局之间切换文件视图。平铺布局在一个列表中展示所有文件路径，树布局则根据目录分组展示。 |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | 开始搜索 |  |
 
 ## 文件
@@ -225,6 +227,8 @@ _图例：`<c-b>` 意味着ctrl+b, `<a-b>意味着Alt+b, `B` 意味着shift+b_
 | `` <c-t> `` | 使用外部差异比较工具(git difftool) |  |
 | `` M `` | 打开外部合并工具(git mergetool) | 执行 `git mergetool`. |
 | `` f `` | 抓取 | 从远程获取变更 |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | 开始搜索 |  |
 
 ## 构建补丁中

--- a/docs/keybindings/Keybindings_zh-TW.md
+++ b/docs/keybindings/Keybindings_zh-TW.md
@@ -219,6 +219,8 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` a `` | 切換所有檔案是否包含在補丁中 | Add/remove all commit's files to custom patch. See https://github.com/jesseduffield/lazygit#rebase-magic-custom-patches. |
 | `` <enter> `` | 輸入檔案以將選定的行添加至補丁（或切換目錄折疊） | If a file is selected, enter the file so that you can add/remove individual lines to the custom patch. If a directory is selected, toggle the directory. |
 | `` ` `` | 顯示檔案樹狀視圖 | Toggle file view between flat and tree layout. Flat layout shows all file paths in a single list, tree layout groups files by directory. |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | 搜尋 |  |
 
 ## 收藏 (Stash)
@@ -320,6 +322,8 @@ If you would instead like to start an interactive rebase from the selected commi
 | `` <c-t> `` | 開啟外部差異工具 (git difftool) |  |
 | `` M `` | 開啟外部合併工具 | 執行 `git mergetool`。 |
 | `` f `` | 擷取 | 同步遠端異動 |
+| `` - `` | Collapse all files | Collapse all directories in the files tree |
+| `` = `` | Expand all files | Expand all directories in the file tree |
 | `` / `` | 搜尋 |  |
 
 ## 狀態

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -456,6 +456,8 @@ type KeybindingFilesConfig struct {
 	OpenMergeTool            string `yaml:"openMergeTool"`
 	OpenStatusFilter         string `yaml:"openStatusFilter"`
 	CopyFileInfoToClipboard  string `yaml:"copyFileInfoToClipboard"`
+	CollapseAll              string `yaml:"collapseAll"`
+	ExpandAll                string `yaml:"expandAll"`
 }
 
 type KeybindingBranchesConfig struct {
@@ -898,6 +900,8 @@ func GetDefaultConfig() *UserConfig {
 				OpenStatusFilter:         "<c-b>",
 				ConfirmDiscard:           "x",
 				CopyFileInfoToClipboard:  "y",
+				CollapseAll:              "-",
+				ExpandAll:                "=",
 			},
 			Branches: KeybindingBranchesConfig{
 				CopyPullRequestURL:     "<c-y>",

--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -109,6 +109,20 @@ func (self *CommitFilesController) GetKeybindings(opts types.KeybindingsOpts) []
 			Description: self.c.Tr.ToggleTreeView,
 			Tooltip:     self.c.Tr.ToggleTreeViewTooltip,
 		},
+		{
+			Key:               opts.GetKey(opts.Config.Files.CollapseAll),
+			Handler:           self.collapseAll,
+			Description:       self.c.Tr.CollapseAll,
+			Tooltip:           self.c.Tr.CollapseAllTooltip,
+			GetDisabledReason: self.require(self.isInTreeMode),
+		},
+		{
+			Key:               opts.GetKey(opts.Config.Files.ExpandAll),
+			Handler:           self.expandAll,
+			Description:       self.c.Tr.ExpandAll,
+			Tooltip:           self.c.Tr.ExpandAllTooltip,
+			GetDisabledReason: self.require(self.isInTreeMode),
+		},
 	}
 
 	return bindings
@@ -401,6 +415,22 @@ func (self *CommitFilesController) toggleTreeView() error {
 	return nil
 }
 
+func (self *CommitFilesController) collapseAll() error {
+	self.context().CommitFileTreeViewModel.CollapseAll()
+
+	self.c.PostRefreshUpdate(self.context())
+
+	return nil
+}
+
+func (self *CommitFilesController) expandAll() error {
+	self.context().CommitFileTreeViewModel.ExpandAll()
+
+	self.c.PostRefreshUpdate(self.context())
+
+	return nil
+}
+
 // NOTE: these functions are identical to those in files_controller.go (except for types) and
 // could also be cleaned up with some generics
 func normalisedSelectedCommitFileNodes(selectedNodes []*filetree.CommitFileNode) []*filetree.CommitFileNode {
@@ -419,4 +449,12 @@ func isDescendentOfSelectedCommitFileNodes(node *filetree.CommitFileNode, select
 		}
 	}
 	return false
+}
+
+func (self *CommitFilesController) isInTreeMode() *types.DisabledReason {
+	if !self.context().CommitFileTreeViewModel.InTreeMode() {
+		return &types.DisabledReason{Text: self.c.Tr.DisabledInFlatView}
+	}
+
+	return nil
 }

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -186,6 +186,20 @@ func (self *FilesController) GetKeybindings(opts types.KeybindingsOpts) []*types
 			Description: self.c.Tr.Fetch,
 			Tooltip:     self.c.Tr.FetchTooltip,
 		},
+		{
+			Key:               opts.GetKey(opts.Config.Files.CollapseAll),
+			Handler:           self.collapseAll,
+			Description:       self.c.Tr.CollapseAll,
+			Tooltip:           self.c.Tr.CollapseAllTooltip,
+			GetDisabledReason: self.require(self.isInTreeMode),
+		},
+		{
+			Key:               opts.GetKey(opts.Config.Files.ExpandAll),
+			Handler:           self.expandAll,
+			Description:       self.c.Tr.ExpandAll,
+			Tooltip:           self.c.Tr.ExpandAllTooltip,
+			GetDisabledReason: self.require(self.isInTreeMode),
+		},
 	}
 }
 
@@ -476,6 +490,22 @@ func (self *FilesController) getSelectedFile() *models.File {
 
 func (self *FilesController) enter() error {
 	return self.EnterFile(types.OnFocusOpts{ClickedWindowName: "", ClickedViewLineIdx: -1})
+}
+
+func (self *FilesController) collapseAll() error {
+	self.context().FileTreeViewModel.CollapseAll()
+
+	self.c.PostRefreshUpdate(self.context())
+
+	return nil
+}
+
+func (self *FilesController) expandAll() error {
+	self.context().FileTreeViewModel.ExpandAll()
+
+	self.c.PostRefreshUpdate(self.context())
+
+	return nil
 }
 
 func (self *FilesController) EnterFile(opts types.OnFocusOpts) error {
@@ -1180,4 +1210,12 @@ func (self *FilesController) formattedPaths(nodes []*filetree.FileNode) string {
 	return utils.FormatPaths(lo.Map(nodes, func(node *filetree.FileNode, _ int) string {
 		return node.GetPath()
 	}))
+}
+
+func (self *FilesController) isInTreeMode() *types.DisabledReason {
+	if !self.context().FileTreeViewModel.InTreeMode() {
+		return &types.DisabledReason{Text: self.c.Tr.DisabledInFlatView}
+	}
+
+	return nil
 }

--- a/pkg/gui/filetree/collapsed_paths.go
+++ b/pkg/gui/filetree/collapsed_paths.go
@@ -36,3 +36,8 @@ func (self *CollapsedPaths) ToggleCollapsed(path string) {
 		self.collapsedPaths.Add(path)
 	}
 }
+
+func (self *CollapsedPaths) ExpandAll() {
+	// Could be cleaner if Set had a Clear() method...
+	self.collapsedPaths.RemoveSlice(self.collapsedPaths.ToSlice())
+}

--- a/pkg/gui/filetree/commit_file_tree.go
+++ b/pkg/gui/filetree/commit_file_tree.go
@@ -25,6 +25,20 @@ type CommitFileTree struct {
 	collapsedPaths *CollapsedPaths
 }
 
+func (self *CommitFileTree) CollapseAll() {
+	dirPaths := lo.FilterMap(self.GetAllItems(), func(file *CommitFileNode, index int) (string, bool) {
+		return file.Path, !file.IsFile()
+	})
+
+	for _, path := range dirPaths {
+		self.collapsedPaths.Collapse(path)
+	}
+}
+
+func (self *CommitFileTree) ExpandAll() {
+	self.collapsedPaths.ExpandAll()
+}
+
 var _ ICommitFileTree = &CommitFileTree{}
 
 func NewCommitFileTree(getFiles func() []*models.CommitFile, log *logrus.Entry, showTree bool) *CommitFileTree {

--- a/pkg/gui/filetree/commit_file_tree_view_model.go
+++ b/pkg/gui/filetree/commit_file_tree_view_model.go
@@ -1,6 +1,7 @@
 package filetree
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
@@ -158,5 +159,35 @@ func (self *CommitFileTreeViewModel) ToggleShowTree() {
 	index, found := self.GetIndexForPath(path)
 	if found {
 		self.SetSelection(index)
+	}
+}
+
+func (self *CommitFileTreeViewModel) CollapseAll() {
+	selectedNode := self.GetSelected()
+
+	self.ICommitFileTree.CollapseAll()
+	if selectedNode == nil {
+		return
+	}
+
+	topLevelPath := strings.Split(selectedNode.Path, "/")[0]
+	index, found := self.GetIndexForPath(topLevelPath)
+	if found {
+		self.SetSelectedLineIdx(index)
+	}
+}
+
+func (self *CommitFileTreeViewModel) ExpandAll() {
+	selectedNode := self.GetSelected()
+
+	self.ICommitFileTree.ExpandAll()
+
+	if selectedNode == nil {
+		return
+	}
+
+	index, found := self.GetIndexForPath(selectedNode.Path)
+	if found {
+		self.SetSelectedLineIdx(index)
 	}
 }

--- a/pkg/gui/filetree/file_tree.go
+++ b/pkg/gui/filetree/file_tree.go
@@ -31,6 +31,8 @@ type ITree[T any] interface {
 	IsCollapsed(path string) bool
 	ToggleCollapsed(path string)
 	CollapsedPaths() *CollapsedPaths
+	CollapseAll()
+	ExpandAll()
 }
 
 type IFileTree interface {
@@ -169,6 +171,20 @@ func (self *FileTree) IsCollapsed(path string) bool {
 
 func (self *FileTree) ToggleCollapsed(path string) {
 	self.collapsedPaths.ToggleCollapsed(path)
+}
+
+func (self *FileTree) CollapseAll() {
+	dirPaths := lo.FilterMap(self.GetAllItems(), func(file *FileNode, index int) (string, bool) {
+		return file.Path, !file.IsFile()
+	})
+
+	for _, path := range dirPaths {
+		self.collapsedPaths.Collapse(path)
+	}
+}
+
+func (self *FileTree) ExpandAll() {
+	self.collapsedPaths.ExpandAll()
 }
 
 func (self *FileTree) Tree() *FileNode {

--- a/pkg/gui/filetree/file_tree_view_model.go
+++ b/pkg/gui/filetree/file_tree_view_model.go
@@ -1,6 +1,7 @@
 package filetree
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
@@ -186,6 +187,36 @@ func (self *FileTreeViewModel) ToggleShowTree() {
 	}
 
 	index, found := self.GetIndexForPath(path)
+	if found {
+		self.SetSelectedLineIdx(index)
+	}
+}
+
+func (self *FileTreeViewModel) CollapseAll() {
+	selectedNode := self.GetSelected()
+
+	self.IFileTree.CollapseAll()
+	if selectedNode == nil {
+		return
+	}
+
+	topLevelPath := strings.Split(selectedNode.Path, "/")[0]
+	index, found := self.GetIndexForPath(topLevelPath)
+	if found {
+		self.SetSelectedLineIdx(index)
+	}
+}
+
+func (self *FileTreeViewModel) ExpandAll() {
+	selectedNode := self.GetSelected()
+
+	self.IFileTree.ExpandAll()
+
+	if selectedNode == nil {
+		return
+	}
+
+	index, found := self.GetIndexForPath(selectedNode.Path)
 	if found {
 		self.SetSelectedLineIdx(index)
 	}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -256,6 +256,11 @@ type TranslationSet struct {
 	NoBranchOnRemote                      string
 	Fetch                                 string
 	FetchTooltip                          string
+	CollapseAll                           string
+	CollapseAllTooltip                    string
+	ExpandAll                             string
+	ExpandAllTooltip                      string
+	DisabledInFlatView                    string
 	FileEnter                             string
 	FileEnterTooltip                      string
 	FileStagingRequirements               string
@@ -1258,6 +1263,11 @@ func EnglishTranslationSet() *TranslationSet {
 		NoBranchOnRemote:                     `This branch doesn't exist on remote. You need to push it to remote first.`,
 		Fetch:                                `Fetch`,
 		FetchTooltip:                         "Fetch changes from remote.",
+		CollapseAll:                          "Collapse all files",
+		CollapseAllTooltip:                   "Collapse all directories in the files tree",
+		ExpandAll:                            "Expand all files",
+		ExpandAllTooltip:                     "Expand all directories in the file tree",
+		DisabledInFlatView:                   "Not available in flat view",
 		FileEnter:                            `Stage lines / Collapse directory`,
 		FileEnterTooltip:                     "If the selected item is a file, focus the staging view so you can stage individual hunks/lines. If the selected item is a directory, collapse/expand it.",
 		FileStagingRequirements:              `Can only stage individual lines for tracked files`,

--- a/pkg/integration/tests/file/collapse_expand.go
+++ b/pkg/integration/tests/file/collapse_expand.go
@@ -1,0 +1,46 @@
+package file
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CollapseExpand = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Collapsing and expanding all files in the file tree",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateDir("dir")
+		shell.CreateFile("dir/file-one", "original content\n")
+		shell.CreateDir("dir2")
+		shell.CreateFile("dir2/file-two", "original content\n")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			IsFocused().
+			Lines(
+				Contains("dir").IsSelected(),
+				Contains("??").Contains("file-one"),
+				Contains("dir2"),
+				Contains("??").Contains("file-two"),
+			)
+
+		t.Views().Files().
+			Press(keys.Files.CollapseAll).
+			Lines(
+				Contains("dir"),
+				Contains("dir2"),
+			)
+
+		t.Views().Files().
+			Press(keys.Files.ExpandAll).
+			Lines(
+				Contains("dir").IsSelected(),
+				Contains("??").Contains("file-one"),
+				Contains("dir2"),
+				Contains("??").Contains("file-two"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -164,6 +164,7 @@ var tests = []*components.IntegrationTest{
 	diff.DiffNonStickyRange,
 	diff.IgnoreWhitespace,
 	diff.RenameSimilarityThresholdChange,
+	file.CollapseExpand,
 	file.CopyMenu,
 	file.DirWithUntrackedFile,
 	file.DiscardAllDirChanges,

--- a/schema/config.json
+++ b/schema/config.json
@@ -1463,6 +1463,14 @@
             "copyFileInfoToClipboard": {
               "type": "string",
               "default": "y"
+            },
+            "collapseAll": {
+              "type": "string",
+              "default": "-"
+            },
+            "expandAll": {
+              "type": "string",
+              "default": "="
             }
           },
           "additionalProperties": false,


### PR DESCRIPTION
Seems like this feature is highly requested #4095 #3554

Ability to collpase/expand all files in the tree both for working files and commit view files. One issue I noticed is that currently any functionality that we want to add related to the file tree has to be duplicated across both controllers/models. I would like to try to unite the functionality using generics but I would prefer if it was done as part of a separate PR as it will greatly increase the scope of this PR and doesn't look trivial. Any feedback is welcome, thanks!

Example of functionality working:
![example](https://github.com/user-attachments/assets/bb480b77-dace-4c5a-90b5-27daddf19eba)
