### PR TITLE
Allow reverting a range of commits

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -285,14 +285,14 @@ func (self *CommitCommands) ShowFileContentCmdObj(hash string, filePath string) 
 	return self.cmd.New(cmdArgs).DontLog()
 }
 
-// Revert reverts the selected commit by hash. If isMerge is true, we'll pass -m 1
+// Revert reverts the selected commits by hash. If isMerge is true, we'll pass -m 1
 // to say we want to revert the first parent of the merge commit, which is the one
 // people want in 99.9% of cases. In current git versions we could unconditionally
 // pass -m 1 even for non-merge commits, but older versions of git choke on it.
-func (self *CommitCommands) Revert(hash string, isMerge bool) error {
+func (self *CommitCommands) Revert(hashes []string, isMerge bool) error {
 	cmdArgs := NewGitCmd("revert").
-		Arg(hash).
 		ArgIf(isMerge, "-m", "1").
+		Arg(hashes...).
 		ToArgv()
 
 	return self.cmd.New(cmdArgs).Run()

--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -285,15 +285,14 @@ func (self *CommitCommands) ShowFileContentCmdObj(hash string, filePath string) 
 	return self.cmd.New(cmdArgs).DontLog()
 }
 
-// Revert reverts the selected commit by hash
-func (self *CommitCommands) Revert(hash string) error {
-	cmdArgs := NewGitCmd("revert").Arg(hash).ToArgv()
-
-	return self.cmd.New(cmdArgs).Run()
-}
-
-func (self *CommitCommands) RevertMerge(hash string, parentNumber int) error {
-	cmdArgs := NewGitCmd("revert").Arg(hash, "-m", fmt.Sprintf("%d", parentNumber)).
+// Revert reverts the selected commit by hash. If isMerge is true, we'll pass -m 1
+// to say we want to revert the first parent of the merge commit, which is the one
+// people want in 99.9% of cases. In current git versions we could unconditionally
+// pass -m 1 even for non-merge commits, but older versions of git choke on it.
+func (self *CommitCommands) Revert(hash string, isMerge bool) error {
+	cmdArgs := NewGitCmd("revert").
+		Arg(hash).
+		ArgIf(isMerge, "-m", "1").
 		ToArgv()
 
 	return self.cmd.New(cmdArgs).Run()

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -872,19 +872,15 @@ func (self *LocalCommitsController) revert(commit *models.Commit) error {
 				if err := self.c.Helpers().MergeAndRebase.CheckMergeOrRebase(result); err != nil {
 					return err
 				}
-				return self.afterRevertCommit()
+				self.context().MoveSelection(1)
+				return self.c.Refresh(types.RefreshOptions{
+					Mode: types.SYNC, Scope: []types.RefreshableView{types.COMMITS, types.BRANCHES},
+				})
 			})
 		},
 	})
 
 	return nil
-}
-
-func (self *LocalCommitsController) afterRevertCommit() error {
-	self.context().MoveSelection(1)
-	return self.c.Refresh(types.RefreshOptions{
-		Mode: types.SYNC, Scope: []types.RefreshableView{types.COMMITS, types.BRANCHES},
-	})
 }
 
 func (self *LocalCommitsController) createFixupCommit(commit *models.Commit) error {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -771,6 +771,7 @@ type TranslationSet struct {
 	OpenCommitInBrowser                      string
 	ViewBisectOptions                        string
 	ConfirmRevertCommit                      string
+	ConfirmRevertCommitRange                 string
 	RewordInEditorTitle                      string
 	RewordInEditorPrompt                     string
 	CheckoutAutostashPrompt                  string
@@ -1837,6 +1838,7 @@ func EnglishTranslationSet() *TranslationSet {
 		OpenCommitInBrowser:                      "Open commit in browser",
 		ViewBisectOptions:                        "View bisect options",
 		ConfirmRevertCommit:                      "Are you sure you want to revert {{.selectedCommit}}?",
+		ConfirmRevertCommitRange:                 "Are you sure you want to revert the selected commits?",
 		RewordInEditorTitle:                      "Reword in editor",
 		RewordInEditorPrompt:                     "Are you sure you want to reword this commit in your editor?",
 		HardResetAutostashPrompt:                 "Are you sure you want to hard reset to '%s'? An auto-stash will be performed if necessary.",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -727,7 +727,6 @@ type TranslationSet struct {
 	FocusCommandLog                          string
 	CommandLogHeader                         string
 	RandomTip                                string
-	SelectParentCommitForMerge               string
 	ToggleWhitespaceInDiffView               string
 	ToggleWhitespaceInDiffViewTooltip        string
 	IgnoreWhitespaceDiffViewSubTitle         string
@@ -1795,7 +1794,6 @@ func EnglishTranslationSet() *TranslationSet {
 		FocusCommandLog:                          "Focus command log",
 		CommandLogHeader:                         "You can hide/focus this panel by pressing '%s'\n",
 		RandomTip:                                "Random tip",
-		SelectParentCommitForMerge:               "Select parent commit for merge",
 		ToggleWhitespaceInDiffView:               "Toggle whitespace",
 		ToggleWhitespaceInDiffViewTooltip:        "Toggle whether or not whitespace changes are shown in the diff view.",
 		IgnoreWhitespaceDiffViewSubTitle:         "(ignoring whitespace)",

--- a/pkg/integration/tests/commit/revert_merge.go
+++ b/pkg/integration/tests/commit/revert_merge.go
@@ -21,14 +21,9 @@ var RevertMerge = NewIntegrationTest(NewIntegrationTestArgs{
 			).
 			Press(keys.Commits.RevertCommit)
 
-		t.ExpectPopup().Menu().
-			Title(Equals("Select parent commit for merge")).
-			Lines(
-				Contains("first change"),
-				Contains("second-change-branch unrelated change"),
-				Contains("Cancel"),
-			).
-			Select(Contains("first change")).
+		t.ExpectPopup().Confirmation().
+			Title(Equals("Revert commit")).
+			Content(MatchesRegexp(`Are you sure you want to revert \w+?`)).
 			Confirm()
 
 		t.Views().Commits().IsFocused().


### PR DESCRIPTION
- **PR Description**

This is part four of a four part series of PRs that improve the cherry-pick and revert experience.

With this PR we support reverting a range selection of commits.

Fixes #3272

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
