### PR TITLE
Add `nvim-qt` to editor presets

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -716,7 +716,7 @@ os:
   editPreset: 'vscode'
 ```
 
-Supported presets are `vim`, `nvim`, `nvim-remote`, `lvim`, `emacs`, `nano`, `micro`, `vscode`, `sublime`, `bbedit`, `kakoune`, `helix`, `xcode`, and `zed`. In many cases lazygit will be able to guess the right preset from your $(git config core.editor), or an environment variable such as $VISUAL or $EDITOR.
+Supported presets are `vim`, `nvim`, `nvim-qt`, `nvim-remote`, `lvim`, `emacs`, `nano`, `micro`, `vscode`, `sublime`, `bbedit`, `kakoune`, `helix`, `xcode`, and `zed`. In many cases lazygit will be able to guess the right preset from your $(git config core.editor), or an environment variable such as $VISUAL or $EDITOR.
 
 `nvim-remote` is an experimental preset for when you have invoked lazygit from within a neovim process, allowing lazygit to open the file from within the parent process rather than spawning a new one.
 

--- a/pkg/config/editor_presets.go
+++ b/pkg/config/editor_presets.go
@@ -126,6 +126,13 @@ func getPreset(osConfig *OSConfig, guessDefaultEditor func() string) *editPreset
 			openDirInEditorTemplate:   "zed -- {{dir}}",
 			suspend:                   returnBool(false),
 		},
+		"nvim-qt": {
+			editTemplate:              "nvim-qt -- {{filename}}",
+			editAtLineTemplate:        "nvim-qt +{{line}} -- {{filename}}",
+			editAtLineAndWaitTemplate: "nvim-qt +{{line}} -- {{filename}}",
+			openDirInEditorTemplate:   "nvim-qt -- {{dir}}",
+			suspend:                   returnBool(false),
+		},
 	}
 
 	// Some of our presets have a different name than the editor they are using.


### PR DESCRIPTION
- **PR Description**
This PR adds `nvim-qt` to the list of editor presets.
I've only tested this on Windows where escaping from the terminal can be handy at times. Not sure if this makes sense in a Mac of Linux environment, but `nvim-qt` looks quite ubiquitous there as well.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
