### PR TITLE
Fix release schedule again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@ name: Release
 
 on:
   schedule:
-    # Runs at 2:00 AM UTC on the first Saturday of every month
-    - cron: '0 2 1-7 * 6'
+    # Runs at 2:00 AM UTC on every Saturday
+    # We'll check below if it's the first Saturday of the month, and fail if not
+    - cron: '0 2 * * 6'
   # Allow manual triggering of the workflow
   workflow_dispatch:
     inputs:
@@ -25,6 +26,13 @@ jobs:
   check-and-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Check for first Saturday of the month
+        run: |
+          if (( $(date +%e) > 7 )); then
+            echo "This is not the first Saturday of the month"
+            exit 1
+          fi
+
       - name: Checkout Code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
There's no way to tell cron to run a job on the first Saturday of a month, so we tell it to run every Saturday, and manually check whether it's the first week of the month. This is not ideal because we'll get notifications about failed releases three times a month, but it's better than nothing for now.
