### PR TITLE
Don't show keybindings option in bottom line when panel is open

### DIFF
--- a/pkg/gui/controllers/global_controller.go
+++ b/pkg/gui/controllers/global_controller.go
@@ -69,10 +69,11 @@ func (self *GlobalController) GetKeybindings(opts types.KeybindingsOpts) []*type
 			Modifier: gocui.ModNone,
 			// we have the description on the alt key and not the main key for legacy reasons
 			// (the original main key was 'x' but we've reassigned that to other purposes)
-			Description:      self.c.Tr.OpenKeybindingsMenu,
-			Handler:          self.createOptionsMenu,
-			ShortDescription: self.c.Tr.Keybindings,
-			DisplayOnScreen:  true,
+			Description:       self.c.Tr.OpenKeybindingsMenu,
+			Handler:           self.createOptionsMenu,
+			ShortDescription:  self.c.Tr.Keybindings,
+			DisplayOnScreen:   true,
+			GetDisabledReason: self.optionsMenuDisabledReason,
 		},
 		{
 			ViewName:    "",
@@ -154,6 +155,17 @@ func (self *GlobalController) prevScreenMode() error {
 
 func (self *GlobalController) createOptionsMenu() error {
 	return (&OptionsMenuAction{c: self.c}).Call()
+}
+
+func (self *GlobalController) optionsMenuDisabledReason() *types.DisabledReason {
+	ctx := self.c.Context().Current()
+	// Don't show options menu while displaying popup.
+	if ctx.GetKind() == types.PERSISTENT_POPUP || ctx.GetKind() == types.TEMPORARY_POPUP {
+		// The empty error text is intentional. We don't want to show an error
+		// toast for this, but only hide it from the options map.
+		return &types.DisabledReason{Text: ""}
+	}
+	return nil
 }
 
 func (self *GlobalController) createFilteringMenu() error {

--- a/pkg/gui/controllers/options_menu_action.go
+++ b/pkg/gui/controllers/options_menu_action.go
@@ -13,11 +13,6 @@ type OptionsMenuAction struct {
 
 func (self *OptionsMenuAction) Call() error {
 	ctx := self.c.Context().Current()
-	// Don't show menu while displaying popup.
-	if ctx.GetKind() == types.PERSISTENT_POPUP || ctx.GetKind() == types.TEMPORARY_POPUP {
-		return nil
-	}
-
 	local, global, navigation := self.getBindings(ctx)
 
 	menuItems := []*types.MenuItem{}

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -453,7 +453,9 @@ func (gui *Gui) callKeybindingHandler(binding *types.Binding) error {
 			return errors.New(disabledReason.Text)
 		}
 
-		gui.c.ErrorToast(gui.Tr.DisabledMenuItemPrefix + disabledReason.Text)
+		if len(disabledReason.Text) > 0 {
+			gui.c.ErrorToast(gui.Tr.DisabledMenuItemPrefix + disabledReason.Text)
+		}
 		return nil
 	}
 	return binding.Handler()


### PR DESCRIPTION
- **PR Description**

Hide the `Keybindings: ?` option from the bottom line if a panel is open.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
