### PR TITLE
Use interactive shell for running shell commands only if shell is bash or zsh

### DIFF
--- a/pkg/commands/oscommands/os_default_platform.go
+++ b/pkg/commands/oscommands/os_default_platform.go
@@ -6,16 +6,29 @@ package oscommands
 import (
 	"os"
 	"runtime"
+	"strings"
 )
 
 func GetPlatform() *Platform {
+	shell := getUserShell()
+
+	interactiveShell := shell
+	interactiveShellArg := "-i"
+	interactiveShellExit := "; exit $?"
+
+	if !(strings.HasSuffix(shell, "bash") || strings.HasSuffix(shell, "zsh")) {
+		interactiveShell = "bash"
+		interactiveShellArg = ""
+		interactiveShellExit = ""
+	}
+
 	return &Platform{
 		OS:                   runtime.GOOS,
 		Shell:                "bash",
-		InteractiveShell:     getUserShell(),
+		InteractiveShell:     interactiveShell,
 		ShellArg:             "-c",
-		InteractiveShellArg:  "-i",
-		InteractiveShellExit: "; exit $?",
+		InteractiveShellArg:  interactiveShellArg,
+		InteractiveShellExit: interactiveShellExit,
 		OpenCommand:          "open {{filename}}",
 		OpenLinkCommand:      "open {{link}}",
 	}


### PR DESCRIPTION
- **PR Description**

Fix running shell commands with fish or nushell.

Fixes #4153.
