### PR TITLE
Avoid crash when the git command to obtain branches fails

### DIFF
--- a/pkg/commands/git_commands/branch_loader.go
+++ b/pkg/commands/git_commands/branch_loader.go
@@ -72,7 +72,10 @@ func (self *BranchLoader) Load(reflogCommits []*models.Commit,
 	onWorker func(func() error),
 	renderFunc func(),
 ) ([]*models.Branch, error) {
-	branches := self.obtainBranches()
+	branches, err := self.obtainBranches()
+	if err != nil {
+		return nil, err
+	}
 
 	if self.AppState.LocalBranchSortOrder == "recency" {
 		reflogBranches := self.obtainReflogBranches(reflogCommits)
@@ -232,16 +235,16 @@ func (self *BranchLoader) GetBaseBranch(branch *models.Branch, mainBranches *Mai
 	return split[0], nil
 }
 
-func (self *BranchLoader) obtainBranches() []*models.Branch {
+func (self *BranchLoader) obtainBranches() ([]*models.Branch, error) {
 	output, err := self.getRawBranches()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	trimmedOutput := strings.TrimSpace(output)
 	outputLines := strings.Split(trimmedOutput, "\n")
 
-	return lo.FilterMap(outputLines, func(line string, _ int) (*models.Branch, bool) {
+	branches := lo.FilterMap(outputLines, func(line string, _ int) (*models.Branch, bool) {
 		if line == "" {
 			return nil, false
 		}
@@ -257,6 +260,7 @@ func (self *BranchLoader) obtainBranches() []*models.Branch {
 		storeCommitDateAsRecency := self.AppState.LocalBranchSortOrder != "recency"
 		return obtainBranch(split, storeCommitDateAsRecency), true
 	})
+	return branches, nil
 }
 
 func (self *BranchLoader) getRawBranches() (string, error) {


### PR DESCRIPTION
- **PR Description**

In #4546 a user reported a crash in refresh when the repository is corrupt. It would be good not to crash, but to handle this gracefully. This PR does that.

However, this is probably not a good enough solution, because we only log the error (in RefreshHelper.refreshBranches) and don't communicate it otherwise to users. This is true for all errors that happen during refresh, though.

It is unclear how we could report refresh errors to users; showing them in a popup doesn't seem right. As long as we don't have a solution for this, it might actually be better to crash, so that users can file an issue and we tell them how to sort it out. Leaving as draft for the time being.