### PR TITLE
Preserve pending commit message when closing/re-opening

### DIFF
--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -113,7 +113,7 @@ func (self *CommitsHelper) UpdateCommitPanelView(message string) {
 	}
 
 	if self.c.Contexts().CommitMessage.GetPreserveMessage() {
-		preservedMessage := self.c.Contexts().CommitMessage.GetPreservedMessage()
+		preservedMessage := self.c.Contexts().CommitMessage.GetPreservedMessageAndLogError()
 		self.SetMessageAndDescriptionInView(preservedMessage)
 		return
 	}
@@ -156,7 +156,7 @@ func (self *CommitsHelper) OpenCommitMessagePanel(opts *OpenCommitMessagePanelOp
 func (self *CommitsHelper) OnCommitSuccess() {
 	// if we have a preserved message we want to clear it on success
 	if self.c.Contexts().CommitMessage.GetPreserveMessage() {
-		self.c.Contexts().CommitMessage.SetPreservedMessage("")
+		self.c.Contexts().CommitMessage.SetPreservedMessageAndLogError("")
 	}
 }
 
@@ -179,7 +179,7 @@ func (self *CommitsHelper) CloseCommitMessagePanel() {
 	if self.c.Contexts().CommitMessage.GetPreserveMessage() {
 		message := self.JoinCommitMessageAndUnwrappedDescription()
 		if message != self.c.Contexts().CommitMessage.GetInitialMessage() {
-			self.c.Contexts().CommitMessage.SetPreservedMessage(message)
+			self.c.Contexts().CommitMessage.SetPreservedMessageAndLogError(message)
 		}
 	} else {
 		self.SetMessageAndDescriptionInView("")

--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -149,7 +149,7 @@ func (self *WorkingTreeHelper) HandleWIPCommitPress() error {
 }
 
 func (self *WorkingTreeHelper) HandleCommitPress() error {
-	message := self.c.Contexts().CommitMessage.GetPreservedMessage()
+	message := self.c.Contexts().CommitMessage.GetPreservedMessageAndLogError()
 
 	if message == "" {
 		commitPrefixConfig := self.commitPrefixConfigForRepo()

--- a/pkg/integration/components/commit_description_panel_driver.go
+++ b/pkg/integration/components/commit_description_panel_driver.go
@@ -52,6 +52,11 @@ func (self *CommitDescriptionPanelDriver) AddCoAuthor(author string) *CommitDesc
 	return self
 }
 
+func (self *CommitDescriptionPanelDriver) Clear() *CommitDescriptionPanelDriver {
+	self.getViewDriver().Clear()
+	return self
+}
+
 func (self *CommitDescriptionPanelDriver) Title(expected *TextMatcher) *CommitDescriptionPanelDriver {
 	self.getViewDriver().Title(expected)
 

--- a/pkg/integration/components/commit_message_panel_driver.go
+++ b/pkg/integration/components/commit_message_panel_driver.go
@@ -39,20 +39,7 @@ func (self *CommitMessagePanelDriver) SwitchToDescription() *CommitDescriptionPa
 }
 
 func (self *CommitMessagePanelDriver) Clear() *CommitMessagePanelDriver {
-	// clearing multiple times in case there's multiple lines
-	//  (the clear button only clears a single line at a time)
-	maxAttempts := 100
-	for i := 0; i < maxAttempts+1; i++ {
-		if self.getViewDriver().getView().Buffer() == "" {
-			break
-		}
-
-		self.t.press(ClearKey)
-		if i == maxAttempts {
-			panic("failed to clear commit message panel")
-		}
-	}
-
+	self.getViewDriver().Clear()
 	return self
 }
 

--- a/pkg/integration/components/view_driver.go
+++ b/pkg/integration/components/view_driver.go
@@ -40,6 +40,24 @@ func (self *ViewDriver) Title(expected *TextMatcher) *ViewDriver {
 	return self
 }
 
+func (self *ViewDriver) Clear() *ViewDriver {
+	// clearing multiple times in case there's multiple lines
+	//  (the clear button only clears a single line at a time)
+	maxAttempts := 100
+	for i := 0; i < maxAttempts+1; i++ {
+		if self.getView().Buffer() == "" {
+			break
+		}
+
+		self.t.press(ClearKey)
+		if i == maxAttempts {
+			panic("failed to clear view buffer")
+		}
+	}
+
+	return self
+}
+
 // asserts that the view has lines matching the given matchers. One matcher must be passed for each line.
 // If you only care about the top n lines, use the TopLines method instead.
 // If you only care about a subset of lines, use the ContainsLines method instead.

--- a/pkg/integration/tests/commit/preserve_commit_message.go
+++ b/pkg/integration/tests/commit/preserve_commit_message.go
@@ -28,6 +28,8 @@ var PreserveCommitMessage = NewIntegrationTest(NewIntegrationTestArgs{
 			Type("second paragraph").
 			Cancel()
 
+		t.FileSystem().PathPresent(".git/LAZYGIT_PENDING_COMMIT")
+
 		t.Views().Files().
 			IsFocused().
 			Press(keys.Files.CommitChanges)
@@ -35,6 +37,22 @@ var PreserveCommitMessage = NewIntegrationTest(NewIntegrationTestArgs{
 		t.ExpectPopup().CommitMessagePanel().
 			Content(Equals("my commit message")).
 			SwitchToDescription().
-			Content(Equals("first paragraph\n\nsecond paragraph"))
+			Content(Equals("first paragraph\n\nsecond paragraph")).
+			Clear().
+			SwitchToSummary().
+			Clear().
+			Cancel()
+
+		t.FileSystem().PathNotPresent(".git/LAZYGIT_PENDING_COMMIT")
+
+		t.Views().Files().
+			IsFocused().
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			Type("my new commit message").
+			Confirm()
+
+		t.FileSystem().PathNotPresent(".git/LAZYGIT_PENDING_COMMIT")
 	},
 })


### PR DESCRIPTION
- **PR Description**
This PR allows lazygit to preserve the commit messages when the commit popup gets closed.

While discussing the feature as part of its issue, two approaches were taken into consideration:
- to store the commit content as part of the global state file
- to store the commit content in a special file to place inside the `.git` folder

I opted for the second approach to avoid worrying about associating each preserved message to the worktree it belongs to. I am happy to reconsider this and opt for the alternative approach, but I wanted to discuss this with the maintainers before deciding.

Note: The preserving file (`.git/LAZYGIT_PENDING_COMMIT`) is deleted when the commit is finalized or when the commit content becomes empty.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
