### PR TITLE
Allow changing diff context size and rename threshold when main view is focused

### DIFF
--- a/pkg/gui/controllers/context_lines_controller.go
+++ b/pkg/gui/controllers/context_lines_controller.go
@@ -22,6 +22,8 @@ var CONTEXT_KEYS_SHOWING_DIFFS = []types.ContextKey{
 	context.STAGING_SECONDARY_CONTEXT_KEY,
 	context.PATCH_BUILDING_MAIN_CONTEXT_KEY,
 	context.PATCH_BUILDING_SECONDARY_CONTEXT_KEY,
+	context.NORMAL_MAIN_CONTEXT_KEY,
+	context.NORMAL_SECONDARY_CONTEXT_KEY,
 }
 
 type ContextLinesController struct {
@@ -97,7 +99,7 @@ func (self *ContextLinesController) applyChange() error {
 	self.c.Toast(fmt.Sprintf(self.c.Tr.DiffContextSizeChanged, self.c.AppState.DiffContextSize))
 	self.c.SaveAppStateAndLogError()
 
-	currentContext := self.c.Context().CurrentStatic()
+	currentContext := self.currentSidePanel()
 	switch currentContext.GetKey() {
 	// we make an exception for our staging and patch building contexts because they actually need to refresh their state afterwards.
 	case context.PATCH_BUILDING_MAIN_CONTEXT_KEY:
@@ -121,6 +123,16 @@ func (self *ContextLinesController) checkCanChangeContext() error {
 func (self *ContextLinesController) isShowingDiff() bool {
 	return lo.Contains(
 		CONTEXT_KEYS_SHOWING_DIFFS,
-		self.c.Context().CurrentStatic().GetKey(),
+		self.currentSidePanel().GetKey(),
 	)
+}
+
+func (self *ContextLinesController) currentSidePanel() types.Context {
+	currentContext := self.c.Context().CurrentStatic()
+	if currentContext.GetKey() == context.NORMAL_MAIN_CONTEXT_KEY ||
+		currentContext.GetKey() == context.NORMAL_SECONDARY_CONTEXT_KEY {
+		return currentContext.GetParentContext()
+	}
+
+	return currentContext
 }

--- a/pkg/gui/controllers/rename_similarity_threshold_controller.go
+++ b/pkg/gui/controllers/rename_similarity_threshold_controller.go
@@ -15,6 +15,8 @@ var CONTEXT_KEYS_SHOWING_RENAMES = []types.ContextKey{
 	context.SUB_COMMITS_CONTEXT_KEY,
 	context.LOCAL_COMMITS_CONTEXT_KEY,
 	context.STASH_CONTEXT_KEY,
+	context.NORMAL_MAIN_CONTEXT_KEY,
+	context.NORMAL_SECONDARY_CONTEXT_KEY,
 }
 
 type RenameSimilarityThresholdController struct {
@@ -82,7 +84,7 @@ func (self *RenameSimilarityThresholdController) applyChange() error {
 	self.c.Toast(fmt.Sprintf(self.c.Tr.RenameSimilarityThresholdChanged, self.c.AppState.RenameSimilarityThreshold))
 	self.c.SaveAppStateAndLogError()
 
-	currentContext := self.c.Context().CurrentStatic()
+	currentContext := self.currentSidePanel()
 	switch currentContext.GetKey() {
 	// we make an exception for our files context, because it actually need to refresh its state afterwards.
 	case context.FILES_CONTEXT_KEY:
@@ -96,6 +98,16 @@ func (self *RenameSimilarityThresholdController) applyChange() error {
 func (self *RenameSimilarityThresholdController) isShowingRenames() bool {
 	return lo.Contains(
 		CONTEXT_KEYS_SHOWING_RENAMES,
-		self.c.Context().CurrentStatic().GetKey(),
+		self.currentSidePanel().GetKey(),
 	)
+}
+
+func (self *RenameSimilarityThresholdController) currentSidePanel() types.Context {
+	currentContext := self.c.Context().CurrentStatic()
+	if currentContext.GetKey() == context.NORMAL_MAIN_CONTEXT_KEY ||
+		currentContext.GetKey() == context.NORMAL_SECONDARY_CONTEXT_KEY {
+		return currentContext.GetParentContext()
+	}
+
+	return currentContext
 }

--- a/pkg/integration/tests/diff/rename_similarity_threshold_change.go
+++ b/pkg/integration/tests/diff/rename_similarity_threshold_change.go
@@ -37,5 +37,17 @@ var RenameSimilarityThresholdChange = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("original => renamed"),
 				Contains("1 file changed, 5 insertions(+)"),
 			)
+
+		t.Views().Commits().
+			Press(keys.Universal.FocusMainView)
+
+		t.Views().Main().
+			Press(keys.Universal.IncreaseRenameSimilarityThreshold).
+			Tap(func() {
+				t.ExpectToast(Equals("Changed rename similarity threshold to 50%"))
+			}).
+			ContainsLines(
+				Contains("2 files changed, 10 insertions(+), 5 deletions(-)"),
+			)
 	},
 })

--- a/pkg/integration/tests/file/rename_similarity_threshold_change.go
+++ b/pkg/integration/tests/file/rename_similarity_threshold_change.go
@@ -31,6 +31,17 @@ var RenameSimilarityThresholdChange = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Lines(
 				Equals("R  original → renamed"),
+			).
+			Press(keys.Universal.FocusMainView).
+			Tap(func() {
+				t.Views().Main().
+					Press(keys.Universal.IncreaseRenameSimilarityThreshold)
+				t.ExpectToast(Equals("Changed rename similarity threshold to 50%"))
+			}).
+			Lines(
+				Equals("▼ /"),
+				Equals("  D  original"),
+				Equals("  A  renamed"),
 			)
 	},
 })


### PR DESCRIPTION
- **PR Description**

Allow pressing `{`, `}`, `(`, and `)` to change the diff context size and rename threshold when the main view is focused. This was forgotten in #4429.

Labeling as ignore-for-release because it can be considered a bug in #4429, which isn't released yet.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
