### PR TITLE
Update to go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 
 env:
-  GO_VERSION: 1.22
+  GO_VERSION: 1.24
 
 on:
   push:
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.24.x
       - name: Test code
         # we're passing -short so that we skip the integration tests, which will be run in parallel below
         run: |
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.24.x
       - name: Print git version
         run: git --version
       - name: Test code
@@ -115,7 +115,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.24.x
       - name: Build linux binary
         run: |
           GOOS=linux go build
@@ -142,7 +142,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.24.x
       - name: Check Vendor Directory
         # ensure our vendor directory matches up with our go modules
         run: |
@@ -168,11 +168,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.24.x
       - name: Lint
-        uses: golangci/golangci-lint-action@v6.1.0
+        uses: golangci/golangci-lint-action@v6.5.0
         with:
-          version: v1.60
+          version: v1.64.6
       - name: errors
         run: golangci-lint run
         if: ${{ failure() }}
@@ -197,7 +197,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.24.x
 
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.24.x
 
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,5 +32,5 @@ linters-settings:
     max-func-lines: 0
 
 run:
-  go: '1.22'
+  go: "1.24"
   timeout: 10m

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # docker build -t lazygit .
 # docker run -it lazygit:latest /bin/sh
 
-FROM golang:1.22 as build
+FROM golang:1.24 as build
 WORKDIR /go/src/github.com/jesseduffield/lazygit/
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jesseduffield/lazygit
 
-go 1.22
+go 1.24
 
 require (
 	github.com/adrg/xdg v0.4.0

--- a/pkg/cheatsheet/generate.go
+++ b/pkg/cheatsheet/generate.go
@@ -11,9 +11,12 @@
 package cheatsheet
 
 import (
+	"cmp"
 	"fmt"
 	"log"
 	"os"
+	"slices"
+	"strings"
 
 	"github.com/jesseduffield/generics/maps"
 	"github.com/jesseduffield/lazycore/pkg/utils"
@@ -23,7 +26,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/i18n"
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 )
 
 type bindingSection struct {
@@ -164,11 +166,11 @@ func getBindingSections(bindings []*types.Binding, tr *i18n.TranslationSet) []*b
 		},
 	)
 
-	slices.SortFunc(bindingGroups, func(a, b headerWithBindings) bool {
+	slices.SortFunc(bindingGroups, func(a, b headerWithBindings) int {
 		if a.header.priority != b.header.priority {
-			return a.header.priority > b.header.priority
+			return cmp.Compare(b.header.priority, a.header.priority)
 		}
-		return a.header.title < b.header.title
+		return strings.Compare(a.header.title, b.header.title)
 	})
 
 	return lo.Map(bindingGroups, func(hb headerWithBindings, _ int) *bindingSection {

--- a/pkg/commands/git_commands/branch_loader.go
+++ b/pkg/commands/git_commands/branch_loader.go
@@ -3,6 +3,7 @@ package git_commands
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -14,7 +15,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/common"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -95,8 +95,8 @@ func (self *BranchLoader) Load(reflogCommits []*models.Commit,
 
 		// Sort branches that don't have a recency value alphabetically
 		// (we're really doing this for the sake of deterministic behaviour across git versions)
-		slices.SortFunc(branches, func(a *models.Branch, b *models.Branch) bool {
-			return a.Name < b.Name
+		slices.SortFunc(branches, func(a *models.Branch, b *models.Branch) int {
+			return strings.Compare(a.Name, b.Name)
 		})
 
 		branches = utils.Prepend(branches, branchesWithRecency...)

--- a/pkg/commands/git_commands/remote_loader.go
+++ b/pkg/commands/git_commands/remote_loader.go
@@ -2,6 +2,7 @@ package git_commands
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/common"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 )
 
 type RemoteLoader struct {
@@ -67,15 +67,15 @@ func (self *RemoteLoader) GetRemotes() ([]*models.Remote, error) {
 	})
 
 	// now lets sort our remotes by name alphabetically
-	slices.SortFunc(remotes, func(a, b *models.Remote) bool {
+	slices.SortFunc(remotes, func(a, b *models.Remote) int {
 		// we want origin at the top because we'll be most likely to want it
 		if a.Name == "origin" {
-			return true
+			return -1
 		}
 		if b.Name == "origin" {
-			return false
+			return 1
 		}
-		return strings.ToLower(a.Name) < strings.ToLower(b.Name)
+		return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
 	})
 
 	return remotes, nil

--- a/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
@@ -1,7 +1,9 @@
 package helpers
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -9,7 +11,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 )
 
 // The best way to add test cases here is to set your args and then get the
@@ -490,16 +491,13 @@ func renderLayout(windows map[string]boxlayout.Dimensions) string {
 	// Sort first by name, then by position. This means our short labels will
 	// increment in the order that the windows appear on the screen.
 	slices.Sort(windowNames)
-	slices.SortStableFunc(windowNames, func(a, b string) bool {
+	slices.SortStableFunc(windowNames, func(a, b string) int {
 		dimensionsA := windows[a]
 		dimensionsB := windows[b]
-		if dimensionsA.Y0 < dimensionsB.Y0 {
-			return true
+		if dimensionsA.Y0 != dimensionsB.Y0 {
+			return cmp.Compare(dimensionsA.Y0, dimensionsB.Y0)
 		}
-		if dimensionsA.Y0 > dimensionsB.Y0 {
-			return false
-		}
-		return dimensionsA.X0 < dimensionsB.X0
+		return cmp.Compare(dimensionsA.X0, dimensionsB.X0)
 	})
 
 	// Uniquify windows by dimensions (so perfectly overlapping windows are de-duped). This prevents getting 'fileshes' as a label where the files and branches windows overlap.

--- a/pkg/gui/filetree/node.go
+++ b/pkg/gui/filetree/node.go
@@ -2,11 +2,12 @@ package filetree
 
 import (
 	"path"
+	"slices"
+	"strings"
 
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 )
 
 // Represents a file or directory in a file tree.
@@ -80,15 +81,15 @@ func (self *Node[T]) SortChildren() {
 
 	children := slices.Clone(self.Children)
 
-	slices.SortFunc(children, func(a, b *Node[T]) bool {
+	slices.SortFunc(children, func(a, b *Node[T]) int {
 		if !a.IsFile() && b.IsFile() {
-			return true
+			return -1
 		}
 		if a.IsFile() && !b.IsFile() {
-			return false
+			return 1
 		}
 
-		return a.GetPath() < b.GetPath()
+		return strings.Compare(a.GetPath(), b.GetPath())
 	})
 
 	// TODO: think about making this in-place

--- a/pkg/gui/presentation/graph/graph.go
+++ b/pkg/gui/presentation/graph/graph.go
@@ -1,7 +1,9 @@
 package graph
 
 import (
+	"cmp"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 
@@ -10,7 +12,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 )
 
 type PipeKind uint8
@@ -269,11 +270,11 @@ func getNextPipes(prevPipes []*Pipe, commit *models.Commit, getStyle func(c *mod
 	}
 
 	// not efficient but doing it for now: sorting my pipes by toPos, then by kind
-	slices.SortFunc(newPipes, func(a, b *Pipe) bool {
+	slices.SortFunc(newPipes, func(a, b *Pipe) int {
 		if a.toPos == b.toPos {
-			return a.kind < b.kind
+			return cmp.Compare(a.kind, b.kind)
 		}
-		return a.toPos < b.toPos
+		return cmp.Compare(a.toPos, b.toPos)
 	})
 
 	return newPipes


### PR DESCRIPTION
- **PR Description**
Update to go 1.24. This is required to use a newer version of go-git.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
