### PR TITLE
Fix json schema for context of CustomCommand

### DIFF
--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -611,8 +611,8 @@ type CustomCommandAfterHook struct {
 type CustomCommand struct {
 	// The key to trigger the command. Use a single letter or one of the values from https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Custom_Keybindings.md
 	Key string `yaml:"key"`
-	// The context in which to listen for the key
-	Context string `yaml:"context" jsonschema:"enum=status,enum=files,enum=worktrees,enum=localBranches,enum=remotes,enum=remoteBranches,enum=tags,enum=commits,enum=reflogCommits,enum=subCommits,enum=commitFiles,enum=stash,enum=global"`
+	// The context in which to listen for the key. Valid values are: status, files, worktrees, localBranches, remotes, remoteBranches, tags, commits, reflogCommits, subCommits, commitFiles, stash, and global. Multiple contexts separated by comma are allowed; most useful for "commits, subCommits" or "files, commitFiles".
+	Context string `yaml:"context" jsonschema:"example=status,example=files,example=worktrees,example=localBranches,example=remotes,example=remoteBranches,example=tags,example=commits,example=reflogCommits,example=subCommits,example=commitFiles,example=stash,example=global"`
 	// The command to run (using Go template syntax for placeholder values)
 	Command string `yaml:"command" jsonschema:"example=git fetch {{.Form.Remote}} {{.Form.Branch}} && git checkout FETCH_HEAD"`
 	// If true, run the command in a subprocess (e.g. if the command requires user input)

--- a/schema/config.json
+++ b/schema/config.json
@@ -875,7 +875,8 @@
           },
           "context": {
             "type": "string",
-            "enum": [
+            "description": "The context in which to listen for the key. Valid values are: status, files, worktrees, localBranches, remotes, remoteBranches, tags, commits, reflogCommits, subCommits, commitFiles, stash, and global. Multiple contexts separated by comma are allowed; most useful for \"commits, subCommits\" or \"files, commitFiles\".",
+            "examples": [
               "status",
               "files",
               "worktrees",
@@ -889,8 +890,7 @@
               "commitFiles",
               "stash",
               "global"
-            ],
-            "description": "The context in which to listen for the key"
+            ]
           },
           "command": {
             "type": "string",


### PR DESCRIPTION
- **PR Description**

Fix ugly error squiggles in VS Code when using a custom command with a context of e.g. "commits, subCommits".

Previously the schema only allowed a single value for the context field; however, it is now possible to specify multiple values separated by comma (see #3784).

The only solution that I can see is to get rid of the "enum" specification, and mention the valid values only in the description. Add examples too so that you get at least auto-completion.
