### PR TITLE
Add '--' to 'git rev-list' to disambiguate branch name from path

### DIFF
--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -275,6 +275,7 @@ func (self *BranchCommands) IsBranchMerged(branch *models.Branch, mainBranches *
 		Arg(lo.Map(branchesToCheckAgainst, func(branch string, _ int) string {
 			return fmt.Sprintf("^%s", branch)
 		})...).
+		Arg("--").
 		ToArgv()
 
 	stdout, _, err := self.cmd.New(cmdArgs).RunWithOutputs()


### PR DESCRIPTION
- **PR Description**

When deleting a local branch that has the same name as a file known to git (say `test`), a popup with the following error is shown:
```
fatal: ambiguous argument 'test': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]' 
```
The command log reveals this:
```
git rev-list --max-count=1 test ^HEAD ^refs/heads/main
```

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
