### PR TITLE
Wait for active pushing operations to finish before opening PR

### DIFF
--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -148,6 +148,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 
 	syncController := controllers.NewSyncController(
 		common,
+		&gui.branchesBeingPushed,
 	)
 
 	submodulesController := controllers.NewSubmodulesController(common)
@@ -182,7 +183,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 	renameSimilarityThresholdController := controllers.NewRenameSimilarityThresholdController(common)
 	verticalScrollControllerFactory := controllers.NewVerticalScrollControllerFactory(common, &gui.viewBufferManagerMap)
 
-	branchesController := controllers.NewBranchesController(common)
+	branchesController := controllers.NewBranchesController(common, &gui.branchesBeingPushed)
 	gitFlowController := controllers.NewGitFlowController(common)
 	stashController := controllers.NewStashController(common)
 	commitFilesController := controllers.NewCommitFilesController(common)

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -53,10 +53,6 @@ func NewRefreshHelper(
 }
 
 func (self *RefreshHelper) Refresh(options types.RefreshOptions) error {
-	if options.Mode == types.ASYNC && options.Then != nil {
-		panic("RefreshOptions.Then doesn't work with mode ASYNC")
-	}
-
 	t := time.Now()
 	defer func() {
 		self.c.Log.Infof("Refresh took %s", time.Since(t))
@@ -103,8 +99,10 @@ func (self *RefreshHelper) Refresh(options types.RefreshOptions) error {
 			// everything happens fast and it's better to have everything update
 			// in the one frame
 			if !self.c.InDemo() && options.Mode == types.ASYNC {
+				wg.Add(1)
 				self.c.OnWorker(func(t gocui.Task) error {
 					f()
+					wg.Done()
 					return nil
 				})
 			} else {
@@ -189,11 +187,20 @@ func (self *RefreshHelper) Refresh(options types.RefreshOptions) error {
 
 		self.refreshStatus()
 
-		wg.Wait()
-
-		if options.Then != nil {
-			if err := options.Then(); err != nil {
-				return err
+		if options.Mode == types.ASYNC {
+			self.c.OnWorker(func(t gocui.Task) error {
+				wg.Wait()
+				if options.Then != nil {
+					return options.Then()
+				}
+				return nil
+			})
+		} else {
+			wg.Wait()
+			if options.Then != nil {
+				if err := options.Then(); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -95,6 +95,8 @@ type Gui struct {
 	// so that you can return to the superproject
 	RepoPathStack *utils.StringStack
 
+	branchesBeingPushed sync.Map // keys: branchName string, value: deadlock.WaitGroup
+
 	// this tells us whether our views have been initially set up
 	ViewsSetup bool
 


### PR DESCRIPTION
- **PR Description**
An early pass at implementing https://github.com/jesseduffield/lazygit/issues/4339

One thing I very much dislike about this PR is the interface of `sync.Map`. I was shocked to learn there wasn't a standard lib implementation with generics yet. https://github.com/puzpuzpuz/xsync seems to be what people have standardized around for a thread safe Map with actual types instead of any, but I didn't want to suggest adding that for a _single_ map. If people like the library though, I'm happy to add it in!

I tested this with a pre-push hook that just did a `sleep 3` to simulate extra-slow pushes. I changed the non-input open pull requests to happen on a background worker thread, and remember their commit has for when they need to retrieve it. In the case of needing user input, I figured it would be better to block the UI so that we don't have a popup show up several seconds later after the keystroke.


- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc
