### PR TITLE
Revert #4313 (Skip post-checkout hook when discarding changes)

### DIFF
--- a/pkg/commands/git_commands/rebase_test.go
+++ b/pkg/commands/git_commands/rebase_test.go
@@ -149,7 +149,7 @@ func TestRebaseDiscardOldFileChanges(t *testing.T) {
 			runner: oscommands.NewFakeRunner(t).
 				ExpectGitArgs([]string{"rebase", "--interactive", "--autostash", "--keep-empty", "--no-autosquash", "--rebase-merges", "abcdef"}, "", nil).
 				ExpectGitArgs([]string{"cat-file", "-e", "HEAD^:test999.txt"}, "", nil).
-				ExpectGitArgs([]string{"-c", disableHooksFlag, "checkout", "HEAD^", "--", "test999.txt"}, "", nil).
+				ExpectGitArgs([]string{"checkout", "HEAD^", "--", "test999.txt"}, "", nil).
 				ExpectGitArgs([]string{"commit", "--amend", "--no-edit", "--allow-empty"}, "", nil).
 				ExpectGitArgs([]string{"rebase", "--continue"}, "", nil),
 			test: func(err error) {

--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -113,10 +113,6 @@ func (self *WorkingTreeCommands) BeforeAndAfterFileForRename(file *models.File) 
 	return beforeFile, afterFile, nil
 }
 
-func newCheckoutCommand() *GitCommandBuilder {
-	return NewGitCmd("checkout").Config(fmt.Sprintf("core.hooksPath=%s", os.DevNull))
-}
-
 // DiscardAllFileChanges directly
 func (self *WorkingTreeCommands) DiscardAllFileChanges(file *models.File) error {
 	if file.IsRename() {
@@ -138,7 +134,7 @@ func (self *WorkingTreeCommands) DiscardAllFileChanges(file *models.File) error 
 
 	if file.ShortStatus == "AA" {
 		if err := self.cmd.New(
-			newCheckoutCommand().Arg("--ours", "--", file.Name).ToArgv(),
+			NewGitCmd("checkout").Arg("--ours", "--", file.Name).ToArgv(),
 		).Run(); err != nil {
 			return err
 		}
@@ -197,7 +193,7 @@ func (self *WorkingTreeCommands) DiscardUnstagedDirChanges(node IFileNode) error
 			return err
 		}
 
-		cmdArgs := newCheckoutCommand().Arg("--", node.GetPath()).ToArgv()
+		cmdArgs := NewGitCmd("checkout").Arg("--", node.GetPath()).ToArgv()
 		if err := self.cmd.New(cmdArgs).Run(); err != nil {
 			return err
 		}
@@ -230,7 +226,7 @@ func (self *WorkingTreeCommands) RemoveUntrackedDirFiles(node IFileNode) error {
 }
 
 func (self *WorkingTreeCommands) DiscardUnstagedFileChanges(file *models.File) error {
-	cmdArgs := newCheckoutCommand().Arg("--", file.Name).ToArgv()
+	cmdArgs := NewGitCmd("checkout").Arg("--", file.Name).ToArgv()
 	return self.cmd.New(cmdArgs).Run()
 }
 
@@ -323,7 +319,7 @@ func (self *WorkingTreeCommands) ShowFileDiffCmdObj(from string, to string, reve
 
 // CheckoutFile checks out the file for the given commit
 func (self *WorkingTreeCommands) CheckoutFile(commitHash, fileName string) error {
-	cmdArgs := newCheckoutCommand().Arg(commitHash, "--", fileName).
+	cmdArgs := NewGitCmd("checkout").Arg(commitHash, "--", fileName).
 		ToArgv()
 
 	return self.cmd.New(cmdArgs).Run()
@@ -331,7 +327,7 @@ func (self *WorkingTreeCommands) CheckoutFile(commitHash, fileName string) error
 
 // DiscardAnyUnstagedFileChanges discards any unstaged file changes via `git checkout -- .`
 func (self *WorkingTreeCommands) DiscardAnyUnstagedFileChanges() error {
-	cmdArgs := newCheckoutCommand().Arg("--", ".").
+	cmdArgs := NewGitCmd("checkout").Arg("--", ".").
 		ToArgv()
 
 	return self.cmd.New(cmdArgs).Run()

--- a/pkg/commands/git_commands/working_tree_test.go
+++ b/pkg/commands/git_commands/working_tree_test.go
@@ -1,8 +1,6 @@
 package git_commands
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
 	"github.com/go-errors/errors"
@@ -11,8 +9,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
-
-var disableHooksFlag = fmt.Sprintf("core.hooksPath=%s", os.DevNull)
 
 func TestWorkingTreeStageFile(t *testing.T) {
 	runner := oscommands.NewFakeRunner(t).
@@ -117,7 +113,7 @@ func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
 			},
 			removeFile: func(string) error { return nil },
 			runner: oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"-c", disableHooksFlag, "checkout", "--", "test"}, "", errors.New("error")),
+				ExpectGitArgs([]string{"checkout", "--", "test"}, "", errors.New("error")),
 			expectedError: "error",
 		},
 		{
@@ -129,7 +125,7 @@ func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
 			},
 			removeFile: func(string) error { return nil },
 			runner: oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"-c", disableHooksFlag, "checkout", "--", "test"}, "", nil),
+				ExpectGitArgs([]string{"checkout", "--", "test"}, "", nil),
 			expectedError: "",
 		},
 		{
@@ -142,7 +138,7 @@ func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
 			removeFile: func(string) error { return nil },
 			runner: oscommands.NewFakeRunner(t).
 				ExpectGitArgs([]string{"reset", "--", "test"}, "", nil).
-				ExpectGitArgs([]string{"-c", disableHooksFlag, "checkout", "--", "test"}, "", nil),
+				ExpectGitArgs([]string{"checkout", "--", "test"}, "", nil),
 			expectedError: "",
 		},
 		{
@@ -155,7 +151,7 @@ func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
 			removeFile: func(string) error { return nil },
 			runner: oscommands.NewFakeRunner(t).
 				ExpectGitArgs([]string{"reset", "--", "test"}, "", nil).
-				ExpectGitArgs([]string{"-c", disableHooksFlag, "checkout", "--", "test"}, "", nil),
+				ExpectGitArgs([]string{"checkout", "--", "test"}, "", nil),
 			expectedError: "",
 		},
 		{
@@ -432,7 +428,7 @@ func TestWorkingTreeCheckoutFile(t *testing.T) {
 			commitHash: "11af912",
 			fileName:   "test999.txt",
 			runner: oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"-c", disableHooksFlag, "checkout", "11af912", "--", "test999.txt"}, "", nil),
+				ExpectGitArgs([]string{"checkout", "11af912", "--", "test999.txt"}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -442,7 +438,7 @@ func TestWorkingTreeCheckoutFile(t *testing.T) {
 			commitHash: "11af912",
 			fileName:   "test999.txt",
 			runner: oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"-c", disableHooksFlag, "checkout", "11af912", "--", "test999.txt"}, "", errors.New("error")),
+				ExpectGitArgs([]string{"checkout", "11af912", "--", "test999.txt"}, "", errors.New("error")),
 			test: func(err error) {
 				assert.Error(t, err)
 			},
@@ -472,7 +468,7 @@ func TestWorkingTreeDiscardUnstagedFileChanges(t *testing.T) {
 			testName: "valid case",
 			file:     &models.File{Name: "test.txt"},
 			runner: oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"-c", disableHooksFlag, "checkout", "--", "test.txt"}, "", nil),
+				ExpectGitArgs([]string{"checkout", "--", "test.txt"}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},
@@ -499,7 +495,7 @@ func TestWorkingTreeDiscardAnyUnstagedFileChanges(t *testing.T) {
 		{
 			testName: "valid case",
 			runner: oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"-c", disableHooksFlag, "checkout", "--", "."}, "", nil),
+				ExpectGitArgs([]string{"checkout", "--", "."}, "", nil),
 			test: func(err error) {
 				assert.NoError(t, err)
 			},


### PR DESCRIPTION
@jesseduffield:

> Let's revert this PR, given that, as @TimShilov says, the post-checkout hook will receive a flag stating whether the checkout was for a file or a branch, meaning it's within the user's power to just update the hook script to only run on branch checkouts if desired.
