### PR TITLE
Use a waiting status for rewording a non-head commit

### DIFF
--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -409,16 +409,13 @@ func (self *LocalCommitsController) switchFromCommitMessagePanelToEditor(filepat
 }
 
 func (self *LocalCommitsController) handleReword(summary string, description string) error {
-	var err error
-
 	if models.IsHeadCommit(self.c.Model().Commits, self.c.Contexts().LocalCommits.GetSelectedLineIdx()) {
 		// we've selected the top commit so no rebase is required
-		err = self.c.Helpers().GPG.WithGpgHandling(self.c.Git().Commit.RewordLastCommit(summary, description),
+		return self.c.Helpers().GPG.WithGpgHandling(self.c.Git().Commit.RewordLastCommit(summary, description),
 			self.c.Tr.CommittingStatus, nil)
-	} else {
-		err = self.c.Git().Rebase.RewordCommit(self.c.Model().Commits, self.c.Contexts().LocalCommits.GetSelectedLineIdx(), summary, description)
 	}
 
+	err := self.c.Git().Rebase.RewordCommit(self.c.Model().Commits, self.c.Contexts().LocalCommits.GetSelectedLineIdx(), summary, description)
 	if err != nil {
 		return err
 	}

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -415,11 +415,13 @@ func (self *LocalCommitsController) handleReword(summary string, description str
 			self.c.Tr.CommittingStatus, nil)
 	}
 
-	err := self.c.Git().Rebase.RewordCommit(self.c.Model().Commits, self.c.Contexts().LocalCommits.GetSelectedLineIdx(), summary, description)
-	if err != nil {
-		return err
-	}
-	return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})
+	return self.c.WithWaitingStatus(self.c.Tr.RewordingStatus, func(gocui.Task) error {
+		err := self.c.Git().Rebase.RewordCommit(self.c.Model().Commits, self.c.Contexts().LocalCommits.GetSelectedLineIdx(), summary, description)
+		if err != nil {
+			return err
+		}
+		return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})
+	})
 }
 
 func (self *LocalCommitsController) doRewordEditor() error {

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -412,7 +412,7 @@ func (self *LocalCommitsController) handleReword(summary string, description str
 	if models.IsHeadCommit(self.c.Model().Commits, self.c.Contexts().LocalCommits.GetSelectedLineIdx()) {
 		// we've selected the top commit so no rebase is required
 		return self.c.Helpers().GPG.WithGpgHandling(self.c.Git().Commit.RewordLastCommit(summary, description),
-			self.c.Tr.CommittingStatus, nil)
+			self.c.Tr.RewordingStatus, nil)
 	}
 
 	return self.c.WithWaitingStatus(self.c.Tr.RewordingStatus, func(gocui.Task) error {

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -422,7 +422,6 @@ func (self *LocalCommitsController) handleReword(summary string, description str
 	if err != nil {
 		return err
 	}
-	self.c.Helpers().Commits.OnCommitSuccess()
 	return self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})
 }
 

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -384,6 +384,7 @@ type TranslationSet struct {
 	RedoingStatus                         string
 	CheckingOutStatus                     string
 	CommittingStatus                      string
+	RewordingStatus                       string
 	RevertingStatus                       string
 	CreatingFixupCommitStatus             string
 	CommitFiles                           string
@@ -1425,6 +1426,7 @@ func EnglishTranslationSet() *TranslationSet {
 		RedoingStatus:                        "Redoing",
 		CheckingOutStatus:                    "Checking out",
 		CommittingStatus:                     "Committing",
+		RewordingStatus:                      "Rewording",
 		RevertingStatus:                      "Reverting",
 		CreatingFixupCommitStatus:            "Creating fixup commit",
 		CommitFiles:                          "Commit files",


### PR DESCRIPTION
- **PR Description**

Rewording a commit at the beginning of a long branch can take very long;
without this change, the commit message panel would stay visible with a blinking
cursor during that time, which is very confusing.

This has the slight downside that it will say "Rebasing" in the lower right
corner until the operation is done; but we already have this problem when doing
custom patch operations, or dropping changes from a commit, so it's not new, and
we can think about how to fix all these another time.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
