### PR TITLE
Fix possible crash when deleting a branch while filtering is active

### DIFF
--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -490,6 +490,8 @@ func (self *RefreshHelper) refreshBranches(refreshWorktrees bool, keepBranchSele
 		self.refreshView(self.c.Contexts().Worktrees)
 	}
 
+	self.refreshView(self.c.Contexts().Branches)
+
 	if !keepBranchSelectionIndex && prevSelectedBranch != nil {
 		_, idx, found := lo.FindIndexOf(self.c.Contexts().Branches.GetItems(),
 			func(b *models.Branch) bool { return b.Name == prevSelectedBranch.Name })
@@ -497,8 +499,6 @@ func (self *RefreshHelper) refreshBranches(refreshWorktrees bool, keepBranchSele
 			self.c.Contexts().Branches.SetSelectedLineIdx(idx)
 		}
 	}
-
-	self.refreshView(self.c.Contexts().Branches)
 
 	// Need to re-render the commits view because the visualization of local
 	// branch heads might have changed

--- a/pkg/integration/tests/branch/delete_while_filtering.go
+++ b/pkg/integration/tests/branch/delete_while_filtering.go
@@ -1,0 +1,49 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+// Regression test for deleting the last branch in the unfiltered list while
+// filtering is on. This used to cause a segfault.
+var DeleteWhileFiltering = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Delete a local branch while there's a filter in the branches panel",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetAppState().LocalBranchSortOrder = "alphabetic"
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("one")
+		shell.NewBranch("branch1")
+		shell.NewBranch("branch2")
+		shell.Checkout("master")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("master").IsSelected(),
+				Contains("branch1"),
+				Contains("branch2"),
+			).
+			FilterOrSearch("branch").
+			Lines(
+				Contains("branch1").IsSelected(),
+				Contains("branch2"),
+			).
+			SelectNextItem().
+			Press(keys.Universal.Remove).
+			Tap(func() {
+				t.ExpectPopup().
+					Menu().
+					Title(Equals("Delete branch 'branch2'?")).
+					Select(Contains("Delete local branch")).
+					Confirm()
+			}).
+			Lines(
+				Contains("branch1").IsSelected(),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -45,6 +45,7 @@ var tests = []*components.IntegrationTest{
 	branch.DeleteMultiple,
 	branch.DeleteRemoteBranchWithCredentialPrompt,
 	branch.DeleteRemoteBranchWithDifferentName,
+	branch.DeleteWhileFiltering,
 	branch.DetachedHead,
 	branch.NewBranchAutostash,
 	branch.NewBranchFromRemoteTrackingDifferentName,


### PR DESCRIPTION
- **PR Description**

Fix #4179.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc
