### PR TITLE
Change switchTabsWithPanelJumpKeys default to true

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -279,7 +279,7 @@ gui:
   switchToFilesAfterStashApply: true
 
   # If true, when using the panel jump keys (default 1 through 5) and target panel is already active, go to next tab instead
-  switchTabsWithPanelJumpKeys: false
+  switchTabsWithPanelJumpKeys: true
 
 # Config relating to git
 git:

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -798,7 +798,7 @@ func GetDefaultConfig() *UserConfig {
 			StatusPanelView:              "dashboard",
 			SwitchToFilesAfterStashPop:   true,
 			SwitchToFilesAfterStashApply: true,
-			SwitchTabsWithPanelJumpKeys:  false,
+			SwitchTabsWithPanelJumpKeys:  true,
 		},
 		Git: GitConfig{
 			Paging: PagingConfig{

--- a/pkg/integration/tests/ui/disable_switch_tab_with_panel_jump_keys.go
+++ b/pkg/integration/tests/ui/disable_switch_tab_with_panel_jump_keys.go
@@ -6,10 +6,11 @@ import (
 )
 
 var DisableSwitchTabWithPanelJumpKeys = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Verify that the tab does not change by default when jumping to an already focused panel",
+	Description:  "Verify that the tab does not change when jumping to an already focused panel with the config SwitchTabsWithPanelJumpKeys to false",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Gui.SwitchTabsWithPanelJumpKeys = false
 	},
 	SetupRepo: func(shell *Shell) {
 	},

--- a/pkg/integration/tests/ui/switch_tab_with_panel_jump_keys.go
+++ b/pkg/integration/tests/ui/switch_tab_with_panel_jump_keys.go
@@ -10,7 +10,6 @@ var SwitchTabWithPanelJumpKeys = NewIntegrationTest(NewIntegrationTestArgs{
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
-		config.GetUserConfig().Gui.SwitchTabsWithPanelJumpKeys = true
 	},
 	SetupRepo: func(shell *Shell) {
 	},

--- a/schema/config.json
+++ b/schema/config.json
@@ -728,7 +728,7 @@
         "switchTabsWithPanelJumpKeys": {
           "type": "boolean",
           "description": "If true, when using the panel jump keys (default 1 through 5) and target panel is already active, go to next tab instead",
-          "default": false
+          "default": true
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
- **PR Description**

As mentioned in #4288 comment ([here](https://github.com/jesseduffield/lazygit/issues/4288#issuecomment-2667752563)), the new configuration  `switchTabsWithPanelJumpKeys` breaks the previous default behaviour leading to various issues opened related to this new default.
This PR changes the default to the regular behaviour while maintaining the feature for those who want to opt-out of this behaviour.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
