### PR TITLE
Filter out dev comments from schema

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,15 @@
       "console": "integratedTerminal",
     },
     {
+      "name": "JSON Schema generator",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/pkg/jsonschema/generator.go",
+      "cwd": "${workspaceFolder}/pkg/jsonschema",
+      "console": "integratedTerminal",
+    },
+    {
       "name": "Attach to a running Lazygit",
       "type": "go",
       "request": "attach",

--- a/pkg/jsonschema/generate.go
+++ b/pkg/jsonschema/generate.go
@@ -56,6 +56,7 @@ func customReflect(v *config.UserConfig) *jsonschema.Schema {
 	if err := r.AddGoComments("github.com/jesseduffield/lazygit/pkg/config", "../config"); err != nil {
 		panic(err)
 	}
+	filterOutDevComments(r)
 	schema := r.Reflect(v)
 	defaultConfig := config.GetDefaultConfig()
 	userConfigSchema := schema.Definitions["UserConfig"]
@@ -74,6 +75,16 @@ func customReflect(v *config.UserConfig) *jsonschema.Schema {
 	}
 
 	return schema
+}
+
+func filterOutDevComments(r *jsonschema.Reflector) {
+	for k, v := range r.CommentMap {
+		commentLines := strings.Split(v, "\n")
+		filteredCommentLines := lo.Filter(commentLines, func(line string, _ int) bool {
+			return !strings.Contains(line, "[dev]")
+		})
+		r.CommentMap[k] = strings.Join(filteredCommentLines, "\n")
+	}
 }
 
 func setDefaultVals(rootSchema, schema *jsonschema.Schema, defaults any) {

--- a/pkg/jsonschema/generate_config_docs.go
+++ b/pkg/jsonschema/generate_config_docs.go
@@ -77,20 +77,13 @@ func prepareMarshalledConfig(buffer bytes.Buffer) []byte {
 }
 
 func setComment(yamlNode *yaml.Node, description string) {
-	// Filter out lines containing "[dev]"; this allows us to add developer
-	// documentation to properties that don't get included in the docs
-	lines := strings.Split(description, "\n")
-	lines = lo.Filter(lines, func(s string, _ int) bool {
-		return !strings.Contains(s, "[dev]")
-	})
-
 	// Workaround for the way yaml formats the HeadComment if it contains
 	// blank lines: it renders these without a leading "#", but we want a
 	// leading "#" even on blank lines. However, yaml respects it if the
 	// HeadComment already contains a leading "#", so we prefix all lines
 	// (including blank ones) with "#".
 	yamlNode.HeadComment = strings.Join(
-		lo.Map(lines, func(s string, _ int) string {
+		lo.Map(strings.Split(description, "\n"), func(s string, _ int) string {
 			if s == "" {
 				return "#" // avoid trailing space on blank lines
 			}

--- a/schema/config.json
+++ b/schema/config.json
@@ -1468,7 +1468,7 @@
         },
         "editInTerminal": {
           "type": "boolean",
-          "description": "Whether lazygit suspends until an edit process returns\n[dev] Pointer to bool so that we can distinguish unset (nil) from false.\n[dev] We're naming this `editInTerminal` for backwards compatibility"
+          "description": "Whether lazygit suspends until an edit process returns"
         },
         "openDirInEditor": {
           "type": "string",


### PR DESCRIPTION
- **PR Description**

Filter out [dev] comments earlier. Previously we only filtered them out from the example config section in Config.md, but they still appeared in the schema. This is not ideal, because the schema descriptions can appear in editors on mouse hover or in auto-completions. So filter them out earlier, so that they don't appear in the schema either.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
