### PR TITLE
docs: Stylize and correct the NixOS section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ nix-shell -p lazygit
 nix run nixpkgs#lazygit
 ```
 
-Or you can add lazygit to you configuration.nix in the environment.systemPackages section.
+Or you can add lazygit to you `configuration.nix` using the `environment.systemPackages` option.
 More details can be found via NixOs search [page](https://search.nixos.org/).
 
 ### Flox


### PR DESCRIPTION

- **PR Description**

configuration.nix is a file, and most files in the README.md are stylized as code blocks. `environment.systemPackages` is actually just a code block, and should be stylized as such.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ x ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [ x ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
