### PR TITLE
Don't try killing processes if we already know the command finished + reduce error logging noise on Windows

### DIFF
--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -277,8 +277,10 @@ func (self *ViewBufferManager) NewCmdTask(start func() (*exec.Cmd, io.Reader), p
 			refreshViewIfStale()
 
 			if err := cmd.Wait(); err != nil {
-				// it's fine if we've killed this program ourselves
-				if !strings.Contains(err.Error(), "signal: killed") {
+				select {
+				case <-opts.Stop:
+					// it's fine if we've killed this program ourselves
+				default:
 					self.Log.Errorf("Unexpected error when running cmd task: %v; Failed command: %v %v", err, cmd.Path, cmd.Args)
 				}
 			}

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -137,29 +137,37 @@ func (self *ViewBufferManager) NewCmdTask(start func() (*exec.Cmd, io.Reader), p
 		cmd, r := start()
 		timeToStart := time.Since(startTime)
 
-		go utils.Safe(func() {
-			<-opts.Stop
-			// we use the time it took to start the program as a way of checking if things
-			// are running slow at the moment. This is admittedly a crude estimate, but
-			// the point is that we only want to throttle when things are running slow
-			// and the user is flicking through a bunch of items.
-			self.throttle = time.Since(startTime) < THROTTLE_TIME && timeToStart > COMMAND_START_THRESHOLD
-			if err := oscommands.Kill(cmd); err != nil {
-				if !strings.Contains(err.Error(), "process already finished") {
-					self.Log.Errorf("error when running cmd task: %v", err)
-				}
-			}
+		done := make(chan struct{})
 
-			// for pty's we need to call onDone here so that cmd.Wait() doesn't block forever
-			onDone()
+		go utils.Safe(func() {
+			select {
+			case <-done:
+				// The command finished and did not have to be preemptively stopped before the next command.
+				// No need to throttle.
+				self.throttle = false
+			case <-opts.Stop:
+				// we use the time it took to start the program as a way of checking if things
+				// are running slow at the moment. This is admittedly a crude estimate, but
+				// the point is that we only want to throttle when things are running slow
+				// and the user is flicking through a bunch of items.
+				self.throttle = time.Since(startTime) < THROTTLE_TIME && timeToStart > COMMAND_START_THRESHOLD
+
+				// Kill the still-running command.
+				if err := oscommands.Kill(cmd); err != nil {
+					if !strings.Contains(err.Error(), "process already finished") {
+						self.Log.Errorf("error when trying to kill cmd task: %v; Command: %v %v", err, cmd.Path, cmd.Args)
+					}
+				}
+
+				// for pty's we need to call onDone here so that cmd.Wait() doesn't block forever
+				onDone()
+			}
 		})
 
 		loadingMutex := deadlock.Mutex{}
 
 		// not sure if it's the right move to redefine this or not
 		self.readLines = make(chan LinesToRead, 1024)
-
-		done := make(chan struct{})
 
 		scanner := bufio.NewScanner(r)
 		scanner.Split(utils.ScanLinesAndTruncateWhenLongerThanBuffer(bufio.MaxScanTokenSize))


### PR DESCRIPTION
- **PR Description**

I was tinkering around with the code and then checking associated logs but even with LOG_LEVEL=error, I found there was a lot of noise on Windows.

This PR fixes two such sources:
1. Navigating through files in the Files panel
1. Navigating through branches in the Branches panel when there are a lot of commits (e.g. this repo)

More details in the comments below.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
