### PR TITLE
Improve the error message when users have gpg signing turned on

### DIFF
--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1438,7 +1438,7 @@ func EnglishTranslationSet() *TranslationSet {
 		DiscardOldFileChangeTooltip:          "Discard this commit's changes to this file. This runs an interactive rebase in the background, so you may get a merge conflict if a later commit also changes this file.",
 		DiscardFileChangesTitle:              "Discard file changes",
 		DiscardFileChangesPrompt:             "Are you sure you want to remove changes to the selected file(s) from this commit?\n\nThis action will start a rebase, reverting these file changes. Be aware that if subsequent commits depend on these changes, you may need to resolve conflicts.\nNote: This will also reset any active custom patches.",
-		DisabledForGPG:                       "Feature not available for users using GPG",
+		DisabledForGPG:                       "Feature not available for users using GPG.\n\nIf you are using a passphrase agent (e.g. gpg-agent) so that you don't have to type your passphrase when signing, you can enable this feature by adding\n\ngit:\n  overrideGpg: true\n\nto your lazygit config file.",
 		CreateRepo:                           "Not in a git repository. Create a new git repository? (y/n): ",
 		BareRepo:                             "You've attempted to open Lazygit in a bare repo but Lazygit does not yet support bare repos. Open most recent repo? (y/n) ",
 		InitialBranch:                        "Branch name? (leave empty for git's default): ",


### PR DESCRIPTION
- **PR Description**

It is not obvious that you can get rid of the error by using the overrideGpg config, so tell them.

Improves #4293 and #3758.
