### PR TITLE
Fix crash with drag selecting and staging

### DIFF
--- a/pkg/gui/patch_exploring/state.go
+++ b/pkg/gui/patch_exploring/state.go
@@ -188,7 +188,7 @@ func (s *State) selectLineWithoutRangeCheck(newSelectedLineIdx int) {
 }
 
 func (s *State) SelectNewLineForRange(newSelectedLineIdx int) {
-	s.rangeStartLineIdx = newSelectedLineIdx
+	s.rangeStartLineIdx = s.clampLineIdx(newSelectedLineIdx)
 
 	s.selectMode = RANGE
 

--- a/pkg/gui/patch_exploring/state.go
+++ b/pkg/gui/patch_exploring/state.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/patch"
 	"github.com/jesseduffield/lazygit/pkg/utils"
+	"github.com/samber/lo"
 )
 
 // State represents the current state of the patch explorer context i.e. when
@@ -177,15 +178,13 @@ func (s *State) SelectLine(newSelectedLineIdx int) {
 	s.selectLineWithoutRangeCheck(newSelectedLineIdx)
 }
 
+func (s *State) clampLineIdx(lineIdx int) int {
+	return lo.Clamp(lineIdx, 0, len(s.patchLineIndices)-1)
+}
+
 // This just moves the cursor without caring about range select
 func (s *State) selectLineWithoutRangeCheck(newSelectedLineIdx int) {
-	if newSelectedLineIdx < 0 {
-		newSelectedLineIdx = 0
-	} else if newSelectedLineIdx > len(s.patchLineIndices)-1 {
-		newSelectedLineIdx = len(s.patchLineIndices) - 1
-	}
-
-	s.selectedLineIdx = newSelectedLineIdx
+	s.selectedLineIdx = s.clampLineIdx(newSelectedLineIdx)
 }
 
 func (s *State) SelectNewLineForRange(newSelectedLineIdx int) {


### PR DESCRIPTION
- **PR Description**

Fix a crash in the staging view when clicking below the end of the diff, dragging upwards into the diff to select a range, and pressing space to stage.

Fixes #4479.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
