### PR TITLE
Drop the git config cache when getting focus

### DIFF
--- a/pkg/commands/git_commands/config.go
+++ b/pkg/commands/git_commands/config.go
@@ -111,3 +111,7 @@ func (self *ConfigCommands) GetCoreCommentChar() byte {
 func (self *ConfigCommands) GetRebaseUpdateRefs() bool {
 	return self.gitConfig.GetBool("rebase.updateRefs")
 }
+
+func (self *ConfigCommands) DropConfigCache() {
+	self.gitConfig.DropCache()
+}

--- a/pkg/commands/git_config/cached_git_config.go
+++ b/pkg/commands/git_config/cached_git_config.go
@@ -15,6 +15,8 @@ type IGitConfig interface {
 	GetGeneral(string) string
 	// this is for when you want to pass 'mykey' and check if the result is truthy
 	GetBool(string) bool
+
+	DropCache()
 }
 
 type CachedGitConfig struct {
@@ -92,4 +94,11 @@ func (self *CachedGitConfig) GetBool(key string) bool {
 func isTruthy(value string) bool {
 	lcValue := strings.ToLower(value)
 	return lcValue == "true" || lcValue == "1" || lcValue == "yes" || lcValue == "on"
+}
+
+func (self *CachedGitConfig) DropCache() {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	self.cache = make(map[string]string)
 }

--- a/pkg/commands/git_config/fake_git_config.go
+++ b/pkg/commands/git_config/fake_git_config.go
@@ -27,3 +27,6 @@ func (self *FakeGitConfig) GetGeneral(args string) string {
 func (self *FakeGitConfig) GetBool(key string) bool {
 	return isTruthy(self.Get(key))
 }
+
+func (self *FakeGitConfig) DropCache() {
+}

--- a/pkg/gui/context/list_renderer_test.go
+++ b/pkg/gui/context/list_renderer_test.go
@@ -115,7 +115,7 @@ func TestListRenderer_renderLines(t *testing.T) {
 	}
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
-			viewModel := NewListViewModel[mystring](func() []mystring { return s.modelStrings })
+			viewModel := NewListViewModel(func() []mystring { return s.modelStrings })
 			var getNonModelItems func() []*NonModelItem
 			if s.nonModelIndices != nil {
 				getNonModelItems = func() []*NonModelItem {
@@ -236,7 +236,7 @@ func TestListRenderer_ModelIndexToViewIndex_and_back(t *testing.T) {
 			assert.Equal(t, len(s.viewIndices), len(s.expectedModelIndices))
 
 			modelInts := lo.Map(lo.Range(s.numModelItems), func(i int, _ int) myint { return myint(i) })
-			viewModel := NewListViewModel[myint](func() []myint { return modelInts })
+			viewModel := NewListViewModel(func() []myint { return modelInts })
 			var getNonModelItems func() []*NonModelItem
 			if s.nonModelIndices != nil {
 				getNonModelItems = func() []*NonModelItem {

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -331,6 +331,8 @@ func (gui *Gui) onNewRepo(startArgs appTypes.StartArgs, contextKey types.Context
 
 	gui.g.SetFocusHandler(func(Focused bool) error {
 		if Focused {
+			gui.git.Config.DropConfigCache()
+
 			oldConfig := gui.Config.GetUserConfig()
 			reloadErr, didChange := gui.Config.ReloadChangedUserConfigFiles()
 			if didChange && reloadErr == nil {


### PR DESCRIPTION
- **PR Description**

This allows changing git config values while lazygit is running (e.g. in a
different terminal tab, or even in lazygit's ":" shell prompt), and have them
take effect immediately, while still getting some benefit from caching them
while lazygit is in the foreground.

Addresses #4240.
