### PR TITLE
docs(custom-command): note on `.PromptResponses`

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -104,6 +104,9 @@ These fields are applicable to all prompts.
 | title             | The title to display in the popup panel                                                        | no         |
 | key | Used to reference the entered value from within the custom command. E.g. a prompt with `key: 'Branch'` can be referred to as `{{.Form.Branch}}` in the command | yes |
 
+> [!TIP]
+> Fetching `key` via `.PromptResponses` is not encouraged, see https://github.com/jesseduffield/lazygit/issues/2103
+
 ### Input
 
 | _field_           | _description_                                                                                  | _required_ |


### PR DESCRIPTION
as `.PromptResponses` is still commonly used [as demonstrated in the command compendium](https://github.com/jesseduffield/lazygit/wiki/Custom-Commands-Compendium), it would be wise to let users know of its disadvantages

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
