### PR TITLE
Print migration changes to the console when migrating config file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-errors/errors v1.5.1
 	github.com/gookit/color v1.4.2
 	github.com/integrii/flaggy v1.4.0
-	github.com/jesseduffield/generics v0.0.0-20250406224309-4f541cb84918
+	github.com/jesseduffield/generics v0.0.0-20250517122708-b0b4a53a6f5c
 	github.com/jesseduffield/go-git/v5 v5.14.1-0.20250407170251-e1a013310ccd
 	github.com/jesseduffield/gocui v0.3.1-0.20250421160159-82c9aaeba2b9
 	github.com/jesseduffield/kill v0.0.0-20250101124109-e216ddbe133a

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/invopop/jsonschema v0.10.0 h1:c1ktzNLBun3LyQQhyty5WE3lulbOdIIyOVlkmDL
 github.com/invopop/jsonschema v0.10.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/jesseduffield/generics v0.0.0-20250406224309-4f541cb84918 h1:meoUDZGF6jZAbhW5IBwj92mTqGmrOn+Cuu0jM7/aUcs=
-github.com/jesseduffield/generics v0.0.0-20250406224309-4f541cb84918/go.mod h1:+LLj9/WUPAP8LqCchs7P+7X0R98HiFujVFANdNaxhGk=
+github.com/jesseduffield/generics v0.0.0-20250517122708-b0b4a53a6f5c h1:tC2PaiisXAC5sOjDPfMArSnbswDObtCssx+xn28edX4=
+github.com/jesseduffield/generics v0.0.0-20250517122708-b0b4a53a6f5c/go.mod h1:F2fEBk0ddf6ixrBrJjY7phfQ3hL9rXG0uSjvwYe50bE=
 github.com/jesseduffield/go-git/v5 v5.14.1-0.20250407170251-e1a013310ccd h1:ViKj6qth8FgcIWizn9KiACWwPemWSymx62OPN0tHT+Q=
 github.com/jesseduffield/go-git/v5 v5.14.1-0.20250407170251-e1a013310ccd/go.mod h1:lRhCiBr6XjQrvcQVa+UYsy/99d3wMXn/a0nSQlhnhlA=
 github.com/jesseduffield/gocui v0.3.1-0.20250421160159-82c9aaeba2b9 h1:k23sCKHCNpAvwJP8Yr16CBUItuarmUHBGH7FaAm2glc=

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -267,7 +267,7 @@ func computeMigratedConfig(path string, content []byte) ([]byte, bool, error) {
 	}
 
 	for _, pathToReplace := range pathsToReplace {
-		err := yaml_utils.RenameYamlKey(&rootNode, pathToReplace.oldPath, pathToReplace.newName)
+		err, _ := yaml_utils.RenameYamlKey(&rootNode, pathToReplace.oldPath, pathToReplace.newName)
 		if err != nil {
 			return nil, false, fmt.Errorf("Couldn't migrate config file at `%s` for key %s: %s", path, strings.Join(pathToReplace.oldPath, "."), err)
 		}

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -250,7 +250,11 @@ func migrateUserConfig(path string, content []byte, isGuiInitialized bool) ([]by
 		fmt.Println(changesText)
 	}
 	if err := os.WriteFile(path, changedContent, 0o644); err != nil {
-		return nil, fmt.Errorf("While attempting to write back fixed user config to %s, an error occurred: %s", path, err)
+		errorMsg := fmt.Sprintf("While attempting to write back migrated user config to %s, an error occurred: %s", path, err)
+		if isGuiInitialized {
+			errorMsg += "\n\n" + changesText
+		}
+		return nil, errors.New(errorMsg)
 	}
 	if !isGuiInitialized {
 		fmt.Printf("Config file saved successfully to %s\n", path)

--- a/pkg/config/app_config_test.go
+++ b/pkg/config/app_config_test.go
@@ -80,9 +80,7 @@ git:
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
 			actual, err := computeMigratedConfig("path doesn't matter", []byte(s.input))
-			if err != nil {
-				t.Error(err)
-			}
+			assert.NoError(t, err)
 			assert.Equal(t, s.expected, string(actual))
 		})
 	}

--- a/pkg/config/app_config_test.go
+++ b/pkg/config/app_config_test.go
@@ -16,7 +16,8 @@ func TestCommitPrefixMigrations(t *testing.T) {
 			name:     "Empty String",
 			input:    "",
 			expected: "",
-		}, {
+		},
+		{
 			name: "Single CommitPrefix Rename",
 			input: `git:
   commitPrefix:
@@ -28,7 +29,8 @@ func TestCommitPrefixMigrations(t *testing.T) {
     - pattern: "^\\w+-\\w+.*"
       replace: '[JIRA $0] '
 `,
-		}, {
+		},
+		{
 			name: "Complicated CommitPrefixes Rename",
 			input: `git:
   commitPrefixes:
@@ -48,11 +50,13 @@ func TestCommitPrefixMigrations(t *testing.T) {
       - pattern: "^foo.bar*"
         replace: '[FUN $0] '
 `,
-		}, {
+		},
+		{
 			name:     "Incomplete Configuration",
 			input:    "git:",
 			expected: "git:",
-		}, {
+		},
+		{
 			// This test intentionally uses non-standard indentation to test that the migration
 			// does not change the input.
 			name: "No changes made when already migrated",
@@ -96,7 +100,8 @@ func TestCustomCommandsOutputMigration(t *testing.T) {
 			name:     "Empty String",
 			input:    "",
 			expected: "",
-		}, {
+		},
+		{
 			name: "Convert subprocess to output=terminal",
 			input: `customCommands:
   - command: echo 'hello'
@@ -106,7 +111,8 @@ func TestCustomCommandsOutputMigration(t *testing.T) {
   - command: echo 'hello'
     output: terminal
 `,
-		}, {
+		},
+		{
 			name: "Convert stream to output=log",
 			input: `customCommands:
   - command: echo 'hello'
@@ -116,7 +122,8 @@ func TestCustomCommandsOutputMigration(t *testing.T) {
   - command: echo 'hello'
     output: log
 `,
-		}, {
+		},
+		{
 			name: "Convert showOutput to output=popup",
 			input: `customCommands:
   - command: echo 'hello'
@@ -126,7 +133,8 @@ func TestCustomCommandsOutputMigration(t *testing.T) {
   - command: echo 'hello'
     output: popup
 `,
-		}, {
+		},
+		{
 			name: "Subprocess wins over the other two",
 			input: `customCommands:
   - command: echo 'hello'
@@ -138,7 +146,8 @@ func TestCustomCommandsOutputMigration(t *testing.T) {
   - command: echo 'hello'
     output: terminal
 `,
-		}, {
+		},
+		{
 			name: "Stream wins over showOutput",
 			input: `customCommands:
   - command: echo 'hello'
@@ -149,7 +158,8 @@ func TestCustomCommandsOutputMigration(t *testing.T) {
   - command: echo 'hello'
     output: log
 `,
-		}, {
+		},
+		{
 			name: "Explicitly setting to false doesn't create an output=none key",
 			input: `customCommands:
   - command: echo 'hello'
@@ -790,7 +800,8 @@ func TestAllBranchesLogCmdMigrations(t *testing.T) {
 			name:     "Incomplete Configuration Passes uneventfully",
 			input:    "git:",
 			expected: "git:",
-		}, {
+		},
+		{
 			name: "Single Cmd with no Cmds",
 			input: `git:
   allBranchesLogCmd: git log --graph --oneline
@@ -799,7 +810,8 @@ func TestAllBranchesLogCmdMigrations(t *testing.T) {
   allBranchesLogCmds:
     - git log --graph --oneline
 `,
-		}, {
+		},
+		{
 			name: "Cmd with one existing Cmds",
 			input: `git:
   allBranchesLogCmd: git log --graph --oneline
@@ -811,7 +823,8 @@ func TestAllBranchesLogCmdMigrations(t *testing.T) {
     - git log --graph --oneline
     - git log --graph --oneline --pretty
 `,
-		}, {
+		},
+		{
 			name: "Only Cmds set have no changes",
 			input: `git:
   allBranchesLogCmds:
@@ -821,7 +834,8 @@ func TestAllBranchesLogCmdMigrations(t *testing.T) {
   allBranchesLogCmds:
     - git log
 `,
-		}, {
+		},
+		{
 			name: "Removes Empty Cmd When at end of yaml",
 			input: `git:
   allBranchesLogCmds:
@@ -832,7 +846,8 @@ func TestAllBranchesLogCmdMigrations(t *testing.T) {
   allBranchesLogCmds:
     - git log --graph --oneline
 `,
-		}, {
+		},
+		{
 			name: "Migrates when sequence defined inline",
 			input: `git:
   allBranchesLogCmds: [foo, bar]
@@ -841,7 +856,8 @@ func TestAllBranchesLogCmdMigrations(t *testing.T) {
 			expected: `git:
   allBranchesLogCmds: [baz, foo, bar]
 `,
-		}, {
+		},
+		{
 			name: "Removes Empty Cmd With Keys Afterwards",
 			input: `git:
   allBranchesLogCmds:

--- a/pkg/utils/yaml_utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils/yaml_utils.go
@@ -65,10 +65,10 @@ func transformNode(node *yaml.Node, path []string, transform func(node *yaml.Nod
 
 // Takes the root node of a yaml document, a path to a key, and a new name for the key.
 // Will rename the key to the new name if it exists, and do nothing otherwise.
-func RenameYamlKey(rootNode *yaml.Node, path []string, newKey string) error {
+func RenameYamlKey(rootNode *yaml.Node, path []string, newKey string) (error, bool) {
 	// Empty document: nothing to do.
 	if len(rootNode.Content) == 0 {
-		return nil
+		return nil, false
 	}
 
 	body := rootNode.Content[0]
@@ -77,25 +77,25 @@ func RenameYamlKey(rootNode *yaml.Node, path []string, newKey string) error {
 }
 
 // Recursive function to rename the YAML key.
-func renameYamlKey(node *yaml.Node, path []string, newKey string) error {
+func renameYamlKey(node *yaml.Node, path []string, newKey string) (error, bool) {
 	if node.Kind != yaml.MappingNode {
-		return errors.New("yaml node in path is not a dictionary")
+		return errors.New("yaml node in path is not a dictionary"), false
 	}
 
 	keyNode, valueNode := LookupKey(node, path[0])
 	if keyNode == nil {
-		return nil
+		return nil, false
 	}
 
 	// end of path reached: rename key
 	if len(path) == 1 {
 		// Check that new key doesn't exist yet
 		if newKeyNode, _ := LookupKey(node, newKey); newKeyNode != nil {
-			return fmt.Errorf("new key `%s' already exists", newKey)
+			return fmt.Errorf("new key `%s' already exists", newKey), false
 		}
 
 		keyNode.Value = newKey
-		return nil
+		return nil, true
 	}
 
 	return renameYamlKey(valueNode, path[1:], newKey)

--- a/pkg/utils/yaml_utils/yaml_utils.go
+++ b/pkg/utils/yaml_utils/yaml_utils.go
@@ -73,11 +73,7 @@ func RenameYamlKey(rootNode *yaml.Node, path []string, newKey string) error {
 
 	body := rootNode.Content[0]
 
-	if err := renameYamlKey(body, path, newKey); err != nil {
-		return err
-	}
-
-	return nil
+	return renameYamlKey(body, path, newKey)
 }
 
 // Recursive function to rename the YAML key.

--- a/vendor/github.com/jesseduffield/generics/maps/maps.go
+++ b/vendor/github.com/jesseduffield/generics/maps/maps.go
@@ -19,7 +19,7 @@ func Values[Key comparable, Value any](m map[Key]Value) []Value {
 func TransformValues[Key comparable, Value any, NewValue any](
 	m map[Key]Value, fn func(Value) NewValue,
 ) map[Key]NewValue {
-	output := make(map[Key]NewValue)
+	output := make(map[Key]NewValue, len(m))
 	for key, value := range m {
 		output[key] = fn(value)
 	}
@@ -27,7 +27,7 @@ func TransformValues[Key comparable, Value any, NewValue any](
 }
 
 func TransformKeys[Key comparable, Value any, NewKey comparable](m map[Key]Value, fn func(Key) NewKey) map[NewKey]Value {
-	output := make(map[NewKey]Value)
+	output := make(map[NewKey]Value, len(m))
 	for key, value := range m {
 		output[fn(key)] = value
 	}

--- a/vendor/github.com/jesseduffield/generics/orderedset/orderedset.go
+++ b/vendor/github.com/jesseduffield/generics/orderedset/orderedset.go
@@ -1,0 +1,65 @@
+package orderedset
+
+import (
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+)
+
+type OrderedSet[T comparable] struct {
+	om *orderedmap.OrderedMap[T, bool]
+}
+
+func New[T comparable]() *OrderedSet[T] {
+	return &OrderedSet[T]{om: orderedmap.New[T, bool]()}
+}
+
+func NewFromSlice[T comparable](slice []T) *OrderedSet[T] {
+	result := &OrderedSet[T]{om: orderedmap.New[T, bool](len(slice))}
+	result.Add(slice...)
+	return result
+}
+
+func (os *OrderedSet[T]) Add(values ...T) {
+	for _, value := range values {
+		os.om.Set(value, true)
+	}
+}
+
+func (os *OrderedSet[T]) Remove(value T) {
+	os.om.Delete(value)
+}
+
+func (os *OrderedSet[T]) RemoveSlice(slice []T) {
+	for _, value := range slice {
+		os.Remove(value)
+	}
+}
+
+func (os *OrderedSet[T]) Includes(value T) bool {
+	return os.om.Value(value)
+}
+
+func (os *OrderedSet[T]) Len() int {
+	return os.om.Len()
+}
+
+func (os *OrderedSet[T]) ToSliceFromOldest() []T {
+	// TODO: can be simplified to
+	//   return os.om.KeysFromOldest()
+	// when we update to a newer version of go-ordered-map
+	result := make([]T, 0, os.Len())
+	for pair := os.om.Oldest(); pair != nil; pair = pair.Next() {
+		result = append(result, pair.Key)
+	}
+	return result
+}
+
+func (os *OrderedSet[T]) ToSliceFromNewest() []T {
+	// TODO: can be simplified to
+	//   return os.om.KeysFromNewest()
+	// when we update to a newer version of go-ordered-map
+	result := make([]T, 0, os.Len())
+	for pair := os.om.Newest(); pair != nil; pair = pair.Prev() {
+		result = append(result, pair.Key)
+	}
+	return result
+}

--- a/vendor/github.com/jesseduffield/generics/set/set.go
+++ b/vendor/github.com/jesseduffield/generics/set/set.go
@@ -11,12 +11,9 @@ func New[T comparable]() *Set[T] {
 }
 
 func NewFromSlice[T comparable](slice []T) *Set[T] {
-	hashMap := make(map[T]bool)
-	for _, value := range slice {
-		hashMap[value] = true
-	}
-
-	return &Set[T]{hashMap: hashMap}
+	result := &Set[T]{hashMap: make(map[T]bool, len(slice))}
+	result.Add(slice...)
+	return result
 }
 
 func (s *Set[T]) Add(values ...T) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -174,9 +174,10 @@ github.com/integrii/flaggy
 # github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
 ## explicit
 github.com/jbenet/go-context/io
-# github.com/jesseduffield/generics v0.0.0-20250406224309-4f541cb84918
+# github.com/jesseduffield/generics v0.0.0-20250517122708-b0b4a53a6f5c
 ## explicit; go 1.18
 github.com/jesseduffield/generics/maps
+github.com/jesseduffield/generics/orderedset
 github.com/jesseduffield/generics/set
 # github.com/jesseduffield/go-git/v5 v5.14.1-0.20250407170251-e1a013310ccd
 ## explicit; go 1.23.0


### PR DESCRIPTION
- **PR Description**

This might be useful to see in general (users will normally only see it after they quit lazygit again, but still). But it is especially useful when writing back the config file fails; some users have their config file in a read-only location, so we had reports of lazygit no longer starting up when migration was necessary. #4210 was supposed to improve this a bit, but it didn't tell users what changes need to be made to the config file. Now we tell them, and users can then make these changes manually if they want.

We do this only at startup, when the GUI hasn't started yet. This is probably good enough, because it is much less likely that writing back a migrated repo-local config fails because it is not writeable.

Example output:
```
The user config file /Users/stk/Library/Application Support/lazygit/config.yml must be migrated. Attempting to do this automatically.
The following changes were made:

- Renamed 'gui.windowSize' to 'screenMode'
- Changed 'null' to '<disabled>' for keybinding 'keybinding.universal.confirmInEditor'
- Changed 'stream: true' to 'output: log' in custom command

Config file saved successfully to /Users/stk/Library/Application Support/lazygit/config.yml
```

The branch also contains a lot of code cleanups.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc