### PR TITLE
URL encode gitlab brackets to make consistent with branch names

### DIFF
--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -33,8 +33,8 @@ var bitbucketServiceDef = ServiceDefinition{
 
 var gitLabServiceDef = ServiceDefinition{
 	provider:                        "gitlab",
-	pullRequestURLIntoDefaultBranch: "/-/merge_requests/new?merge_request[source_branch]={{.From}}",
-	pullRequestURLIntoTargetBranch:  "/-/merge_requests/new?merge_request[source_branch]={{.From}}&merge_request[target_branch]={{.To}}",
+	pullRequestURLIntoDefaultBranch: "/-/merge_requests/new?merge_request%5Bsource_branch%5D={{.From}}",
+	pullRequestURLIntoTargetBranch:  "/-/merge_requests/new?merge_request%5Bsource_branch%5D={{.From}}&merge_request%5Btarget_branch%5D={{.To}}",
 	commitURL:                       "/-/commit/{{.CommitHash}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,

--- a/pkg/commands/hosting_service/hosting_service_test.go
+++ b/pkg/commands/hosting_service/hosting_service_test.go
@@ -112,7 +112,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "git@gitlab.com:peter/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/peter/calculator/-/merge_requests/new?merge_request[source_branch]=feature%2Fui", url)
+				assert.Equal(t, "https://gitlab.com/peter/calculator/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fui", url)
 			},
 		},
 		{
@@ -121,7 +121,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "git@gitlab.com:peter/public/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/peter/public/calculator/-/merge_requests/new?merge_request[source_branch]=feature%2Fui", url)
+				assert.Equal(t, "https://gitlab.com/peter/public/calculator/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fui", url)
 			},
 		},
 		{
@@ -130,7 +130,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "https://gitlab.com/peter/public/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/peter/public/calculator/-/merge_requests/new?merge_request[source_branch]=feature%2Fui", url)
+				assert.Equal(t, "https://gitlab.com/peter/public/calculator/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fui", url)
 			},
 		},
 		{
@@ -140,7 +140,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "git@gitlab.com:peter/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/peter/calculator/-/merge_requests/new?merge_request[source_branch]=feature%2Fcommit-ui&merge_request[target_branch]=epic%2Fui", url)
+				assert.Equal(t, "https://gitlab.com/peter/calculator/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fcommit-ui&merge_request%5Btarget_branch%5D=epic%2Fui", url)
 			},
 		},
 		{
@@ -150,7 +150,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "git@gitlab.com:peter/public/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/peter/public/calculator/-/merge_requests/new?merge_request[source_branch]=feature%2Fcommit-ui&merge_request[target_branch]=epic%2Fui", url)
+				assert.Equal(t, "https://gitlab.com/peter/public/calculator/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fcommit-ui&merge_request%5Btarget_branch%5D=epic%2Fui", url)
 			},
 		},
 		{
@@ -160,7 +160,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "https://gitlab.com/peter/public/calculator.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/peter/public/calculator/-/merge_requests/new?merge_request[source_branch]=feature%2Fcommit-ui&merge_request[target_branch]=epic%2Fui", url)
+				assert.Equal(t, "https://gitlab.com/peter/public/calculator/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fcommit-ui&merge_request%5Btarget_branch%5D=epic%2Fui", url)
 			},
 		},
 		{
@@ -362,7 +362,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			},
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://my.domain.test:1111/johndoe/social_network/-/merge_requests/new?merge_request[source_branch]=feature%2Fprofile-page", url)
+				assert.Equal(t, "https://my.domain.test:1111/johndoe/social_network/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fprofile-page", url)
 			},
 		},
 		{
@@ -410,7 +410,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "git@gitlab.com:me/public/repo-with-issues.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/me/public/repo-with-issues/-/merge_requests/new?merge_request[source_branch]=feature%2FsomeIssue%23123&merge_request[target_branch]=master", url)
+				assert.Equal(t, "https://gitlab.com/me/public/repo-with-issues/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2FsomeIssue%23123&merge_request%5Btarget_branch%5D=master", url)
 			},
 		},
 		{
@@ -420,7 +420,7 @@ func TestGetPullRequestURL(t *testing.T) {
 			remoteUrl: "git@gitlab.com:me/public/repo-with-issues.git",
 			test: func(url string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://gitlab.com/me/public/repo-with-issues/-/merge_requests/new?merge_request[source_branch]=yolo&merge_request[target_branch]=archive%2Fnever-ending-feature%23666", url)
+				assert.Equal(t, "https://gitlab.com/me/public/repo-with-issues/-/merge_requests/new?merge_request%5Bsource_branch%5D=yolo&merge_request%5Btarget_branch%5D=archive%2Fnever-ending-feature%23666", url)
 			},
 		},
 	}


### PR DESCRIPTION
- **PR Description**
Some operating systems 'open' implementations do not like when some special characters are unencoded, so they will double-encode the branch name, which we already encode.

This particularly matters since branch names with / are common.

Fixes https://github.com/jesseduffield/lazygit/issues/4321

- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc
