### PR TITLE
Fix adding blank line at end of commit message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/integrii/flaggy v1.4.0
 	github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68
 	github.com/jesseduffield/go-git/v5 v5.1.2-0.20221018185014-fdd53fef665d
-	github.com/jesseduffield/gocui v0.3.1-0.20250111205211-82d518436b5a
+	github.com/jesseduffield/gocui v0.3.1-0.20250120165138-5935496e64e2
 	github.com/jesseduffield/kill v0.0.0-20250101124109-e216ddbe133a
 	github.com/jesseduffield/lazycore v0.0.0-20221012050358-03d2e40243c5
 	github.com/jesseduffield/minimal/gitignore v0.3.3-0.20211018110810-9cde264e6b1e

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68 h1:EQP2Tv8T
 github.com/jesseduffield/generics v0.0.0-20220320043834-727e535cbe68/go.mod h1:+LLj9/WUPAP8LqCchs7P+7X0R98HiFujVFANdNaxhGk=
 github.com/jesseduffield/go-git/v5 v5.1.2-0.20221018185014-fdd53fef665d h1:bO+OmbreIv91rCe8NmscRwhFSqkDJtzWCPV4Y+SQuXE=
 github.com/jesseduffield/go-git/v5 v5.1.2-0.20221018185014-fdd53fef665d/go.mod h1:nGNEErzf+NRznT+N2SWqmHnDnF9aLgANB1CUNEan09o=
-github.com/jesseduffield/gocui v0.3.1-0.20250111205211-82d518436b5a h1:GLFWB8rESraTt2eIe2yssy4d4VEkCnmKbPeeZ5vCT2s=
-github.com/jesseduffield/gocui v0.3.1-0.20250111205211-82d518436b5a/go.mod h1:sLIyZ2J42R6idGdtemZzsiR3xY5EF0KsvYEGh3dQv3s=
+github.com/jesseduffield/gocui v0.3.1-0.20250120165138-5935496e64e2 h1:hTLMy8PImlsblWrKcs3ATfNHT5d1IhW3QUcieMrvnOE=
+github.com/jesseduffield/gocui v0.3.1-0.20250120165138-5935496e64e2/go.mod h1:sLIyZ2J42R6idGdtemZzsiR3xY5EF0KsvYEGh3dQv3s=
 github.com/jesseduffield/kill v0.0.0-20250101124109-e216ddbe133a h1:UDeJ3EBk04bXDLOPvuqM3on8HvyJfISw0+UMqW+0a4g=
 github.com/jesseduffield/kill v0.0.0-20250101124109-e216ddbe133a/go.mod h1:FSWDLKT0NQpntbDd1H3lbz51fhCVlMzy/J0S6nM727Q=
 github.com/jesseduffield/lazycore v0.0.0-20221012050358-03d2e40243c5 h1:CDuQmfOjAtb1Gms6a1p5L2P8RhbLUq5t8aL7PiQd2uY=

--- a/pkg/gui/controllers/helpers/confirmation_helper.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper.go
@@ -56,8 +56,8 @@ func (self *ConfirmationHelper) DeactivateConfirmationPrompt() {
 	self.clearConfirmationViewKeyBindings()
 }
 
-func getMessageHeight(wrap bool, message string, width int) int {
-	wrappedLines, _, _ := utils.WrapViewLinesToWidth(wrap, message, width)
+func getMessageHeight(wrap bool, editable bool, message string, width int) int {
+	wrappedLines, _, _ := utils.WrapViewLinesToWidth(wrap, editable, message, width)
 	return len(wrappedLines)
 }
 
@@ -265,7 +265,7 @@ func (self *ConfirmationHelper) resizeMenu(parentPopupContext types.Context) {
 	if selectedItem != nil {
 		tooltip = self.TooltipForMenuItem(selectedItem)
 	}
-	tooltipHeight := getMessageHeight(true, tooltip, contentWidth) + 2 // plus 2 for the frame
+	tooltipHeight := getMessageHeight(true, false, tooltip, contentWidth) + 2 // plus 2 for the frame
 	_, _ = self.c.GocuiGui().SetView(self.c.Views().Tooltip.Name(), x0, tooltipTop, x1, tooltipTop+tooltipHeight-1, 0)
 }
 
@@ -276,7 +276,7 @@ func (self *ConfirmationHelper) layoutMenuPrompt(contentWidth int) int {
 	var promptLines []string
 	prompt := self.c.Contexts().Menu.GetPrompt()
 	if len(prompt) > 0 {
-		promptLines, _, _ = utils.WrapViewLinesToWidth(true, prompt, contentWidth)
+		promptLines, _, _ = utils.WrapViewLinesToWidth(true, false, prompt, contentWidth)
 		promptLines = append(promptLines, "")
 	}
 	self.c.Contexts().Menu.SetPromptLines(promptLines)
@@ -307,11 +307,12 @@ func (self *ConfirmationHelper) resizeConfirmationPanel(parentPopupContext types
 	contentWidth := panelWidth - 2 // minus 2 for the frame
 	prompt := self.c.Views().Confirmation.Buffer()
 	wrap := true
-	if self.c.Views().Confirmation.Editable {
+	editable := self.c.Views().Confirmation.Editable
+	if editable {
 		prompt = self.c.Views().Confirmation.TextArea.GetContent()
 		wrap = false
 	}
-	panelHeight := getMessageHeight(wrap, prompt, contentWidth) + suggestionsViewHeight
+	panelHeight := getMessageHeight(wrap, editable, prompt, contentWidth) + suggestionsViewHeight
 	x0, y0, x1, y1 := self.getPopupPanelDimensionsAux(panelWidth, panelHeight, parentPopupContext)
 	confirmationViewBottom := y1 - suggestionsViewHeight
 	_, _ = self.c.GocuiGui().SetView(self.c.Views().Confirmation.Name(), x0, y0, x1, confirmationViewBottom, 0)
@@ -324,7 +325,7 @@ func (self *ConfirmationHelper) ResizeCommitMessagePanels(parentPopupContext typ
 	panelWidth := self.getPopupPanelWidth()
 	content := self.c.Views().CommitDescription.TextArea.GetContent()
 	summaryViewHeight := 3
-	panelHeight := getMessageHeight(false, content, panelWidth)
+	panelHeight := getMessageHeight(false, true, content, panelWidth)
 	minHeight := 7
 	if panelHeight < minHeight {
 		panelHeight = minHeight

--- a/pkg/gui/patch_exploring/state.go
+++ b/pkg/gui/patch_exploring/state.go
@@ -323,6 +323,6 @@ func (s *State) CalculateOrigin(currentOrigin int, bufferHeight int, numLines in
 
 func wrapPatchLines(diff string, view *gocui.View) ([]int, []int) {
 	_, viewLineIndices, patchLineIndices := utils.WrapViewLinesToWidth(
-		view.Wrap, strings.TrimSuffix(diff, "\n"), view.InnerWidth())
+		view.Wrap, view.Editable, strings.TrimSuffix(diff, "\n"), view.InnerWidth())
 	return viewLineIndices, patchLineIndices
 }

--- a/pkg/utils/lines.go
+++ b/pkg/utils/lines.go
@@ -109,8 +109,10 @@ func ScanLinesAndTruncateWhenLongerThanBuffer(maxBufferSize int) func(data []byt
 // - the line indices of the original lines, indexed by the wrapped line indices
 // If wrap is false, the text is returned as is.
 // This code needs to behave the same as `gocui.lineWrap` does.
-func WrapViewLinesToWidth(wrap bool, text string, width int) ([]string, []int, []int) {
-	text = strings.TrimSuffix(text, "\n")
+func WrapViewLinesToWidth(wrap bool, editable bool, text string, width int) ([]string, []int, []int) {
+	if !editable {
+		text = strings.TrimSuffix(text, "\n")
+	}
 	lines := strings.Split(text, "\n")
 	if !wrap {
 		indices := make([]int, len(lines))

--- a/pkg/utils/lines_test.go
+++ b/pkg/utils/lines_test.go
@@ -170,6 +170,7 @@ func TestWrapViewLinesToWidth(t *testing.T) {
 	tests := []struct {
 		name                         string
 		wrap                         bool
+		editable                     bool
 		text                         string
 		width                        int
 		expectedWrappedLines         []string
@@ -378,10 +379,53 @@ func TestWrapViewLinesToWidth(t *testing.T) {
 			expectedWrappedLinesIndices:  []int{0, 2, 6},
 			expectedOriginalLinesIndices: []int{0, 0, 1, 1, 1, 1, 2, 2},
 		},
+		{
+			name:     "Avoid blank line at end if not editable",
+			wrap:     true,
+			editable: false,
+			text:     "First\nSecond\nThird\n",
+			width:    10,
+			expectedWrappedLines: []string{
+				"First",
+				"Second",
+				"Third",
+			},
+			expectedWrappedLinesIndices:  []int{0, 1, 2},
+			expectedOriginalLinesIndices: []int{0, 1, 2},
+		},
+		{
+			name:     "Avoid blank line at end if not editable",
+			wrap:     true,
+			editable: false,
+			text:     "First\nSecond\nThird\n",
+			width:    10,
+			expectedWrappedLines: []string{
+				"First",
+				"Second",
+				"Third",
+			},
+			expectedWrappedLinesIndices:  []int{0, 1, 2},
+			expectedOriginalLinesIndices: []int{0, 1, 2},
+		},
+		{
+			name:     "Keep blank line at end if editable",
+			wrap:     true,
+			editable: true,
+			text:     "First\nSecond\nThird\n",
+			width:    10,
+			expectedWrappedLines: []string{
+				"First",
+				"Second",
+				"Third",
+				"",
+			},
+			expectedWrappedLinesIndices:  []int{0, 1, 2, 3},
+			expectedOriginalLinesIndices: []int{0, 1, 2, 3},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			wrappedLines, wrappedLinesIndices, originalLinesIndices := WrapViewLinesToWidth(tt.wrap, tt.text, tt.width)
+			wrappedLines, wrappedLinesIndices, originalLinesIndices := WrapViewLinesToWidth(tt.wrap, tt.editable, tt.text, tt.width)
 			assert.Equal(t, tt.expectedWrappedLines, wrappedLines)
 			if tt.expectedWrappedLinesIndices != nil {
 				assert.Equal(t, tt.expectedWrappedLinesIndices, wrappedLinesIndices)
@@ -394,6 +438,7 @@ func TestWrapViewLinesToWidth(t *testing.T) {
 			view := gocui.NewView("", 0, 0, tt.width+1, 1000, gocui.OutputNormal)
 			assert.Equal(t, tt.width, view.InnerWidth())
 			view.Wrap = tt.wrap
+			view.Editable = tt.editable
 			view.SetContent(tt.text)
 			assert.Equal(t, wrappedLines, view.ViewBufferLines())
 		})

--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -787,7 +787,7 @@ func (v *View) writeRunes(p []rune) {
 	}
 
 	until := len(p)
-	if until > 0 && p[until-1] == '\n' {
+	if !v.Editable && until > 0 && p[until-1] == '\n' {
 		v.pendingNewline = true
 		until--
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -171,7 +171,7 @@ github.com/jesseduffield/go-git/v5/utils/merkletrie/filesystem
 github.com/jesseduffield/go-git/v5/utils/merkletrie/index
 github.com/jesseduffield/go-git/v5/utils/merkletrie/internal/frame
 github.com/jesseduffield/go-git/v5/utils/merkletrie/noder
-# github.com/jesseduffield/gocui v0.3.1-0.20250111205211-82d518436b5a
+# github.com/jesseduffield/gocui v0.3.1-0.20250120165138-5935496e64e2
 ## explicit; go 1.12
 github.com/jesseduffield/gocui
 # github.com/jesseduffield/kill v0.0.0-20250101124109-e216ddbe133a


### PR DESCRIPTION
- **PR Description**

This fixes a bug where adding enough new lines to a commit message description such that it becomes taller than the window so that the window needs to resize vertically, the cursor wouldn't move to the added blank line, but stay at the end of the previous line. This was a regression introduced with #4152.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
