### PR TITLE
Don't skip hooks when checking out file from old commit

### DIFF
--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -516,7 +516,7 @@ func (self *RebaseCommands) DiscardOldFileChanges(commits []*models.Commit, comm
 			if err := self.workingTree.StageFile(filePath); err != nil {
 				return err
 			}
-		} else if err := self.workingTree.CheckoutFile("HEAD^", filePath); err != nil {
+		} else if err := self.workingTree.CheckoutFile("HEAD^", filePath, true); err != nil {
 			return err
 		}
 	}

--- a/pkg/commands/git_commands/working_tree_test.go
+++ b/pkg/commands/git_commands/working_tree_test.go
@@ -422,6 +422,7 @@ func TestWorkingTreeCheckoutFile(t *testing.T) {
 		testName   string
 		commitHash string
 		fileName   string
+		skipHooks  bool
 		runner     *oscommands.FakeCmdObjRunner
 		test       func(error)
 	}
@@ -431,8 +432,20 @@ func TestWorkingTreeCheckoutFile(t *testing.T) {
 			testName:   "typical case",
 			commitHash: "11af912",
 			fileName:   "test999.txt",
+			skipHooks:  true,
 			runner: oscommands.NewFakeRunner(t).
 				ExpectGitArgs([]string{"-c", disableHooksFlag, "checkout", "11af912", "--", "test999.txt"}, "", nil),
+			test: func(err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			testName:   "typical case",
+			commitHash: "11af912",
+			fileName:   "test999.txt",
+			skipHooks:  false,
+			runner: oscommands.NewFakeRunner(t).
+				ExpectGitArgs([]string{"checkout", "11af912", "--", "test999.txt"}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -441,6 +454,7 @@ func TestWorkingTreeCheckoutFile(t *testing.T) {
 			testName:   "returns error if there is one",
 			commitHash: "11af912",
 			fileName:   "test999.txt",
+			skipHooks:  true,
 			runner: oscommands.NewFakeRunner(t).
 				ExpectGitArgs([]string{"-c", disableHooksFlag, "checkout", "11af912", "--", "test999.txt"}, "", errors.New("error")),
 			test: func(err error) {
@@ -453,7 +467,7 @@ func TestWorkingTreeCheckoutFile(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildWorkingTreeCommands(commonDeps{runner: s.runner})
 
-			s.test(instance.CheckoutFile(s.commitHash, s.fileName))
+			s.test(instance.CheckoutFile(s.commitHash, s.fileName, s.skipHooks))
 			s.runner.CheckForMissingCalls()
 		})
 	}

--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -260,7 +260,7 @@ func (self *CommitFilesController) openCopyMenu() error {
 
 func (self *CommitFilesController) checkout(node *filetree.CommitFileNode) error {
 	self.c.LogAction(self.c.Tr.Actions.CheckoutFile)
-	if err := self.c.Git().WorkingTree.CheckoutFile(self.context().GetRef().RefName(), node.GetPath()); err != nil {
+	if err := self.c.Git().WorkingTree.CheckoutFile(self.context().GetRef().RefName(), node.GetPath(), false); err != nil {
 		return err
 	}
 

--- a/pkg/integration/tests/commit/checkout_file_from_commit.go
+++ b/pkg/integration/tests/commit/checkout_file_from_commit.go
@@ -45,16 +45,11 @@ var CheckoutFileFromCommit = NewIntegrationTest(NewIntegrationTestArgs{
 			Focus().
 			Lines(
 				Contains("M  file"),
-				/* EXPECTED:
 				Contains("?? hook-result"),
-				*/
 			)
 
 		t.FileSystem().FileContent("file", Equals("one\n"))
-		/* EXPECTED:
 		t.FileSystem().FileContent("hook-result", Equals("post-checkout hook called\n"))
-		ACTUAL: */
-		t.FileSystem().PathNotPresent("hook-result")
 	},
 },
 )

--- a/pkg/integration/tests/commit/checkout_file_from_commit.go
+++ b/pkg/integration/tests/commit/checkout_file_from_commit.go
@@ -5,12 +5,20 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
+var postCheckoutHook = `#!/bin/bash
+
+echo "post-checkout hook called" > hook-result
+`
+
 var CheckoutFileFromCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Checkout an individual file from a commit",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
+		shell.CreateFile(".git/hooks/post-checkout", postCheckoutHook)
+		shell.MakeExecutable(".git/hooks/post-checkout")
+
 		shell.CreateFileAndAdd("file", "one\n")
 		shell.Commit("one")
 		shell.UpdateFileAndAdd("file", "one\ntwo\n")
@@ -37,9 +45,16 @@ var CheckoutFileFromCommit = NewIntegrationTest(NewIntegrationTestArgs{
 			Focus().
 			Lines(
 				Contains("M  file"),
+				/* EXPECTED:
+				Contains("?? hook-result"),
+				*/
 			)
 
 		t.FileSystem().FileContent("file", Equals("one\n"))
+		/* EXPECTED:
+		t.FileSystem().FileContent("hook-result", Equals("post-checkout hook called\n"))
+		ACTUAL: */
+		t.FileSystem().PathNotPresent("hook-result")
 	},
 },
 )

--- a/pkg/integration/tests/commit/checkout_file_from_commit.go
+++ b/pkg/integration/tests/commit/checkout_file_from_commit.go
@@ -1,0 +1,45 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CheckoutFileFromCommit = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Checkout an individual file from a commit",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file", "one\n")
+		shell.Commit("one")
+		shell.UpdateFileAndAdd("file", "one\ntwo\n")
+		shell.Commit("two")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("two").IsSelected(),
+				Contains("one"),
+			).
+			SelectNextItem().
+			PressEnter()
+
+		t.Views().CommitFiles().
+			IsFocused().
+			Lines(
+				Contains("file").IsSelected(),
+			).
+			Press(keys.CommitFiles.CheckoutCommitFile)
+
+		t.Views().Files().
+			Focus().
+			Lines(
+				Contains("M  file"),
+			)
+
+		t.FileSystem().FileContent("file", Equals("one\n"))
+	},
+},
+)

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -89,6 +89,7 @@ var tests = []*components.IntegrationTest{
 	commit.AmendWhenThereAreConflictsAndContinue,
 	commit.AutoWrapMessage,
 	commit.Checkout,
+	commit.CheckoutFileFromCommit,
 	commit.Commit,
 	commit.CommitMultiline,
 	commit.CommitSwitchToEditor,


### PR DESCRIPTION
- **PR Description**

In #4313 we disabled post-checkout hooks when discarding file changes. We went a little too far with this and also disabled the hook when checking out a file from an older commit; this was a mistake, and it is fixed here.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
