### PR TITLE
Fix truncation of branches when scrolling branches panel to the left

### DIFF
--- a/pkg/gui/context/branches_context.go
+++ b/pkg/gui/context/branches_context.go
@@ -30,7 +30,7 @@ func NewBranchesContext(c *ContextCommon) *BranchesContext {
 			c.State().GetItemOperation,
 			c.State().GetRepoState().GetScreenMode() != types.SCREEN_NORMAL,
 			c.Modes().Diffing.Ref,
-			c.Views().Branches.InnerWidth(),
+			c.Views().Branches.InnerWidth()+c.Views().Branches.OriginX(),
 			c.Tr,
 			c.UserConfig(),
 			c.Model().Worktrees,

--- a/pkg/gui/controllers/list_controller.go
+++ b/pkg/gui/controllers/list_controller.go
@@ -74,6 +74,9 @@ func (self *ListController) scrollHorizontal(scrollFunc func()) error {
 	scrollFunc()
 
 	self.context.HandleFocus(types.OnFocusOpts{})
+	if self.context.NeedsRerenderOnWidthChange() == types.NEEDS_RERENDER_ON_WIDTH_CHANGE_WHEN_WIDTH_CHANGES {
+		self.context.HandleRender()
+	}
 	return nil
 }
 


### PR DESCRIPTION
- **PR Description**

Truncation of long branch names didn't take the horizontal scroll position into account; when scrolling the panel to the left using `H`, the long names were truncated way before the right edge of the view.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
