### PR TITLE
Default to half-screen mode when opening with certain CLI args

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -583,7 +583,7 @@ func initialScreenMode(startArgs appTypes.StartArgs, config config.AppConfigurer
 	if startArgs.ScreenMode != "" {
 		return getWindowMaximisation(startArgs.ScreenMode)
 	} else if startArgs.FilterPath != "" || startArgs.GitArg != appTypes.GitArgNone {
-		return types.SCREEN_FULL
+		return types.SCREEN_HALF
 	} else {
 		return getWindowMaximisation(config.GetUserConfig().Gui.WindowSize)
 	}

--- a/pkg/integration/tests/demo/bisect.go
+++ b/pkg/integration/tests/demo/bisect.go
@@ -7,7 +7,7 @@ import (
 
 var Bisect = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Interactive rebase",
-	ExtraCmdArgs: []string{"log"},
+	ExtraCmdArgs: []string{"log", "--screen-mode=full"},
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {

--- a/pkg/integration/tests/demo/commit_graph.go
+++ b/pkg/integration/tests/demo/commit_graph.go
@@ -7,7 +7,7 @@ import (
 
 var CommitGraph = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Show commit graph",
-	ExtraCmdArgs: []string{"log"},
+	ExtraCmdArgs: []string{"log", "--screen-mode=full"},
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {

--- a/pkg/integration/tests/demo/interactive_rebase.go
+++ b/pkg/integration/tests/demo/interactive_rebase.go
@@ -7,7 +7,7 @@ import (
 
 var InteractiveRebase = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Interactive rebase",
-	ExtraCmdArgs: []string{"log"},
+	ExtraCmdArgs: []string{"log", "--screen-mode=full"},
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {

--- a/pkg/integration/tests/demo/nuke_working_tree.go
+++ b/pkg/integration/tests/demo/nuke_working_tree.go
@@ -7,7 +7,7 @@ import (
 
 var NukeWorkingTree = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Nuke the working tree",
-	ExtraCmdArgs: []string{"status"},
+	ExtraCmdArgs: []string{"status", "--screen-mode=full"},
 	Skip:         false,
 	IsDemo:       true,
 	SetupConfig: func(config *config.AppConfig) {


### PR DESCRIPTION
It should have been half-screen from the get-go. I think I just used full-screen to make demos look nicer. Now that we have a CLI arg for the screen mode we can make use of that in the demos.

Relates to https://github.com/jesseduffield/lazygit/issues/3042

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
