### PR TITLE
Filter out deprecated user config fields from generated Config.md

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -41,10 +41,6 @@ gui:
   authorColors: {}
 
   # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-branch-color
-  # Deprecated: use branchColorPatterns instead
-  branchColors: {}
-
-  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-branch-color
   branchColorPatterns: {}
 
   # The number of lines you scroll by when scrolling the main window
@@ -200,9 +196,6 @@ gui:
   # If true, show jump-to-window keybindings in window titles.
   showPanelJumps: true
 
-  # Deprecated: use nerdFontsVersion instead
-  showIcons: false
-
   # Nerd fonts version to use.
   # One of: '2' | '3' | empty string (default)
   # If empty, do not show icons.
@@ -347,10 +340,6 @@ git:
   # Command used when displaying the current branch git log in the main window
   branchLogCmd: git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --
 
-  # Command used to display git log of all branches in the main window.
-  # Deprecated: Use `allBranchesLogCmds` instead.
-  allBranchesLogCmd: git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium
-
   # Commands used to display git log of all branches in the main window, they will be cycled in order of appearance (array of strings)
   allBranchesLogCmds: []
 
@@ -375,19 +364,6 @@ git:
 
   # Config for showing the log in the commits view
   log:
-    # One of: 'date-order' | 'author-date-order' | 'topo-order' | 'default'
-    # 'topo-order' makes it easier to read the git log graph, but commits may not
-    # appear chronologically. See https://git-scm.com/docs/
-    #
-    # Deprecated: Configure this with `Log menu -> Commit sort order` (<c-l> in the commits window by default).
-    order: topo-order
-
-    # This determines whether the git graph is rendered in the commits panel
-    # One of 'always' | 'never' | 'when-maximised'
-    #
-    # Deprecated: Configure this with `Log menu -> Show git graph` (<c-l> in the commits window by default).
-    showGraph: always
-
     # displays the whole git graph by default in the commits view (equivalent to passing the `--all` argument to `git log`)
     showWholeGraph: false
 
@@ -448,24 +424,6 @@ os:
 
   # Command for opening a link. Should contain "{{link}}".
   openLink: ""
-
-  # EditCommand is the command for editing a file.
-  # Deprecated: use Edit instead. Note that semantics are different:
-  # EditCommand is just the command itself, whereas Edit contains a
-  # "{{filename}}" variable.
-  editCommand: ""
-
-  # EditCommandTemplate is the command template for editing a file
-  # Deprecated: use EditAtLine instead.
-  editCommandTemplate: ""
-
-  # OpenCommand is the command for opening a file
-  # Deprecated: use Open instead.
-  openCommand: ""
-
-  # OpenLinkCommand is the command for opening a link
-  # Deprecated: use OpenLink instead.
-  openLinkCommand: ""
 
   # CopyToClipboardCmd is the command for copying to clipboard.
   # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -54,7 +54,7 @@ type GuiConfig struct {
 	AuthorColors map[string]string `yaml:"authorColors"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-branch-color
 	// Deprecated: use branchColorPatterns instead
-	BranchColors map[string]string `yaml:"branchColors"`
+	BranchColors map[string]string `yaml:"branchColors" jsonschema:"deprecated"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-branch-color
 	BranchColorPatterns map[string]string `yaml:"branchColorPatterns"`
 	// The number of lines you scroll by when scrolling the main window
@@ -131,7 +131,7 @@ type GuiConfig struct {
 	// If true, show jump-to-window keybindings in window titles.
 	ShowPanelJumps bool `yaml:"showPanelJumps"`
 	// Deprecated: use nerdFontsVersion instead
-	ShowIcons bool `yaml:"showIcons"`
+	ShowIcons bool `yaml:"showIcons" jsonschema:"deprecated"`
 	// Nerd fonts version to use.
 	// One of: '2' | '3' | empty string (default)
 	// If empty, do not show icons.
@@ -252,7 +252,7 @@ type GitConfig struct {
 	BranchLogCmd string `yaml:"branchLogCmd"`
 	// Command used to display git log of all branches in the main window.
 	// Deprecated: Use `allBranchesLogCmds` instead.
-	AllBranchesLogCmd string `yaml:"allBranchesLogCmd"`
+	AllBranchesLogCmd string `yaml:"allBranchesLogCmd" jsonschema:"deprecated"`
 	// Commands used to display git log of all branches in the main window, they will be cycled in order of appearance (array of strings)
 	AllBranchesLogCmds []string `yaml:"allBranchesLogCmds"`
 	// If true, do not spawn a separate process when using GPG
@@ -587,19 +587,19 @@ type OSConfig struct {
 	// Deprecated: use Edit instead. Note that semantics are different:
 	// EditCommand is just the command itself, whereas Edit contains a
 	// "{{filename}}" variable.
-	EditCommand string `yaml:"editCommand,omitempty"`
+	EditCommand string `yaml:"editCommand,omitempty" jsonschema:"deprecated"`
 
 	// EditCommandTemplate is the command template for editing a file
 	// Deprecated: use EditAtLine instead.
-	EditCommandTemplate string `yaml:"editCommandTemplate,omitempty"`
+	EditCommandTemplate string `yaml:"editCommandTemplate,omitempty" jsonschema:"deprecated"`
 
 	// OpenCommand is the command for opening a file
 	// Deprecated: use Open instead.
-	OpenCommand string `yaml:"openCommand,omitempty"`
+	OpenCommand string `yaml:"openCommand,omitempty" jsonschema:"deprecated"`
 
 	// OpenLinkCommand is the command for opening a link
 	// Deprecated: use OpenLink instead.
-	OpenLinkCommand string `yaml:"openLinkCommand,omitempty"`
+	OpenLinkCommand string `yaml:"openLinkCommand,omitempty" jsonschema:"deprecated"`
 
 	// CopyToClipboardCmd is the command for copying to clipboard.
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard

--- a/pkg/jsonschema/generate_config_docs.go
+++ b/pkg/jsonschema/generate_config_docs.go
@@ -205,6 +205,10 @@ func recurseOverSchema(rootSchema, schema *jsonschema.Schema, parent *Node) {
 	for pair := schema.Properties.Oldest(); pair != nil; pair = pair.Next() {
 		subSchema := getSubSchema(rootSchema, schema, pair.Key)
 
+		if strings.Contains(strings.ToLower(subSchema.Description), "deprecated") {
+			continue
+		}
+
 		node := Node{
 			Name:        pair.Key,
 			Description: subSchema.Description,


### PR DESCRIPTION
- **PR Description**

This removes generated Config.md entries that are contain the word: `deprecated` (case insensitive) anywhere in their header comment.

I think adding in deprecated configs into the reference config clutters it at best, and encourages users to use those configs at worst. They are still going to be validated by the schema, but this PR removes them from the generated config.

I also added in the missing `deprecated` yaml tags in our user config in anticipation of https://github.com/invopop/jsonschema/pull/79 getting merged.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
