### PR TITLE
Include empty arrays and maps in config docs

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -37,6 +37,16 @@ This is only meant as a reference for what config options exist, and what their 
 ```yaml
 # Config relating to the Lazygit UI
 gui:
+  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-author-color
+  authorColors: {}
+
+  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-branch-color
+  # Deprecated: use branchColorPatterns instead
+  branchColors: {}
+
+  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-branch-color
+  branchColorPatterns: {}
+
   # The number of lines you scroll by when scrolling the main window
   scrollHeight: 2
 
@@ -341,11 +351,20 @@ git:
   # Deprecated: Use `allBranchesLogCmds` instead.
   allBranchesLogCmd: git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium
 
+  # Commands used to display git log of all branches in the main window, they will be cycled in order of appearance (array of strings)
+  allBranchesLogCmds: []
+
   # If true, do not spawn a separate process when using GPG
   overrideGpg: false
 
   # If true, do not allow force pushes
   disableForcePushing: false
+
+  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix
+  commitPrefix: []
+
+  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix
+  commitPrefixes: {}
 
   # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-branch-name-prefix
   branchPrefix: ""
@@ -458,6 +477,13 @@ os:
 
 # If true, don't display introductory popups upon opening Lazygit.
 disableStartupPopups: false
+
+# User-configured commands that can be invoked from within Lazygit
+# See https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Command_Keybindings.md
+customCommands: []
+
+# See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-pull-request-urls
+services: {}
 
 # What to do when opening Lazygit outside of a git repo.
 # - 'prompt': (default) ask whether to initialize a new repo or open in the most recent repo

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -24,6 +24,7 @@ type UserConfig struct {
 	// If true, don't display introductory popups upon opening Lazygit.
 	DisableStartupPopups bool `yaml:"disableStartupPopups"`
 	// User-configured commands that can be invoked from within Lazygit
+	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Command_Keybindings.md
 	CustomCommands []CustomCommand `yaml:"customCommands" jsonschema:"uniqueItems=true"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-pull-request-urls
 	Services map[string]string `yaml:"services"`
@@ -252,7 +253,7 @@ type GitConfig struct {
 	// Command used to display git log of all branches in the main window.
 	// Deprecated: Use `allBranchesLogCmds` instead.
 	AllBranchesLogCmd string `yaml:"allBranchesLogCmd"`
-	// Commands used to display git log of all branches in the main window, they will be cycled in order of appearance
+	// Commands used to display git log of all branches in the main window, they will be cycled in order of appearance (array of strings)
 	AllBranchesLogCmds []string `yaml:"allBranchesLogCmds"`
 	// If true, do not spawn a separate process when using GPG
 	OverrideGpg bool `yaml:"overrideGpg"`

--- a/pkg/jsonschema/generate_config_docs.go
+++ b/pkg/jsonschema/generate_config_docs.go
@@ -205,16 +205,6 @@ func recurseOverSchema(rootSchema, schema *jsonschema.Schema, parent *Node) {
 	for pair := schema.Properties.Oldest(); pair != nil; pair = pair.Next() {
 		subSchema := getSubSchema(rootSchema, schema, pair.Key)
 
-		// Skip empty objects
-		if subSchema.Type == "object" && subSchema.Properties == nil {
-			continue
-		}
-
-		// Skip empty arrays
-		if isZeroValue(subSchema.Default) && subSchema.Type == "array" {
-			continue
-		}
-
 		node := Node{
 			Name:        pair.Key,
 			Description: subSchema.Description,
@@ -235,6 +225,10 @@ func getZeroValue(val any, t string) any {
 		return ""
 	case "boolean":
 		return false
+	case "object":
+		return map[string]any{}
+	case "array":
+		return []any{}
 	default:
 		return nil
 	}

--- a/schema/config.json
+++ b/schema/config.json
@@ -329,7 +329,7 @@
             "type": "string"
           },
           "type": "array",
-          "description": "Commands used to display git log of all branches in the main window, they will be cycled in order of appearance"
+          "description": "Commands used to display git log of all branches in the main window, they will be cycled in order of appearance (array of strings)"
         },
         "overrideGpg": {
           "type": "boolean",
@@ -1838,7 +1838,7 @@
           },
           "type": "array",
           "uniqueItems": true,
-          "description": "User-configured commands that can be invoked from within Lazygit"
+          "description": "User-configured commands that can be invoked from within Lazygit\nSee https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Command_Keybindings.md"
         },
         "services": {
           "additionalProperties": {


### PR DESCRIPTION
- **PR Description**

Include empty arrays and maps in the generated Config.md

It's not an ideal solution because there's no indication of what kind of objects
you can add to those maps or arrays, but at least they show up at all (with a
comment containing a link to more information), and that's already an
improvement.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
