### PR TITLE
Fix flaky integration test

### DIFF
--- a/pkg/gui/main_panels.go
+++ b/pkg/gui/main_panels.go
@@ -20,10 +20,7 @@ func (gui *Gui) runTaskForView(view *gocui.View, task types.UpdateTask) error {
 		return gui.newCmdTask(view, v.Cmd, v.Prefix)
 
 	case *types.RunPtyTask:
-		gui.afterLayout(func() error {
-			return gui.newPtyTask(view, v.Cmd, v.Prefix)
-		})
-		return nil
+		return gui.newPtyTask(view, v.Cmd, v.Prefix)
 	}
 
 	return nil

--- a/pkg/gui/pty.go
+++ b/pkg/gui/pty.go
@@ -54,43 +54,53 @@ func (gui *Gui) newPtyTask(view *gocui.View, cmd *exec.Cmd, prefix string) error
 		return gui.newCmdTask(view, cmd, prefix)
 	}
 
-	cmdStr := strings.Join(cmd.Args, " ")
+	// Run the pty after layout so that it gets the correct size
+	gui.afterLayout(func() error {
+		// Need to get the width and the pager again because the layout might have
+		// changed the size of the view
+		width = view.InnerWidth()
+		pager = gui.git.Config.GetPager(width)
 
-	// This communicates to pagers that we're in a very simple
-	// terminal that they should not expect to have much capabilities.
-	// Moving the cursor, clearing the screen, or querying for colors are among such "advanced" capabilities.
-	// Context: https://github.com/jesseduffield/lazygit/issues/3419
-	cmd.Env = removeExistingTermEnvVars(cmd.Env)
-	cmd.Env = append(cmd.Env, "TERM=dumb")
+		cmdStr := strings.Join(cmd.Args, " ")
 
-	cmd.Env = append(cmd.Env, "GIT_PAGER="+pager)
+		// This communicates to pagers that we're in a very simple
+		// terminal that they should not expect to have much capabilities.
+		// Moving the cursor, clearing the screen, or querying for colors are among such "advanced" capabilities.
+		// Context: https://github.com/jesseduffield/lazygit/issues/3419
+		cmd.Env = removeExistingTermEnvVars(cmd.Env)
+		cmd.Env = append(cmd.Env, "TERM=dumb")
 
-	manager := gui.getManager(view)
+		cmd.Env = append(cmd.Env, "GIT_PAGER="+pager)
 
-	var ptmx *os.File
-	start := func() (*exec.Cmd, io.Reader) {
-		var err error
-		ptmx, err = pty.StartWithSize(cmd, gui.desiredPtySize(view))
-		if err != nil {
-			gui.c.Log.Error(err)
+		manager := gui.getManager(view)
+
+		var ptmx *os.File
+		start := func() (*exec.Cmd, io.Reader) {
+			var err error
+			ptmx, err = pty.StartWithSize(cmd, gui.desiredPtySize(view))
+			if err != nil {
+				gui.c.Log.Error(err)
+			}
+
+			gui.Mutexes.PtyMutex.Lock()
+			gui.viewPtmxMap[view.Name()] = ptmx
+			gui.Mutexes.PtyMutex.Unlock()
+
+			return cmd, ptmx
 		}
 
-		gui.Mutexes.PtyMutex.Lock()
-		gui.viewPtmxMap[view.Name()] = ptmx
-		gui.Mutexes.PtyMutex.Unlock()
+		onClose := func() {
+			gui.Mutexes.PtyMutex.Lock()
+			ptmx.Close()
+			delete(gui.viewPtmxMap, view.Name())
+			gui.Mutexes.PtyMutex.Unlock()
+		}
 
-		return cmd, ptmx
-	}
+		linesToRead := gui.linesToReadFromCmdTask(view)
+		return manager.NewTask(manager.NewCmdTask(start, prefix, linesToRead, onClose), cmdStr)
+	})
 
-	onClose := func() {
-		gui.Mutexes.PtyMutex.Lock()
-		ptmx.Close()
-		delete(gui.viewPtmxMap, view.Name())
-		gui.Mutexes.PtyMutex.Unlock()
-	}
-
-	linesToRead := gui.linesToReadFromCmdTask(view)
-	return manager.NewTask(manager.NewCmdTask(start, prefix, linesToRead, onClose), cmdStr)
+	return nil
 }
 
 func removeExistingTermEnvVars(env []string) []string {

--- a/pkg/gui/pty.go
+++ b/pkg/gui/pty.go
@@ -90,11 +90,7 @@ func (gui *Gui) newPtyTask(view *gocui.View, cmd *exec.Cmd, prefix string) error
 	}
 
 	linesToRead := gui.linesToReadFromCmdTask(view)
-	if err := manager.NewTask(manager.NewCmdTask(start, prefix, linesToRead, onClose), cmdStr); err != nil {
-		return err
-	}
-
-	return nil
+	return manager.NewTask(manager.NewCmdTask(start, prefix, linesToRead, onClose), cmdStr)
 }
 
 func removeExistingTermEnvVars(env []string) []string {


### PR DESCRIPTION
- **PR Description**

The integration test `stash/rename.go` occasionally fails for me locally. This PR fixes it.

In 8b8343b8a9f we made a change to run newPtyTask from AfterLayout; this is needed so that the PTY gets the new, updated view size. However, this created a race condition for integration tests that select a line in a list view and then expect the main view to have certain content; sometimes that content gets rendered too late.

I'm surprised that this didn't cause more tests to fail; right now I only know of one test that occasionally fails because of this, which is `stash/rename.go`.

Fix this by moving the AfterLayout to inside newPtyTask, and do it only when we are actually using a PTY (we don't when no pager is configured, which is the case for integration tests).

The diff is best viewed with "ignore whitespace" turned on.
