### PR TITLE
Add a "Content of selected file" entry to the copy menu for commit files

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -279,6 +279,13 @@ func (self *CommitCommands) ShowCmdObj(hash string, filterPath string) oscommand
 	return self.cmd.New(cmdArgs).DontLog()
 }
 
+func (self *CommitCommands) ShowFileContentCmdObj(hash string, filePath string) oscommands.ICmdObj {
+	cmdArgs := NewGitCmd("show").
+		Arg(fmt.Sprintf("%s:%s", hash, filePath)).
+		ToArgv()
+	return self.cmd.New(cmdArgs).DontLog()
+}
+
 // Revert reverts the selected commit by hash
 func (self *CommitCommands) Revert(hash string) error {
 	cmdArgs := NewGitCmd("revert").Arg(hash).ToArgv()

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -80,11 +80,13 @@ type TranslationSet struct {
 	CopyFileDiffTooltip                   string
 	CopySelectedDiff                      string
 	CopyAllFilesDiff                      string
+	CopyFileContent                       string
 	NoContentToCopyError                  string
 	FileNameCopiedToast                   string
 	FilePathCopiedToast                   string
 	FileDiffCopiedToast                   string
 	AllFilesDiffCopiedToast               string
+	FileContentCopiedToast                string
 	FilterStagedFiles                     string
 	FilterUnstagedFiles                   string
 	FilterTrackedFiles                    string
@@ -696,6 +698,7 @@ type TranslationSet struct {
 	PatchCopiedToClipboard                   string
 	CopiedToClipboard                        string
 	ErrCannotEditDirectory                   string
+	ErrCannotCopyContentOfDirectory          string
 	ErrStageDirWithInlineMergeConflicts      string
 	ErrRepositoryMovedOrDeleted              string
 	ErrWorktreeMovedOrRemoved                string
@@ -1120,11 +1123,13 @@ func EnglishTranslationSet() *TranslationSet {
 		CopyFileDiffTooltip:                  "If there are staged items, this command considers only them. Otherwise, it considers all the unstaged ones.",
 		CopySelectedDiff:                     "Diff of selected file",
 		CopyAllFilesDiff:                     "Diff of all files",
+		CopyFileContent:                      "Content of selected file",
 		NoContentToCopyError:                 "Nothing to copy",
 		FileNameCopiedToast:                  "File name copied to clipboard",
 		FilePathCopiedToast:                  "File path copied to clipboard",
 		FileDiffCopiedToast:                  "File diff copied to clipboard",
 		AllFilesDiffCopiedToast:              "All files diff copied to clipboard",
+		FileContentCopiedToast:               "File content copied to clipboard",
 		FilterStagedFiles:                    "Show only staged files",
 		FilterUnstagedFiles:                  "Show only unstaged files",
 		FilterTrackedFiles:                   "Show only tracked files",
@@ -1737,6 +1742,7 @@ func EnglishTranslationSet() *TranslationSet {
 		PatchCopiedToClipboard:                   "Patch copied to clipboard",
 		CopiedToClipboard:                        "copied to clipboard",
 		ErrCannotEditDirectory:                   "Cannot edit directories: you can only edit individual files",
+		ErrCannotCopyContentOfDirectory:          "Cannot copy content of directories: you can only copy content of individual files",
 		ErrStageDirWithInlineMergeConflicts:      "Cannot stage/unstage directory containing files with inline merge conflicts. Please fix up the merge conflicts first",
 		ErrRepositoryMovedOrDeleted:              "Cannot find repo. It might have been moved or deleted ¯\\_(ツ)_/¯",
 		CommandLog:                               "Command log",


### PR DESCRIPTION
- **PR Description**

Some people have the need to get at the file content of a file as it was in an earlier commit. They expect to press `e` in the commit files view and get the file opened in the state it was in at that commit, somehow. I explained a few times (e.g. in #3902, #4109, and #4327) that this is not how `e` should work; so if we want this as a feature, we'd need it as a separate command. However, it's a bit tricky to implement; if we check out the selected file to a temp file, it's unclear when to remove the file again. Alternatively we could use EditAndWait to open the file, then we would block until the user closes the editor and delete the file then. This is probably not the best user experience though, e.g. it wouldn't allow opening two files from an older commit at once.

Instead of finding solutions to all these questions, this PR takes a simpler route and adds a command to the "Copy to Clipboard" menu that allows copying the entire content of a file. Users can then open a new, empty editor buffer and paste it in, this is almost as good as opening a temp file, but without all the questions. This was suggested in #4327.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
