### PR TITLE
More navigation keybindings for confirmation panel

### DIFF
--- a/pkg/gui/extras_panel.go
+++ b/pkg/gui/extras_panel.go
@@ -58,6 +58,38 @@ func (gui *Gui) scrollDownExtra() error {
 	return nil
 }
 
+func (gui *Gui) pageUpExtrasPanel() error {
+	gui.Views.Extras.Autoscroll = false
+
+	gui.Views.Extras.ScrollUp(gui.Contexts().CommandLog.GetViewTrait().PageDelta())
+
+	return nil
+}
+
+func (gui *Gui) pageDownExtrasPanel() error {
+	gui.Views.Extras.Autoscroll = false
+
+	gui.Views.Extras.ScrollDown(gui.Contexts().CommandLog.GetViewTrait().PageDelta())
+
+	return nil
+}
+
+func (gui *Gui) goToExtrasPanelTop() error {
+	gui.Views.Extras.Autoscroll = false
+
+	gui.Views.Extras.ScrollUp(gui.Views.Extras.ViewLinesHeight())
+
+	return nil
+}
+
+func (gui *Gui) goToExtrasPanelBottom() error {
+	gui.Views.Extras.Autoscroll = true
+
+	gui.Views.Extras.ScrollDown(gui.Views.Extras.ViewLinesHeight())
+
+	return nil
+}
+
 func (gui *Gui) getCmdWriter() io.Writer {
 	return &prefixWriter{writer: gui.Views.Extras, prefix: style.FgMagenta.Sprintf("\n\n%s\n", gui.c.Tr.GitOutput)}
 }

--- a/pkg/gui/global_handlers.go
+++ b/pkg/gui/global_handlers.go
@@ -109,6 +109,46 @@ func (gui *Gui) scrollDownConfirmationPanel() error {
 	return nil
 }
 
+func (gui *Gui) pageUpConfirmationPanel() error {
+	if gui.Views.Confirmation.Editable {
+		return nil
+	}
+
+	gui.Views.Confirmation.ScrollUp(gui.Contexts().Confirmation.GetViewTrait().PageDelta())
+
+	return nil
+}
+
+func (gui *Gui) pageDownConfirmationPanel() error {
+	if gui.Views.Confirmation.Editable {
+		return nil
+	}
+
+	gui.Views.Confirmation.ScrollDown(gui.Contexts().Confirmation.GetViewTrait().PageDelta())
+
+	return nil
+}
+
+func (gui *Gui) goToConfirmationPanelTop() error {
+	if gui.Views.Confirmation.Editable {
+		return nil
+	}
+
+	gui.Views.Confirmation.ScrollUp(gui.Views.Confirmation.ViewLinesHeight())
+
+	return nil
+}
+
+func (gui *Gui) goToConfirmationPanelBottom() error {
+	if gui.Views.Confirmation.Editable {
+		return nil
+	}
+
+	gui.Views.Confirmation.ScrollDown(gui.Views.Confirmation.ViewLinesHeight())
+
+	return nil
+}
+
 func (gui *Gui) handleCopySelectedSideContextItemToClipboard() error {
 	return gui.handleCopySelectedSideContextItemToClipboardWithTruncation(-1)
 }

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -261,6 +261,42 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 			Handler:  self.scrollDownConfirmationPanel,
 		},
 		{
+			ViewName: "confirmation",
+			Key:      opts.GetKey(opts.Config.Universal.NextPage),
+			Modifier: gocui.ModNone,
+			Handler:  self.pageDownConfirmationPanel,
+		},
+		{
+			ViewName: "confirmation",
+			Key:      opts.GetKey(opts.Config.Universal.PrevPage),
+			Modifier: gocui.ModNone,
+			Handler:  self.pageUpConfirmationPanel,
+		},
+		{
+			ViewName: "confirmation",
+			Key:      opts.GetKey(opts.Config.Universal.GotoTop),
+			Modifier: gocui.ModNone,
+			Handler:  self.goToConfirmationPanelTop,
+		},
+		{
+			ViewName: "confirmation",
+			Key:      opts.GetKey(opts.Config.Universal.GotoTopAlt),
+			Modifier: gocui.ModNone,
+			Handler:  self.goToConfirmationPanelTop,
+		},
+		{
+			ViewName: "confirmation",
+			Key:      opts.GetKey(opts.Config.Universal.GotoBottom),
+			Modifier: gocui.ModNone,
+			Handler:  self.goToConfirmationPanelBottom,
+		},
+		{
+			ViewName: "confirmation",
+			Key:      opts.GetKey(opts.Config.Universal.GotoBottomAlt),
+			Modifier: gocui.ModNone,
+			Handler:  self.goToConfirmationPanelBottom,
+		},
+		{
 			ViewName:          "submodules",
 			Key:               opts.GetKey(opts.Config.Universal.CopyToClipboard),
 			Handler:           self.handleCopySelectedSideContextItemToClipboard,

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -343,6 +343,42 @@ func (self *Gui) GetInitialKeybindings() ([]*types.Binding, []*gocui.ViewMouseBi
 		},
 		{
 			ViewName: "extras",
+			Key:      opts.GetKey(opts.Config.Universal.NextPage),
+			Modifier: gocui.ModNone,
+			Handler:  self.pageDownExtrasPanel,
+		},
+		{
+			ViewName: "extras",
+			Key:      opts.GetKey(opts.Config.Universal.PrevPage),
+			Modifier: gocui.ModNone,
+			Handler:  self.pageUpExtrasPanel,
+		},
+		{
+			ViewName: "extras",
+			Key:      opts.GetKey(opts.Config.Universal.GotoTop),
+			Modifier: gocui.ModNone,
+			Handler:  self.goToExtrasPanelTop,
+		},
+		{
+			ViewName: "extras",
+			Key:      opts.GetKey(opts.Config.Universal.GotoTopAlt),
+			Modifier: gocui.ModNone,
+			Handler:  self.goToExtrasPanelTop,
+		},
+		{
+			ViewName: "extras",
+			Key:      opts.GetKey(opts.Config.Universal.GotoBottom),
+			Modifier: gocui.ModNone,
+			Handler:  self.goToExtrasPanelBottom,
+		},
+		{
+			ViewName: "extras",
+			Key:      opts.GetKey(opts.Config.Universal.GotoBottomAlt),
+			Modifier: gocui.ModNone,
+			Handler:  self.goToExtrasPanelBottom,
+		},
+		{
+			ViewName: "extras",
 			Tag:      "navigation",
 			Key:      gocui.MouseLeft,
 			Modifier: gocui.ModNone,


### PR DESCRIPTION
- **PR Description**

Add bindings for `,` (page up), `.` (page down), `<` or `<home>` (top), and `>` or `<end>` (bottom), for scrolling long text in confirmation panels. This is useful for example for git hooks that output a lot of error text on failure, where the most interesting bit of information is probably at the end.

I chose not to bind `<pgUp>` and `<pgDown>`, since they are normally used for scrolling the main view. Which is not a thing when a confirmation is shown or the Extras panel is focused, so we *could* use them in these cases, but I thought it might be confusing when they are used for different things in different contexts.

While we're at it, add the same navigation bindings also to the Extras panel (i.e. the command log when it has the focus).

Fixes #4372.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
