### PR TITLE
Make losing focus on Confirmations count as closing them

### DIFF
--- a/pkg/gui/controllers/confirmation_controller.go
+++ b/pkg/gui/controllers/confirmation_controller.go
@@ -61,6 +61,12 @@ func (self *ConfirmationController) GetKeybindings(opts types.KeybindingsOpts) [
 
 func (self *ConfirmationController) GetOnFocusLost() func(types.OnFocusLostOpts) {
 	return func(types.OnFocusLostOpts) {
+		if self.context().State.OnClose != nil {
+			err := self.context().State.OnClose()
+			if err != nil {
+				self.c.Log.Error(err)
+			}
+		}
 		self.c.Helpers().Confirmation.DeactivateConfirmationPrompt()
 	}
 }


### PR DESCRIPTION
- **PR Description**

This will fix https://github.com/jesseduffield/lazygit/issues/4052 where new users click out of the panel, but the state never gets updated.

It makes sense to do this as a close and not a confirm, because losing focus could be due to many things, and doesn't indicate an explicit confirmation.

It is up to the implementation of the initial popup message that a cancelling or closing should mean they don't see it again. Most popups don't have a meaningful `ConfirmOpts.OnClose` method, so this change will be a no-op for them.
The helper that creates the `OnClose` method I call here _should_ ensure that it is not `nil` in normal operations, but I fear there could be some moment where it ends up as nil, so I'm guarding against that.

Here is a list of potentially impacted closing methods. The only one I worry about a little bit because I am unfamiliar with its section of code is the CredentialsHelper.

Introductory Message  (what the issue was reported on):
https://github.com/jesseduffield/lazygit/blob/01eece3737f9435faf305029decba6d630b13515/pkg/gui/gui.go#L1008-L1020

Breaking Changes Message
https://github.com/jesseduffield/lazygit/blob/01eece3737f9435faf305029decba6d630b13515/pkg/gui/gui.go#L1077-L1087

CredentialsHelper
https://github.com/jesseduffield/lazygit/blob/01eece3737f9435faf305029decba6d630b13515/pkg/gui/controllers/helpers/credentials_helper.go#L38-L42

Fixes https://github.com/jesseduffield/lazygit/issues/4052
- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [X] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc
