### PR TITLE
Fix `micro` editor preset

### DIFF
--- a/pkg/config/editor_presets.go
+++ b/pkg/config/editor_presets.go
@@ -66,9 +66,15 @@ func getPreset(osConfig *OSConfig, guessDefaultEditor func() string) *editPreset
 				return !ok
 			},
 		},
-		"lvim":    standardTerminalEditorPreset("lvim"),
-		"emacs":   standardTerminalEditorPreset("emacs"),
-		"micro":   standardTerminalEditorPreset("micro"),
+		"lvim":  standardTerminalEditorPreset("lvim"),
+		"emacs": standardTerminalEditorPreset("emacs"),
+		"micro": {
+			editTemplate:              "micro {{filename}}",
+			editAtLineTemplate:        "micro +{{line}} {{filename}}",
+			editAtLineAndWaitTemplate: "micro +{{line}} {{filename}}",
+			openDirInEditorTemplate:   "micro {{dir}}",
+			suspend:                   returnBool(true),
+		},
 		"nano":    standardTerminalEditorPreset("nano"),
 		"kakoune": standardTerminalEditorPreset("kak"),
 		"helix": {


### PR DESCRIPTION
- **PR Description**

I don't know what was I thinking when making #3049, because Micro does not actually support `--` as delimiter between options and files. As such, when trying to edit files with `micro` set as editor, an empty file named `--` would be open first.

This PR fixes this by explicitly defining a preset for `micro`. I've double-tested it to make sure that it doesn't behave wierdly any more :D

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
