### PR TITLE
Fix documentation of gui.showFileTree config

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -166,7 +166,7 @@ gui:
   showListFooter: true
 
   # If true, display the files in the file views as a tree. If false, display the files as a flat list.
-  # This can be toggled from within Lazygit with the '~' key, but that will not change the default.
+  # This can be toggled from within Lazygit with the '`' key, but that will not change the default.
   showFileTree: true
 
   # If true, show the number of lines changed per file in the Files view

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -114,7 +114,7 @@ type GuiConfig struct {
 	// If true, show the '5 of 20' footer at the bottom of list views
 	ShowListFooter bool `yaml:"showListFooter"`
 	// If true, display the files in the file views as a tree. If false, display the files as a flat list.
-	// This can be toggled from within Lazygit with the '~' key, but that will not change the default.
+	// This can be toggled from within Lazygit with the '`' key, but that will not change the default.
 	ShowFileTree bool `yaml:"showFileTree"`
 	// If true, show the number of lines changed per file in the Files view
 	ShowNumstatInFilesView bool `yaml:"showNumstatInFilesView"`

--- a/schema/config.json
+++ b/schema/config.json
@@ -302,7 +302,7 @@
         },
         "showFileTree": {
           "type": "boolean",
-          "description": "If true, display the files in the file views as a tree. If false, display the files as a flat list.\nThis can be toggled from within Lazygit with the '~' key, but that will not change the default.",
+          "description": "If true, display the files in the file views as a tree. If false, display the files as a flat list.\nThis can be toggled from within Lazygit with the '`' key, but that will not change the default.",
           "default": true
         },
         "showNumstatInFilesView": {


### PR DESCRIPTION
- **PR Description**
Change `~` to `` ` `` as it's the correct key.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
