### PR TITLE
Expose {{.SelectedCommitRange}} to custom commands

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -297,6 +297,7 @@ Your commands can contain placeholder strings using Go's [template syntax](https
 
 ```
 SelectedCommit
+SelectedCommitRange
 SelectedFile
 SelectedPath
 SelectedLocalBranch
@@ -313,6 +314,11 @@ CheckedOutBranch
 
 
 To see what fields are available on e.g. the `SelectedFile`, see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/gui/services/custom_commands/models.go) (all the modelling lives in the same file).
+
+We don't support accessing all elements of a range selection yet. We might add this in the future, but as a special case you can access the range of selected commits by using `SelectedCommitRange`, which has two properties `.To` and `.From` which are the hashes of the bottom and top selected commits, respectively. This is useful for passing them to a git command that operates on a range of commits. For example, to create patches for all selected commits, you might use
+```yml
+  command: "git format-patch {{.SelectedCommitRange.From}}^..{{.SelectedCommitRange.To}}"
+```
 
 ## Keybinding collisions
 

--- a/pkg/integration/tests/custom_commands/selected_commit_range.go
+++ b/pkg/integration/tests/custom_commands/selected_commit_range.go
@@ -1,0 +1,41 @@
+package custom_commands
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var SelectedCommitRange = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Use the {{ .SelectedCommitRange }} template variable",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo: func(shell *Shell) {
+		shell.CreateNCommits(3)
+	},
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.GetUserConfig().CustomCommands = []config.CustomCommand{
+			{
+				Key:     "X",
+				Context: "global",
+				Command: `git log --format="%s" {{.SelectedCommitRange.From}}^..{{.SelectedCommitRange.To}} > file.txt`,
+			},
+		}
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().Focus().
+			Lines(
+				Contains("commit 03").IsSelected(),
+				Contains("commit 02"),
+				Contains("commit 01"),
+			)
+
+		t.GlobalPress("X")
+		t.FileSystem().FileContent("file.txt", Equals("commit 03\n"))
+
+		t.Views().Commits().Focus().
+			Press(keys.Universal.RangeSelectDown)
+
+		t.GlobalPress("X")
+		t.FileSystem().FileContent("file.txt", Equals("commit 03\ncommit 02\n"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -139,6 +139,7 @@ var tests = []*components.IntegrationTest{
 	custom_commands.MultipleContexts,
 	custom_commands.MultiplePrompts,
 	custom_commands.SelectedCommit,
+	custom_commands.SelectedCommitRange,
 	custom_commands.SelectedPath,
 	custom_commands.ShowOutputInPanel,
 	custom_commands.SuggestionsCommand,


### PR DESCRIPTION
- **PR Description**

Expose `{{.SelectedCommitRange}}` to custom commands. It has fields .To and .From (the hashes of the last and the first selected commits, respectively), and it is useful for creating git commands that act on a range of commits.

Fixes #4184.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
