### PR TITLE
Show the alt-enter keybinding at bottom of commit description view

### DIFF
--- a/pkg/gui/controllers/commit_description_controller.go
+++ b/pkg/gui/controllers/commit_description_controller.go
@@ -3,7 +3,9 @@ package controllers
 import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
+	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 type CommitDescriptionController struct {
@@ -56,6 +58,15 @@ func (self *CommitDescriptionController) GetMouseKeybindings(opts types.Keybindi
 			Key:      gocui.MouseLeft,
 			Handler:  self.onClick,
 		},
+	}
+}
+
+func (self *CommitDescriptionController) GetOnFocus() func(types.OnFocusOpts) {
+	return func(types.OnFocusOpts) {
+		self.c.Views().CommitDescription.Footer = utils.ResolvePlaceholderString(self.c.Tr.CommitDescriptionFooter,
+			map[string]string{
+				"confirmInEditorKeybinding": keybindings.Label(self.c.UserConfig().Keybinding.Universal.ConfirmInEditor),
+			})
 	}
 }
 

--- a/pkg/gui/controllers/commit_message_controller.go
+++ b/pkg/gui/controllers/commit_message_controller.go
@@ -69,6 +69,12 @@ func (self *CommitMessageController) GetMouseKeybindings(opts types.KeybindingsO
 	}
 }
 
+func (self *CommitMessageController) GetOnFocus() func(types.OnFocusOpts) {
+	return func(types.OnFocusOpts) {
+		self.c.Views().CommitDescription.Footer = ""
+	}
+}
+
 func (self *CommitMessageController) GetOnFocusLost() func(types.OnFocusLostOpts) {
 	return func(types.OnFocusLostOpts) {
 		self.context().RenderCommitLength()

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -290,6 +290,7 @@ type TranslationSet struct {
 	CommitSummaryTitle                    string
 	CommitDescriptionTitle                string
 	CommitDescriptionSubTitle             string
+	CommitDescriptionFooter               string
 	LocalBranchesTitle                    string
 	SearchTitle                           string
 	TagsTitle                             string
@@ -1290,6 +1291,7 @@ func EnglishTranslationSet() *TranslationSet {
 		CommitSummaryTitle:                   "Commit summary",
 		CommitDescriptionTitle:               "Commit description",
 		CommitDescriptionSubTitle:            "Press {{.togglePanelKeyBinding}} to toggle focus, {{.commitMenuKeybinding}} to open menu",
+		CommitDescriptionFooter:              "Press {{.confirmInEditorKeybinding}} to commit",
 		LocalBranchesTitle:                   "Local branches",
 		SearchTitle:                          "Search",
 		TagsTitle:                            "Tags",


### PR DESCRIPTION
- **PR Description**

It wasn't really obvious how to commit when the focus is in the commit description view, since pressing enter inserts a newline there. To improve this, show the `<a-enter>` keybinding at the bottom of the description view when it is focused.

Fixes #4134.
