### PR TITLE
Fix commitPrefix setting with empty pattern

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -31,6 +31,8 @@ to the top of your config file or via [Visual Studio Code settings.json config][
 
 ## Default
 
+This is only meant as a reference for what config options exist, and what their default values are. It is not meant to be copied and pasted into your config file as a whole; that's not a good idea for several reasons. It is recommended to include only those settings in your config file that you actually want to change.
+
 <!-- START CONFIG YAML: AUTOMATICALLY GENERATED with `go generate ./..., DO NOT UPDATE MANUALLY -->
 ```yaml
 # Config relating to the Lazygit UI

--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -155,6 +155,9 @@ func (self *WorkingTreeHelper) HandleCommitPress() error {
 		commitPrefixConfigs := self.commitPrefixConfigsForRepo()
 		for _, commitPrefixConfig := range commitPrefixConfigs {
 			prefixPattern := commitPrefixConfig.Pattern
+			if prefixPattern == "" {
+				continue
+			}
 			prefixReplace := commitPrefixConfig.Replace
 			branchName := self.refHelper.GetCheckedOutRef().Name
 			rgx, err := regexp.Compile(prefixPattern)


### PR DESCRIPTION
Before we changed the commitPrefix config to a list in #4261, we had this bug where the defaults section in `Config.md` would erroneously list the default for commitPrefix as

```yml
  git:
    commitPrefix:
      pattern: ""
      replace: ""
```

This was not correct, commitPrefix was a pointer, and the default for that was nil, which is not the same.

Now, some people copied and pasted the entire defaults section into their config files, setting the commitPrefix to an empty pattern (which is not the same as not setting it at all). And this caused the branch name to be filled in to the subject field for every commit; see for example https://github.com/jesseduffield/lazygit/discussions/3632.

New users copying the defaults section into their config file in the current version no longer have this problem because now that commitPrefix is a list, it is no longer included in the defaults section. However, the migration that we added in #4261 would happily carry over those empty strings into a list entry, so people migrating from an older version still have the broken config in their config files.

To work around the issue, ignore commit prefix settings whose pattern is an empty string. I can't imagine a valid reason why people would actually want to set the pattern to an empty string, so I assume this only comes from the broken defaults problem described above.
