### PR TITLE
Standardise on 'screen mode' naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Undo uses the reflog which is specific to commits and branches so we can't undo 
 
 ### Commit graph
 
-When viewing the commit graph in an enlarged window (use `+` and `_` to cycle window sizes), the commit graph is shown. Colours correspond to the commit authors, and as you navigate down the graph, the parent commits of the selected commit are highlighted.
+When viewing the commit graph in an enlarged window (use `+` and `_` to cycle screen modes), the commit graph is shown. Colours correspond to the commit authors, and as you navigate down the graph, the parent commits of the selected commit are highlighted.
 
 ![commit_graph](../assets/demo/commit_graph-compressed.gif)
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -219,9 +219,9 @@ gui:
   # If 'auto', only split the main window when a file has both staged and unstaged changes
   splitDiff: auto
 
-  # Default size for focused window. Window size can be changed from within Lazygit with '+' and '_' (but this won't change the default).
+  # Default size for focused window. Can be changed from within Lazygit with '+' and '_' (but this won't change the default).
   # One of: 'normal' (default) | 'half' | 'full'
-  windowSize: normal
+  screenMode: normal
 
   # Window border style.
   # One of 'rounded' (default) | 'single' | 'double' | 'hidden'

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -217,16 +217,23 @@ func loadUserConfig(configFiles []*ConfigFile, base *UserConfig) (*UserConfig, e
 // from one container to another, or changing the type of a key (e.g. from bool
 // to an enum).
 func migrateUserConfig(path string, content []byte) ([]byte, error) {
-	changedContent, err := yaml_utils.RenameYamlKey(content, []string{"gui", "skipUnstageLineWarning"},
-		"skipDiscardChangeWarning")
-	if err != nil {
-		return nil, fmt.Errorf("Couldn't migrate config file at `%s`: %s", path, err)
+	changedContent := content
+
+	pathsToReplace := []struct {
+		oldPath []string
+		newName string
+	}{
+		{[]string{"gui", "skipUnstageLineWarning"}, "skipDiscardChangeWarning"},
+		{[]string{"keybinding", "universal", "executeCustomCommand"}, "executeShellCommand"},
+		{[]string{"gui", "windowSize"}, "screenMode"},
 	}
 
-	changedContent, err = yaml_utils.RenameYamlKey(changedContent, []string{"keybinding", "universal", "executeCustomCommand"},
-		"executeShellCommand")
-	if err != nil {
-		return nil, fmt.Errorf("Couldn't migrate config file at `%s`: %s", path, err)
+	var err error
+	for _, pathToReplace := range pathsToReplace {
+		changedContent, err = yaml_utils.RenameYamlKey(changedContent, pathToReplace.oldPath, pathToReplace.newName)
+		if err != nil {
+			return nil, fmt.Errorf("Couldn't migrate config file at `%s` for key %s: %s", path, strings.Join(pathToReplace.oldPath, "."), err)
+		}
 	}
 
 	changedContent, err = changeNullKeybindingsToDisabled(changedContent)

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -148,9 +148,9 @@ type GuiConfig struct {
 	// One of: 'auto' | 'always'
 	// If 'auto', only split the main window when a file has both staged and unstaged changes
 	SplitDiff string `yaml:"splitDiff" jsonschema:"enum=auto,enum=always"`
-	// Default size for focused window. Window size can be changed from within Lazygit with '+' and '_' (but this won't change the default).
+	// Default size for focused window. Can be changed from within Lazygit with '+' and '_' (but this won't change the default).
 	// One of: 'normal' (default) | 'half' | 'full'
-	WindowSize string `yaml:"windowSize" jsonschema:"enum=normal,enum=half,enum=full"`
+	ScreenMode string `yaml:"screenMode" jsonschema:"enum=normal,enum=half,enum=full"`
 	// Window border style.
 	// One of 'rounded' (default) | 'single' | 'double' | 'hidden'
 	Border string `yaml:"border" jsonschema:"enum=single,enum=double,enum=rounded,enum=hidden"`
@@ -734,7 +734,7 @@ func GetDefaultConfig() *UserConfig {
 			CommandLogSize:               8,
 			SplitDiff:                    "auto",
 			SkipRewordInEditorWarning:    false,
-			WindowSize:                   "normal",
+			ScreenMode:                   "normal",
 			Border:                       "rounded",
 			AnimateExplosion:             true,
 			PortraitMode:                 "auto",

--- a/pkg/gui/controllers/helpers/window_arrangement_helper.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper.go
@@ -53,7 +53,7 @@ type WindowArrangementArgs struct {
 	// staged and unstaged changes)
 	SplitMainPanel bool
 	// The current screen mode (normal, half, full)
-	ScreenMode types.WindowMaximisation
+	ScreenMode types.ScreenMode
 	// The content shown on the bottom left of the screen when showing a loader
 	// or toast e.g. 'Rebasing /'
 	AppStatus string

--- a/pkg/gui/controllers/screen_mode_actions.go
+++ b/pkg/gui/controllers/screen_mode_actions.go
@@ -12,7 +12,7 @@ type ScreenModeActions struct {
 func (self *ScreenModeActions) Next() error {
 	self.c.State().GetRepoState().SetScreenMode(
 		nextIntInCycle(
-			[]types.WindowMaximisation{types.SCREEN_NORMAL, types.SCREEN_HALF, types.SCREEN_FULL},
+			[]types.ScreenMode{types.SCREEN_NORMAL, types.SCREEN_HALF, types.SCREEN_FULL},
 			self.c.State().GetRepoState().GetScreenMode(),
 		),
 	)
@@ -24,7 +24,7 @@ func (self *ScreenModeActions) Next() error {
 func (self *ScreenModeActions) Prev() error {
 	self.c.State().GetRepoState().SetScreenMode(
 		prevIntInCycle(
-			[]types.WindowMaximisation{types.SCREEN_NORMAL, types.SCREEN_HALF, types.SCREEN_FULL},
+			[]types.ScreenMode{types.SCREEN_NORMAL, types.SCREEN_HALF, types.SCREEN_FULL},
 			self.c.State().GetRepoState().GetScreenMode(),
 		),
 	)
@@ -53,7 +53,7 @@ func (self *ScreenModeActions) rerenderView(view *gocui.View) {
 	context.HandleRender()
 }
 
-func nextIntInCycle(sl []types.WindowMaximisation, current types.WindowMaximisation) types.WindowMaximisation {
+func nextIntInCycle(sl []types.ScreenMode, current types.ScreenMode) types.ScreenMode {
 	for i, val := range sl {
 		if val == current {
 			if i == len(sl)-1 {
@@ -65,7 +65,7 @@ func nextIntInCycle(sl []types.WindowMaximisation, current types.WindowMaximisat
 	return sl[0]
 }
 
-func prevIntInCycle(sl []types.WindowMaximisation, current types.WindowMaximisation) types.WindowMaximisation {
+func prevIntInCycle(sl []types.ScreenMode, current types.ScreenMode) types.ScreenMode {
 	for i, val := range sl {
 		if val == current {
 			if i > 0 {

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -244,7 +244,7 @@ type GuiRepoState struct {
 	// back in sync with the repo state
 	ViewsSetup bool
 
-	ScreenMode types.WindowMaximisation
+	ScreenMode types.ScreenMode
 
 	CurrentPopupOpts *types.CreatePopupPanelOpts
 }
@@ -275,11 +275,11 @@ func (self *GuiRepoState) SetCurrentPopupOpts(value *types.CreatePopupPanelOpts)
 	self.CurrentPopupOpts = value
 }
 
-func (self *GuiRepoState) GetScreenMode() types.WindowMaximisation {
+func (self *GuiRepoState) GetScreenMode() types.ScreenMode {
 	return self.ScreenMode
 }
 
-func (self *GuiRepoState) SetScreenMode(value types.WindowMaximisation) {
+func (self *GuiRepoState) SetScreenMode(value types.ScreenMode) {
 	self.ScreenMode = value
 }
 
@@ -580,18 +580,18 @@ func initialWindowViewNameMap(contextTree *context.ContextTree) *utils.ThreadSaf
 	return result
 }
 
-func initialScreenMode(startArgs appTypes.StartArgs, config config.AppConfigurer) types.WindowMaximisation {
+func initialScreenMode(startArgs appTypes.StartArgs, config config.AppConfigurer) types.ScreenMode {
 	if startArgs.ScreenMode != "" {
-		return getWindowMaximisation(startArgs.ScreenMode)
+		return parseScreenModeArg(startArgs.ScreenMode)
 	} else if startArgs.FilterPath != "" || startArgs.GitArg != appTypes.GitArgNone {
 		return types.SCREEN_HALF
 	} else {
-		return getWindowMaximisation(config.GetUserConfig().Gui.WindowSize)
+		return parseScreenModeArg(config.GetUserConfig().Gui.ScreenMode)
 	}
 }
 
-func getWindowMaximisation(modeString string) types.WindowMaximisation {
-	switch modeString {
+func parseScreenModeArg(screenModeArg string) types.ScreenMode {
+	switch screenModeArg {
 	case "half":
 		return types.SCREEN_HALF
 	case "full":

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -362,8 +362,8 @@ type IRepoStateAccessor interface {
 	SetStartupStage(stage StartupStage)
 	GetCurrentPopupOpts() *CreatePopupPanelOpts
 	SetCurrentPopupOpts(*CreatePopupPanelOpts)
-	GetScreenMode() WindowMaximisation
-	SetScreenMode(WindowMaximisation)
+	GetScreenMode() ScreenMode
+	SetScreenMode(ScreenMode)
 	InSearchPrompt() bool
 	GetSearchState() *SearchState
 	SetSplitMainPanel(bool)
@@ -382,10 +382,10 @@ const (
 // as in panel, not your terminal's window). Sometimes you want a bit more space
 // to see the contents of a panel, and this keeps track of how much maximisation
 // you've set
-type WindowMaximisation int
+type ScreenMode int
 
 const (
-	SCREEN_NORMAL WindowMaximisation = iota
+	SCREEN_NORMAL ScreenMode = iota
 	SCREEN_HALF
 	SCREEN_FULL
 )

--- a/schema/config.json
+++ b/schema/config.json
@@ -388,14 +388,14 @@
           "description": "Whether to split the main window when viewing file changes.\nOne of: 'auto' | 'always'\nIf 'auto', only split the main window when a file has both staged and unstaged changes",
           "default": "auto"
         },
-        "windowSize": {
+        "screenMode": {
           "type": "string",
           "enum": [
             "normal",
             "half",
             "full"
           ],
-          "description": "Default size for focused window. Window size can be changed from within Lazygit with '+' and '_' (but this won't change the default).\nOne of: 'normal' (default) | 'half' | 'full'",
+          "description": "Default size for focused window. Can be changed from within Lazygit with '+' and '_' (but this won't change the default).\nOne of: 'normal' (default) | 'half' | 'full'",
           "default": "normal"
         },
         "border": {


### PR DESCRIPTION
We had some conflicting names: screen-mode, window-size, and window-maximisation. I think panel-size sounds good.

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
