### PR TITLE
Use correct executable name depending on OS #4269

### DIFF
--- a/pkg/updates/updates.go
+++ b/pkg/updates/updates.go
@@ -219,6 +219,14 @@ func (u *Updater) zipExtension() string {
 	return "tar.gz"
 }
 
+func (u *Updater) executableName() string {
+	if runtime.GOOS == "windows" {
+		return "lazygit.exe"
+	}
+
+	return "lazygit"
+}
+
 // example: https://github.com/jesseduffield/lazygit/releases/download/v0.1.73/lazygit_0.1.73_Darwin_x86_64.tar.gz
 func (u *Updater) getBinaryUrl(newVersion string) string {
 	url := fmt.Sprintf(
@@ -282,8 +290,10 @@ func (u *Updater) downloadAndInstall(rawUrl string) error {
 		return err
 	}
 
+	executableName := u.executableName()
+
 	u.Log.Info("untarring tarball/unzipping zip file")
-	err = u.OSCommand.Cmd.New([]string{"tar", "-zxf", zipPath, "lazygit"}).Run()
+	err = u.OSCommand.Cmd.New([]string{"tar", "-zxf", zipPath, executableName}).Run()
 	if err != nil {
 		return err
 	}
@@ -291,7 +301,7 @@ func (u *Updater) downloadAndInstall(rawUrl string) error {
 	// the `tar` terminal cannot store things in a new location without permission
 	// so it creates it in the current directory. As such our path is fairly simple.
 	// You won't see it because it's gitignored.
-	tempLazygitFilePath := "lazygit"
+	tempLazygitFilePath := executableName
 
 	u.Log.Infof("Path to temp binary is %s", tempLazygitFilePath)
 


### PR DESCRIPTION
- **PR Description**
Use correct executable name depending on OS.

When unzipping the new version, we were always extracting `lazygit`. On Windows, the executable is named `lazygit.exe`. This PR fixes that issue.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

I'm not really sure how to test this (and as far as I can tell there are no integration tests for this feature yet). When attempting to use the feature from a version started using `go run main.go` it fails when trying to replace the current executable. I'm unsure whether this is due to something `go run` does, or whether that is Windows specific behavior. If I remember correctly, on Windows you can't replace the current executable, so perhaps that needs dedicated support on Windows.

Fixes #4269

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
