### PR TITLE
Make '>' first jump to the beginning of the branch, and only then to the first commit

### DIFF
--- a/pkg/gui/context/list_context_trait.go
+++ b/pkg/gui/context/list_context_trait.go
@@ -149,3 +149,7 @@ func (self *ListContextTrait) TotalContentHeight() int {
 	}
 	return result
 }
+
+func (self *ListContextTrait) IndexForGotoBottom() int {
+	return self.list.Len() - 1
+}

--- a/pkg/gui/context/local_commits_context.go
+++ b/pkg/gui/context/local_commits_context.go
@@ -289,3 +289,20 @@ func searchModelCommits(caseSensitive bool, commits []*models.Commit, columnPosi
 			strings.Contains(normalize(commit.ExtraInfo), searchStr) // allow searching for tags
 	})
 }
+
+func (self *LocalCommitsContext) IndexForGotoBottom() int {
+	commits := self.GetCommits()
+	selectedIdx := self.GetSelectedLineIdx()
+	if selectedIdx >= 0 && selectedIdx < len(commits)-1 {
+		if commits[selectedIdx+1].Status != models.StatusMerged {
+			_, idx, found := lo.FindIndexOf(commits, func(c *models.Commit) bool {
+				return c.Status == models.StatusMerged
+			})
+			if found {
+				return idx - 1
+			}
+		}
+	}
+
+	return self.list.Len() - 1
+}

--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -227,3 +227,20 @@ func (self *SubCommitsContext) RefForAdjustingLineNumberInDiff() string {
 func (self *SubCommitsContext) ModelSearchResults(searchStr string, caseSensitive bool) []gocui.SearchPosition {
 	return searchModelCommits(caseSensitive, self.GetCommits(), self.ColumnPositions(), searchStr)
 }
+
+func (self *SubCommitsContext) IndexForGotoBottom() int {
+	commits := self.GetCommits()
+	selectedIdx := self.GetSelectedLineIdx()
+	if selectedIdx >= 0 && selectedIdx < len(commits)-1 {
+		if commits[selectedIdx+1].Status != models.StatusMerged {
+			_, idx, found := lo.FindIndexOf(commits, func(c *models.Commit) bool {
+				return c.Status == models.StatusMerged
+			})
+			if found {
+				return idx - 1
+			}
+		}
+	}
+
+	return self.list.Len() - 1
+}

--- a/pkg/gui/controllers/list_controller.go
+++ b/pkg/gui/controllers/list_controller.go
@@ -138,7 +138,9 @@ func (self *ListController) HandleGotoTop() error {
 }
 
 func (self *ListController) HandleGotoBottom() error {
-	return self.handleLineChange(self.context.GetList().Len())
+	bottomIdx := self.context.IndexForGotoBottom()
+	change := bottomIdx - self.context.GetList().GetSelectedLineIdx()
+	return self.handleLineChange(change)
 }
 
 func (self *ListController) HandleToggleRangeSelect() error {

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -207,14 +207,6 @@ func (self *LocalCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 			Description:       self.c.Tr.MarkAsBaseCommit,
 			Tooltip:           self.c.Tr.MarkAsBaseCommitTooltip,
 		},
-		// overriding this navigation keybinding because we might need to load
-		// more commits on demand
-		{
-			Key:         opts.GetKey(opts.Config.Universal.GotoBottom),
-			Handler:     self.gotoBottom,
-			Description: self.c.Tr.GotoBottom,
-			Tag:         "navigation",
-		},
 	}
 
 	for _, binding := range outsideFilterModeBindings {
@@ -1152,20 +1144,6 @@ func (self *LocalCommitsController) openSearch() error {
 	}
 
 	return self.c.Helpers().Search.OpenSearchPrompt(self.context())
-}
-
-func (self *LocalCommitsController) gotoBottom() error {
-	// we usually lazyload these commits but now that we're jumping to the bottom we need to load them now
-	if self.context().GetLimitCommits() {
-		self.context().SetLimitCommits(false)
-		if err := self.c.Refresh(types.RefreshOptions{Mode: types.SYNC, Scope: []types.RefreshableView{types.COMMITS}}); err != nil {
-			return err
-		}
-	}
-
-	self.context().SetSelectedLineIdx(self.context().Len() - 1)
-
-	return nil
 }
 
 func (self *LocalCommitsController) handleOpenLogMenu() error {

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -180,6 +180,8 @@ type IListContext interface {
 	IsListContext() // used for type switch
 	RangeSelectEnabled() bool
 	RenderOnlyVisibleLines() bool
+
+	IndexForGotoBottom() int
 }
 
 type IPatchExplorerContext interface {


### PR DESCRIPTION
- **PR Description**

In longer branches there's often the need to jump to the beginning of the branch, e.g. in order to re-review all commits from the beginning. There's no easy way to do this in lazygit.

In this PR I overload the "go to bottom" key (`>`) to jump to the first commit of the current branch if the selection is above it, and only then jump to the very bottom. I like that we don't need to introduce a new key binding for this.

I'm not super convinced this is the best solution, but after some brief testing I like it so far. @jesseduffield Keen to hear your thoughts!