### PR TITLE
Fix nvim-remote commands for fish shell

### DIFF
--- a/pkg/commands/git_commands/file.go
+++ b/pkg/commands/git_commands/file.go
@@ -86,7 +86,7 @@ func (self *FileCommands) GetEditCmdStr(filenames []string) (string, bool) {
 		}
 	}
 
-	template, suspend := config.GetEditTemplate(&self.UserConfig().OS, self.guessDefaultEditor)
+	template, suspend := config.GetEditTemplate(self.os.Platform.Shell, &self.UserConfig().OS, self.guessDefaultEditor)
 	quotedFilenames := lo.Map(filenames, func(filename string, _ int) string { return self.cmd.Quote(filename) })
 
 	templateValues := map[string]string{
@@ -105,7 +105,7 @@ func (self *FileCommands) GetEditAtLineCmdStr(filename string, lineNumber int) (
 		}
 	}
 
-	template, suspend := config.GetEditAtLineTemplate(&self.UserConfig().OS, self.guessDefaultEditor)
+	template, suspend := config.GetEditAtLineTemplate(self.os.Platform.Shell, &self.UserConfig().OS, self.guessDefaultEditor)
 
 	templateValues := map[string]string{
 		"filename": self.cmd.Quote(filename),
@@ -124,7 +124,7 @@ func (self *FileCommands) GetEditAtLineAndWaitCmdStr(filename string, lineNumber
 		}
 	}
 
-	template := config.GetEditAtLineAndWaitTemplate(&self.UserConfig().OS, self.guessDefaultEditor)
+	template := config.GetEditAtLineAndWaitTemplate(self.os.Platform.Shell, &self.UserConfig().OS, self.guessDefaultEditor)
 
 	templateValues := map[string]string{
 		"filename": self.cmd.Quote(filename),
@@ -136,7 +136,7 @@ func (self *FileCommands) GetEditAtLineAndWaitCmdStr(filename string, lineNumber
 }
 
 func (self *FileCommands) GetOpenDirInEditorCmdStr(path string) (string, bool) {
-	template, suspend := config.GetOpenDirInEditorTemplate(&self.UserConfig().OS, self.guessDefaultEditor)
+	template, suspend := config.GetOpenDirInEditorTemplate(self.os.Platform.Shell, &self.UserConfig().OS, self.guessDefaultEditor)
 
 	templateValues := map[string]string{
 		"dir": self.cmd.Quote(path),

--- a/pkg/config/editor_presets_test.go
+++ b/pkg/config/editor_presets_test.go
@@ -111,15 +111,15 @@ func TestGetEditTemplate(t *testing.T) {
 	}
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
-			template, suspend := GetEditTemplate(s.osConfig, s.guessDefaultEditor)
+			template, suspend := GetEditTemplate("bash", s.osConfig, s.guessDefaultEditor)
 			assert.Equal(t, s.expectedEditTemplate, template)
 			assert.Equal(t, s.expectedSuspend, suspend)
 
-			template, suspend = GetEditAtLineTemplate(s.osConfig, s.guessDefaultEditor)
+			template, suspend = GetEditAtLineTemplate("bash", s.osConfig, s.guessDefaultEditor)
 			assert.Equal(t, s.expectedEditAtLineTemplate, template)
 			assert.Equal(t, s.expectedSuspend, suspend)
 
-			template = GetEditAtLineAndWaitTemplate(s.osConfig, s.guessDefaultEditor)
+			template = GetEditAtLineAndWaitTemplate("bash", s.osConfig, s.guessDefaultEditor)
 			assert.Equal(t, s.expectedEditAtLineAndWaitTemplate, template)
 		})
 	}


### PR DESCRIPTION
Fish shell does not support "&&" and "||" operators like POSIX-compatible shells. Instead, it uses a different syntax structure based on begin/end and if/else.

This caused existing lazygit nvim-remote integration templates to break when fish was the user's default shell.

This commit adds explicit fish shell detection using the FISH_VERSION environment variable, and provides fish-compatible templates that correctly handle launching Neovim or sending remote commands via $NVIM.

Fixes behavior where edits would not open in a new Neovim tab or line navigation would fail when $NVIM was set.

Ensures smoother editing experience for users running fish shell (supported since Nov 2012 with FISH_VERSION).

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
