### PR TITLE
Add pending task capability for opening pull requests

### DIFF
--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -148,6 +148,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 
 	syncController := controllers.NewSyncController(
 		common,
+		&gui.branchesBeingPushed,
 	)
 
 	submodulesController := controllers.NewSubmodulesController(common)
@@ -182,7 +183,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 	renameSimilarityThresholdController := controllers.NewRenameSimilarityThresholdController(common)
 	verticalScrollControllerFactory := controllers.NewVerticalScrollControllerFactory(common, &gui.viewBufferManagerMap)
 
-	branchesController := controllers.NewBranchesController(common)
+	branchesController := controllers.NewBranchesController(common, &gui.branchesBeingPushed)
 	gitFlowController := controllers.NewGitFlowController(common)
 	stashController := controllers.NewStashController(common)
 	commitFilesController := controllers.NewCommitFilesController(common)

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
@@ -12,18 +13,21 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
+	"github.com/sasha-s/go-deadlock"
 )
 
 type BranchesController struct {
 	baseController
 	*ListControllerTrait[*models.Branch]
-	c *ControllerCommon
+	c                   *ControllerCommon
+	branchesBeingPushed *sync.Map
 }
 
 var _ types.IController = &BranchesController{}
 
 func NewBranchesController(
 	c *ControllerCommon,
+	branchesBeingPushed *sync.Map,
 ) *BranchesController {
 	return &BranchesController{
 		baseController: baseController{},
@@ -34,6 +38,7 @@ func NewBranchesController(
 			c.Contexts().Branches.GetSelected,
 			c.Contexts().Branches.GetSelectedItems,
 		),
+		branchesBeingPushed: branchesBeingPushed,
 	}
 }
 
@@ -421,11 +426,58 @@ func (self *BranchesController) promptToCheckoutWorktree(worktree *models.Worktr
 	return nil
 }
 
-func (self *BranchesController) handleCreatePullRequest(selectedBranch *models.Branch) error {
-	if !selectedBranch.IsTrackingRemote() {
-		return errors.New(self.c.Tr.PullRequestNoUpstream)
+func (self *BranchesController) blockForBranchFinishPush(branch *models.Branch) *models.Branch {
+	if val, ok := self.branchesBeingPushed.Load(branch.Name); ok {
+		// We only store waitgroups in here, so there isn't much thought into the false case
+		if wg, ok := val.(*deadlock.WaitGroup); ok {
+			wg.Wait()
+			// When we refresh after a branch push, the entire branch list gets replaced, so we must re-retrieve the
+			// branch pointer. The currently selected item might have changed since we initially requested the pull request,
+			// but the commit hash should continue to be the same.
+			updatedBranch, found := lo.Find(self.context().ListViewModel.GetItems(), func(b *models.Branch) bool {
+				return b.CommitHash == branch.CommitHash
+			})
+			// If it _isn't_ found, something wack is going on, so lets stick with the original
+			if found {
+				branch = updatedBranch
+			}
+		}
 	}
-	return self.createPullRequest(selectedBranch.UpstreamBranch, "")
+	return branch
+}
+
+func (self *BranchesController) handleCreatePullRequest(selectedBranch *models.Branch) error {
+	message := utils.ResolvePlaceholderString(
+		self.c.Tr.PendingCreatePullRequest, map[string]string{
+			"branchName": selectedBranch.Name,
+		})
+	err := self.c.WithPendingMessage(message,
+		func(_ gocui.Task) error {
+			_ = self.blockForBranchFinishPush(selectedBranch)
+			return nil
+		},
+		func(_ gocui.Task) error {
+			// When we refresh after a branch push, the entire branch list gets replaced, so we must re-retrieve the
+			// branch pointer. The currently selected item might have changed since we initially requested the pull request,
+			// but the commit hash should continue to be the same.
+			updatedBranch, found := lo.Find(self.context().ListViewModel.GetItems(), func(b *models.Branch) bool {
+				return b.CommitHash == selectedBranch.CommitHash
+			})
+			// If it _isn't_ found, something wack is going on, so lets stick with the original
+			if found {
+				selectedBranch = updatedBranch
+			}
+
+			if !selectedBranch.IsTrackingRemote() {
+				return errors.New(self.c.Tr.PullRequestNoUpstream)
+			}
+
+			return self.createPullRequest(selectedBranch.UpstreamBranch, "")
+		})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (self *BranchesController) handleCreatePullRequestMenu(selectedBranch *models.Branch) error {

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -99,7 +99,9 @@ func (self *RefreshHelper) Refresh(options types.RefreshOptions) error {
 			// everything happens fast and it's better to have everything update
 			// in the one frame
 			if !self.c.InDemo() && options.Mode == types.ASYNC {
+				wg.Add(1)
 				self.c.OnWorker(func(t gocui.Task) error {
+					defer wg.Done()
 					f()
 					return nil
 				})

--- a/pkg/gui/controllers/quit_actions.go
+++ b/pkg/gui/controllers/quit_actions.go
@@ -53,6 +53,13 @@ func (self *QuitActions) confirmQuitDuringUpdate() error {
 }
 
 func (self *QuitActions) Escape() error {
+	pendingTasks := self.c.State().GetPendingTasks()
+	if len(pendingTasks) > 0 {
+		head := pendingTasks[0]
+		head.CancelFunc()
+		return nil
+	}
+
 	currentContext := self.c.Context().Current()
 
 	if listContext, ok := currentContext.(types.IListContext); ok {

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -95,6 +95,8 @@ type Gui struct {
 	// so that you can return to the superproject
 	RepoPathStack *utils.StringStack
 
+	branchesBeingPushed sync.Map // keys: branchName string, value: deadlock.WaitGroup
+
 	// this tells us whether our views have been initially set up
 	ViewsSetup bool
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -690,6 +690,9 @@ func NewGui(
 		func() types.Context { return gui.State.ContextMgr.Current() },
 		gui.createMenu,
 		func(message string, f func(gocui.Task) error) { gui.helpers.AppStatus.WithWaitingStatus(message, f) },
+		func(message string, pending func(gocui.Task) error, f func(gocui.Task) error) {
+			gui.helpers.AppStatus.WithPendingMessage(message, pending, f)
+		},
 		func(message string, f func() error) error {
 			return gui.helpers.AppStatus.WithWaitingStatusSync(message, f)
 		},
@@ -1116,6 +1119,10 @@ func (gui *Gui) onUIThread(f func() error) {
 
 func (gui *Gui) onWorker(f func(gocui.Task) error) {
 	gui.g.OnWorker(f)
+}
+
+func (gui *Gui) onWorkerPending(ctx goContext.Context, pending func(gocui.Task) error, main func(gocui.Task) error) *gocui.PendingTask {
+	return gui.g.OnWorkerPending(ctx, pending, main)
 }
 
 func (gui *Gui) getWindowDimensions(informationStr string, appStatus string) map[string]boxlayout.Dimensions {

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -156,6 +156,10 @@ func (self *StateAccessor) GetRepoPathStack() *utils.StringStack {
 	return self.gui.RepoPathStack
 }
 
+func (self *StateAccessor) GetPendingTasks() []*gocui.PendingTask {
+	return self.gui.g.PendingTasks()
+}
+
 func (self *StateAccessor) GetUpdating() bool {
 	return self.gui.Updating
 }

--- a/pkg/gui/gui_common.go
+++ b/pkg/gui/gui_common.go
@@ -1,6 +1,8 @@
 package gui
 
 import (
+	"context"
+
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
@@ -113,6 +115,10 @@ func (self *guiCommon) OnUIThread(f func() error) {
 
 func (self *guiCommon) OnWorker(f func(gocui.Task) error) {
 	self.gui.onWorker(f)
+}
+
+func (self *guiCommon) OnWorkerPending(ctx context.Context, pending func(gocui.Task) error, main func(gocui.Task) error) *gocui.PendingTask {
+	return self.gui.onWorkerPending(ctx, pending, main)
 }
 
 func (self *guiCommon) RenderToMainViews(opts types.RefreshMainOpts) {

--- a/pkg/gui/popup/popup_handler.go
+++ b/pkg/gui/popup/popup_handler.go
@@ -18,6 +18,7 @@ type PopupHandler struct {
 	currentContextFn        func() types.Context
 	createMenuFn            func(types.CreateMenuOptions) error
 	withWaitingStatusFn     func(message string, f func(gocui.Task) error)
+	withPendingMessageFn    func(message string, pending func(gocui.Task) error, f func(gocui.Task) error)
 	withWaitingStatusSyncFn func(message string, f func() error) error
 	toastFn                 func(message string, kind types.ToastKind)
 	getPromptInputFn        func() string
@@ -34,6 +35,7 @@ func NewPopupHandler(
 	currentContextFn func() types.Context,
 	createMenuFn func(types.CreateMenuOptions) error,
 	withWaitingStatusFn func(message string, f func(gocui.Task) error),
+	withPendingMessageFn func(message string, pending func(gocui.Task) error, f func(gocui.Task) error),
 	withWaitingStatusSyncFn func(message string, f func() error) error,
 	toastFn func(message string, kind types.ToastKind),
 	getPromptInputFn func() string,
@@ -47,6 +49,7 @@ func NewPopupHandler(
 		currentContextFn:        currentContextFn,
 		createMenuFn:            createMenuFn,
 		withWaitingStatusFn:     withWaitingStatusFn,
+		withPendingMessageFn:    withPendingMessageFn,
 		withWaitingStatusSyncFn: withWaitingStatusSyncFn,
 		toastFn:                 toastFn,
 		getPromptInputFn:        getPromptInputFn,
@@ -72,6 +75,11 @@ func (self *PopupHandler) SetToastFunc(f func(string, types.ToastKind)) {
 
 func (self *PopupHandler) WithWaitingStatus(message string, f func(gocui.Task) error) error {
 	self.withWaitingStatusFn(message, f)
+	return nil
+}
+
+func (self *PopupHandler) WithPendingMessage(message string, pending func(gocui.Task) error, f func(gocui.Task) error) error {
+	self.withPendingMessageFn(message, pending, f)
 	return nil
 }
 

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"context"
+
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
@@ -68,6 +70,7 @@ type IGuiCommon interface {
 	// Runs a function in a goroutine. Use this whenever you want to run a goroutine and keep track of the fact
 	// that lazygit is still busy. See docs/dev/Busy.md
 	OnWorker(f func(gocui.Task) error)
+	OnWorkerPending(ctx context.Context, pending func(gocui.Task) error, main func(gocui.Task) error) *gocui.PendingTask
 	// Function to call at the end of our 'layout' function which renders views
 	// For example, you may want a view's line to be focused only after that view is
 	// resized, if in accordion mode.
@@ -126,6 +129,7 @@ type IPopupHandler interface {
 	// Shows a popup prompting the user for input.
 	Prompt(opts PromptOpts)
 	WithWaitingStatus(message string, f func(gocui.Task) error) error
+	WithPendingMessage(message string, pending func(gocui.Task) error, f func(gocui.Task) error) error
 	WithWaitingStatusSync(message string, f func() error) error
 	Menu(opts CreateMenuOptions) error
 	Toast(message string)
@@ -353,6 +357,7 @@ type IStateAccessor interface {
 	GetItemOperation(item HasUrn) ItemOperation
 	SetItemOperation(item HasUrn, operation ItemOperation)
 	ClearItemOperation(item HasUrn)
+	GetPendingTasks() []*gocui.PendingTask
 }
 
 type IRepoStateAccessor interface {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -724,6 +724,7 @@ type TranslationSet struct {
 	SelectTargetRemote                       string
 	NoValidRemoteName                        string
 	CreatePullRequest                        string
+	PendingCreatePullRequest                 string
 	SelectConfigFile                         string
 	NoConfigFileFoundErr                     string
 	LoadingFileSuggestions                   string
@@ -1292,6 +1293,7 @@ func EnglishTranslationSet() *TranslationSet {
 		AllBranchesLogGraph:                  `Show/cycle all branch logs`,
 		UnsupportedGitService:                `Unsupported git service`,
 		CreatePullRequest:                    `Create pull request`,
+		PendingCreatePullRequest:             `Waiting to create pull request for {{.branchName}}`,
 		CopyPullRequestURL:                   `Copy pull request URL to clipboard`,
 		NoBranchOnRemote:                     `This branch doesn't exist on remote. You need to push it to remote first.`,
 		Fetch:                                `Fetch`,

--- a/vendor/github.com/jesseduffield/gocui/pending_task.go
+++ b/vendor/github.com/jesseduffield/gocui/pending_task.go
@@ -1,0 +1,9 @@
+package gocui
+
+import "context"
+
+type PendingTask struct {
+	id         int
+	Ctx        context.Context
+	CancelFunc context.CancelFunc
+}

--- a/vendor/github.com/jesseduffield/gocui/task_manager.go
+++ b/vendor/github.com/jesseduffield/gocui/task_manager.go
@@ -1,6 +1,9 @@
 package gocui
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 // Tracks whether the program is busy (i.e. either something is happening on
 // the main goroutine or a worker goroutine). Used by integration tests
@@ -10,7 +13,8 @@ type TaskManager struct {
 	idleListeners []chan struct{}
 	tasks         map[int]Task
 	// auto-incrementing id for new tasks
-	nextId int
+	nextId       int
+	pendingTasks []*PendingTask
 
 	mutex sync.Mutex
 }
@@ -20,6 +24,10 @@ func newTaskManager() *TaskManager {
 		tasks:         make(map[int]Task),
 		idleListeners: []chan struct{}{},
 	}
+}
+
+func (self *TaskManager) GetPendingTasks() []*PendingTask {
+	return self.pendingTasks
 }
 
 func (self *TaskManager) NewTask() *TaskImpl {
@@ -34,6 +42,27 @@ func (self *TaskManager) NewTask() *TaskImpl {
 	self.tasks[taskId] = task
 
 	return task
+}
+
+func (self *TaskManager) NewPendingTask(ctx context.Context) *PendingTask {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+	ctx, cancelFunc := context.WithCancel(ctx)
+
+	self.nextId++
+	taskId := self.nextId
+	go func() {
+		<-ctx.Done()
+		self.deletePendingTask(taskId)
+	}()
+
+	pendingTask := PendingTask{
+		id:         taskId,
+		Ctx:        ctx,
+		CancelFunc: cancelFunc,
+	}
+	self.pendingTasks = append(self.pendingTasks, &pendingTask)
+	return &pendingTask
 }
 
 func (self *TaskManager) addIdleListener(c chan struct{}) {
@@ -63,5 +92,17 @@ func (self *TaskManager) withMutex(f func()) {
 func (self *TaskManager) delete(taskId int) {
 	self.withMutex(func() {
 		delete(self.tasks, taskId)
+	})
+}
+
+func (self *TaskManager) deletePendingTask(pendingTaskId int) {
+	self.withMutex(func() {
+		pendingTasks := make([]*PendingTask, 0, len(self.pendingTasks)-1)
+		for _, task := range self.pendingTasks {
+			if task.id != pendingTaskId {
+				pendingTasks = append(pendingTasks, task)
+			}
+		}
+		self.pendingTasks = pendingTasks
 	})
 }


### PR DESCRIPTION
- **PR Description**

Implements https://github.com/jesseduffield/lazygit/issues/4339.

Creates the new concept of a `PendingTask`, where gocui is waiting for some action to complete before beginning the real work. In this application, the PendingTask is watching WaitGroup that records that a certain branch is being pushed. Once the branch is finished being pushed, it will automatically start the open pull request command. While waiting on the pending phase of the task, it can be cancelled with the global `<escape>` keybinding. (I'm not positive _where_ the pending tasks should go in that sequence of cancelling. Perhaps they should be later in that file)

The behavior Demo and ASYNC's Then might also need some more tweaks, I'm not sure about that.

- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [X] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [X] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc
