### PR TITLE
Specify a go release minor version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jesseduffield/lazygit
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/adrg/xdg v0.4.0


### PR DESCRIPTION
- **PR Description**
Since they started releasing .0 versions with 1.21.0, the go version need to be a full release version specifier and not a go language version. They relented and added support for defaulting to a .0 release if none is specified in later 1.23.x releases, but for users with local 1.21 or 1.22 toolchains the lack of a full release specifier breaks them. And going forwards this is more technically correct anyway.

See https://github.com/golang/go/issues/62278#issuecomment-1693620853

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
