### PR TITLE
Better support for shell aliases

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -428,6 +428,14 @@ os:
   # Command for opening a link. Should contain "{{link}}".
   openLink: ""
 
+  # CopyToClipboardCmd is the command for copying to clipboard.
+  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
+  copyToClipboardCmd: ""
+
+  # ReadFromClipboardCmd is the command for reading the clipboard.
+  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
+  readFromClipboardCmd: ""
+
   # EditCommand is the command for editing a file.
   # Deprecated: use Edit instead. Note that semantics are different:
   # EditCommand is just the command itself, whereas Edit contains a
@@ -445,14 +453,6 @@ os:
   # OpenLinkCommand is the command for opening a link
   # Deprecated: use OpenLink instead.
   openLinkCommand: ""
-
-  # CopyToClipboardCmd is the command for copying to clipboard.
-  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
-  copyToClipboardCmd: ""
-
-  # ReadFromClipboardCmd is the command for reading the clipboard.
-  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
-  readFromClipboardCmd: ""
 
 # If true, don't display introductory popups upon opening Lazygit.
 disableStartupPopups: false

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -436,6 +436,10 @@ os:
   # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
   readFromClipboardCmd: ""
 
+  # A shell startup file containing shell aliases or shell functions. This will be sourced before running any shell commands, so that shell aliases are available in the `:` command prompt or even in custom commands.
+  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#using-aliases-or-functions-in-shell-commands
+  shellAliasesFile: ""
+
   # EditCommand is the command for editing a file.
   # Deprecated: use Edit instead. Note that semantics are different:
   # EditCommand is just the command itself, whereas Edit contains a
@@ -733,6 +737,19 @@ os:
 The `editInTerminal` option is used to decide whether lazygit needs to suspend itself to the background before calling the editor. It should really be named `suspend` because for some cases like when lazygit is opened from within a neovim session and you're using the `nvim-remote` preset, you're technically still in a terminal. Nonetheless we're sticking with the name `editInTerminal` for backwards compatibility.
 
 Contributions of new editor presets are welcome; see the `getPreset` function in [`editor_presets.go`](https://github.com/jesseduffield/lazygit/blob/master/pkg/config/editor_presets.go).
+
+## Using aliases or functions in shell commands
+
+Lazygit has a command prompt (`:`) for quickly executing shell commands without having to quit lazygit or switch to a different terminal. Most people find it convenient to have their usual shell aliases or shell functions available at this prompt. To achieve this, put your alias definitions in a separate shell startup file (which you source from your normal startup file, i.e. from `.bashrc` or `.zshrc`), and then tell lazygit about this file like so:
+
+```yml
+os:
+  shellAliasesFile: ~/.my_aliases.sh
+```
+
+For many people it might work well enough to use their entire shell config file (`~/.bashrc` or `~/.zshrc`) as the `shellAliasesFile`, but these config files typically do a lot more than defining aliases (e.g. initialize the completion system, start an ssh-agent, etc.) and this may unnecessarily delay execution of shell commands.
+
+Note that the shell aliases file is not only used when executing shell commands, but also for [custom commands](Custom_Command_Keybindings.md), and when opening a file in the editor.
 
 ## Overriding default config file location
 

--- a/pkg/commands/git_cmd_obj_builder.go
+++ b/pkg/commands/git_cmd_obj_builder.go
@@ -38,10 +38,6 @@ func (self *gitCmdObjBuilder) NewShell(cmdStr string) oscommands.ICmdObj {
 	return self.innerBuilder.NewShell(cmdStr).AddEnvVars(defaultEnvVar)
 }
 
-func (self *gitCmdObjBuilder) NewInteractiveShell(cmdStr string) oscommands.ICmdObj {
-	return self.innerBuilder.NewInteractiveShell(cmdStr).AddEnvVars(defaultEnvVar)
-}
-
 func (self *gitCmdObjBuilder) Quote(str string) string {
 	return self.innerBuilder.Quote(str)
 }

--- a/pkg/commands/git_cmd_obj_builder.go
+++ b/pkg/commands/git_cmd_obj_builder.go
@@ -34,8 +34,8 @@ func (self *gitCmdObjBuilder) New(args []string) oscommands.ICmdObj {
 	return self.innerBuilder.New(args).AddEnvVars(defaultEnvVar)
 }
 
-func (self *gitCmdObjBuilder) NewShell(cmdStr string) oscommands.ICmdObj {
-	return self.innerBuilder.NewShell(cmdStr).AddEnvVars(defaultEnvVar)
+func (self *gitCmdObjBuilder) NewShell(cmdStr string, aliasesFile string) oscommands.ICmdObj {
+	return self.innerBuilder.NewShell(cmdStr, aliasesFile).AddEnvVars(defaultEnvVar)
 }
 
 func (self *gitCmdObjBuilder) Quote(str string) string {

--- a/pkg/commands/oscommands/cmd_obj_builder.go
+++ b/pkg/commands/oscommands/cmd_obj_builder.go
@@ -14,8 +14,6 @@ type ICmdObjBuilder interface {
 	New(args []string) ICmdObj
 	// NewShell takes a string like `git commit` and returns an executable shell command for it e.g. `sh -c 'git commit'`
 	NewShell(commandStr string) ICmdObj
-	// Like NewShell, but uses the user's shell rather than "bash", and passes -i to it
-	NewInteractiveShell(commandStr string) ICmdObj
 	// Quote wraps a string in quotes with any necessary escaping applied. The reason for bundling this up with the other methods in this interface is that we basically always need to make use of this when creating new command objects.
 	Quote(str string) string
 }
@@ -47,13 +45,6 @@ func (self *CmdObjBuilder) NewWithEnviron(args []string, env []string) ICmdObj {
 func (self *CmdObjBuilder) NewShell(commandStr string) ICmdObj {
 	quotedCommand := self.quotedCommandString(commandStr)
 	cmdArgs := str.ToArgv(fmt.Sprintf("%s %s %s", self.platform.Shell, self.platform.ShellArg, quotedCommand))
-
-	return self.New(cmdArgs)
-}
-
-func (self *CmdObjBuilder) NewInteractiveShell(commandStr string) ICmdObj {
-	quotedCommand := self.quotedCommandString(commandStr + self.platform.InteractiveShellExit)
-	cmdArgs := str.ToArgv(fmt.Sprintf("%s %s %s %s", self.platform.InteractiveShell, self.platform.InteractiveShellArg, self.platform.ShellArg, quotedCommand))
 
 	return self.New(cmdArgs)
 }

--- a/pkg/commands/oscommands/cmd_obj_builder.go
+++ b/pkg/commands/oscommands/cmd_obj_builder.go
@@ -13,7 +13,7 @@ type ICmdObjBuilder interface {
 	// NewFromArgs takes a slice of strings like []string{"git", "commit"} and returns a new command object.
 	New(args []string) ICmdObj
 	// NewShell takes a string like `git commit` and returns an executable shell command for it e.g. `sh -c 'git commit'`
-	NewShell(commandStr string) ICmdObj
+	NewShell(commandStr string, aliasesFile string) ICmdObj
 	// Quote wraps a string in quotes with any necessary escaping applied. The reason for bundling this up with the other methods in this interface is that we basically always need to make use of this when creating new command objects.
 	Quote(str string) string
 }
@@ -42,7 +42,10 @@ func (self *CmdObjBuilder) NewWithEnviron(args []string, env []string) ICmdObj {
 	}
 }
 
-func (self *CmdObjBuilder) NewShell(commandStr string) ICmdObj {
+func (self *CmdObjBuilder) NewShell(commandStr string, aliasesFile string) ICmdObj {
+	if len(aliasesFile) > 0 {
+		commandStr = fmt.Sprintf("%ssource %s\n%s", self.platform.PrefixForShellAliasesFile, aliasesFile, commandStr)
+	}
 	quotedCommand := self.quotedCommandString(commandStr)
 	cmdArgs := str.ToArgv(fmt.Sprintf("%s %s %s", self.platform.Shell, self.platform.ShellArg, quotedCommand))
 

--- a/pkg/commands/oscommands/dummies.go
+++ b/pkg/commands/oscommands/dummies.go
@@ -51,14 +51,11 @@ func NewDummyCmdObjBuilder(runner ICmdObjRunner) *CmdObjBuilder {
 }
 
 var dummyPlatform = &Platform{
-	OS:                   "darwin",
-	Shell:                "bash",
-	InteractiveShell:     "bash",
-	ShellArg:             "-c",
-	InteractiveShellArg:  "-i",
-	InteractiveShellExit: "; exit $?",
-	OpenCommand:          "open {{filename}}",
-	OpenLinkCommand:      "open {{link}}",
+	OS:              "darwin",
+	Shell:           "bash",
+	ShellArg:        "-c",
+	OpenCommand:     "open {{filename}}",
+	OpenLinkCommand: "open {{link}}",
 }
 
 func NewDummyOSCommandWithRunner(runner *FakeCmdObjRunner) *OSCommand {

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -35,14 +35,11 @@ type OSCommand struct {
 
 // Platform stores the os state
 type Platform struct {
-	OS                   string
-	Shell                string
-	InteractiveShell     string
-	ShellArg             string
-	InteractiveShellArg  string
-	InteractiveShellExit string
-	OpenCommand          string
-	OpenLinkCommand      string
+	OS              string
+	Shell           string
+	ShellArg        string
+	OpenCommand     string
+	OpenLinkCommand string
 }
 
 // NewOSCommand os command runner

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -35,11 +35,12 @@ type OSCommand struct {
 
 // Platform stores the os state
 type Platform struct {
-	OS              string
-	Shell           string
-	ShellArg        string
-	OpenCommand     string
-	OpenLinkCommand string
+	OS                        string
+	Shell                     string
+	ShellArg                  string
+	PrefixForShellAliasesFile string
+	OpenCommand               string
+	OpenLinkCommand           string
 }
 
 // NewOSCommand os command runner
@@ -90,7 +91,7 @@ func (c *OSCommand) OpenFile(filename string) error {
 		"filename": c.Quote(filename),
 	}
 	command := utils.ResolvePlaceholderString(commandTemplate, templateValues)
-	return c.Cmd.NewShell(command).Run()
+	return c.Cmd.NewShell(command, c.UserConfig().OS.ShellAliasesFile).Run()
 }
 
 func (c *OSCommand) OpenLink(link string) error {
@@ -107,7 +108,7 @@ func (c *OSCommand) OpenLink(link string) error {
 	}
 
 	command := utils.ResolvePlaceholderString(commandTemplate, templateValues)
-	return c.Cmd.NewShell(command).Run()
+	return c.Cmd.NewShell(command, c.UserConfig().OS.ShellAliasesFile).Run()
 }
 
 // Quote wraps a message in platform-specific quotation marks
@@ -296,7 +297,7 @@ func (c *OSCommand) CopyToClipboard(str string) error {
 		cmdStr := utils.ResolvePlaceholderString(c.UserConfig().OS.CopyToClipboardCmd, map[string]string{
 			"text": c.Cmd.Quote(str),
 		})
-		return c.Cmd.NewShell(cmdStr).Run()
+		return c.Cmd.NewShell(cmdStr, c.UserConfig().OS.ShellAliasesFile).Run()
 	}
 
 	return clipboard.WriteAll(str)
@@ -307,7 +308,7 @@ func (c *OSCommand) PasteFromClipboard() (string, error) {
 	var err error
 	if c.UserConfig().OS.CopyToClipboardCmd != "" {
 		cmdStr := c.UserConfig().OS.ReadFromClipboardCmd
-		s, err = c.Cmd.NewShell(cmdStr).RunWithOutput()
+		s, err = c.Cmd.NewShell(cmdStr, c.UserConfig().OS.ShellAliasesFile).RunWithOutput()
 	} else {
 		s, err = clipboard.ReadAll()
 	}
@@ -357,5 +358,5 @@ func (c *OSCommand) UpdateWindowTitle() error {
 		return getWdErr
 	}
 	argString := fmt.Sprint("title ", filepath.Base(path), " - Lazygit")
-	return c.Cmd.NewShell(argString).Run()
+	return c.Cmd.NewShell(argString, c.UserConfig().OS.ShellAliasesFile).Run()
 }

--- a/pkg/commands/oscommands/os_default_platform.go
+++ b/pkg/commands/oscommands/os_default_platform.go
@@ -4,15 +4,33 @@
 package oscommands
 
 import (
+	"os"
 	"runtime"
+	"strings"
 )
 
 func GetPlatform() *Platform {
-	return &Platform{
-		OS:              runtime.GOOS,
-		Shell:           "bash",
-		ShellArg:        "-c",
-		OpenCommand:     "open {{filename}}",
-		OpenLinkCommand: "open {{link}}",
+	shell := getUserShell()
+
+	prefixForShellAliasesFile := ""
+	if strings.HasSuffix(shell, "bash") {
+		prefixForShellAliasesFile = "shopt -s expand_aliases\n"
 	}
+
+	return &Platform{
+		OS:                        runtime.GOOS,
+		Shell:                     shell,
+		ShellArg:                  "-c",
+		PrefixForShellAliasesFile: prefixForShellAliasesFile,
+		OpenCommand:               "open {{filename}}",
+		OpenLinkCommand:           "open {{link}}",
+	}
+}
+
+func getUserShell() string {
+	if shell := os.Getenv("SHELL"); shell != "" {
+		return shell
+	}
+
+	return "bash"
 }

--- a/pkg/commands/oscommands/os_default_platform.go
+++ b/pkg/commands/oscommands/os_default_platform.go
@@ -4,42 +4,15 @@
 package oscommands
 
 import (
-	"os"
 	"runtime"
-	"strings"
 )
 
 func GetPlatform() *Platform {
-	shell := getUserShell()
-
-	interactiveShell := shell
-	interactiveShellArg := "-i"
-	interactiveShellExit := "; exit $?"
-
-	if strings.HasSuffix(shell, "fish") {
-		interactiveShellExit = "; exit $status"
-	} else if !(strings.HasSuffix(shell, "bash") || strings.HasSuffix(shell, "zsh")) {
-		interactiveShell = "bash"
-		interactiveShellArg = ""
-		interactiveShellExit = ""
-	}
-
 	return &Platform{
-		OS:                   runtime.GOOS,
-		Shell:                "bash",
-		InteractiveShell:     interactiveShell,
-		ShellArg:             "-c",
-		InteractiveShellArg:  interactiveShellArg,
-		InteractiveShellExit: interactiveShellExit,
-		OpenCommand:          "open {{filename}}",
-		OpenLinkCommand:      "open {{link}}",
+		OS:              runtime.GOOS,
+		Shell:           "bash",
+		ShellArg:        "-c",
+		OpenCommand:     "open {{filename}}",
+		OpenLinkCommand: "open {{link}}",
 	}
-}
-
-func getUserShell() string {
-	if shell := os.Getenv("SHELL"); shell != "" {
-		return shell
-	}
-
-	return "bash"
 }

--- a/pkg/commands/oscommands/os_windows.go
+++ b/pkg/commands/oscommands/os_windows.go
@@ -2,11 +2,8 @@ package oscommands
 
 func GetPlatform() *Platform {
 	return &Platform{
-		OS:                   "windows",
-		Shell:                "cmd",
-		InteractiveShell:     "cmd",
-		ShellArg:             "/c",
-		InteractiveShellArg:  "",
-		InteractiveShellExit: "",
+		OS:       "windows",
+		Shell:    "cmd",
+		ShellArg: "/c",
 	}
 }

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -583,6 +583,10 @@ type OSConfig struct {
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
 	ReadFromClipboardCmd string `yaml:"readFromClipboardCmd,omitempty"`
 
+	// A shell startup file containing shell aliases or shell functions. This will be sourced before running any shell commands, so that shell aliases are available in the `:` command prompt or even in custom commands.
+	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#using-aliases-or-functions-in-shell-commands
+	ShellAliasesFile string `yaml:"shellAliasesFile"`
+
 	// --------
 
 	// The following configs are all deprecated and kept for backward

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -575,6 +575,14 @@ type OSConfig struct {
 	// Command for opening a link. Should contain "{{link}}".
 	OpenLink string `yaml:"openLink,omitempty"`
 
+	// CopyToClipboardCmd is the command for copying to clipboard.
+	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
+	CopyToClipboardCmd string `yaml:"copyToClipboardCmd,omitempty"`
+
+	// ReadFromClipboardCmd is the command for reading the clipboard.
+	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
+	ReadFromClipboardCmd string `yaml:"readFromClipboardCmd,omitempty"`
+
 	// --------
 
 	// The following configs are all deprecated and kept for backward
@@ -597,14 +605,6 @@ type OSConfig struct {
 	// OpenLinkCommand is the command for opening a link
 	// Deprecated: use OpenLink instead.
 	OpenLinkCommand string `yaml:"openLinkCommand,omitempty"`
-
-	// CopyToClipboardCmd is the command for copying to clipboard.
-	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
-	CopyToClipboardCmd string `yaml:"copyToClipboardCmd,omitempty"`
-
-	// ReadFromClipboardCmd is the command for reading the clipboard.
-	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
-	ReadFromClipboardCmd string `yaml:"readFromClipboardCmd,omitempty"`
 }
 
 type CustomCommandAfterHook struct {

--- a/pkg/gui/controllers/helpers/files_helper.go
+++ b/pkg/gui/controllers/helpers/files_helper.go
@@ -71,11 +71,11 @@ func (self *FilesHelper) OpenDirInEditor(path string) error {
 func (self *FilesHelper) callEditor(cmdStr string, suspend bool) error {
 	if suspend {
 		return self.c.RunSubprocessAndRefresh(
-			self.c.OS().Cmd.NewShell(cmdStr),
+			self.c.OS().Cmd.NewShell(cmdStr, self.c.UserConfig().OS.ShellAliasesFile),
 		)
 	}
 
-	return self.c.OS().Cmd.NewShell(cmdStr).Run()
+	return self.c.OS().Cmd.NewShell(cmdStr, self.c.UserConfig().OS.ShellAliasesFile).Run()
 }
 
 func (self *FilesHelper) OpenFile(filename string) error {

--- a/pkg/gui/controllers/shell_command_action.go
+++ b/pkg/gui/controllers/shell_command_action.go
@@ -31,7 +31,7 @@ func (self *ShellCommandAction) Call() error {
 
 			self.c.LogAction(self.c.Tr.Actions.CustomCommand)
 			return self.c.RunSubprocessAndRefresh(
-				self.c.OS().Cmd.NewInteractiveShell(command),
+				self.c.OS().Cmd.NewShell(command),
 			)
 		},
 		HandleDeleteSuggestion: func(index int) error {

--- a/pkg/gui/controllers/shell_command_action.go
+++ b/pkg/gui/controllers/shell_command_action.go
@@ -31,7 +31,7 @@ func (self *ShellCommandAction) Call() error {
 
 			self.c.LogAction(self.c.Tr.Actions.CustomCommand)
 			return self.c.RunSubprocessAndRefresh(
-				self.c.OS().Cmd.NewShell(command),
+				self.c.OS().Cmd.NewShell(command, self.c.UserConfig().OS.ShellAliasesFile),
 			)
 		},
 		HandleDeleteSuggestion: func(index int) error {

--- a/pkg/gui/services/custom_commands/handler_creator.go
+++ b/pkg/gui/services/custom_commands/handler_creator.go
@@ -148,7 +148,7 @@ func (self *HandlerCreator) generateFindSuggestionsFunc(prompt *config.CustomCom
 
 func (self *HandlerCreator) getCommandSuggestionsFn(command string) (func(string) []*types.Suggestion, error) {
 	lines := []*types.Suggestion{}
-	err := self.c.OS().Cmd.NewShell(command).RunAndProcessLines(func(line string) (bool, error) {
+	err := self.c.OS().Cmd.NewShell(command, self.c.UserConfig().OS.ShellAliasesFile).RunAndProcessLines(func(line string) (bool, error) {
 		lines = append(lines, &types.Suggestion{Value: line, Label: line})
 		return false, nil
 	})
@@ -259,7 +259,7 @@ func (self *HandlerCreator) finalHandler(customCommand config.CustomCommand, ses
 		return err
 	}
 
-	cmdObj := self.c.OS().Cmd.NewShell(cmdStr)
+	cmdObj := self.c.OS().Cmd.NewShell(cmdStr, self.c.UserConfig().OS.ShellAliasesFile)
 
 	if customCommand.Subprocess != nil && *customCommand.Subprocess {
 		return self.c.RunSubprocessAndRefresh(cmdObj)

--- a/schema/config.json
+++ b/schema/config.json
@@ -1514,6 +1514,10 @@
           "type": "string",
           "description": "ReadFromClipboardCmd is the command for reading the clipboard.\nSee https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard"
         },
+        "shellAliasesFile": {
+          "type": "string",
+          "description": "A shell startup file containing shell aliases or shell functions. This will be sourced before running any shell commands, so that shell aliases are available in the `:` command prompt or even in custom commands.\nSee https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#using-aliases-or-functions-in-shell-commands"
+        },
         "editCommand": {
           "type": "string",
           "description": "EditCommand is the command for editing a file.\nDeprecated: use Edit instead. Note that semantics are different:\nEditCommand is just the command itself, whereas Edit contains a\n\"{{filename}}\" variable."

--- a/schema/config.json
+++ b/schema/config.json
@@ -1506,6 +1506,14 @@
           "type": "string",
           "description": "Command for opening a link. Should contain \"{{link}}\"."
         },
+        "copyToClipboardCmd": {
+          "type": "string",
+          "description": "CopyToClipboardCmd is the command for copying to clipboard.\nSee https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard"
+        },
+        "readFromClipboardCmd": {
+          "type": "string",
+          "description": "ReadFromClipboardCmd is the command for reading the clipboard.\nSee https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard"
+        },
         "editCommand": {
           "type": "string",
           "description": "EditCommand is the command for editing a file.\nDeprecated: use Edit instead. Note that semantics are different:\nEditCommand is just the command itself, whereas Edit contains a\n\"{{filename}}\" variable."
@@ -1521,14 +1529,6 @@
         "openLinkCommand": {
           "type": "string",
           "description": "OpenLinkCommand is the command for opening a link\nDeprecated: use OpenLink instead."
-        },
-        "copyToClipboardCmd": {
-          "type": "string",
-          "description": "CopyToClipboardCmd is the command for copying to clipboard.\nSee https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard"
-        },
-        "readFromClipboardCmd": {
-          "type": "string",
-          "description": "ReadFromClipboardCmd is the command for reading the clipboard.\nSee https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
- **PR Description**

In version 0.45.0 we started to use an interactive shell for running shell commands (see #4159). The idea was that this allows users to use their aliases and shell functions in lazygit without having to do any additional configuration.

Unfortunately, this hasn't worked out well. For some users this resulted in lazygit hanging in the background upon trying to return from the shell command; we tried various fixes for this (see #4126, #4159, and #4350), but some users still have this problem (e.g. #4320).

Also, starting an interactive shell can be a lot slower than starting a non-interactive one, depending on how much happens in the `.bashrc` or `.zshrc` file. For example, on my machine calling `zsh -ic true` takes 600ms, whereas `zsh -c true` takes less than 2ms. This is too high of a price to pay for using shell aliases, especially when _all_ users have to pay it, even those who don't care about using their aliases in lazygit.

This PR reverts all commits related to interactive shells, and instead introduces a different approach: we let users specify a shell aliases file that will be sourced before running a command. The downside is that it doesn't work transparently out of the box, but requires configuration, and it may also require that users restructure their shell startup file(s) if they currently only have a single big one. The advantage is that only users who actually want to use aliases or functions are affected, and that we can now use this mechanism not only for shell commands, but also for custom commands and for calling the editor (some users have asked for this in the past).

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
