### PR TITLE
feat: Support multiple commit prefixes

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -341,14 +341,6 @@ git:
   # If true, do not allow force pushes
   disableForcePushing: false
 
-  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix
-  commitPrefix:
-    # pattern to match on. E.g. for 'feature/AB-123' to match on the AB-123 use "^\\w+\\/(\\w+-\\w+).*"
-    pattern: ""
-
-    # Replace directive. E.g. for 'feature/AB-123' to start the commit message with 'AB-123 ' use "[$1] "
-    replace: ""
-
   # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-branch-name-prefix
   branchPrefix: ""
 
@@ -922,27 +914,40 @@ Where:
 ## Predefined commit message prefix
 
 In situations where certain naming pattern is used for branches and commits, pattern can be used to populate commit message with prefix that is parsed from the branch name.
+If you define multiple naming patterns, they will be attempted in order until one matches.
 
-Example:
+Example hitting first match:
 
 - Branch name: feature/AB-123
-- Commit message: [AB-123] Adding feature
+- Generated commit message prefix: [AB-123]
+
+Example hitting second match:
+
+- Branch name: CD-456_fix_problem
+- Generated commit message prefix: (CD-456)
 
 ```yaml
 git:
   commitPrefix:
-    pattern: "^\\w+\\/(\\w+-\\w+).*"
-    replace: '[$1] '
+    - pattern: "^\\w+\\/(\\w+-\\w+).*"
+      replace: '[$1] '
+    - pattern: "^([^_]+)_.*" # Take all text prior to the first underscore
+      replace: '($1) '
 ```
 
-If you want repository-specific prefixes, you can map them with `commitPrefixes`. If you have both `commitPrefixes` defined and an entry in `commitPrefixes` for the current repo, the `commitPrefixes` entry is given higher precedence. Repository folder names must be an exact match.
+If you want repository-specific prefixes, you can map them with `commitPrefixes`. If you have both entries in `commitPrefix` defined and an repository match in `commitPrefixes` for the current repo, the `commitPrefixes` entries will be attempted first. Repository folder names must be an exact match.
 
 ```yaml
 git:
   commitPrefixes:
     my_project: # This is repository folder name
-      pattern: "^\\w+\\/(\\w+-\\w+).*"
-      replace: '[$1] '
+      - pattern: "^\\w+\\/(\\w+-\\w+).*"
+        replace: '[$1] '
+  commitPrefix:
+      - pattern: "^(\\w+)-.*" # A more general match for any leading word
+        replace : '[$1] '
+      - pattern: ".*" # The final fallthrough regex that copies over the whole branch name
+        replace : '[$0] '
 ```
 
 > [!IMPORTANT]

--- a/pkg/config/app_config_test.go
+++ b/pkg/config/app_config_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCommitPrefixMigrations(t *testing.T) {
+	scenarios := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			"Empty String",
+			"",
+			"",
+		}, {
+			"Single CommitPrefix Rename",
+			`
+git:
+  commitPrefix:
+     pattern: "^\\w+-\\w+.*"
+     replace: '[JIRA $0] '`,
+			`
+git:
+  commitPrefix:
+    - pattern: "^\\w+-\\w+.*"
+      replace: '[JIRA $0] '`,
+		}, {
+			"Complicated CommitPrefixes Rename",
+			`
+git:
+  commitPrefixes:
+    foo:
+      pattern: "^\\w+-\\w+.*"
+      replace: '[OTHER $0] '
+    CrazyName!@#$^*&)_-)[[}{f{[]:
+      pattern: "^foo.bar*"
+      replace: '[FUN $0] '`,
+			`
+git:
+  commitPrefixes:
+     foo:
+       - pattern: "^\\w+-\\w+.*"
+         replace: '[OTHER $0] '
+     CrazyName!@#$^*&)_-)[[}{f{[]:
+       - pattern: "^foo.bar*"
+         replace: '[FUN $0] '`,
+		}, {
+			"Incomplete Configuration",
+			"git:",
+			"git:",
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			expectedConfig := GetDefaultConfig()
+			err := yaml.Unmarshal([]byte(s.expected), expectedConfig)
+			if err != nil {
+				t.Error(err)
+			}
+			actual, err := computeMigratedConfig("path doesn't matter", []byte(s.input))
+			if err != nil {
+				t.Error(err)
+			}
+			actualConfig := GetDefaultConfig()
+			err = yaml.Unmarshal(actual, actualConfig)
+			if err != nil {
+				t.Error(err)
+			}
+			assert.Equal(t, expectedConfig, actualConfig)
+		})
+	}
+}

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -256,9 +256,9 @@ type GitConfig struct {
 	// If true, do not allow force pushes
 	DisableForcePushing bool `yaml:"disableForcePushing"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix
-	CommitPrefix *CommitPrefixConfig `yaml:"commitPrefix"`
+	CommitPrefix []CommitPrefixConfig `yaml:"commitPrefix"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix
-	CommitPrefixes map[string]CommitPrefixConfig `yaml:"commitPrefixes"`
+	CommitPrefixes map[string][]CommitPrefixConfig `yaml:"commitPrefixes"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-branch-name-prefix
 	BranchPrefix string `yaml:"branchPrefix"`
 	// If true, parse emoji strings in commit messages e.g. render :rocket: as 🚀
@@ -784,7 +784,7 @@ func GetDefaultConfig() *UserConfig {
 			BranchLogCmd:                 "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",
 			AllBranchesLogCmd:            "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium",
 			DisableForcePushing:          false,
-			CommitPrefixes:               map[string]CommitPrefixConfig(nil),
+			CommitPrefixes:               map[string][]CommitPrefixConfig(nil),
 			BranchPrefix:                 "",
 			ParseEmoji:                   false,
 			TruncateCopiedCommitHashesTo: 12,

--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -152,8 +152,8 @@ func (self *WorkingTreeHelper) HandleCommitPress() error {
 	message := self.c.Contexts().CommitMessage.GetPreservedMessageAndLogError()
 
 	if message == "" {
-		commitPrefixConfig := self.commitPrefixConfigForRepo()
-		if commitPrefixConfig != nil {
+		commitPrefixConfigs := self.commitPrefixConfigsForRepo()
+		for _, commitPrefixConfig := range commitPrefixConfigs {
 			prefixPattern := commitPrefixConfig.Pattern
 			prefixReplace := commitPrefixConfig.Replace
 			branchName := self.refHelper.GetCheckedOutRef().Name
@@ -165,6 +165,7 @@ func (self *WorkingTreeHelper) HandleCommitPress() error {
 			if rgx.MatchString(branchName) {
 				prefix := rgx.ReplaceAllString(branchName, prefixReplace)
 				message = prefix
+				break
 			}
 		}
 	}
@@ -228,11 +229,11 @@ func (self *WorkingTreeHelper) prepareFilesForCommit() error {
 	return nil
 }
 
-func (self *WorkingTreeHelper) commitPrefixConfigForRepo() *config.CommitPrefixConfig {
+func (self *WorkingTreeHelper) commitPrefixConfigsForRepo() []config.CommitPrefixConfig {
 	cfg, ok := self.c.UserConfig().Git.CommitPrefixes[self.c.Git().RepoPaths.RepoName()]
 	if ok {
-		return &cfg
+		return append(cfg, self.c.UserConfig().Git.CommitPrefix...)
+	} else {
+		return self.c.UserConfig().Git.CommitPrefix
 	}
-
-	return self.c.UserConfig().Git.CommitPrefix
 }

--- a/pkg/integration/tests/commit/commit_wip_with_prefix.go
+++ b/pkg/integration/tests/commit/commit_wip_with_prefix.go
@@ -10,7 +10,7 @@ var CommitWipWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(cfg *config.AppConfig) {
-		cfg.GetUserConfig().Git.CommitPrefixes = map[string]config.CommitPrefixConfig{"repo": {Pattern: "^\\w+\\/(\\w+-\\w+).*", Replace: "[$1]: "}}
+		cfg.GetUserConfig().Git.CommitPrefixes = map[string][]config.CommitPrefixConfig{"repo": {{Pattern: "^\\w+\\/(\\w+-\\w+).*", Replace: "[$1]: "}}}
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.NewBranch("feature/TEST-002")

--- a/pkg/integration/tests/commit/commit_with_global_prefix.go
+++ b/pkg/integration/tests/commit/commit_with_global_prefix.go
@@ -10,7 +10,7 @@ var CommitWithGlobalPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(cfg *config.AppConfig) {
-		cfg.GetUserConfig().Git.CommitPrefix = &config.CommitPrefixConfig{Pattern: "^\\w+\\/(\\w+-\\w+).*", Replace: "[$1]: "}
+		cfg.GetUserConfig().Git.CommitPrefix = []config.CommitPrefixConfig{{Pattern: "^\\w+\\/(\\w+-\\w+).*", Replace: "[$1]: "}}
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.NewBranch("feature/TEST-001")

--- a/pkg/integration/tests/commit/commit_with_non_matching_branch_name.go
+++ b/pkg/integration/tests/commit/commit_with_non_matching_branch_name.go
@@ -10,10 +10,10 @@ var CommitWithNonMatchingBranchName = NewIntegrationTest(NewIntegrationTestArgs{
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(cfg *config.AppConfig) {
-		cfg.GetUserConfig().Git.CommitPrefix = &config.CommitPrefixConfig{
+		cfg.GetUserConfig().Git.CommitPrefix = []config.CommitPrefixConfig{{
 			Pattern: "^\\w+\\/(\\w+-\\w+).*",
 			Replace: "[$1]: ",
-		}
+		}}
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.NewBranch("branchnomatch")

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -93,6 +93,7 @@ var tests = []*components.IntegrationTest{
 	commit.CommitMultiline,
 	commit.CommitSwitchToEditor,
 	commit.CommitWipWithPrefix,
+	commit.CommitWithFallthroughPrefix,
 	commit.CommitWithGlobalPrefix,
 	commit.CommitWithNonMatchingBranchName,
 	commit.CommitWithPrefix,

--- a/schema/config.json
+++ b/schema/config.json
@@ -638,28 +638,7 @@
           "default": false
         },
         "commitPrefix": {
-          "properties": {
-            "pattern": {
-              "type": "string",
-              "description": "pattern to match on. E.g. for 'feature/AB-123' to match on the AB-123 use \"^\\\\w+\\\\/(\\\\w+-\\\\w+).*\"",
-              "examples": [
-                "^\\w+\\/(\\w+-\\w+).*"
-              ]
-            },
-            "replace": {
-              "type": "string",
-              "description": "Replace directive. E.g. for 'feature/AB-123' to start the commit message with 'AB-123 ' use \"[$1] \"",
-              "examples": [
-                "[$1]"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix"
-        },
-        "commitPrefixes": {
-          "additionalProperties": {
+          "items": {
             "properties": {
               "pattern": {
                 "type": "string",
@@ -678,6 +657,33 @@
             },
             "additionalProperties": false,
             "type": "object"
+          },
+          "type": "array",
+          "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix"
+        },
+        "commitPrefixes": {
+          "additionalProperties": {
+            "items": {
+              "properties": {
+                "pattern": {
+                  "type": "string",
+                  "description": "pattern to match on. E.g. for 'feature/AB-123' to match on the AB-123 use \"^\\\\w+\\\\/(\\\\w+-\\\\w+).*\"",
+                  "examples": [
+                    "^\\w+\\/(\\w+-\\w+).*"
+                  ]
+                },
+                "replace": {
+                  "type": "string",
+                  "description": "Replace directive. E.g. for 'feature/AB-123' to start the commit message with 'AB-123 ' use \"[$1] \"",
+                  "examples": [
+                    "[$1]"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "type": "object"
+            },
+            "type": "array"
           },
           "type": "object",
           "description": "See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix"


### PR DESCRIPTION
- **PR Description**
This implementation, unlike that proposed in https://github.com/jesseduffield/lazygit/pull/4253 keeps the yaml schema easy, and does a migration from the single elements to a sequence of elements.

Addresses https://github.com/jesseduffield/lazygit/issues/4194

- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [X] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [X] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc
