### PR TITLE
Validate user config keybindings

### DIFF
--- a/docs/keybindings/Custom_Keybindings.md
+++ b/docs/keybindings/Custom_Keybindings.md
@@ -20,11 +20,15 @@
 | `<pgup>`      | Pgup           |
 | `<pgdown>`    | Pgdn           |
 | `<up>`        | ArrowUp        |
+| `<s-up>`      | ShiftArrowUp   |
 | `<down>`      | ArrowDown      |
+| `<s-down>`    | ShiftArrowDown |
 | `<left>`      | ArrowLeft      |
 | `<right>`     | ArrowRight     |
 | `<tab>`       | Tab            |
+| `<backtab>`   | Backtab        |
 | `<enter>`     | Enter          |
+| `<a-enter>`   | AltEnter       |
 | `<esc>`       | Esc            |
 | `<backspace>` | Backspace      |
 | `<c-space>`   | CtrlSpace      |

--- a/pkg/config/keynames.go
+++ b/pkg/config/keynames.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"strings"
+	"unicode/utf8"
+
 	"github.com/jesseduffield/gocui"
 	"github.com/samber/lo"
 )
@@ -74,3 +77,17 @@ var LabelByKey = map[gocui.Key]string{
 }
 
 var KeyByLabel = lo.Invert(LabelByKey)
+
+func isValidKeybindingKey(key string) bool {
+	runeCount := utf8.RuneCountInString(key)
+	if key == "<disabled>" {
+		return true
+	}
+
+	if runeCount > 1 {
+		_, ok := KeyByLabel[strings.ToLower(key)]
+		return ok
+	}
+
+	return true
+}

--- a/pkg/config/keynames.go
+++ b/pkg/config/keynames.go
@@ -5,6 +5,9 @@ import (
 	"github.com/samber/lo"
 )
 
+// NOTE: if you make changes to this table, be sure to update
+// docs/keybindings/Custom_Keybindings.md as well
+
 var LabelByKey = map[gocui.Key]string{
 	gocui.KeyF1:             "<f1>",
 	gocui.KeyF2:             "<f2>",

--- a/pkg/config/keynames.go
+++ b/pkg/config/keynames.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"github.com/jesseduffield/gocui"
+	"github.com/samber/lo"
+)
+
+var LabelByKey = map[gocui.Key]string{
+	gocui.KeyF1:             "<f1>",
+	gocui.KeyF2:             "<f2>",
+	gocui.KeyF3:             "<f3>",
+	gocui.KeyF4:             "<f4>",
+	gocui.KeyF5:             "<f5>",
+	gocui.KeyF6:             "<f6>",
+	gocui.KeyF7:             "<f7>",
+	gocui.KeyF8:             "<f8>",
+	gocui.KeyF9:             "<f9>",
+	gocui.KeyF10:            "<f10>",
+	gocui.KeyF11:            "<f11>",
+	gocui.KeyF12:            "<f12>",
+	gocui.KeyInsert:         "<insert>",
+	gocui.KeyDelete:         "<delete>",
+	gocui.KeyHome:           "<home>",
+	gocui.KeyEnd:            "<end>",
+	gocui.KeyPgup:           "<pgup>",
+	gocui.KeyPgdn:           "<pgdown>",
+	gocui.KeyArrowUp:        "<up>",
+	gocui.KeyShiftArrowUp:   "<s-up>",
+	gocui.KeyArrowDown:      "<down>",
+	gocui.KeyShiftArrowDown: "<s-down>",
+	gocui.KeyArrowLeft:      "<left>",
+	gocui.KeyArrowRight:     "<right>",
+	gocui.KeyTab:            "<tab>", // <c-i>
+	gocui.KeyBacktab:        "<backtab>",
+	gocui.KeyEnter:          "<enter>", // <c-m>
+	gocui.KeyAltEnter:       "<a-enter>",
+	gocui.KeyEsc:            "<esc>",       // <c-[>, <c-3>
+	gocui.KeyBackspace:      "<backspace>", // <c-h>
+	gocui.KeyCtrlSpace:      "<c-space>",   // <c-~>, <c-2>
+	gocui.KeyCtrlSlash:      "<c-/>",       // <c-_>
+	gocui.KeySpace:          "<space>",
+	gocui.KeyCtrlA:          "<c-a>",
+	gocui.KeyCtrlB:          "<c-b>",
+	gocui.KeyCtrlC:          "<c-c>",
+	gocui.KeyCtrlD:          "<c-d>",
+	gocui.KeyCtrlE:          "<c-e>",
+	gocui.KeyCtrlF:          "<c-f>",
+	gocui.KeyCtrlG:          "<c-g>",
+	gocui.KeyCtrlJ:          "<c-j>",
+	gocui.KeyCtrlK:          "<c-k>",
+	gocui.KeyCtrlL:          "<c-l>",
+	gocui.KeyCtrlN:          "<c-n>",
+	gocui.KeyCtrlO:          "<c-o>",
+	gocui.KeyCtrlP:          "<c-p>",
+	gocui.KeyCtrlQ:          "<c-q>",
+	gocui.KeyCtrlR:          "<c-r>",
+	gocui.KeyCtrlS:          "<c-s>",
+	gocui.KeyCtrlT:          "<c-t>",
+	gocui.KeyCtrlU:          "<c-u>",
+	gocui.KeyCtrlV:          "<c-v>",
+	gocui.KeyCtrlW:          "<c-w>",
+	gocui.KeyCtrlX:          "<c-x>",
+	gocui.KeyCtrlY:          "<c-y>",
+	gocui.KeyCtrlZ:          "<c-z>",
+	gocui.KeyCtrl4:          "<c-4>", // <c-\>
+	gocui.KeyCtrl5:          "<c-5>", // <c-]>
+	gocui.KeyCtrl6:          "<c-6>",
+	gocui.KeyCtrl8:          "<c-8>",
+	gocui.MouseWheelUp:      "mouse wheel up",
+	gocui.MouseWheelDown:    "mouse wheel down",
+}
+
+var KeyByLabel = lo.Invert(LabelByKey)

--- a/pkg/config/user_config_validation.go
+++ b/pkg/config/user_config_validation.go
@@ -22,6 +22,9 @@ func (config *UserConfig) Validate() error {
 	if err := validateKeybindings(config.Keybinding); err != nil {
 		return err
 	}
+	if err := validateCustomCommands(config.CustomCommands); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -77,5 +80,22 @@ func validateKeybindings(keybindingConfig KeybindingConfig) error {
 			len(keybindingConfig.Universal.JumpToBlock))
 	}
 
+	return nil
+}
+
+func validateCustomCommandKey(key string) error {
+	if !isValidKeybindingKey(key) {
+		return fmt.Errorf("Unrecognized key '%s' for custom command. For permitted values see %s",
+			key, constants.Links.Docs.CustomKeybindings)
+	}
+	return nil
+}
+
+func validateCustomCommands(customCommands []CustomCommand) error {
+	for _, customCommand := range customCommands {
+		if err := validateCustomCommandKey(customCommand.Key); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/config/user_config_validation.go
+++ b/pkg/config/user_config_validation.go
@@ -68,5 +68,14 @@ func validateKeybindingsRecurse(path string, node any) error {
 }
 
 func validateKeybindings(keybindingConfig KeybindingConfig) error {
-	return validateKeybindingsRecurse("", keybindingConfig)
+	if err := validateKeybindingsRecurse("", keybindingConfig); err != nil {
+		return err
+	}
+
+	if len(keybindingConfig.Universal.JumpToBlock) != 5 {
+		return fmt.Errorf("keybinding.universal.jumpToBlock must have 5 elements; found %d.",
+			len(keybindingConfig.Universal.JumpToBlock))
+	}
+
+	return nil
 }

--- a/pkg/config/user_config_validation_test.go
+++ b/pkg/config/user_config_validation_test.go
@@ -56,6 +56,24 @@ func TestUserConfigValidate_enums(t *testing.T) {
 				{value: "1,2,3,4,5,6", valid: false},
 			},
 		},
+		{
+			name: "Custom command keybinding",
+			setup: func(config *UserConfig, value string) {
+				config.CustomCommands = []CustomCommand{
+					{
+						Key:     value,
+						Command: "echo 'hello'",
+					},
+				}
+			},
+			testCases: []testCase{
+				{value: "", valid: true},
+				{value: "<disabled>", valid: true},
+				{value: "q", valid: true},
+				{value: "<c-c>", valid: true},
+				{value: "invalid_value", valid: false},
+			},
+		},
 	}
 
 	for _, s := range scenarios {

--- a/pkg/config/user_config_validation_test.go
+++ b/pkg/config/user_config_validation_test.go
@@ -29,6 +29,19 @@ func TestUserConfigValidate_enums(t *testing.T) {
 				{value: "invalid_value", valid: false},
 			},
 		},
+		{
+			name: "Keybindings",
+			setup: func(config *UserConfig, value string) {
+				config.Keybinding.Universal.Quit = value
+			},
+			testCases: []testCase{
+				{value: "", valid: true},
+				{value: "<disabled>", valid: true},
+				{value: "q", valid: true},
+				{value: "<c-c>", valid: true},
+				{value: "invalid_value", valid: false},
+			},
+		},
 	}
 
 	for _, s := range scenarios {

--- a/pkg/config/user_config_validation_test.go
+++ b/pkg/config/user_config_validation_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,6 +41,19 @@ func TestUserConfigValidate_enums(t *testing.T) {
 				{value: "q", valid: true},
 				{value: "<c-c>", valid: true},
 				{value: "invalid_value", valid: false},
+			},
+		},
+		{
+			name: "JumpToBlock keybinding",
+			setup: func(config *UserConfig, value string) {
+				config.Keybinding.Universal.JumpToBlock = strings.Split(value, ",")
+			},
+			testCases: []testCase{
+				{value: "", valid: false},
+				{value: "1,2,3", valid: false},
+				{value: "1,2,3,4,5", valid: true},
+				{value: "1,2,3,4,invalid", valid: false},
+				{value: "1,2,3,4,5,6", valid: false},
 			},
 		},
 	}

--- a/pkg/gui/keybindings/keybindings.go
+++ b/pkg/gui/keybindings/keybindings.go
@@ -7,77 +7,10 @@ import (
 	"unicode/utf8"
 
 	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/constants"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
-	"github.com/samber/lo"
 )
-
-var labelByKey = map[gocui.Key]string{
-	gocui.KeyF1:             "<f1>",
-	gocui.KeyF2:             "<f2>",
-	gocui.KeyF3:             "<f3>",
-	gocui.KeyF4:             "<f4>",
-	gocui.KeyF5:             "<f5>",
-	gocui.KeyF6:             "<f6>",
-	gocui.KeyF7:             "<f7>",
-	gocui.KeyF8:             "<f8>",
-	gocui.KeyF9:             "<f9>",
-	gocui.KeyF10:            "<f10>",
-	gocui.KeyF11:            "<f11>",
-	gocui.KeyF12:            "<f12>",
-	gocui.KeyInsert:         "<insert>",
-	gocui.KeyDelete:         "<delete>",
-	gocui.KeyHome:           "<home>",
-	gocui.KeyEnd:            "<end>",
-	gocui.KeyPgup:           "<pgup>",
-	gocui.KeyPgdn:           "<pgdown>",
-	gocui.KeyArrowUp:        "<up>",
-	gocui.KeyShiftArrowUp:   "<s-up>",
-	gocui.KeyArrowDown:      "<down>",
-	gocui.KeyShiftArrowDown: "<s-down>",
-	gocui.KeyArrowLeft:      "<left>",
-	gocui.KeyArrowRight:     "<right>",
-	gocui.KeyTab:            "<tab>", // <c-i>
-	gocui.KeyBacktab:        "<backtab>",
-	gocui.KeyEnter:          "<enter>", // <c-m>
-	gocui.KeyAltEnter:       "<a-enter>",
-	gocui.KeyEsc:            "<esc>",       // <c-[>, <c-3>
-	gocui.KeyBackspace:      "<backspace>", // <c-h>
-	gocui.KeyCtrlSpace:      "<c-space>",   // <c-~>, <c-2>
-	gocui.KeyCtrlSlash:      "<c-/>",       // <c-_>
-	gocui.KeySpace:          "<space>",
-	gocui.KeyCtrlA:          "<c-a>",
-	gocui.KeyCtrlB:          "<c-b>",
-	gocui.KeyCtrlC:          "<c-c>",
-	gocui.KeyCtrlD:          "<c-d>",
-	gocui.KeyCtrlE:          "<c-e>",
-	gocui.KeyCtrlF:          "<c-f>",
-	gocui.KeyCtrlG:          "<c-g>",
-	gocui.KeyCtrlJ:          "<c-j>",
-	gocui.KeyCtrlK:          "<c-k>",
-	gocui.KeyCtrlL:          "<c-l>",
-	gocui.KeyCtrlN:          "<c-n>",
-	gocui.KeyCtrlO:          "<c-o>",
-	gocui.KeyCtrlP:          "<c-p>",
-	gocui.KeyCtrlQ:          "<c-q>",
-	gocui.KeyCtrlR:          "<c-r>",
-	gocui.KeyCtrlS:          "<c-s>",
-	gocui.KeyCtrlT:          "<c-t>",
-	gocui.KeyCtrlU:          "<c-u>",
-	gocui.KeyCtrlV:          "<c-v>",
-	gocui.KeyCtrlW:          "<c-w>",
-	gocui.KeyCtrlX:          "<c-x>",
-	gocui.KeyCtrlY:          "<c-y>",
-	gocui.KeyCtrlZ:          "<c-z>",
-	gocui.KeyCtrl4:          "<c-4>", // <c-\>
-	gocui.KeyCtrl5:          "<c-5>", // <c-]>
-	gocui.KeyCtrl6:          "<c-6>",
-	gocui.KeyCtrl8:          "<c-8>",
-	gocui.MouseWheelUp:      "mouse wheel up",
-	gocui.MouseWheelDown:    "mouse wheel down",
-}
-
-var keyByLabel = lo.Invert(labelByKey)
 
 func Label(name string) string {
 	return LabelFromKey(GetKey(name))
@@ -90,7 +23,7 @@ func LabelFromKey(key types.Key) string {
 	case rune:
 		keyInt = int(key)
 	case gocui.Key:
-		value, ok := labelByKey[key]
+		value, ok := config.LabelByKey[key]
 		if ok {
 			return value
 		}
@@ -105,7 +38,7 @@ func GetKey(key string) types.Key {
 	if key == "<disabled>" {
 		return nil
 	} else if runeCount > 1 {
-		binding, ok := keyByLabel[strings.ToLower(key)]
+		binding, ok := config.KeyByLabel[strings.ToLower(key)]
 		if !ok {
 			log.Fatalf("Unrecognized key %s for keybinding. For permitted values see %s", strings.ToLower(key), constants.Links.Docs.CustomKeybindings)
 		} else {


### PR DESCRIPTION
- **PR Description**

This improves the user experience when users try to use an invalid key name in their config, either for one of our standard keybindings or for the key of a custom command.

Fixes half of #4256 (only the keybindings aspect of it, not the context names).

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
