### PR TITLE
When creating a new branch off of a main branch that is behind its upstream, use the upstream instead

### DIFF
--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -731,6 +731,15 @@ func (self *BranchesController) rename(branch *models.Branch) error {
 }
 
 func (self *BranchesController) newBranch(selectedBranch *models.Branch) error {
+	isMainBranch := lo.Contains(self.c.UserConfig().Git.MainBranches, selectedBranch.Name)
+	if isMainBranch && selectedBranch.RemoteBranchStoredLocally() {
+		isStrictlyBehind := selectedBranch.IsBehindForPull() && !selectedBranch.IsAheadForPull()
+		if isStrictlyBehind {
+			return self.c.Helpers().Refs.NewBranch(
+				selectedBranch.FullUpstreamRefName(), selectedBranch.ShortUpstreamRefName(), "")
+		}
+	}
+
 	return self.c.Helpers().Refs.NewBranch(selectedBranch.FullRefName(), selectedBranch.RefName(), "")
 }
 

--- a/pkg/integration/tests/branch/new_branch_from_main_branch_behind_upstream.go
+++ b/pkg/integration/tests/branch/new_branch_from_main_branch_behind_upstream.go
@@ -1,0 +1,44 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var NewBranchFromMainBranchBehindUpstream = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Create a new branch from a main branch that is behind its upstream",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateNCommits(2)
+		shell.CloneIntoRemote("origin")
+		shell.PushBranchAndSetUpstream("origin", "master")
+		shell.HardReset("HEAD^")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("master ↓1").DoesNotContain("↑").IsSelected(),
+			).
+			Press(keys.Universal.New)
+
+		t.ExpectPopup().Prompt().
+			Title(Contains("New branch name (branch is off of 'origin/master')")).
+			Type("new-branch").
+			Confirm()
+
+		t.Views().Branches().
+			Lines(
+				Contains("new-branch").IsSelected(),
+				Contains("master"),
+			)
+
+		t.Views().Commits().
+			Lines(
+				Contains("commit 02"),
+				Contains("commit 01"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -48,6 +48,7 @@ var tests = []*components.IntegrationTest{
 	branch.DeleteWhileFiltering,
 	branch.DetachedHead,
 	branch.NewBranchAutostash,
+	branch.NewBranchFromMainBranchBehindUpstream,
 	branch.NewBranchFromRemoteTrackingDifferentName,
 	branch.NewBranchFromRemoteTrackingSameName,
 	branch.NewBranchWithPrefix,


### PR DESCRIPTION
- **PR Description**

Very often my local main branch is behind its upstream, because I have no reason to keep it up to date. In the olden days it used to be necessary to keep it up to date in order to rebase feature branches onto it, so you'd have to press `f` on it occasionally before pressing `r`. This is no longer necessary now that we have the "rebase onto base branch" command (`r b`).

The only time I now need an up-to-date local main is when I want to create a new branch off of it. This is annoying, because I have to press `f` and wait for it to complete before I can create a new branch; but I know that origin/main is probably up to date (or close to up to date), because lazygit fetches it in the background all the time. So why can't I just create my new branch off of origin/main, then? (Sure, I could switch over to the Remotes tab, open origin, and select origin/main there, but that's cumbersome.)

So this is exactly what this PR does: if the local main is strictly behind its upstream (as opposed to diverged, which should be very rare for a main branch), then when pressing `n` on it we create the new branch off of origin/main.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
