### PR TITLE
Standardize selection of upstream branches

### DIFF
--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -112,7 +112,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 		MergeAndRebase:  rebaseHelper,
 		MergeConflicts:  mergeConflictsHelper,
 		CherryPick:      cherryPickHelper,
-		Upstream:        helpers.NewUpstreamHelper(helperCommon, suggestionsHelper.GetRemoteBranchesSuggestionsFunc),
+		Upstream:        helpers.NewUpstreamHelper(helperCommon, suggestionsHelper),
 		AmendHelper:     helpers.NewAmendHelper(helperCommon, gpgHelper),
 		FixupHelper:     helpers.NewFixupHelper(helperCommon),
 		Commits:         commitsHelper,

--- a/pkg/gui/controllers/helpers/upstream_helper.go
+++ b/pkg/gui/controllers/helpers/upstream_helper.go
@@ -1,75 +1,86 @@
 package helpers
 
 import (
-	"errors"
-	"strings"
+	"fmt"
 
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/samber/lo"
 )
 
 type UpstreamHelper struct {
 	c *HelperCommon
 
-	getRemoteBranchesSuggestionsFunc func(string) func(string) []*types.Suggestion
+	suggestions *SuggestionsHelper
 }
 
 type IUpstreamHelper interface {
-	ParseUpstream(string) (string, string, error)
-	PromptForUpstreamWithInitialContent(*models.Branch, func(string) error) error
-	PromptForUpstreamWithoutInitialContent(*models.Branch, func(string) error) error
-	GetSuggestedRemote() string
+	PromptForUpstream(suggestedBranch string, branchSelectionTitle func(string) string, onConfirm func(Upstream) error) error
 }
 
 var _ IUpstreamHelper = &UpstreamHelper{}
 
 func NewUpstreamHelper(
 	c *HelperCommon,
-	getRemoteBranchesSuggestionsFunc func(string) func(string) []*types.Suggestion,
+	suggestions *SuggestionsHelper,
 ) *UpstreamHelper {
 	return &UpstreamHelper{
-		c:                                c,
-		getRemoteBranchesSuggestionsFunc: getRemoteBranchesSuggestionsFunc,
+		c:           c,
+		suggestions: suggestions,
 	}
 }
 
-func (self *UpstreamHelper) ParseUpstream(upstream string) (string, string, error) {
-	var upstreamBranch, upstreamRemote string
-	split := strings.Split(upstream, " ")
-	if len(split) != 2 {
-		return "", "", errors.New(self.c.Tr.InvalidUpstream)
-	}
-
-	upstreamRemote = split[0]
-	upstreamBranch = split[1]
-
-	return upstreamRemote, upstreamBranch, nil
+type Upstream struct {
+	Remote string
+	Branch string
 }
 
-func (self *UpstreamHelper) promptForUpstream(initialContent string, onConfirm func(string) error) error {
-	self.c.Prompt(types.PromptOpts{
-		Title:               self.c.Tr.EnterUpstream,
-		InitialContent:      initialContent,
-		FindSuggestionsFunc: self.getRemoteBranchesSuggestionsFunc(" "),
-		HandleConfirm:       onConfirm,
+func (self *UpstreamHelper) promptForUpstreamBranch(chosenRemote string, initialBranch string, branchSelectionTitle func(string) string, onConfirm func(Upstream) error) error {
+	remoteDoesNotExist := lo.NoneBy(self.c.Model().Remotes, func(remote *models.Remote) bool {
+		return remote.Name == chosenRemote
 	})
+	if remoteDoesNotExist {
+		return fmt.Errorf(self.c.Tr.NoValidRemoteName, chosenRemote)
+	}
 
+	self.c.Prompt(types.PromptOpts{
+		Title:               branchSelectionTitle(chosenRemote),
+		InitialContent:      initialBranch,
+		FindSuggestionsFunc: self.suggestions.GetRemoteBranchesForRemoteSuggestionsFunc(chosenRemote),
+		HandleConfirm: func(chosenBranch string) error {
+			self.c.Log.Debugf("User selected branch '%s' on remote '%s'", chosenRemote, chosenBranch)
+			return onConfirm(Upstream{chosenRemote, chosenBranch})
+		},
+	})
 	return nil
 }
 
-func (self *UpstreamHelper) PromptForUpstreamWithInitialContent(currentBranch *models.Branch, onConfirm func(string) error) error {
-	suggestedRemote := self.GetSuggestedRemote()
-	initialContent := suggestedRemote + " " + currentBranch.Name
+// Creates a series of two prompts that will gather an upstream remote and branch from the user.
+// The first prompt gathers the remote name, with a pre-filled default of origin, or the first remote in the list.
+// After selecting a remote, only branches present on that remote will be displayed.
+// If there is only one remote in the current repository, the remote prompt will be skipped.
+//
+// suggestedBranch pre-fills the second prompt, but can be an empty string if no suggestion would make sense. Often it is the current local branch name.
+// branchSelectionTitle allows customization of the second prompt to remind the user what their action entails.
+// onConfirm is called once the user has fully specified what their desired upstream is.
+func (self *UpstreamHelper) PromptForUpstream(suggestedBranch string, branchSelectionTitle func(string) string, onConfirm func(Upstream) error) error {
+	if len(self.c.Model().Remotes) == 1 {
+		remote := self.c.Model().Remotes[0].Name
+		self.c.Log.Debugf("Defaulting to only remote %s", remote)
+		return self.promptForUpstreamBranch(remote, suggestedBranch, branchSelectionTitle, onConfirm)
+	} else {
+		suggestedRemote := getSuggestedRemote(self.c.Model().Remotes)
+		self.c.Prompt(types.PromptOpts{
+			Title:               self.c.Tr.SelectTargetRemote,
+			InitialContent:      suggestedRemote,
+			FindSuggestionsFunc: self.suggestions.GetRemoteSuggestionsFunc(),
+			HandleConfirm: func(chosenRemote string) error {
+				return self.promptForUpstreamBranch(chosenRemote, suggestedBranch, branchSelectionTitle, onConfirm)
+			},
+		})
+	}
 
-	return self.promptForUpstream(initialContent, onConfirm)
-}
-
-func (self *UpstreamHelper) PromptForUpstreamWithoutInitialContent(_ *models.Branch, onConfirm func(string) error) error {
-	return self.promptForUpstream("", onConfirm)
-}
-
-func (self *UpstreamHelper) GetSuggestedRemote() string {
-	return getSuggestedRemote(self.c.Model().Remotes)
+	return nil
 }
 
 func getSuggestedRemote(remotes []*models.Remote) string {

--- a/pkg/integration/tests/branch/open_pull_request_invalid_target_remote_name.go
+++ b/pkg/integration/tests/branch/open_pull_request_invalid_target_remote_name.go
@@ -42,6 +42,7 @@ var OpenPullRequestInvalidTargetRemoteName = NewIntegrationTest(NewIntegrationTe
 		t.ExpectPopup().
 			Prompt().
 			Title(Equals("Select target remote")).
+			Clear().
 			Type("non-existing-remote").
 			Confirm()
 

--- a/pkg/integration/tests/branch/set_upstream.go
+++ b/pkg/integration/tests/branch/set_upstream.go
@@ -28,9 +28,11 @@ var SetUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 					Select(Contains(" Set upstream of selected branch")). // using leading space to disambiguate from the 'reset' option
 					Confirm()
 
+				// Origin is preselected on the users behalf because there is only one remote
+
 				t.ExpectPopup().Prompt().
-					Title(Equals("Enter upstream as '<remote> <branchname>'")).
-					SuggestionLines(Equals("origin master")).
+					Title(Equals("Enter upstream branch on remote 'origin'")).
+					SuggestionLines(Equals("master")).
 					ConfirmFirstSuggestion()
 			}).
 			Lines(

--- a/pkg/integration/tests/sync/pull_and_set_upstream.go
+++ b/pkg/integration/tests/sync/pull_and_set_upstream.go
@@ -30,8 +30,8 @@ var PullAndSetUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Files().IsFocused().Press(keys.Universal.Pull)
 
 		t.ExpectPopup().Prompt().
-			Title(Equals("Enter upstream as '<remote> <branchname>'")).
-			SuggestionLines(Equals("origin master")).
+			Title(Equals("Enter upstream branch on remote 'origin'")).
+			SuggestionLines(Equals("master")).
 			ConfirmFirstSuggestion()
 
 		t.Views().Commits().

--- a/pkg/integration/tests/sync/push_and_set_upstream.go
+++ b/pkg/integration/tests/sync/push_and_set_upstream.go
@@ -26,8 +26,8 @@ var PushAndSetUpstream = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Universal.Push)
 
 		t.ExpectPopup().Prompt().
-			Title(Equals("Enter upstream as '<remote> <branchname>'")).
-			SuggestionLines(Equals("origin master")).
+			Title(Equals("Enter upstream branch on remote 'origin'")).
+			SuggestionLines(Equals("master")).
 			ConfirmFirstSuggestion()
 
 		assertSuccessfullyPushed(t)


### PR DESCRIPTION
- **PR Description**

Changes the behavior of all upstream related commands I could find to behave similar to how multi-remote pull requests currently behave:
> Changes: Pull, Push, Set Upstream, Open Pull Request

The new flow behaves as I describe in the comment I wrote:

Creates a series of two prompts that will gather an upstream remote and branch from the user.
The first prompt gathers the remote name, with a pre-filled default of origin, or the first remote in the list.
After selecting a remote, only branches present on that remote will be displayed.
If there is only one remote in the current repository, the remote prompt will be skipped.

For users who only work on single-remote repositories, this should be basically unchanged, with the exception of the prompt they are displayed. (They no longer have the option to enter a remote at all, since they only have 1 choice).
For users who work in multi-remote repositories, I hope this flow should be quite smooth! The most controversial choice I made was pre-filling the default repository. In my head, users are dealing with a small number of remotes (<5), and probably still dealing with the primary more often than not. Therefore, having it prefilled can save them a keystroke in many cases, and when they need other remotes, they can press tab and arrow down.

If we want to change the behavior so the default remote is never filled, I am totally open to that option!

Currently have in a draft because I know I need to do some internationalization.

Implements https://github.com/jesseduffield/lazygit/issues/4292
- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [X] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc
