### PR TITLE
Prefill the commit subject with the skipHook prefix when pressing `w`

### DIFF
--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -139,7 +139,13 @@ func (self *WorkingTreeHelper) HandleCommitEditorPress() error {
 }
 
 func (self *WorkingTreeHelper) HandleWIPCommitPress() error {
-	return self.HandleCommitPressWithMessage("", true)
+	var initialMessage string
+	preservedMessage := self.c.Contexts().CommitMessage.GetPreservedMessageAndLogError()
+	if preservedMessage == "" {
+		// Use the skipHook prefix only if we don't have a preserved message
+		initialMessage = self.c.UserConfig().Git.SkipHookPrefix
+	}
+	return self.HandleCommitPressWithMessage(initialMessage, true)
 }
 
 func (self *WorkingTreeHelper) HandleCommitPress() error {

--- a/pkg/integration/tests/commit/commit_wip_with_prefix.go
+++ b/pkg/integration/tests/commit/commit_wip_with_prefix.go
@@ -32,7 +32,8 @@ var CommitWipWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).
-			Type("foo").
+			InitialText(Equals("WIP")).
+			Type(" foo").
 			Cancel()
 
 		t.Views().Files().
@@ -41,7 +42,7 @@ var CommitWipWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).
-			InitialText(Equals("foo")).
+			InitialText(Equals("WIP foo")).
 			Type(" bar").
 			Cancel()
 
@@ -51,11 +52,11 @@ var CommitWipWithPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.ExpectPopup().CommitMessagePanel().
 			Title(Equals("Commit summary")).
-			InitialText(Equals("foo bar")).
+			InitialText(Equals("WIP foo bar")).
 			Type(". Added something else").
 			Confirm()
 
 		t.Views().Commits().Focus()
-		t.Views().Main().Content(Contains("foo bar. Added something else"))
+		t.Views().Main().Content(Contains("WIP foo bar. Added something else"))
 	},
 })


### PR DESCRIPTION
We removed prefilling the skipHook prefix in b102646b207 (#4374) with the intention of making it clearer that using the prefix in normal commits and typing `w` to skip hooks are now two independent features.

It turns out that some people liked it with prefilling the prefix and perceive it as a regression, so put it back in.

But only if we don't have a preserved message; this is an important use case, when you try to make a normal commit, the hook fails, and then you want to make the same commit with skipping the hook, but with the same message that you already typed.

Labeled as ignore-for-release because it reverts some of the behavior of #4374 which isn't released yet.
