### PR TITLE
Add an alternate keybinding (default <c-s>) for ConfirmInEditor

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -516,6 +516,7 @@ keybinding:
     goInto: <enter>
     confirm: <enter>
     confirmInEditor: <a-enter>
+    confirmInEditor-alt: <c-s>
     remove: d
     new: "n"
     edit: e

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -405,6 +405,7 @@ type KeybindingUniversalConfig struct {
 	GoInto                            string   `yaml:"goInto"`
 	Confirm                           string   `yaml:"confirm"`
 	ConfirmInEditor                   string   `yaml:"confirmInEditor"`
+	ConfirmInEditorAlt                string   `yaml:"confirmInEditor-alt"`
 	Remove                            string   `yaml:"remove"`
 	New                               string   `yaml:"new"`
 	Edit                              string   `yaml:"edit"`
@@ -882,6 +883,7 @@ func GetDefaultConfig() *UserConfig {
 				GoInto:                            "<enter>",
 				Confirm:                           "<enter>",
 				ConfirmInEditor:                   "<a-enter>",
+				ConfirmInEditorAlt:                "<c-s>",
 				Remove:                            "d",
 				New:                               "n",
 				Edit:                              "e",

--- a/pkg/gui/controllers/commit_description_controller.go
+++ b/pkg/gui/controllers/commit_description_controller.go
@@ -39,6 +39,10 @@ func (self *CommitDescriptionController) GetKeybindings(opts types.KeybindingsOp
 			Handler: self.confirm,
 		},
 		{
+			Key:     opts.GetKey(opts.Config.Universal.ConfirmInEditorAlt),
+			Handler: self.confirm,
+		},
+		{
 			Key:     opts.GetKey(opts.Config.CommitMessage.CommitMenu),
 			Handler: self.openCommitMenu,
 		},
@@ -63,10 +67,27 @@ func (self *CommitDescriptionController) GetMouseKeybindings(opts types.Keybindi
 
 func (self *CommitDescriptionController) GetOnFocus() func(types.OnFocusOpts) {
 	return func(types.OnFocusOpts) {
-		self.c.Views().CommitDescription.Footer = utils.ResolvePlaceholderString(self.c.Tr.CommitDescriptionFooter,
-			map[string]string{
-				"confirmInEditorKeybinding": keybindings.Label(self.c.UserConfig().Keybinding.Universal.ConfirmInEditor),
-			})
+		footer := ""
+		if self.c.UserConfig().Keybinding.Universal.ConfirmInEditor != "<disabled>" || self.c.UserConfig().Keybinding.Universal.ConfirmInEditorAlt != "<disabled>" {
+			if self.c.UserConfig().Keybinding.Universal.ConfirmInEditor == "<disabled>" {
+				footer = utils.ResolvePlaceholderString(self.c.Tr.CommitDescriptionFooter,
+					map[string]string{
+						"confirmInEditorKeybinding": keybindings.Label(self.c.UserConfig().Keybinding.Universal.ConfirmInEditorAlt),
+					})
+			} else if self.c.UserConfig().Keybinding.Universal.ConfirmInEditorAlt == "<disabled>" {
+				footer = utils.ResolvePlaceholderString(self.c.Tr.CommitDescriptionFooter,
+					map[string]string{
+						"confirmInEditorKeybinding": keybindings.Label(self.c.UserConfig().Keybinding.Universal.ConfirmInEditor),
+					})
+			} else {
+				footer = utils.ResolvePlaceholderString(self.c.Tr.CommitDescriptionFooterTwoBindings,
+					map[string]string{
+						"confirmInEditorKeybinding1": keybindings.Label(self.c.UserConfig().Keybinding.Universal.ConfirmInEditor),
+						"confirmInEditorKeybinding2": keybindings.Label(self.c.UserConfig().Keybinding.Universal.ConfirmInEditorAlt),
+					})
+			}
+		}
+		self.c.Views().CommitDescription.Footer = footer
 	}
 }
 

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -330,6 +330,7 @@ type TranslationSet struct {
 	CommitDescriptionTitle                string
 	CommitDescriptionSubTitle             string
 	CommitDescriptionFooter               string
+	CommitDescriptionFooterTwoBindings    string
 	CommitHooksDisabledSubTitle           string
 	LocalBranchesTitle                    string
 	SearchTitle                           string
@@ -1410,7 +1411,8 @@ func EnglishTranslationSet() *TranslationSet {
 		CommitSummaryTitle:                   "Commit summary",
 		CommitDescriptionTitle:               "Commit description",
 		CommitDescriptionSubTitle:            "Press {{.togglePanelKeyBinding}} to toggle focus, {{.commitMenuKeybinding}} to open menu",
-		CommitDescriptionFooter:              "Press {{.confirmInEditorKeybinding}} to commit",
+		CommitDescriptionFooter:              "Press {{.confirmInEditorKeybinding}} to submit",
+		CommitDescriptionFooterTwoBindings:   "Press {{.confirmInEditorKeybinding1}} or {{.confirmInEditorKeybinding2}} to submit",
 		CommitHooksDisabledSubTitle:          "(hooks disabled)",
 		LocalBranchesTitle:                   "Local branches",
 		SearchTitle:                          "Search",

--- a/schema/config.json
+++ b/schema/config.json
@@ -1310,6 +1310,10 @@
           "type": "string",
           "default": "\u003ca-enter\u003e"
         },
+        "confirmInEditor-alt": {
+          "type": "string",
+          "default": "\u003cc-s\u003e"
+        },
         "remove": {
           "type": "string",
           "default": "d"


### PR DESCRIPTION
- **PR Description**

The default binding for ConfirmInEditor is <a-enter>, which has two problems:
- some terminal emulators don't support it, including the default terminal on Mac (Terminal.app)
- on Windows it is bound to toggling full-screen

Ideally we would use `<c-enter>` instead (and Command-Enter on Mac), but neither is possible without https://github.com/gdamore/tcell/issues/671, so for the time being add an alternate keybinding which works everywhere.

Show both bindings in the footer of the commit description panel if they are both non-null. While we're at it, fix the footer for the case where either or both of the keybindings are set to `<disabled>`.

And finally, change "commit" to "submit" in that footer; we use the same panel also for creating tags, in which case "commit" is not quite right.
