### PR TITLE
Fix checking out a file from a range selection of commits

### DIFF
--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -292,7 +292,8 @@ func (self *CommitFilesController) openCopyMenu() error {
 
 func (self *CommitFilesController) checkout(node *filetree.CommitFileNode) error {
 	self.c.LogAction(self.c.Tr.Actions.CheckoutFile)
-	if err := self.c.Git().WorkingTree.CheckoutFile(self.context().GetRef().RefName(), node.GetPath()); err != nil {
+	_, to := self.context().GetFromAndToForDiff()
+	if err := self.c.Git().WorkingTree.CheckoutFile(to, node.GetPath()); err != nil {
 		return err
 	}
 

--- a/pkg/integration/tests/commit/checkout_file_from_commit.go
+++ b/pkg/integration/tests/commit/checkout_file_from_commit.go
@@ -1,0 +1,55 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CheckoutFileFromCommit = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Checkout a file from a commit",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file.txt", "one\n")
+		shell.Commit("one")
+		shell.CreateFileAndAdd("file.txt", "two\n")
+		shell.Commit("two")
+		shell.CreateFileAndAdd("file.txt", "three\n")
+		shell.Commit("three")
+		shell.CreateFileAndAdd("file.txt", "four\n")
+		shell.Commit("four")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("four").IsSelected(),
+				Contains("three"),
+				Contains("two"),
+				Contains("one"),
+			).
+			NavigateToLine(Contains("three")).
+			Tap(func() {
+				t.Views().Main().ContainsLines(
+					Contains("-two"),
+					Contains("+three"),
+				)
+			}).
+			PressEnter()
+
+		t.Views().CommitFiles().
+			IsFocused().
+			Lines(
+				Equals("M file.txt"),
+			).
+			Press(keys.CommitFiles.CheckoutCommitFile)
+
+		t.Views().Files().
+			Lines(
+				Equals("M  file.txt"),
+			)
+
+		t.FileSystem().FileContent("file.txt", Equals("three\n"))
+	},
+})

--- a/pkg/integration/tests/commit/checkout_file_from_range_selection_of_commits.go
+++ b/pkg/integration/tests/commit/checkout_file_from_range_selection_of_commits.go
@@ -51,9 +51,6 @@ var CheckoutFileFromRangeSelectionOfCommits = NewIntegrationTest(NewIntegrationT
 				Equals("M  file.txt"),
 			)
 
-		/* EXPECTED:
 		t.FileSystem().FileContent("file.txt", Equals("three\n"))
-		ACTUAL: */
-		t.FileSystem().FileContent("file.txt", Equals("two\n"))
 	},
 })

--- a/pkg/integration/tests/commit/checkout_file_from_range_selection_of_commits.go
+++ b/pkg/integration/tests/commit/checkout_file_from_range_selection_of_commits.go
@@ -1,0 +1,59 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CheckoutFileFromRangeSelectionOfCommits = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Checkout a file from a range selection of commits",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file.txt", "one\n")
+		shell.Commit("one")
+		shell.CreateFileAndAdd("file.txt", "two\n")
+		shell.Commit("two")
+		shell.CreateFileAndAdd("file.txt", "three\n")
+		shell.Commit("three")
+		shell.CreateFileAndAdd("file.txt", "four\n")
+		shell.Commit("four")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("four").IsSelected(),
+				Contains("three"),
+				Contains("two"),
+				Contains("one"),
+			).
+			NavigateToLine(Contains("three")).
+			Press(keys.Universal.RangeSelectDown).
+			Tap(func() {
+				t.Views().Main().ContainsLines(
+					Contains("-one"),
+					Contains("+three"),
+				)
+			}).
+			PressEnter()
+
+		t.Views().CommitFiles().
+			IsFocused().
+			Lines(
+				Equals("M file.txt"),
+			).
+			Press(keys.CommitFiles.CheckoutCommitFile)
+
+		t.Views().Files().
+			Lines(
+				Equals("M  file.txt"),
+			)
+
+		/* EXPECTED:
+		t.FileSystem().FileContent("file.txt", Equals("three\n"))
+		ACTUAL: */
+		t.FileSystem().FileContent("file.txt", Equals("two\n"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -89,6 +89,7 @@ var tests = []*components.IntegrationTest{
 	commit.AmendWhenThereAreConflictsAndContinue,
 	commit.AutoWrapMessage,
 	commit.Checkout,
+	commit.CheckoutFileFromCommit,
 	commit.Commit,
 	commit.CommitMultiline,
 	commit.CommitSkipHooks,

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -90,6 +90,7 @@ var tests = []*components.IntegrationTest{
 	commit.AutoWrapMessage,
 	commit.Checkout,
 	commit.CheckoutFileFromCommit,
+	commit.CheckoutFileFromRangeSelectionOfCommits,
 	commit.Commit,
 	commit.CommitMultiline,
 	commit.CommitSkipHooks,


### PR DESCRIPTION
- **PR Description**

When selecting a range of commits by selecting the top one and then pressing shift-down to create a range, and then pressing enter and checking out one of the files by pressing `c`, you would get the file checked out with its state at the bottom end of the range, which is not what you want; it is expected to check out the file at the state that the diff shows it changes to. (And if the file was only created in the middle of that range, trying to check it out would result in an error.) Fix this by paying attention to a "from-to" range selection, and checking out the file at the "to" state.

Related to #4420.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
