### PR TITLE
Fix wrong main view content after pressing `e` in a stack of branches

### DIFF
--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -608,6 +608,7 @@ func (self *LocalCommitsController) restoreSelectionRangeAndMode(selectionRangeA
 	})
 	if ok1 && ok2 {
 		self.context().SetSelectionRangeAndMode(newSelectedIdx, newRangeStartIdx, selectionRangeAndMode.mode)
+		self.context().HandleFocus(types.OnFocusOpts{})
 	}
 }
 

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
@@ -48,6 +48,12 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("<-- YOU ARE HERE --- commit 02").IsSelected(),
 				Contains("CI commit 01"),
 			).
+			Tap(func() {
+				/* EXPECTED:
+				t.Views().Main().Content(Contains("commit 02"))
+				ACTUAL: */
+				t.Views().Main().Content(Contains("commit 03"))
+			}).
 			NavigateToLine(Contains("commit 06")).
 			Press(keys.Universal.Remove)
 

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
@@ -49,10 +49,7 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("CI commit 01"),
 			).
 			Tap(func() {
-				/* EXPECTED:
 				t.Views().Main().Content(Contains("commit 02"))
-				ACTUAL: */
-				t.Views().Main().Content(Contains("commit 03"))
 			}).
 			NavigateToLine(Contains("commit 06")).
 			Press(keys.Universal.Remove)


### PR DESCRIPTION
- **PR Description**

When pressing `e` (or `i`) in a stack of branches, we take care of maintaining the selected commit (as of #2954 for `e`, and #3247 for `i`), to account for the selection index changing because of added update-ref todos. This is great, however we missed that the main view diff now shows the wrong commit, which is very confusing. I'm surprised that this hasn't been noticed yet.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
