### PR TITLE
Use indentation of 2 when rewriting auto-migrated config file

### DIFF
--- a/pkg/utils/yaml_utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils/yaml_utils.go
@@ -1,6 +1,7 @@
 package yaml_utils
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 
@@ -34,7 +35,7 @@ func UpdateYamlValue(yamlBytes []byte, path []string, value string) ([]byte, err
 	}
 
 	// Convert the updated YAML node back to YAML bytes.
-	updatedYAMLBytes, err := yaml.Marshal(body)
+	updatedYAMLBytes, err := yamlMarshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert YAML node to bytes: %w", err)
 	}
@@ -126,7 +127,7 @@ func TransformNode(yamlBytes []byte, path []string, transform func(node *yaml.No
 	}
 
 	// Convert the updated YAML node back to YAML bytes.
-	updatedYAMLBytes, err := yaml.Marshal(body)
+	updatedYAMLBytes, err := yamlMarshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert YAML node to bytes: %w", err)
 	}
@@ -170,7 +171,7 @@ func RenameYamlKey(yamlBytes []byte, path []string, newKey string) ([]byte, erro
 	}
 
 	// Convert the updated YAML node back to YAML bytes.
-	updatedYAMLBytes, err := yaml.Marshal(body)
+	updatedYAMLBytes, err := yamlMarshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert YAML node to bytes: %w", err)
 	}
@@ -227,7 +228,7 @@ func Walk(yamlBytes []byte, callback func(node *yaml.Node, path string) bool) ([
 	}
 
 	// Convert the updated YAML node back to YAML bytes.
-	updatedYAMLBytes, err := yaml.Marshal(body)
+	updatedYAMLBytes, err := yamlMarshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert YAML node to bytes: %w", err)
 	}
@@ -272,4 +273,13 @@ func walk(node *yaml.Node, path string, callback func(*yaml.Node, string) bool) 
 	}
 
 	return didChange, nil
+}
+
+func yamlMarshal(node *yaml.Node) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := yaml.NewEncoder(&buffer)
+	encoder.SetIndent(2)
+
+	err := encoder.Encode(node)
+	return buffer.Bytes(), err
 }

--- a/pkg/utils/yaml_utils/yaml_utils_test.go
+++ b/pkg/utils/yaml_utils/yaml_utils_test.go
@@ -50,12 +50,11 @@ func TestUpdateYamlValue(t *testing.T) {
 			expectedErr: "",
 		},
 		{
-			name:  "nested update",
-			in:    "foo:\n  bar: baz\n",
-			path:  []string{"foo", "bar"},
-			value: "qux",
-			// indentation is not preserved. See https://github.com/go-yaml/yaml/issues/899
-			expectedOut: "foo:\n    bar: qux\n",
+			name:        "nested update",
+			in:          "foo:\n  bar: baz\n",
+			path:        []string{"foo", "bar"},
+			value:       "qux",
+			expectedOut: "foo:\n  bar: qux\n",
 			expectedErr: "",
 		},
 		{
@@ -63,7 +62,7 @@ func TestUpdateYamlValue(t *testing.T) {
 			in:          "",
 			path:        []string{"foo", "bar", "baz"},
 			value:       "qux",
-			expectedOut: "foo:\n    bar:\n        baz: qux\n",
+			expectedOut: "foo:\n  bar:\n    baz: qux\n",
 			expectedErr: "",
 		},
 		{
@@ -134,21 +133,19 @@ func TestRenameYamlKey(t *testing.T) {
 			expectedErr: "",
 		},
 		{
-			name:   "rename key, nested",
-			in:     "foo:\n  bar: 5\n",
-			path:   []string{"foo", "bar"},
-			newKey: "baz",
-			// indentation is not preserved. See https://github.com/go-yaml/yaml/issues/899
-			expectedOut: "foo:\n    baz: 5\n",
+			name:        "rename key, nested",
+			in:          "foo:\n  bar: 5\n",
+			path:        []string{"foo", "bar"},
+			newKey:      "baz",
+			expectedOut: "foo:\n  baz: 5\n",
 			expectedErr: "",
 		},
 		{
-			name:   "rename non-scalar key",
-			in:     "foo:\n  bar: 5\n",
-			path:   []string{"foo"},
-			newKey: "qux",
-			// indentation is not preserved. See https://github.com/go-yaml/yaml/issues/899
-			expectedOut: "qux:\n    bar: 5\n",
+			name:        "rename non-scalar key",
+			in:          "foo:\n  bar: 5\n",
+			path:        []string{"foo"},
+			newKey:      "qux",
+			expectedOut: "qux:\n  bar: 5\n",
 			expectedErr: "",
 		},
 		{
@@ -288,8 +285,7 @@ func TestWalk_inPlaceChanges(t *testing.T) {
 				}
 				return false
 			},
-			// indentation is not preserved. See https://github.com/go-yaml/yaml/issues/899
-			expectedOut: "x:\n    y: 7\n",
+			expectedOut: "x:\n  y: 7\n",
 		},
 		{
 			name: "change array value",
@@ -301,8 +297,7 @@ func TestWalk_inPlaceChanges(t *testing.T) {
 				}
 				return false
 			},
-			// indentation is not preserved. See https://github.com/go-yaml/yaml/issues/899
-			expectedOut: "x:\n    - y: 7\n",
+			expectedOut: "x:\n  - y: 7\n",
 		},
 	}
 
@@ -366,8 +361,8 @@ foo:
 			path:      []string{"foo", "bar"},
 			transform: transformIntValueToString,
 			expectedOut: `foo:
-    bar: "2"
-`, // Note the indentiation change and newlines because of how it re-marshalls
+  bar: "2"
+`, // Note the trailing newline changes because of how it re-marshalls
 		},
 		{
 			name: "Does nothing when already transformed",


### PR DESCRIPTION
- **PR Description**

Use indentation of 2 when rewriting auto-migrated config file. This seems to be what most people use when indenting yaml files, and it seems to make more sense than the default of 4. We also use it the example config in Config.md.
