### PR TITLE
Escape special characters in filenames when git-ignoring files

### DIFF
--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/go-errors/errors"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
@@ -230,15 +231,21 @@ func (self *WorkingTreeCommands) DiscardUnstagedFileChanges(file *models.File) e
 	return self.cmd.New(cmdArgs).Run()
 }
 
+// Escapes special characters in a filename for gitignore and exclude files
+func escapeFilename(filename string) string {
+	re := regexp.MustCompile(`^[!#]|[\[\]*]`)
+	return re.ReplaceAllString(filename, `\${0}`)
+}
+
 // Ignore adds a file to the gitignore for the repo
 func (self *WorkingTreeCommands) Ignore(filename string) error {
-	return self.os.AppendLineToFile(".gitignore", filename)
+	return self.os.AppendLineToFile(".gitignore", escapeFilename(filename))
 }
 
 // Exclude adds a file to the .git/info/exclude for the repo
 func (self *WorkingTreeCommands) Exclude(filename string) error {
 	excludeFile := filepath.Join(self.repoPaths.repoGitDirPath, "info", "exclude")
-	return self.os.AppendLineToFile(excludeFile, filename)
+	return self.os.AppendLineToFile(excludeFile, escapeFilename(filename))
 }
 
 // WorktreeFileDiff returns the diff of a file

--- a/pkg/integration/tests/file/gitignore_special_characters.go
+++ b/pkg/integration/tests/file/gitignore_special_characters.go
@@ -1,0 +1,87 @@
+package file
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var GitignoreSpecialCharacters = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Ignore files with special characters in their names",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFile(".gitignore", "")
+		shell.CreateFile("#file", "")
+		shell.CreateFile("file#abc", "")
+		shell.CreateFile("!file", "")
+		shell.CreateFile("file!abc", "")
+		shell.CreateFile("abc*def", "")
+		shell.CreateFile("abc_def", "")
+		shell.CreateFile("file[x]", "")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		excludeFile := func(fileName string) {
+			t.Views().Files().
+				NavigateToLine(Contains(fileName)).
+				Press(keys.Files.IgnoreFile)
+
+			t.ExpectPopup().Menu().
+				Title(Equals("Ignore or exclude file")).
+				Select(Contains("Add to .gitignore")).
+				Confirm()
+		}
+
+		t.Views().Files().
+			Focus().
+			Lines(
+				Equals("▼ /"),
+				Equals("  ?? !file"),
+				Equals("  ?? #file"),
+				Equals("  ?? .gitignore"),
+				Equals("  ?? abc*def"),
+				Equals("  ?? abc_def"),
+				Equals("  ?? file!abc"),
+				Equals("  ?? file#abc"),
+				Equals("  ?? file[x]"),
+			)
+
+		excludeFile("#file")
+		excludeFile("file#abc")
+		excludeFile("!file")
+		excludeFile("file!abc")
+		excludeFile("abc*def")
+		excludeFile("file[x]")
+
+		t.Views().Files().
+			/* EXPECTED:
+			Lines(
+				Equals("▼ /"),
+				Equals("  ?? .gitignore"),
+				Equals("  ?? abc_def"),
+			)
+			ACTUAL:
+			  As you can see, it did ignore the 'file!abc' and 'file#abc' files
+			  correctly. Those don't need to be quoted because # and ! are only
+			  special at the beginning.
+
+			  Most of the other files are not ignored properly because their
+			  special characters need to be escaped. For * it's the other way
+			  round: while it does hide 'abc*def', it also hides 'abc_def',
+			  which we don't want.
+			*/
+			Lines(
+				Equals("▼ /"),
+				Equals("  ?? !file"),
+				Equals("  ?? #file"),
+				Equals("  ?? .gitignore"),
+				Equals("  ?? file[x]"),
+			)
+
+		/* EXPECTED:
+		t.FileSystem().FileContent(".gitignore", Equals("\\#file\nfile#abc\n\\!file\nfile!abc\nabc\\*def\nfile\\[x\\]\n"))
+		ACTUAL: */
+		t.FileSystem().FileContent(".gitignore", Equals("#file\nfile#abc\n!file\nfile!abc\nabc*def\nfile[x]\n"))
+	},
+})

--- a/pkg/integration/tests/file/gitignore_special_characters.go
+++ b/pkg/integration/tests/file/gitignore_special_characters.go
@@ -55,33 +55,12 @@ var GitignoreSpecialCharacters = NewIntegrationTest(NewIntegrationTestArgs{
 		excludeFile("file[x]")
 
 		t.Views().Files().
-			/* EXPECTED:
 			Lines(
 				Equals("▼ /"),
 				Equals("  ?? .gitignore"),
 				Equals("  ?? abc_def"),
 			)
-			ACTUAL:
-			  As you can see, it did ignore the 'file!abc' and 'file#abc' files
-			  correctly. Those don't need to be quoted because # and ! are only
-			  special at the beginning.
 
-			  Most of the other files are not ignored properly because their
-			  special characters need to be escaped. For * it's the other way
-			  round: while it does hide 'abc*def', it also hides 'abc_def',
-			  which we don't want.
-			*/
-			Lines(
-				Equals("▼ /"),
-				Equals("  ?? !file"),
-				Equals("  ?? #file"),
-				Equals("  ?? .gitignore"),
-				Equals("  ?? file[x]"),
-			)
-
-		/* EXPECTED:
 		t.FileSystem().FileContent(".gitignore", Equals("\\#file\nfile#abc\n\\!file\nfile!abc\nabc\\*def\nfile\\[x\\]\n"))
-		ACTUAL: */
-		t.FileSystem().FileContent(".gitignore", Equals("#file\nfile#abc\n!file\nfile!abc\nabc*def\nfile[x]\n"))
 	},
 })

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -197,6 +197,7 @@ var tests = []*components.IntegrationTest{
 	file.DiscardVariousChanges,
 	file.DiscardVariousChangesRangeSelect,
 	file.Gitignore,
+	file.GitignoreSpecialCharacters,
 	file.RememberCommitMessageAfterFail,
 	file.RenameSimilarityThresholdChange,
 	file.RenamedFiles,


### PR DESCRIPTION
- **PR Description**

Some characters in file names need to be escaped so that they work correctly in .gitignore files. These include `#` and `!` (only at the beginning of a filename), as well as `[`, `]`, and `*` anywhere in the name.

Fixes #4075
Fixes #4445

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
