### PR TITLE
Add Debian installation instructions alongside Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you're a mere mortal like me and you're tired of hearing how powerful git is 
   - [Arch Linux](#arch-linux)
   - [Fedora and RHEL](#fedora-and-rhel)
   - [Solus Linux](#solus-linux)
-  - [Ubuntu](#ubuntu)
+  - [Debian and Ubuntu](#debian-and-ubuntu)
   - [Funtoo Linux](#funtoo-linux)
   - [Gentoo Linux](#gentoo-linux)
   - [FreeBSD](#freebsd)
@@ -306,7 +306,15 @@ sudo dnf install lazygit
 sudo eopkg install lazygit
 ```
 
-### Ubuntu
+### Debian and Ubuntu
+
+For **Debian 13 "Trixie", Sid**, and later, or **Ubuntu 25.10 "Questing Quokka"** and later:
+
+```sh
+sudo apt install lazygit
+```
+
+For **Debian 12 "Bookworm", Ubuntu 25.04 "Plucky Puffin"** and earlier:
 
 ```sh
 LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | \grep -Po '"tag_name": *"v\K[^"]*')


### PR DESCRIPTION
**PR Description**

This PR updates the README to include installation instructions for Debian.

* Renames the "Ubuntu" section to "Debian and Ubuntu"
* Adds the `sudo apt install lazygit` for Debian Trixie, Sid, and Ubuntu 25.10 and later
* Keeps the manual installation method for Debian Bookworm, Ubuntu 25.04 and earlier

This helps Debian and Ubuntu users install lazygit using either apt or manual download, depending on the distribution version.

**Affected files**

* Documentation
    * `README.md`: Renames the "Ubuntu" section to "Debian and Ubuntu" and adds Debian installation instructions

**Requirements fulfilled by this PR**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc