### PR TITLE
Fix tag being truncated when copying to clipboard

### DIFF
--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -148,7 +148,7 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 		{
 			ViewName:          "tags",
 			Key:               opts.GetKey(opts.Config.Universal.CopyToClipboard),
-			Handler:           self.handleCopySelectedSideContextItemCommitHashToClipboard,
+			Handler:           self.handleCopySelectedSideContextItemToClipboard,
 			GetDisabledReason: self.getCopySelectedSideContextItemToClipboardDisabledReason,
 			Description:       self.c.Tr.CopyTagToClipboard,
 		},

--- a/pkg/integration/tests/tag/copy_to_clipboard.go
+++ b/pkg/integration/tests/tag/copy_to_clipboard.go
@@ -15,7 +15,7 @@ var CopyToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("one")
-		shell.CreateLightweightTag("tag1", "HEAD")
+		shell.CreateLightweightTag("super.l000ongtag", "HEAD")
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Tags().
@@ -25,7 +25,7 @@ var CopyToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			Press(keys.Universal.CopyToClipboard)
 
-		t.ExpectToast(Equals("'tag1' copied to clipboard"))
+		t.ExpectToast(Equals("'super.l000ongtag' copied to clipboard"))
 
 		t.Views().Files().
 			Focus().
@@ -34,6 +34,6 @@ var CopyToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("clipboard").IsSelected(),
 			)
 
-		t.Views().Main().Content(Contains("_tag1_"))
+		t.Views().Main().Content(Contains("super.l000ongtag"))
 	},
 })


### PR DESCRIPTION
Copy the whole tag to clipboard instead of truncating to the value of TruncateCopiedCommitHashesTo.

- **PR Description**
My PR for copying the tag to clipboard was recently merged (#4219).
While using LazyGit built from the latest master I noticed that some tags were being truncated, turns out it was due to a bug I introduced on that previous PR.
Sorry for that.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

