### PR TITLE
[FEAT] Add Recursive Bulk Initialize and Update for Submodules

### DIFF
--- a/pkg/commands/git_commands/submodule.go
+++ b/pkg/commands/git_commands/submodule.go
@@ -258,6 +258,13 @@ func (self *SubmoduleCommands) ForceBulkUpdateCmdObj() oscommands.ICmdObj {
 	return self.cmd.New(cmdArgs)
 }
 
+func (self *SubmoduleCommands) BulkUpdateRecursivelyCmdObj() oscommands.ICmdObj {
+	cmdArgs := NewGitCmd("submodule").Arg("update", "--init", "--recursive").
+		ToArgv()
+
+	return self.cmd.New(cmdArgs)
+}
+
 func (self *SubmoduleCommands) BulkDeinitCmdObj() oscommands.ICmdObj {
 	cmdArgs := NewGitCmd("submodule").Arg("deinit", "--all", "--force").
 		ToArgv()

--- a/pkg/gui/controllers/submodules_controller.go
+++ b/pkg/gui/controllers/submodules_controller.go
@@ -248,6 +248,20 @@ func (self *SubmodulesController) openBulkActionsMenu() error {
 				Key: 'u',
 			},
 			{
+				LabelColumns: []string{self.c.Tr.BulkUpdateRecursiveSubmodules, style.FgYellow.Sprint(self.c.Git().Submodule.BulkUpdateRecursivelyCmdObj().ToString())},
+				OnPress: func() error {
+					return self.c.WithWaitingStatus(self.c.Tr.RunningCommand, func(gocui.Task) error {
+						self.c.LogAction(self.c.Tr.Actions.BulkUpdateRecursiveSubmodules)
+						if err := self.c.Git().Submodule.BulkUpdateRecursivelyCmdObj().Run(); err != nil {
+							return err
+						}
+
+						return self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.SUBMODULES}})
+					})
+				},
+				Key: 'r',
+			},
+			{
 				LabelColumns: []string{self.c.Tr.BulkDeinitSubmodules, style.FgRed.Sprint(self.c.Git().Submodule.BulkDeinitCmdObj().ToString())},
 				OnPress: func() error {
 					return self.c.WithWaitingStatus(self.c.Tr.RunningCommand, func(gocui.Task) error {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -673,6 +673,7 @@ type TranslationSet struct {
 	BulkInitSubmodules                    string
 	BulkUpdateSubmodules                  string
 	BulkDeinitSubmodules                  string
+	BulkUpdateRecursiveSubmodules         string
 	ViewBulkSubmoduleOptions              string
 	BulkSubmoduleOptions                  string
 	RunningCommand                        string
@@ -982,6 +983,7 @@ type Actions struct {
 	BulkInitialiseSubmodules          string
 	BulkUpdateSubmodules              string
 	BulkDeinitialiseSubmodules        string
+	BulkUpdateRecursiveSubmodules     string
 	UpdateSubmodule                   string
 	CreateLightweightTag              string
 	CreateAnnotatedTag                string
@@ -1718,6 +1720,7 @@ func EnglishTranslationSet() *TranslationSet {
 		BulkInitSubmodules:                       "Bulk init submodules",
 		BulkUpdateSubmodules:                     "Bulk update submodules",
 		BulkDeinitSubmodules:                     "Bulk deinit submodules",
+		BulkUpdateRecursiveSubmodules:            "Bulk init and update submodules recursively",
 		ViewBulkSubmoduleOptions:                 "View bulk submodule options",
 		BulkSubmoduleOptions:                     "Bulk submodule options",
 		RunningCommand:                           "Running command",
@@ -1989,6 +1992,7 @@ func EnglishTranslationSet() *TranslationSet {
 			BulkInitialiseSubmodules:        "Bulk initialise submodules",
 			BulkUpdateSubmodules:            "Bulk update submodules",
 			BulkDeinitialiseSubmodules:      "Bulk deinitialise submodules",
+			BulkUpdateRecursiveSubmodules:   "Bulk initialise and update submodules recursively",
 			UpdateSubmodule:                 "Update submodule",
 			DeleteLocalTag:                  "Delete local tag",
 			DeleteRemoteTag:                 "Delete remote tag",


### PR DESCRIPTION
- **PR Description**
This PR adds a new bulk action for submodules.
As I often work with a lot of submodules that are hierarchically structured, the flag "--recursive" saves a lot of work.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
