### PR TITLE
Show files filter status

### DIFF
--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -753,6 +753,7 @@ func (self *FilesController) isResolvingConflicts() bool {
 }
 
 func (self *FilesController) handleStatusFilterPressed() error {
+	currentFilter := self.context().GetFilter()
 	return self.c.Menu(types.CreateMenuOptions{
 		Title: self.c.Tr.FilteringMenuTitle,
 		Items: []*types.MenuItem{
@@ -761,35 +762,40 @@ func (self *FilesController) handleStatusFilterPressed() error {
 				OnPress: func() error {
 					return self.setStatusFiltering(filetree.DisplayStaged)
 				},
-				Key: 's',
+				Key:    's',
+				Widget: types.MakeMenuRadioButton(currentFilter == filetree.DisplayStaged),
 			},
 			{
 				Label: self.c.Tr.FilterUnstagedFiles,
 				OnPress: func() error {
 					return self.setStatusFiltering(filetree.DisplayUnstaged)
 				},
-				Key: 'u',
+				Key:    'u',
+				Widget: types.MakeMenuRadioButton(currentFilter == filetree.DisplayUnstaged),
 			},
 			{
 				Label: self.c.Tr.FilterTrackedFiles,
 				OnPress: func() error {
 					return self.setStatusFiltering(filetree.DisplayTracked)
 				},
-				Key: 't',
+				Key:    't',
+				Widget: types.MakeMenuRadioButton(currentFilter == filetree.DisplayTracked),
 			},
 			{
 				Label: self.c.Tr.FilterUntrackedFiles,
 				OnPress: func() error {
 					return self.setStatusFiltering(filetree.DisplayUntracked)
 				},
-				Key: 'T',
+				Key:    'T',
+				Widget: types.MakeMenuRadioButton(currentFilter == filetree.DisplayUntracked),
 			},
 			{
-				Label: self.c.Tr.ResetFilter,
+				Label: self.c.Tr.NoFilter,
 				OnPress: func() error {
 					return self.setStatusFiltering(filetree.DisplayAll)
 				},
-				Key: 'r',
+				Key:    'r',
+				Widget: types.MakeMenuRadioButton(currentFilter == filetree.DisplayAll),
 			},
 		},
 	})

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/jesseduffield/gocui"
@@ -801,10 +802,30 @@ func (self *FilesController) handleStatusFilterPressed() error {
 	})
 }
 
+func (self *FilesController) filteringLabel(filter filetree.FileTreeDisplayFilter) string {
+	switch filter {
+	case filetree.DisplayAll:
+		return ""
+	case filetree.DisplayStaged:
+		return self.c.Tr.FilterLabelStagedFiles
+	case filetree.DisplayUnstaged:
+		return self.c.Tr.FilterLabelUnstagedFiles
+	case filetree.DisplayTracked:
+		return self.c.Tr.FilterLabelTrackedFiles
+	case filetree.DisplayUntracked:
+		return self.c.Tr.FilterLabelUntrackedFiles
+	case filetree.DisplayConflicted:
+		return self.c.Tr.FilterLabelConflictingFiles
+	}
+
+	panic(fmt.Sprintf("Unexpected files display filter: %d", filter))
+}
+
 func (self *FilesController) setStatusFiltering(filter filetree.FileTreeDisplayFilter) error {
 	previousFilter := self.context().GetFilter()
 
 	self.context().FileTreeViewModel.SetStatusFilter(filter)
+	self.c.Contexts().Files.GetView().Subtitle = self.filteringLabel(filter)
 
 	// Whenever we switch between untracked and other filters, we need to refresh the files view
 	// because the untracked files filter applies when running `git status`.

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -591,9 +591,11 @@ func (self *RefreshHelper) refreshStateFiles() error {
 	if conflictFileCount > 0 && prevConflictFileCount == 0 {
 		if fileTreeViewModel.GetFilter() == filetree.DisplayAll {
 			fileTreeViewModel.SetStatusFilter(filetree.DisplayConflicted)
+			self.c.Contexts().Files.GetView().Subtitle = self.c.Tr.FilterLabelConflictingFiles
 		}
 	} else if conflictFileCount == 0 && fileTreeViewModel.GetFilter() == filetree.DisplayConflicted {
 		fileTreeViewModel.SetStatusFilter(filetree.DisplayAll)
+		self.c.Contexts().Files.GetView().Subtitle = ""
 	}
 
 	self.c.Model().Files = files

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -588,15 +588,11 @@ func (self *RefreshHelper) refreshStateFiles() error {
 	fileTreeViewModel.RWMutex.Lock()
 
 	// only taking over the filter if it hasn't already been set by the user.
-	// Though this does make it impossible for the user to actually say they want to display all if
-	// conflicts are currently being shown. Hmm. Worth it I reckon. If we need to add some
-	// extra state here to see if the user's set the filter themselves we can do that, but
-	// I'd prefer to maintain as little state as possible.
-	if conflictFileCount > 0 {
+	if conflictFileCount > 0 && prevConflictFileCount == 0 {
 		if fileTreeViewModel.GetFilter() == filetree.DisplayAll {
 			fileTreeViewModel.SetStatusFilter(filetree.DisplayConflicted)
 		}
-	} else if fileTreeViewModel.GetFilter() == filetree.DisplayConflicted {
+	} else if conflictFileCount == 0 && fileTreeViewModel.GetFilter() == filetree.DisplayConflicted {
 		fileTreeViewModel.SetStatusFilter(filetree.DisplayAll)
 	}
 

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -89,7 +89,7 @@ type TranslationSet struct {
 	FilterUnstagedFiles                   string
 	FilterTrackedFiles                    string
 	FilterUntrackedFiles                  string
-	ResetFilter                           string
+	NoFilter                              string
 	MergeConflictsTitle                   string
 	Checkout                              string
 	CheckoutTooltip                       string
@@ -1115,7 +1115,7 @@ func EnglishTranslationSet() *TranslationSet {
 		FilterUnstagedFiles:                  "Show only unstaged files",
 		FilterTrackedFiles:                   "Show only tracked files",
 		FilterUntrackedFiles:                 "Show only untracked files",
-		ResetFilter:                          "Reset filter",
+		NoFilter:                             "No filter",
 		NoChangedFiles:                       "No changed files",
 		SoftReset:                            "Soft reset",
 		AlreadyCheckedOutBranch:              "You have already checked out this branch",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -90,6 +90,11 @@ type TranslationSet struct {
 	FilterTrackedFiles                    string
 	FilterUntrackedFiles                  string
 	NoFilter                              string
+	FilterLabelStagedFiles                string
+	FilterLabelUnstagedFiles              string
+	FilterLabelTrackedFiles               string
+	FilterLabelUntrackedFiles             string
+	FilterLabelConflictingFiles           string
 	MergeConflictsTitle                   string
 	Checkout                              string
 	CheckoutTooltip                       string
@@ -1116,6 +1121,11 @@ func EnglishTranslationSet() *TranslationSet {
 		FilterTrackedFiles:                   "Show only tracked files",
 		FilterUntrackedFiles:                 "Show only untracked files",
 		NoFilter:                             "No filter",
+		FilterLabelStagedFiles:               "(only staged)",
+		FilterLabelUnstagedFiles:             "(only unstaged)",
+		FilterLabelTrackedFiles:              "(only tracked)",
+		FilterLabelUntrackedFiles:            "(only untracked)",
+		FilterLabelConflictingFiles:          "(only conflicting)",
 		NoChangedFiles:                       "No changed files",
 		SoftReset:                            "Soft reset",
 		AlreadyCheckedOutBranch:              "You have already checked out this branch",

--- a/pkg/integration/tests/conflicts/filter.go
+++ b/pkg/integration/tests/conflicts/filter.go
@@ -25,7 +25,7 @@ var Filter = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Filtering")).
-					Select(Contains("Reset filter")).
+					Select(Contains("No filter")).
 					Confirm()
 			}).
 			Lines(

--- a/pkg/integration/tests/filter_and_search/filter_by_file_status.go
+++ b/pkg/integration/tests/filter_and_search/filter_by_file_status.go
@@ -52,7 +52,7 @@ var FilterByFileStatus = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Filtering")).
-					Select(Contains("Reset filter")).
+					Select(Contains("No filter")).
 					Confirm()
 			}).
 			Lines(


### PR DESCRIPTION
- **PR Description**

This PR contains three improvements to the Files panel filtering:
- it allows the user to switch to a different filter type (or reset the filter) when we are auto-showing only conflicting files
- it shows the filter menu as radio buttons
- it displays the current filter in the top-right corner of the Files panel's frame

See the individual commits for details.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
