### PR TITLE
Fix race condition when starting several command tasks in quick succession

### DIFF
--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -373,8 +373,6 @@ func (self *ViewBufferManager) NewTask(f func(TaskOpts) error, key string) error
 	go utils.Safe(func() {
 		defer completeGocuiTask()
 
-		self.readLines = nil
-
 		self.taskIDMutex.Lock()
 		self.newTaskID++
 		taskID := self.newTaskID
@@ -399,6 +397,8 @@ func (self *ViewBufferManager) NewTask(f func(TaskOpts) error, key string) error
 		if self.stopCurrentTask != nil {
 			self.stopCurrentTask()
 		}
+
+		self.readLines = nil
 
 		stop := make(chan struct{})
 		notifyStopped := make(chan struct{})


### PR DESCRIPTION
- **PR Description**

Fixes #4507, see there for an elaborate description of the problem.

Labeled as ignore-for-release since this fixes a regression that was only introduced after the last release.