### PR TITLE
Improve undo action to restore files upon undoing a commit

### DIFF
--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -732,8 +732,9 @@ type TranslationSet struct {
 	ConfirmRevertCommit                      string
 	RewordInEditorTitle                      string
 	RewordInEditorPrompt                     string
-	CheckoutPrompt                           string
+	CheckoutAutostashPrompt                  string
 	HardResetAutostashPrompt                 string
+	SoftResetPrompt                          string
 	UpstreamGone                             string
 	NukeDescription                          string
 	DiscardStagedChangesDescription          string
@@ -1745,7 +1746,8 @@ func EnglishTranslationSet() *TranslationSet {
 		RewordInEditorTitle:                      "Reword in editor",
 		RewordInEditorPrompt:                     "Are you sure you want to reword this commit in your editor?",
 		HardResetAutostashPrompt:                 "Are you sure you want to hard reset to '%s'? An auto-stash will be performed if necessary.",
-		CheckoutPrompt:                           "Are you sure you want to checkout '%s'?",
+		SoftResetPrompt:                          "Are you sure you want to soft reset to '%s'?",
+		CheckoutAutostashPrompt:                  "Are you sure you want to checkout '%s'? An auto-stash will be performed if necessary.",
 		UpstreamGone:                             "(upstream gone)",
 		NukeDescription:                          "If you want to make all the changes in the worktree go away, this is the way to do it. If there are dirty submodule changes this will stash those changes in the submodule(s).",
 		DiscardStagedChangesDescription:          "This will create a new stash entry containing only staged files and then drop it, so that the working tree is left with only unstaged changes",

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -367,6 +367,7 @@ var tests = []*components.IntegrationTest{
 	ui.SwitchTabFromMenu,
 	ui.SwitchTabWithPanelJumpKeys,
 	undo.UndoCheckoutAndDrop,
+	undo.UndoCommit,
 	undo.UndoDrop,
 	worktree.AddFromBranch,
 	worktree.AddFromBranchDetached,

--- a/pkg/integration/tests/undo/undo_commit.go
+++ b/pkg/integration/tests/undo/undo_commit.go
@@ -1,0 +1,110 @@
+package undo
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var UndoCommit = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Undo/redo a commit",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("other-file", "other-file-1")
+		shell.Commit("one")
+		shell.CreateFileAndAdd("file", "file-1")
+		shell.Commit("two")
+		shell.UpdateFile("other-file", "other-file-2")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		confirmUndo := func() {
+			t.ExpectPopup().Confirmation().
+				Title(Equals("Undo")).
+				Content(MatchesRegexp(`Are you sure you want to soft reset to '.*'\?`)).
+				Confirm()
+		}
+
+		confirmRedo := func() {
+			t.ExpectPopup().Confirmation().
+				Title(Equals("Redo")).
+				Content(MatchesRegexp(`Are you sure you want to hard reset to '.*'\? An auto-stash will be performed if necessary\.`)).
+				Confirm()
+		}
+
+		confirmDiscardFile := func() {
+			t.ExpectPopup().Menu().
+				Title(Equals("Discard changes")).
+				Select(Contains("Discard all changes")).
+				Confirm()
+		}
+
+		t.Views().Files().
+			Lines(
+				Contains(" M other-file"),
+			)
+
+		t.Views().Commits().Focus().
+			Lines(
+				Contains("two").IsSelected(),
+				Contains("one"),
+			).
+			Press(keys.Universal.Undo).
+			Tap(confirmUndo).
+			Lines(
+				Contains("one").IsSelected(),
+			)
+
+		t.Views().Files().
+			Lines(
+				Contains("A  file"),
+				Contains(" M other-file"),
+			)
+
+		t.Views().Commits().Focus().
+			Press(keys.Universal.Redo).
+			Tap(confirmRedo).
+			Lines(
+				Contains("two").IsSelected(),
+				Contains("one"),
+			)
+
+		t.Views().Files().
+			Lines(
+				Contains(" M other-file"),
+			)
+
+		// Undo again, this time discarding the original change before redoing again
+		t.Views().Commits().Focus().
+			Press(keys.Universal.Undo).
+			Tap(confirmUndo).
+			Lines(
+				Contains("one").IsSelected(),
+			)
+
+		t.Views().Files().Focus().
+			Lines(
+				Contains("A  file"),
+				Contains(" M other-file").IsSelected(),
+			).
+			Press(keys.Universal.PrevItem).
+			Press(keys.Universal.Remove).
+			Tap(confirmDiscardFile).
+			Lines(
+				Contains(" M other-file"),
+			).
+			Press(keys.Universal.Redo).
+			Tap(confirmRedo)
+
+		t.Views().Commits().
+			Lines(
+				Contains("two"),
+				Contains("one"),
+			)
+
+		t.Views().Files().
+			Lines(
+				Contains(" M other-file"),
+			)
+	},
+})


### PR DESCRIPTION
- **PR Description**

Right now, undoing a commit performs a hard reset, which also discards all the changes from that commit. This PR adds new config options (and a new `undo` section) which allow users to choose between `hard` and `soft` reset modes when undoing commits.

Personally, I think that the default should be `soft`, because the state before the commit had the files, so undoing a commit should put the files where they were before. But this PR keeps `hard` as the default and does not change current behavior.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
