### PR TITLE
Add number of commits to cherry-pick confirmation prompt

### DIFF
--- a/pkg/gui/controllers/helpers/cherry_pick_helper.go
+++ b/pkg/gui/controllers/helpers/cherry_pick_helper.go
@@ -1,10 +1,13 @@
 package helpers
 
 import (
+	"strconv"
+
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/modes/cherrypicking"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
 )
 
@@ -67,8 +70,12 @@ func (self *CherryPickHelper) CopyRange(commitsList []*models.Commit, context ty
 // Only to be called from the branch commits controller
 func (self *CherryPickHelper) Paste() error {
 	self.c.Confirm(types.ConfirmOpts{
-		Title:  self.c.Tr.CherryPick,
-		Prompt: self.c.Tr.SureCherryPick,
+		Title: self.c.Tr.CherryPick,
+		Prompt: utils.ResolvePlaceholderString(
+			self.c.Tr.SureCherryPick,
+			map[string]string{
+				"numCommits": strconv.Itoa(len(self.getData().CherryPickedCommits)),
+			}),
 		HandleConfirm: func() error {
 			isInRebase, err := self.c.Git().Status.IsInInteractiveRebase()
 			if err != nil {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1337,7 +1337,7 @@ func EnglishTranslationSet() *TranslationSet {
 		CherryPickCopyTooltip:                "Mark commit as copied. Then, within the local commits view, you can press `{{.paste}}` to paste (cherry-pick) the copied commit(s) into your checked out branch. At any time you can press `{{.escape}}` to cancel the selection.",
 		CherryPickCopyRangeTooltip:           "Mark commits as copied from the last copied commit to the selected commit.",
 		PasteCommits:                         "Paste (cherry-pick)",
-		SureCherryPick:                       "Are you sure you want to cherry-pick the copied commits onto this branch?",
+		SureCherryPick:                       "Are you sure you want to cherry-pick the {{.numCommits}} copied commit(s) onto this branch?",
 		CherryPick:                           "Cherry-pick",
 		CannotCherryPickNonCommit:            "Cannot cherry-pick this kind of todo item",
 		CannotCherryPickMergeCommit:          "Cherry-picking merge commits is not supported",

--- a/pkg/integration/tests/cherry_pick/cherry_pick.go
+++ b/pkg/integration/tests/cherry_pick/cherry_pick.go
@@ -66,7 +66,7 @@ var CherryPick = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Alert().
 					Title(Equals("Cherry-pick")).
-					Content(Contains("Are you sure you want to cherry-pick the copied commits onto this branch?")).
+					Content(Contains("Are you sure you want to cherry-pick the 2 copied commit(s) onto this branch?")).
 					Confirm()
 			}).
 			Tap(func() {
@@ -95,7 +95,7 @@ var CherryPick = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Alert().
 					Title(Equals("Cherry-pick")).
-					Content(Contains("Are you sure you want to cherry-pick the copied commits onto this branch?")).
+					Content(Contains("Are you sure you want to cherry-pick the 2 copied commit(s) onto this branch?")).
 					Confirm()
 			}).
 			Tap(func() {

--- a/pkg/integration/tests/cherry_pick/cherry_pick_conflicts.go
+++ b/pkg/integration/tests/cherry_pick/cherry_pick_conflicts.go
@@ -49,7 +49,7 @@ var CherryPickConflicts = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().Alert().
 			Title(Equals("Cherry-pick")).
-			Content(Contains("Are you sure you want to cherry-pick the copied commits onto this branch?")).
+			Content(Contains("Are you sure you want to cherry-pick the 2 copied commit(s) onto this branch?")).
 			Confirm()
 
 		t.Common().AcknowledgeConflicts()

--- a/pkg/integration/tests/cherry_pick/cherry_pick_during_rebase.go
+++ b/pkg/integration/tests/cherry_pick/cherry_pick_during_rebase.go
@@ -67,7 +67,7 @@ var CherryPickDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Alert().
 					Title(Equals("Cherry-pick")).
-					Content(Contains("Are you sure you want to cherry-pick the copied commits onto this branch?")).
+					Content(Contains("Are you sure you want to cherry-pick the 1 copied commit(s) onto this branch?")).
 					Confirm()
 			}).
 			Tap(func() {

--- a/pkg/integration/tests/cherry_pick/cherry_pick_range.go
+++ b/pkg/integration/tests/cherry_pick/cherry_pick_range.go
@@ -63,7 +63,7 @@ var CherryPickRange = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Alert().
 					Title(Equals("Cherry-pick")).
-					Content(Contains("Are you sure you want to cherry-pick the copied commits onto this branch?")).
+					Content(Contains("Are you sure you want to cherry-pick the 2 copied commit(s) onto this branch?")).
 					Confirm()
 			}).
 			Tap(func() {

--- a/pkg/integration/tests/demo/cherry_pick.go
+++ b/pkg/integration/tests/demo/cherry_pick.go
@@ -71,7 +71,7 @@ var CherryPick = NewIntegrationTest(NewIntegrationTestArgs{
 				t.Wait(1000)
 				t.ExpectPopup().Alert().
 					Title(Equals("Cherry-pick")).
-					Content(Contains("Are you sure you want to cherry-pick the copied commits onto this branch?")).
+					Content(Contains("Are you sure you want to cherry-pick the 2 copied commit(s) onto this branch?")).
 					Confirm()
 			}).
 			TopLines(

--- a/pkg/integration/tests/reflog/cherry_pick.go
+++ b/pkg/integration/tests/reflog/cherry_pick.go
@@ -39,7 +39,7 @@ var CherryPick = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Alert().
 					Title(Equals("Cherry-pick")).
-					Content(Contains("Are you sure you want to cherry-pick the copied commits onto this branch?")).
+					Content(Contains("Are you sure you want to cherry-pick the 1 copied commit(s) onto this branch?")).
 					Confirm()
 			}).
 			Lines(


### PR DESCRIPTION
- **PR Description**

The other day, I was cherry-picking a selection of commits and was annoyed that the "Are you sure..." prompt did not include the actual number of commits I was about to cherry-pick.

I failed to realize the number of copied commits is displayed at the bottom right until going to update the integration tests. I personally think it's still nice to display the number in the actual confirmation prompt but feel free to close this PR if the change is unwanted.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
