### PR TITLE
Add "Absolute path" item to the file view's copy menu

### DIFF
--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"errors"
+	"path/filepath"
 	"strings"
 
 	"github.com/jesseduffield/gocui"
@@ -228,8 +229,8 @@ func (self *CommitFilesController) openCopyMenu() error {
 		DisabledReason: self.require(self.singleItemSelected())(),
 		Key:            'n',
 	}
-	copyPathItem := &types.MenuItem{
-		Label: self.c.Tr.CopyFilePath,
+	copyRelativePathItem := &types.MenuItem{
+		Label: self.c.Tr.CopyRelativeFilePath,
 		OnPress: func() error {
 			if err := self.c.OS().CopyToClipboard(node.GetPath()); err != nil {
 				return err
@@ -239,6 +240,18 @@ func (self *CommitFilesController) openCopyMenu() error {
 		},
 		DisabledReason: self.require(self.singleItemSelected())(),
 		Key:            'p',
+	}
+	copyAbsolutePathItem := &types.MenuItem{
+		Label: self.c.Tr.CopyAbsoluteFilePath,
+		OnPress: func() error {
+			if err := self.c.OS().CopyToClipboard(filepath.Join(self.c.Git().RepoPaths.RepoPath(), node.GetPath())); err != nil {
+				return err
+			}
+			self.c.Toast(self.c.Tr.FilePathCopiedToast)
+			return nil
+		},
+		DisabledReason: self.require(self.singleItemSelected())(),
+		Key:            'P',
 	}
 	copyFileDiffItem := &types.MenuItem{
 		Label: self.c.Tr.CopySelectedDiff,
@@ -282,7 +295,8 @@ func (self *CommitFilesController) openCopyMenu() error {
 		Title: self.c.Tr.CopyToClipboardMenu,
 		Items: []*types.MenuItem{
 			copyNameItem,
-			copyPathItem,
+			copyRelativePathItem,
+			copyAbsolutePathItem,
 			copyFileDiffItem,
 			copyAllDiff,
 			copyFileContentItem,

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/jesseduffield/gocui"
@@ -976,8 +977,8 @@ func (self *FilesController) openCopyMenu() error {
 		DisabledReason: self.require(self.singleItemSelected())(),
 		Key:            'n',
 	}
-	copyPathItem := &types.MenuItem{
-		Label: self.c.Tr.CopyFilePath,
+	copyRelativePathItem := &types.MenuItem{
+		Label: self.c.Tr.CopyRelativeFilePath,
 		OnPress: func() error {
 			if err := self.c.OS().CopyToClipboard(node.GetPath()); err != nil {
 				return err
@@ -987,6 +988,18 @@ func (self *FilesController) openCopyMenu() error {
 		},
 		DisabledReason: self.require(self.singleItemSelected())(),
 		Key:            'p',
+	}
+	copyAbsolutePathItem := &types.MenuItem{
+		Label: self.c.Tr.CopyAbsoluteFilePath,
+		OnPress: func() error {
+			if err := self.c.OS().CopyToClipboard(filepath.Join(self.c.Git().RepoPaths.RepoPath(), node.GetPath())); err != nil {
+				return err
+			}
+			self.c.Toast(self.c.Tr.FilePathCopiedToast)
+			return nil
+		},
+		DisabledReason: self.require(self.singleItemSelected())(),
+		Key:            'P',
 	}
 	copyFileDiffItem := &types.MenuItem{
 		Label:   self.c.Tr.CopySelectedDiff,
@@ -1044,7 +1057,8 @@ func (self *FilesController) openCopyMenu() error {
 		Title: self.c.Tr.CopyToClipboardMenu,
 		Items: []*types.MenuItem{
 			copyNameItem,
-			copyPathItem,
+			copyRelativePathItem,
+			copyAbsolutePathItem,
 			copyFileDiffItem,
 			copyAllDiff,
 		},

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -76,7 +76,8 @@ type TranslationSet struct {
 	FileFilter                            string
 	CopyToClipboardMenu                   string
 	CopyFileName                          string
-	CopyFilePath                          string
+	CopyRelativeFilePath                  string
+	CopyAbsoluteFilePath                  string
 	CopyFileDiffTooltip                   string
 	CopySelectedDiff                      string
 	CopyAllFilesDiff                      string
@@ -1120,7 +1121,8 @@ func EnglishTranslationSet() *TranslationSet {
 		FileFilter:                           "Filter files by status",
 		CopyToClipboardMenu:                  "Copy to clipboard",
 		CopyFileName:                         "File name",
-		CopyFilePath:                         "Path",
+		CopyRelativeFilePath:                 "Relative path",
+		CopyAbsoluteFilePath:                 "Absolute path",
 		CopyFileDiffTooltip:                  "If there are staged items, this command considers only them. Otherwise, it considers all the unstaged ones.",
 		CopySelectedDiff:                     "Diff of selected file",
 		CopyAllFilesDiff:                     "Diff of all files",

--- a/pkg/integration/tests/diff/copy_to_clipboard.go
+++ b/pkg/integration/tests/diff/copy_to_clipboard.go
@@ -1,6 +1,8 @@
 package diff
 
 import (
+	"os"
+
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
@@ -63,11 +65,24 @@ var CopyToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Copy to clipboard")).
-					Select(Contains("Path")).
+					Select(Contains("Relative path")).
 					Confirm().
 					Tap(func() {
 						t.ExpectToast(Equals("File path copied to clipboard"))
 						expectClipboard(t, Equals("dir/file1"))
+					})
+			}).
+			Press(keys.Files.CopyFileInfoToClipboard).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Copy to clipboard")).
+					Select(Contains("Absolute path")).
+					Confirm().
+					Tap(func() {
+						t.ExpectToast(Equals("File path copied to clipboard"))
+						repoDir, _ := os.Getwd()
+						// On windows the following path would have backslashes, but we don't run integration tests on windows yet.
+						expectClipboard(t, Equals(repoDir+"/dir/file1"))
 					})
 			}).
 			Press(keys.Files.CopyFileInfoToClipboard).

--- a/pkg/integration/tests/file/copy_menu.go
+++ b/pkg/integration/tests/file/copy_menu.go
@@ -1,6 +1,8 @@
 package file
 
 import (
+	"os"
+
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
@@ -103,18 +105,34 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 				expectClipboard(t, Equals("1-unstaged_file"))
 			})
 
-		// Copy file path
+		// Copy relative file path
 		t.Views().Files().
 			Press(keys.Files.CopyFileInfoToClipboard).
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Copy to clipboard")).
-					Select(Contains("Path")).
+					Select(Contains("Relative path")).
 					Confirm()
 
 				t.ExpectToast(Equals("File path copied to clipboard"))
 
 				expectClipboard(t, Equals("dir/1-unstaged_file"))
+			})
+
+		// Copy absolute file path
+		t.Views().Files().
+			Press(keys.Files.CopyFileInfoToClipboard).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Copy to clipboard")).
+					Select(Contains("Absolute path")).
+					Confirm()
+
+				t.ExpectToast(Equals("File path copied to clipboard"))
+
+				repoDir, _ := os.Getwd()
+				// On windows the following path would have backslashes, but we don't run integration tests on windows yet.
+				expectClipboard(t, Equals(repoDir+"/dir/1-unstaged_file"))
 			})
 
 		// Selected path diff on a single (unstaged) file


### PR DESCRIPTION
- **PR Description**

Make it possible to copy the absolute path of a file to the clipboard.

Addresses #4409.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
