### PR TITLE
Allow closing issues via github actions

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,39 @@
+name: Close Issues
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  close_issue:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request == null && startsWith(github.event.comment.body, '/close') }}
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const trustedUsers = ['ChrisMcD1', 'jesseduffield', 'stefanhaller']
+            const commenter = context.payload.comment.user.login
+
+            console.log(`Commenter: ${commenter}`)
+
+            if (!trustedUsers.includes(commenter)) {
+              console.log(`User ${commenter} is not trusted. Ignoring.`)
+              return
+            }
+
+            const issueNumber = context.payload.issue.number
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              state: 'closed'
+            })
+
+            console.log(`Closed issue #${issueNumber} by request from ${commenter}.`)


### PR DESCRIPTION
- **PR Description**

As discussed, this'll allow @ChrisMcD1 to clean up any issues that have already been resolved.

Basically if you want to close an issue just leave a comment saying '/close'.

Tested this over in my [OK?](https://github.com/jesseduffield/OK) and works like a charm.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
