### PR TITLE
Add config to use a pager in the staging panel

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -280,6 +280,11 @@ git:
     # ydiff -p cat -s --wrap --width={{columnWidth}}
     pager: ""
 
+    # e.g.
+    # delta --dark --paging=never --color-only
+    # diff-so-fancy --patch
+    pagerForStaging: ""
+
     # If true, Lazygit will use whatever pager is specified in `$GIT_PAGER`, `$PAGER`, or your *git config*. If the pager ends with something like ` | less` we will strip that part out, because less doesn't play nice with our rendering approach. If the custom pager uses less under the hood, that will also break rendering (hence the `--paging=never` flag for the `delta` pager).
     useConfig: false
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -284,6 +284,15 @@ func (PagerType) JSONSchemaExtend(schema *jsonschema.Schema) {
 	}
 }
 
+type PagerForStagingType string
+
+func (PagerForStagingType) JSONSchemaExtend(schema *jsonschema.Schema) {
+	schema.Examples = []any{
+		"delta --dark --paging=never --color-only",
+		"diff-so-fancy --patch",
+	}
+}
+
 type PagingConfig struct {
 	// Value of the --color arg in the git diff command. Some pagers want this to be set to 'always' and some want it set to 'never'
 	ColorArg string `yaml:"colorArg" jsonschema:"enum=always,enum=never"`
@@ -292,6 +301,10 @@ type PagingConfig struct {
 	// delta --dark --paging=never
 	// ydiff -p cat -s --wrap --width={{columnWidth}}
 	Pager PagerType `yaml:"pager"`
+	// e.g.
+	// delta --dark --paging=never --color-only
+	// diff-so-fancy --patch
+	PagerForStaging PagerForStagingType `yaml:"pagerForStaging"`
 	// If true, Lazygit will use whatever pager is specified in `$GIT_PAGER`, `$PAGER`, or your *git config*. If the pager ends with something like ` | less` we will strip that part out, because less doesn't play nice with our rendering approach. If the custom pager uses less under the hood, that will also break rendering (hence the `--paging=never` flag for the `delta` pager).
 	UseConfig bool `yaml:"useConfig"`
 	// e.g. 'difft --color=always'

--- a/pkg/gui/controllers/helpers/patch_building_helper.go
+++ b/pkg/gui/controllers/helpers/patch_building_helper.go
@@ -91,7 +91,7 @@ func (self *PatchBuildingHelper) RefreshPatchBuildingPanel(opts types.OnFocusOpt
 
 	oldState := context.GetState()
 
-	state := patch_exploring.NewState(diff, selectedLineIdx, context.GetView(), oldState)
+	state := patch_exploring.NewState(diff, selectedLineIdx, context.GetView(), oldState, string(self.c.UserConfig().Git.Paging.PagerForStaging))
 	context.SetState(state)
 	if state == nil {
 		self.Escape()

--- a/pkg/gui/controllers/helpers/staging_helper.go
+++ b/pkg/gui/controllers/helpers/staging_helper.go
@@ -62,12 +62,14 @@ func (self *StagingHelper) RefreshStagingPanel(focusOpts types.OnFocusOpts) {
 	mainContext.GetMutex().Lock()
 	secondaryContext.GetMutex().Lock()
 
+	pagerCommand := string(self.c.UserConfig().Git.Paging.PagerForStaging)
+
 	mainContext.SetState(
-		patch_exploring.NewState(mainDiff, mainSelectedLineIdx, mainContext.GetView(), mainContext.GetState()),
+		patch_exploring.NewState(mainDiff, mainSelectedLineIdx, mainContext.GetView(), mainContext.GetState(), pagerCommand),
 	)
 
 	secondaryContext.SetState(
-		patch_exploring.NewState(secondaryDiff, secondarySelectedLineIdx, secondaryContext.GetView(), secondaryContext.GetState()),
+		patch_exploring.NewState(secondaryDiff, secondarySelectedLineIdx, secondaryContext.GetView(), secondaryContext.GetState(), pagerCommand),
 	)
 
 	mainState := mainContext.GetState()

--- a/schema/config.json
+++ b/schema/config.json
@@ -1548,6 +1548,15 @@
             "ydiff -p cat -s --wrap --width={{columnWidth}}"
           ]
         },
+        "pagerForStaging": {
+          "type": "string",
+          "description": "e.g.\ndelta --dark --paging=never --color-only\ndiff-so-fancy --patch",
+          "default": "",
+          "examples": [
+            "delta --dark --paging=never --color-only",
+            "diff-so-fancy --patch"
+          ]
+        },
         "useConfig": {
           "type": "boolean",
           "description": "If true, Lazygit will use whatever pager is specified in `$GIT_PAGER`, `$PAGER`, or your *git config*. If the pager ends with something like ` | less` we will strip that part out, because less doesn't play nice with our rendering approach. If the custom pager uses less under the hood, that will also break rendering (hence the `--paging=never` flag for the `delta` pager).",


### PR DESCRIPTION
- **PR Description**

Very rough, preliminary prototype of enabling a pager in the staging panel. It adds a separate config option for this, because the staging pager likely needs special command-line options (e.g. `--patch` in case of diff-so-fancy, `--color-only` in case of delta).

This is not for real use yet, it doesn't work well enough; it's just to see what problems we would have to solve if we wanted this.

Some of the problems:
- When line wrapping is on (default), there's sometimes a discrepancy between what's selected and what it acts on (can be seen when jumping between hunks with arrow left/right, it doesn't select the first changed line of the hunk, but one before). I suspect this may be caused by the Decolorize function not working well enough. For testing it's probably a good idea to disable wrapping (`gui.wrapLinesInStagingView: false`) to work around this.
- In the patch building panel it stops using the pager as soon as you stage a line. This is because it wants to color the line starts of the lines included in the patch; we'd need to figure out some other way of visualizing this.
- For delta, the highlighted line is almost invisible on added or deleted lines, because highlighting changes only the background color, but delta paints over the entire background for added and deleted lines. diff-so-fancy doesn't do this, so it works a little better there.

Would fix #4201, #2117, and #1939 if we got this to work for real.