### PR TITLE
Fix race condition with reselecting the focused branch and rendering

### DIFF
--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -490,15 +490,17 @@ func (self *RefreshHelper) refreshBranches(refreshWorktrees bool, keepBranchSele
 		self.refreshView(self.c.Contexts().Worktrees)
 	}
 
-	self.refreshView(self.c.Contexts().Branches)
-
 	if !keepBranchSelectionIndex && prevSelectedBranch != nil {
+		self.searchHelper.ReApplyFilter(self.c.Contexts().Branches)
+
 		_, idx, found := lo.FindIndexOf(self.c.Contexts().Branches.GetItems(),
 			func(b *models.Branch) bool { return b.Name == prevSelectedBranch.Name })
 		if found {
 			self.c.Contexts().Branches.SetSelectedLineIdx(idx)
 		}
 	}
+
+	self.refreshView(self.c.Contexts().Branches)
 
 	// Need to re-render the commits view because the visualization of local
 	// branch heads might have changed


### PR DESCRIPTION
In ff4ae4a544 we changed the order of the calls to render before selecting the branch. This was done only to save an extra call to ReApplyFilter, which is done by refreshView; I claimed that the order of refreshView vs. SetSelectedLineIdx doesn't matter here. I guess I was wrong about that, it makes the integration test custom_commands/suggestions_preset.go flaky. To fix this, put the refreshView call back to where it was (after the SetSelectedLineIdx call), and instead insert an extra call to ReApplyFilter where necessary to fix the bug that ff4ae4a544 was trying to fix.

I still don't think there was any user facing problem caused by this (@ChrisMcD1 correct me if I'm wrong), so I don't think we need to cut a 0.46.1 release with the fix (otherwise it would have been a regression in 0.46), and I only label it as `maintenance` because it only fixes CI.

Fixes #4267.