### PR TITLE
Show "(hooks disabled)" in title bar of commit message editor

### DIFF
--- a/pkg/gui/controllers/commit_message_controller.go
+++ b/pkg/gui/controllers/commit_message_controller.go
@@ -77,7 +77,7 @@ func (self *CommitMessageController) GetOnFocus() func(types.OnFocusOpts) {
 
 func (self *CommitMessageController) GetOnFocusLost() func(types.OnFocusLostOpts) {
 	return func(types.OnFocusLostOpts) {
-		self.context().RenderCommitLength()
+		self.context().RenderSubtitle()
 	}
 }
 

--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -50,7 +50,7 @@ func (self *CommitsHelper) SetMessageAndDescriptionInView(message string) {
 
 	self.setCommitSummary(summary)
 	self.setCommitDescription(description)
-	self.c.Contexts().CommitMessage.RenderCommitLength()
+	self.c.Contexts().CommitMessage.RenderSubtitle()
 }
 
 func (self *CommitsHelper) JoinCommitMessageAndUnwrappedDescription() string {
@@ -123,6 +123,14 @@ type OpenCommitMessagePanelOpts struct {
 	OnConfirm        func(summary string, description string) error
 	OnSwitchToEditor func(string) error
 	InitialMessage   string
+
+	// The following two fields are only for the display of the "(hooks
+	// disabled)" display in the commit message panel. They have no effect on
+	// the actual behavior; make sure what you are passing in matches that.
+	// Leave unassigned if the concept of skipping hooks doesn't make sense for
+	// what you are doing, e.g. when creating a tag.
+	ForceSkipHooks  bool
+	SkipHooksPrefix string
 }
 
 func (self *CommitsHelper) OpenCommitMessagePanel(opts *OpenCommitMessagePanelOpts) {
@@ -140,6 +148,8 @@ func (self *CommitsHelper) OpenCommitMessagePanel(opts *OpenCommitMessagePanelOp
 		opts.InitialMessage,
 		onConfirm,
 		opts.OnSwitchToEditor,
+		opts.ForceSkipHooks,
+		opts.SkipHooksPrefix,
 	)
 
 	self.UpdateCommitPanelView(opts.InitialMessage)

--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -95,6 +95,8 @@ func (self *WorkingTreeHelper) HandleCommitPressWithMessage(initialMessage strin
 				OnSwitchToEditor: func(filepath string) error {
 					return self.switchFromCommitMessagePanelToEditor(filepath, forceSkipHooks)
 				},
+				ForceSkipHooks:  forceSkipHooks,
+				SkipHooksPrefix: self.c.UserConfig().Git.SkipHookPrefix,
 			},
 		)
 

--- a/pkg/gui/editors.go
+++ b/pkg/gui/editors.go
@@ -61,7 +61,7 @@ func (gui *Gui) handleEditorKeypress(textArea *gocui.TextArea, key gocui.Key, ch
 func (gui *Gui) commitMessageEditor(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) bool {
 	matched := gui.handleEditorKeypress(v.TextArea, key, ch, mod, false)
 	v.RenderTextArea()
-	gui.c.Contexts().CommitMessage.RenderCommitLength()
+	gui.c.Contexts().CommitMessage.RenderSubtitle()
 	return matched
 }
 

--- a/pkg/gui/editors.go
+++ b/pkg/gui/editors.go
@@ -68,7 +68,6 @@ func (gui *Gui) commitMessageEditor(v *gocui.View, key gocui.Key, ch rune, mod g
 func (gui *Gui) commitDescriptionEditor(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) bool {
 	matched := gui.handleEditorKeypress(v.TextArea, key, ch, mod, true)
 	v.RenderTextArea()
-	gui.c.Contexts().CommitMessage.RenderCommitLength()
 	return matched
 }
 

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -315,6 +315,7 @@ type TranslationSet struct {
 	CommitDescriptionTitle                string
 	CommitDescriptionSubTitle             string
 	CommitDescriptionFooter               string
+	CommitHooksDisabledSubTitle           string
 	LocalBranchesTitle                    string
 	SearchTitle                           string
 	TagsTitle                             string
@@ -1366,6 +1367,7 @@ func EnglishTranslationSet() *TranslationSet {
 		CommitDescriptionTitle:               "Commit description",
 		CommitDescriptionSubTitle:            "Press {{.togglePanelKeyBinding}} to toggle focus, {{.commitMenuKeybinding}} to open menu",
 		CommitDescriptionFooter:              "Press {{.confirmInEditorKeybinding}} to commit",
+		CommitHooksDisabledSubTitle:          "(hooks disabled)",
 		LocalBranchesTitle:                   "Local branches",
 		SearchTitle:                          "Search",
 		TagsTitle:                            "Tags",


### PR DESCRIPTION
- **PR Description**

It is shown either when committing with `w`, or when typing the skipHooks prefix
if there is one. This should hopefully make it clearer when the hooks are run
and when they are not.

```
╭─Commit summary───────────────────(hooks disabled)─ 7 ─────╮
│WIP foo                                                    │
╰───────────────────────────────────────────────────────────╯
```

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
