### PR TITLE
Fix reset/rebase to upstream

### DIFF
--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -194,6 +194,10 @@ func (self *BranchesController) GetOnRenderToMain() func() {
 }
 
 func (self *BranchesController) viewUpstreamOptions(selectedBranch *models.Branch) error {
+	upstream := lo.Ternary(selectedBranch.RemoteBranchStoredLocally(),
+		selectedBranch.ShortUpstreamRefName(),
+		self.c.Tr.UpstreamGenericName)
+
 	viewDivergenceItem := &types.MenuItem{
 		LabelColumns: []string{self.c.Tr.ViewDivergenceFromUpstream},
 		OnPress: func() error {
@@ -204,7 +208,7 @@ func (self *BranchesController) viewUpstreamOptions(selectedBranch *models.Branc
 
 			return self.c.Helpers().SubCommits.ViewSubCommits(helpers.ViewSubCommitsOpts{
 				Ref:                     branch,
-				TitleRef:                fmt.Sprintf("%s <-> %s", branch.RefName(), branch.ShortUpstreamRefName()),
+				TitleRef:                fmt.Sprintf("%s <-> %s", branch.RefName(), upstream),
 				RefToShowDivergenceFrom: branch.FullUpstreamRefName(),
 				Context:                 self.context(),
 				ShowBranchHeads:         false,
@@ -293,9 +297,6 @@ func (self *BranchesController) viewUpstreamOptions(selectedBranch *models.Branc
 		Key: 's',
 	}
 
-	upstream := lo.Ternary(selectedBranch.RemoteBranchStoredLocally(),
-		selectedBranch.ShortUpstreamRefName(),
-		self.c.Tr.UpstreamGenericName)
 	upstreamResetOptions := utils.ResolvePlaceholderString(
 		self.c.Tr.ViewUpstreamResetOptions,
 		map[string]string{"upstream": upstream},
@@ -332,7 +333,7 @@ func (self *BranchesController) viewUpstreamOptions(selectedBranch *models.Branc
 		LabelColumns: []string{upstreamRebaseOptions},
 		OpensMenu:    true,
 		OnPress: func() error {
-			if err := self.c.Helpers().MergeAndRebase.RebaseOntoRef(selectedBranch.ShortUpstreamRefName()); err != nil {
+			if err := self.c.Helpers().MergeAndRebase.RebaseOntoRef(upstream); err != nil {
 				return err
 			}
 			return nil

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -294,7 +294,7 @@ func (self *BranchesController) viewUpstreamOptions(selectedBranch *models.Branc
 	}
 
 	upstream := lo.Ternary(selectedBranch.RemoteBranchStoredLocally(),
-		fmt.Sprintf("%s/%s", selectedBranch.UpstreamRemote, selectedBranch.Name),
+		selectedBranch.ShortUpstreamRefName(),
 		self.c.Tr.UpstreamGenericName)
 	upstreamResetOptions := utils.ResolvePlaceholderString(
 		self.c.Tr.ViewUpstreamResetOptions,

--- a/pkg/integration/components/shell.go
+++ b/pkg/integration/components/shell.go
@@ -142,6 +142,10 @@ func (self *Shell) NewBranchFrom(name string, from string) *Shell {
 	return self.RunCommand([]string{"git", "checkout", "-b", name, from})
 }
 
+func (self *Shell) RenameCurrentBranch(newName string) *Shell {
+	return self.RunCommand([]string{"git", "branch", "-m", newName})
+}
+
 func (self *Shell) Checkout(name string) *Shell {
 	return self.RunCommand([]string{"git", "checkout", name})
 }

--- a/pkg/integration/tests/branch/rebase_to_upstream.go
+++ b/pkg/integration/tests/branch/rebase_to_upstream.go
@@ -16,8 +16,9 @@ var RebaseToUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 			EmptyCommit("ensure-master").
 			EmptyCommit("to-be-added"). // <- this will only exist remotely
 			PushBranchAndSetUpstream("origin", "master").
+			RenameCurrentBranch("master-local").
 			HardReset("HEAD~1").
-			NewBranchFrom("base-branch", "master").
+			NewBranchFrom("base-branch", "master-local").
 			EmptyCommit("base-branch-commit").
 			NewBranch("target").
 			EmptyCommit("target-commit")
@@ -34,13 +35,13 @@ var RebaseToUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 			Lines(
 				Contains("target").IsSelected(),
 				Contains("base-branch"),
-				Contains("master"),
+				Contains("master-local"),
 			).
 			SelectNextItem().
 			Lines(
 				Contains("target"),
 				Contains("base-branch").IsSelected(),
-				Contains("master"),
+				Contains("master-local"),
 			).
 			Press(keys.Branches.SetUpstream).
 			Tap(func() {
@@ -58,13 +59,16 @@ var RebaseToUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 			Lines(
 				Contains("target"),
 				Contains("base-branch"),
-				Contains("master").IsSelected(),
+				Contains("master-local").IsSelected(),
 			).
 			Press(keys.Branches.SetUpstream).
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Upstream options")).
+					/* EXPECTED:
 					Select(Contains("Rebase checked-out branch onto origin/master...")).
+					ACTUAL: */
+					Select(Contains("Rebase checked-out branch onto origin/master-local...")).
 					Confirm()
 				t.ExpectPopup().Menu().
 					Title(Equals("Rebase 'target'")).

--- a/pkg/integration/tests/branch/rebase_to_upstream.go
+++ b/pkg/integration/tests/branch/rebase_to_upstream.go
@@ -65,10 +65,7 @@ var RebaseToUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Upstream options")).
-					/* EXPECTED:
 					Select(Contains("Rebase checked-out branch onto origin/master...")).
-					ACTUAL: */
-					Select(Contains("Rebase checked-out branch onto origin/master-local...")).
 					Confirm()
 				t.ExpectPopup().Menu().
 					Title(Equals("Rebase 'target'")).

--- a/pkg/integration/tests/branch/reset_to_upstream.go
+++ b/pkg/integration/tests/branch/reset_to_upstream.go
@@ -59,27 +59,14 @@ var ResetToUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Upstream options")).
-					/* EXPECTED:
 					Select(Contains("Reset checked-out branch onto origin/soft-branch...")).
-					ACTUAL: */
-					Select(Contains("Reset checked-out branch onto origin/soft-branch-local...")).
 					Confirm()
 
 				t.ExpectPopup().Menu().
-					/* EXPECTED:
 					Title(Equals("Reset to origin/soft-branch")).
-					ACTUAL: */
-					Title(Equals("Reset to origin/soft-branch-local")).
 					Select(Contains("Soft reset")).
 					Confirm()
-
-				// Bug: the command fails
-				t.ExpectPopup().Alert().
-					Title(Equals("Error")).
-					Content(Contains("fatal: ambiguous argument 'origin/soft-branch-local': unknown revision or path not in the working tree.")).
-					Confirm()
 			})
-		/* Since the command failed, the following assertions are not valid
 		t.Views().Commits().Lines(
 			Contains("soft commit"),
 			Contains("hard commit"),
@@ -88,7 +75,6 @@ var ResetToUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 			Contains("file-1").Contains("A"),
 			Contains("file-2").Contains("A"),
 		)
-		*/
 
 		// hard reset
 		t.Views().Branches().


### PR DESCRIPTION
- **PR Description**

Resetting to the upstream branch was broken when the remote branch has a different name than the local branch.

Rebasing onto the upstream worked fine, but also displayed the wrong branch name in the menu.

Fixes #4148.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
