### PR TITLE
feature commits filter by date range

### DIFF
--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -67,6 +67,8 @@ type GetCommitsOptions struct {
 	// If non-empty, show divergence from this ref (left-right log)
 	RefToShowDivergenceFrom string
 	MainBranches            *MainBranches
+	Since                   string
+	Until                   string
 }
 
 // GetCommits obtains the commits of the current branch
@@ -517,6 +519,8 @@ func (self *CommitLoader) getLogCmd(opts GetCommitsOptions) oscommands.ICmdObj {
 		ArgIf(opts.FilterPath != "", "--follow").
 		Arg("--no-show-signature").
 		ArgIf(opts.RefToShowDivergenceFrom != "", "--left-right").
+		ArgIf(opts.Since != "", "--since="+opts.Since). // Date filtering (start date)
+		ArgIf(opts.Until != "", "--until="+opts.Until). // Date filtering (end date)
 		Arg("--").
 		ArgIf(opts.FilterPath != "", opts.FilterPath).
 		ToArgv()

--- a/pkg/gui/controllers/filtering_menu_action.go
+++ b/pkg/gui/controllers/filtering_menu_action.go
@@ -90,6 +90,27 @@ func (self *FilteringMenuAction) Call() error {
 		Tooltip: tooltip,
 	})
 
+	menuItems = append(menuItems, &types.MenuItem{
+		Label: self.c.Tr.FilterDateRangeOption,
+		OnPress: func() error {
+			self.c.Prompt(types.PromptOpts{
+				Title: "Enter start date (YYYY-MM-DD)",
+				HandleConfirm: func(since string) error {
+					self.c.Prompt(types.PromptOpts{
+						Title: "Enter end date (YYYY-MM-DD)",
+						HandleConfirm: func(until string) error {
+							return self.setFilteringDateRange(strings.TrimSpace(since), strings.TrimSpace(until))
+						},
+					})
+					return nil
+				},
+			})
+
+			return nil
+		},
+		Tooltip: tooltip,
+	})
+
 	if self.c.Modes().Filtering.Active() {
 		menuItems = append(menuItems, &types.MenuItem{
 			Label:   self.c.Tr.ExitFilterMode,
@@ -109,6 +130,13 @@ func (self *FilteringMenuAction) setFilteringPath(path string) error {
 func (self *FilteringMenuAction) setFilteringAuthor(author string) error {
 	self.c.Modes().Filtering.Reset()
 	self.c.Modes().Filtering.SetAuthor(author)
+	return self.setFiltering()
+}
+
+func (self *FilteringMenuAction) setFilteringDateRange(since string, until string) error {
+	self.c.Modes().Filtering.Reset()
+	self.c.Modes().Filtering.SetSince(since)
+	self.c.Modes().Filtering.SetUntil(until)
 	return self.setFiltering()
 }
 

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -333,6 +333,8 @@ func (self *RefreshHelper) refreshCommitsWithLimit() error {
 			RefForPushedStatus:   checkedOutBranchName,
 			All:                  self.c.Contexts().LocalCommits.GetShowWholeGitGraph(),
 			MainBranches:         self.c.Model().MainBranches,
+			Since:                self.c.Modes().Filtering.GetSince(),
+			Until:                self.c.Modes().Filtering.GetUntil(),
 		},
 	)
 	if err != nil {

--- a/pkg/gui/modes/filtering/filtering.go
+++ b/pkg/gui/modes/filtering/filtering.go
@@ -4,6 +4,8 @@ type Filtering struct {
 	path               string // the filename that gets passed to git log
 	author             string // the author that gets passed to git log
 	selectedCommitHash string // the commit that was selected before we entered filtering mode
+	since              string
+	until              string
 }
 
 func New(path string, author string) Filtering {
@@ -41,4 +43,20 @@ func (m *Filtering) SetSelectedCommitHash(hash string) {
 
 func (m *Filtering) GetSelectedCommitHash() string {
 	return m.selectedCommitHash
+}
+
+func (m *Filtering) SetSince(since string) {
+	m.since = since
+}
+
+func (m *Filtering) SetUntil(until string) {
+	m.until = until
+}
+
+func (m *Filtering) GetSince() string {
+	return m.since
+}
+
+func (m *Filtering) GetUntil() string {
+	return m.until
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -841,6 +841,7 @@ type TranslationSet struct {
 	BreakingChangesTitle                     string
 	BreakingChangesMessage                   string
 	BreakingChangesByVersion                 map[string]string
+	FilterDateRangeOption                    string
 }
 
 type Bisect struct {
@@ -1860,7 +1861,7 @@ func EnglishTranslationSet() *TranslationSet {
 		RangeSelectNotSupportedForSubmodules:     "Range select not supported for submodules",
 		OldCherryPickKeyWarning:                  "The 'c' key is no longer the default key for copying commits to cherry pick. Please use `{{.copy}}` instead (and `{{.paste}}` to paste). The reason for this change is that the 'v' key for selecting a range of lines when staging is now also used for selecting a range of lines in any list view, meaning that we needed to find a new key for pasting commits, and if we're going to now use `{{.paste}}` for pasting commits, we may as well use `{{.copy}}` for copying them. If you want to configure the keybindings to get the old behaviour, set the following in your config:\n\nkeybinding:\n  universal:\n    toggleRangeSelect: <something other than v>\n  commits:\n    cherryPickCopy: 'c'\n    pasteCommits: 'v'",
 		CommandDoesNotSupportOpeningInEditor:     "This command doesn't support switching to the editor",
-
+		FilterDateRangeOption:                    "Filter Date Range",
 		Actions: Actions{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)
 			CheckoutCommit:                 "Checkout commit",


### PR DESCRIPTION
- **PR Description**
This PR allows filtering of the commits by providing a date range.
User can provide start date and end date see the commits between a certain time period.
Closes #4229
- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
