### PR TITLE
Show background fetch status in bottom line

### DIFF
--- a/pkg/gui/background.go
+++ b/pkg/gui/background.go
@@ -76,7 +76,9 @@ func (self *BackgroundRoutineMgr) startBackgroundFetch() {
 	self.gui.waitForIntro.Wait()
 
 	fetch := func() error {
-		return self.backgroundFetch()
+		return self.gui.PopupHandler.WithWaitingStatusSync(self.gui.Tr.FetchingStatus, func() error {
+			return self.backgroundFetch()
+		})
 	}
 
 	// We want an immediate fetch at startup, and since goEvery starts by

--- a/pkg/gui/background.go
+++ b/pkg/gui/background.go
@@ -76,9 +76,7 @@ func (self *BackgroundRoutineMgr) startBackgroundFetch() {
 	self.gui.waitForIntro.Wait()
 
 	fetch := func() error {
-		err := self.backgroundFetch()
-		self.gui.c.Render()
-		return err
+		return self.backgroundFetch()
 	}
 
 	// We want an immediate fetch at startup, and since goEvery starts by


### PR DESCRIPTION
- **PR Description**

This shows a status as if the user had typed 'f' manually in the files panel.

I want this particularly for the first fetch after startup. There are often
situations where I need to wait for this first background fetch to be done
before I can do what I want (e.g. rebase my branch onto its base branch, or
check out a branch that my coworker has told me they just pushed), but currently
it's hard to tell when that is.

For every subsequent background fetch after the first one it is less important,
but it hopefully doesn't hurt, and it might be nice to have some visual
indication that background activity is happening.