### PR TITLE
Add an integration test for a config with a negative refspec

### DIFF
--- a/pkg/integration/tests/config/negative_refspec.go
+++ b/pkg/integration/tests/config/negative_refspec.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var NegativeRefspec = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Having a config with a negative refspec",
+	ExtraCmdArgs: []string{},
+	GitVersion:   AtLeast("2.29.0"),
+	SetupRepo: func(shell *Shell) {
+		shell.
+			SetConfig("remote.origin.fetch", "^refs/heads/test").
+			CreateNCommits(2)
+	},
+	SetupConfig: func(cfg *config.AppConfig) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		// the failure case with an unpatched go-git is that no branches display
+		t.Views().Branches().
+			Lines(
+				Contains("master"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -130,6 +130,7 @@ var tests = []*components.IntegrationTest{
 	commit.StagedWithoutHooks,
 	commit.Unstaged,
 	config.CustomCommandsInPerRepoConfig,
+	config.NegativeRefspec,
 	config.RemoteNamedStar,
 	conflicts.Filter,
 	conflicts.ResolveExternally,


### PR DESCRIPTION
- **PR Description**

This is a sanity check to verify that lazygit has been built with a patched version of go-git that does not error on negative refspecs.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
