### PR TITLE
Fix git apply error during applying custom patch

### DIFF
--- a/pkg/commands/git_commands/patch.go
+++ b/pkg/commands/git_commands/patch.go
@@ -71,6 +71,7 @@ func (self *PatchCommands) applyPatchFile(filepath string, opts ApplyPatchOpts) 
 		ArgIf(opts.Cached, "--cached").
 		ArgIf(opts.Index, "--index").
 		ArgIf(opts.Reverse, "--reverse").
+		Arg("--unidiff-zero").
 		Arg(filepath).
 		ToArgv()
 


### PR DESCRIPTION
- **PR Description**

Man page of `git apply` says that:

```
  --unidiff-zero
      By default, git apply expects that the patch being applied is a
      unified diff with at least one line of context. This provides
      good safety measures, but breaks down when applying a diff
      generated with --unified=0. To bypass these checks use
      --unidiff-zero.

      Note, for the reasons stated above, the usage of context-free
      patches is discouraged.
```

Lazygit always render custom patch with zero context,
so this --unidiff-zero option is needed when pass such patch to
`git apply`.

Check https://github.com/black-desk/lazygit-bug-report-2025-04-29
for details.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
