### PR TITLE
Remove double space between rebase todo and author columns

### DIFF
--- a/pkg/gui/presentation/commits.go
+++ b/pkg/gui/presentation/commits.go
@@ -387,7 +387,7 @@ func displayCommit(
 
 	actionString := ""
 	if commit.Action != models.ActionNone {
-		actionString = actionColorMap(commit.Action, commit.Status).Sprint(commit.Action.String()) + " "
+		actionString = actionColorMap(commit.Action, commit.Status).Sprint(commit.Action.String())
 	}
 
 	tagString := ""

--- a/pkg/gui/presentation/commits_test.go
+++ b/pkg/gui/presentation/commits_test.go
@@ -224,11 +224,11 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			cherryPickedCommitHashSet: set.New[string](),
 			now:                       time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
-		hash1 pick  commit1
-		hash2 pick  commit2
-		hash3       ◯ commit3
-		hash4       ◯ commit4
-		hash5       ◯ commit5
+		hash1 pick commit1
+		hash2 pick commit2
+		hash3      ◯ commit3
+		hash4      ◯ commit4
+		hash5      ◯ commit5
 				`),
 		},
 		{
@@ -247,10 +247,10 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			cherryPickedCommitHashSet: set.New[string](),
 			now:                       time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
-		hash2 pick  commit2
-		hash3       ◯ commit3
-		hash4       ◯ commit4
-		hash5       ◯ commit5
+		hash2 pick commit2
+		hash3      ◯ commit3
+		hash4      ◯ commit4
+		hash5      ◯ commit5
 				`),
 		},
 		{
@@ -289,8 +289,8 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			cherryPickedCommitHashSet: set.New[string](),
 			now:                       time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
-		hash1 pick  commit1
-		hash2 pick  commit2
+		hash1 pick commit1
+		hash2 pick commit2
 				`),
 		},
 		{
@@ -328,8 +328,8 @@ func TestGetCommitListDisplayStrings(t *testing.T) {
 			cherryPickedCommitHashSet: set.New[string](),
 			now:                       time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected: formatExpected(`
-			hash1 pick  commit1
-			hash2 pick  commit2
+			hash1 pick commit1
+			hash2 pick commit2
 				`),
 		},
 		{

--- a/pkg/integration/tests/cherry_pick/cherry_pick_during_rebase.go
+++ b/pkg/integration/tests/cherry_pick/cherry_pick_during_rebase.go
@@ -60,10 +60,10 @@ var CherryPickDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick  CI two"),
+				Contains("pick CI two"),
 				Contains("--- Commits ---"),
-				Contains("      CI one").IsSelected(),
-				Contains("      CI base"),
+				Contains("     CI one").IsSelected(),
+				Contains("     CI base"),
 			).
 			Press(keys.Commits.PasteCommits).
 			Tap(func() {
@@ -77,11 +77,11 @@ var CherryPickDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick  CI two"),
+				Contains("pick CI two"),
 				Contains("--- Commits ---"),
-				Contains("      CI three"),
-				Contains("      CI one"),
-				Contains("      CI base"),
+				Contains("     CI three"),
+				Contains("     CI one"),
+				Contains("     CI base"),
 			).
 			Tap(func() {
 				t.Common().ContinueRebase()

--- a/pkg/integration/tests/interactive_rebase/edit_range_select_down_to_merge_outside_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/edit_range_select_down_to_merge_outside_rebase.go
@@ -28,17 +28,17 @@ var EditRangeSelectDownToMergeOutsideRebase = NewIntegrationTest(NewIntegrationT
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("edit  CI commit 02").IsSelected(),
-				Contains("edit  CI commit 01").IsSelected(),
+				Contains("edit CI commit 02").IsSelected(),
+				Contains("edit CI commit 01").IsSelected(),
 				Contains("--- Commits ---").IsSelected(),
-				Contains("      CI ⏣─╮ Merge branch 'second-change-branch' into first-change-branch").IsSelected(),
-				Contains("      CI │ ◯ * second-change-branch unrelated change"),
-				Contains("      CI │ ◯ second change"),
-				Contains("      CI ◯ │ first change"),
-				Contains("      CI ◯─╯ * original"),
-				Contains("      CI ◯ three"),
-				Contains("      CI ◯ two"),
-				Contains("      CI ◯ one"),
+				Contains("     CI ⏣─╮ Merge branch 'second-change-branch' into first-change-branch").IsSelected(),
+				Contains("     CI │ ◯ * second-change-branch unrelated change"),
+				Contains("     CI │ ◯ second change"),
+				Contains("     CI ◯ │ first change"),
+				Contains("     CI ◯─╯ * original"),
+				Contains("     CI ◯ three"),
+				Contains("     CI ◯ two"),
+				Contains("     CI ◯ one"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/edit_range_select_outside_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/edit_range_select_outside_rebase.go
@@ -38,15 +38,15 @@ var EditRangeSelectOutsideRebase = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("merge  CI Merge branch 'second-change-branch' into first-change-branch").IsSelected(),
-				Contains("edit   CI first change").IsSelected(),
-				Contains("edit   CI * second-change-branch unrelated change").IsSelected(),
-				Contains("edit   CI second change").IsSelected(),
-				Contains("edit   CI * original").IsSelected(),
+				Contains("merge CI Merge branch 'second-change-branch' into first-change-branch").IsSelected(),
+				Contains("edit  CI first change").IsSelected(),
+				Contains("edit  CI * second-change-branch unrelated change").IsSelected(),
+				Contains("edit  CI second change").IsSelected(),
+				Contains("edit  CI * original").IsSelected(),
 				Contains("--- Commits ---").IsSelected(),
-				Contains("       CI ◯ three").IsSelected(),
-				Contains("       CI ◯ two"),
-				Contains("       CI ◯ one"),
+				Contains("      CI ◯ three").IsSelected(),
+				Contains("      CI ◯ two"),
+				Contains("      CI ◯ one"),
 			)
 	},
 })


### PR DESCRIPTION
- **PR Description**

In the commits list of an interactive rebase, the gap between the rebase todo column and the author column was two instead of one. Remove the extra space to make this gap the same as for all other columns.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
