### PR TITLE
Add option to delete local and remote tag

### DIFF
--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -518,8 +518,10 @@ type TranslationSet struct {
 	DeleteTagTitle                        string
 	DeleteLocalTag                        string
 	DeleteRemoteTag                       string
+	DeleteLocalAndRemoteTag               string
 	SelectRemoteTagUpstream               string
 	DeleteRemoteTagPrompt                 string
+	DeleteLocalAndRemoteTagPrompt         string
 	RemoteTagDeletedMessage               string
 	PushTagTitle                          string
 	PushTag                               string
@@ -1539,9 +1541,11 @@ func EnglishTranslationSet() *TranslationSet {
 		DeleteTagTitle:                       "Delete tag '{{.tagName}}'?",
 		DeleteLocalTag:                       "Delete local tag",
 		DeleteRemoteTag:                      "Delete remote tag",
+		DeleteLocalAndRemoteTag:              "Delete local and remote tag",
 		RemoteTagDeletedMessage:              "Remote tag deleted",
 		SelectRemoteTagUpstream:              "Remote from which to remove tag '{{.tagName}}':",
 		DeleteRemoteTagPrompt:                "Are you sure you want to delete the remote tag '{{.tagName}}' from '{{.upstream}}'?",
+		DeleteLocalAndRemoteTagPrompt:        "Are you sure you want to delete '{{.tagName}}' from both your machine and from '{{.upstream}}'?",
 		PushTagTitle:                         "Remote to push tag '{{.tagName}}' to:",
 		// Using 'push tag' rather than just 'push' to disambiguate from a global push
 		PushTag:                        "Push tag",

--- a/pkg/integration/components/shell.go
+++ b/pkg/integration/components/shell.go
@@ -190,6 +190,10 @@ func (self *Shell) Revert(ref string) *Shell {
 	return self.RunCommand([]string{"git", "revert", ref})
 }
 
+func (self *Shell) AssertRemoteTagNotFound(upstream, name string) *Shell {
+	return self.RunCommandExpectError([]string{"git", "ls-remote", "--exit-code", upstream, fmt.Sprintf("refs/tags/%s", name)})
+}
+
 func (self *Shell) CreateLightweightTag(name string, ref string) *Shell {
 	return self.RunCommand([]string{"git", "tag", name, ref})
 }

--- a/pkg/integration/tests/tag/delete_local_and_remote.go
+++ b/pkg/integration/tests/tag/delete_local_and_remote.go
@@ -1,0 +1,75 @@
+package tag
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var DeleteLocalAndRemote = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Create and delete both local and remote annotated tag",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("initial commit")
+		shell.CloneIntoRemote("origin")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Tags().
+			Focus().
+			IsEmpty().
+			Press(keys.Universal.New).
+			Tap(func() {
+				t.ExpectPopup().CommitMessagePanel().
+					Title(Equals("Tag name")).
+					Type("new-tag").
+					SwitchToDescription().
+					Title(Equals("Tag description")).
+					Type("message").
+					SwitchToSummary().
+					Confirm()
+			}).
+			Lines(
+				MatchesRegexp(`new-tag.*message`).IsSelected(),
+			).
+			Press(keys.Universal.Push).
+			Tap(func() {
+				t.ExpectPopup().Prompt().
+					Title(Equals("Remote to push tag 'new-tag' to:")).
+					InitialText(Equals("origin")).
+					SuggestionLines(
+						Contains("origin"),
+					).
+					Confirm()
+			}).
+			Press(keys.Universal.Remove).
+			Tap(func() {
+				t.ExpectPopup().
+					Menu().
+					Title(Equals("Delete tag 'new-tag'?")).
+					Select(Contains("Delete local and remote tag")).
+					Confirm()
+			}).
+			Tap(func() {
+				t.ExpectPopup().Prompt().
+					Title(Equals("Remote from which to remove tag 'new-tag':")).
+					InitialText(Equals("origin")).
+					SuggestionLines(
+						Contains("origin"),
+					).
+					Confirm()
+			}).
+			Tap(func() {
+				t.ExpectPopup().
+					Confirmation().
+					Title(Equals("Delete tag 'new-tag'?")).
+					Content(Equals("Are you sure you want to delete 'new-tag' from both your machine and from 'origin'?")).
+					Confirm()
+			}).
+			IsEmpty().
+			Press(keys.Universal.New).
+			Tap(func() {
+				t.Shell().AssertRemoteTagNotFound("origin", "new-tag")
+			})
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -356,6 +356,7 @@ var tests = []*components.IntegrationTest{
 	tag.CreateWhileCommitting,
 	tag.CrudAnnotated,
 	tag.CrudLightweight,
+	tag.DeleteLocalAndRemote,
 	tag.ForceTagAnnotated,
 	tag.ForceTagLightweight,
 	tag.Reset,


### PR DESCRIPTION
- **PR Description**

Option to delete both local and remote tag, closes #4203.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
