### PR TITLE
fix: update vscode color to logo color

### DIFF
--- a/pkg/gui/presentation/icons/file_icons.go
+++ b/pkg/gui/presentation/icons/file_icons.go
@@ -70,7 +70,7 @@ var nameIconMap = map[string]IconProperties{
 	".tmux.conf.local":           {Icon: "\uebc8", Color: "#14BA19"},     // 
 	".Trash":                     {Icon: "\uf1f8", Color: "#ACBCEF"},     // 
 	".vimrc":                     {Icon: "\ue62b", Color: "#019833"},     // 
-	".vscode":                    {Icon: "\ue70c", Color: "#854CC7"},     // 
+	".vscode":                    {Icon: "\ue70c", Color: "#007ACC"},     // 
 	".Xauthority":                {Icon: "\uf369", Color: "#E54D18"},     // 
 	".Xresources":                {Icon: "\uf369", Color: "#E54D18"},     // 
 	".xinitrc":                   {Icon: "\uf369", Color: "#E54D18"},     // 


### PR DESCRIPTION
- **PR Description**
The vscode folder color appears to be using the visual studio purple color which is different from the vscode blue color. This updates it using a color picker on the inner part of the logo.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
