### PR TITLE
Fix incorrect stash diff after rename

### DIFF
--- a/pkg/gui/controllers/stash_controller.go
+++ b/pkg/gui/controllers/stash_controller.go
@@ -201,13 +201,13 @@ func (self *StashController) handleRenameStashEntry(stashEntry *models.StashEntr
 		HandleConfirm: func(response string) error {
 			self.c.LogAction(self.c.Tr.Actions.RenameStash)
 			err := self.c.Git().Stash.Rename(stashEntry.Index, response)
-			_ = self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.STASH}})
 			if err != nil {
+				_ = self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.STASH}})
 				return err
 			}
 			self.context().SetSelection(0) // Select the renamed stash
 			self.context().FocusLine()
-			return nil
+			return self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.STASH}})
 		},
 	})
 

--- a/pkg/integration/tests/stash/rename.go
+++ b/pkg/integration/tests/stash/rename.go
@@ -31,5 +31,7 @@ var Rename = NewIntegrationTest(NewIntegrationTestArgs{
 				t.ExpectPopup().Prompt().Title(Equals("Rename stash: stash@{1}")).Type(" baz").Confirm()
 			}).
 			SelectedLine(Contains("On master: foo baz"))
+
+		t.Views().Main().Content(Contains("file-1"))
 	},
 })


### PR DESCRIPTION
- **PR Description**

Reproduction:
```bash
git init
git commit --allow-empty -m "first commit"
touch file1
git add .
git stash push -m "stash1"
touch file2
git add .
git stash push -m "stash2"
lazygit
```
Navigate to the Stash view and rename stash 1
![image](https://github.com/user-attachments/assets/f43b065c-9d28-4375-a5d7-cfe39a4bf216)

Manually refreshing fixes the diff.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
