### PR TITLE
Retain index position of allBranchesLogCmd when toggling status panel

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -346,6 +346,7 @@ Note that this disregards the selection, the new branch is always created either
 | `` u `` | Check for update |  |
 | `` <enter> `` | Switch to a recent repo |  |
 | `` a `` | Show/cycle all branch logs |  |
+| `` 0 `` | Focus main view |  |
 
 ## Sub-commits
 

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -198,6 +198,7 @@ Note that this disregards the selection, the new branch is always created either
 | `` u `` | 更新を確認 |  |
 | `` <enter> `` | 最近使用したリポジトリに切り替え |  |
 | `` a `` | Show/cycle all branch logs |  |
+| `` 0 `` | Focus main view |  |
 
 ## タグ
 

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -238,6 +238,7 @@ Note that this disregards the selection, the new branch is always created either
 | `` u `` | 업데이트 확인 |  |
 | `` <enter> `` | 최근에 사용한 저장소로 전환 |  |
 | `` a `` | Show/cycle all branch logs |  |
+| `` 0 `` | Focus main view |  |
 
 ## 서브모듈
 

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -346,6 +346,7 @@ Note that this disregards the selection, the new branch is always created either
 | `` u `` | Check voor updates |  |
 | `` <enter> `` | Wissel naar een recente repo |  |
 | `` a `` | Show/cycle all branch logs |  |
+| `` 0 `` | Focus main view |  |
 
 ## Sub-commits
 

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -326,6 +326,7 @@ Note that this disregards the selection, the new branch is always created either
 | `` u `` | Sprawdź aktualizacje |  |
 | `` <enter> `` | Przełącz na ostatnie repozytorium |  |
 | `` a `` | Show/cycle all branch logs |  |
+| `` 0 `` | Focus main view |  |
 
 ## Sub-commity
 

--- a/docs/keybindings/Keybindings_pt.md
+++ b/docs/keybindings/Keybindings_pt.md
@@ -359,6 +359,7 @@ Note that this disregards the selection, the new branch is always created either
 | `` u `` | Verificar atualização |  |
 | `` <enter> `` | Mudar para um repositório recente |  |
 | `` a `` | Mostrar/ciclo todos os logs de filiais |  |
+| `` 0 `` | Focus main view |  |
 
 ## Sub-commits
 

--- a/docs/keybindings/Keybindings_ru.md
+++ b/docs/keybindings/Keybindings_ru.md
@@ -315,6 +315,7 @@ Note that this disregards the selection, the new branch is always created either
 | `` u `` | Проверить обновления |  |
 | `` <enter> `` | Переключиться на последний репозиторий |  |
 | `` a `` | Show/cycle all branch logs |  |
+| `` 0 `` | Focus main view |  |
 
 ## Теги
 

--- a/docs/keybindings/Keybindings_zh-CN.md
+++ b/docs/keybindings/Keybindings_zh-CN.md
@@ -349,6 +349,7 @@ Note that this disregards the selection, the new branch is always created either
 | `` u `` | 检查更新 |  |
 | `` <enter> `` | 切换到最近的仓库 |  |
 | `` a `` | Show/cycle all branch logs |  |
+| `` 0 `` | Focus main view |  |
 
 ## 确认面板
 

--- a/docs/keybindings/Keybindings_zh-TW.md
+++ b/docs/keybindings/Keybindings_zh-TW.md
@@ -371,6 +371,7 @@ Note that this disregards the selection, the new branch is always created either
 | `` u `` | 檢查更新 |  |
 | `` <enter> `` | 切換到最近使用的版本庫 |  |
 | `` a `` | Show/cycle all branch logs |  |
+| `` 0 `` | Focus main view |  |
 
 ## 確認面板
 

--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -274,9 +274,8 @@ func (self *BranchCommands) rotateAllBranchesIdx() {
 }
 
 func (self *BranchCommands) RotateAllBranchesLogCmdObj() *oscommands.CmdObj {
-	cmd := self.CurrentAllBranchesLogCmdObj()
 	self.rotateAllBranchesIdx()
-	return cmd
+	return self.CurrentAllBranchesLogCmdObj()
 }
 
 func (self *BranchCommands) IsBranchMerged(branch *models.Branch, mainBranches *MainBranches) (bool, error) {

--- a/pkg/commands/git_commands/branch_test.go
+++ b/pkg/commands/git_commands/branch_test.go
@@ -230,7 +230,7 @@ func TestBranchGetAllBranchGraph(t *testing.T) {
 		"log", "--graph", "--all", "--color=always", "--abbrev-commit", "--decorate", "--date=relative", "--pretty=medium",
 	}, "", nil)
 	instance := buildBranchCommands(commonDeps{runner: runner})
-	err := instance.AllBranchesLogCmdObj().Run()
+	err := instance.RotateAllBranchesLogCmdObj().Run()
 	assert.NoError(t, err)
 }
 

--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -266,6 +266,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 	}
 
 	for _, context := range []types.Context{
+		gui.State.Contexts.Status,
 		gui.State.Contexts.Files,
 		gui.State.Contexts.Branches,
 		gui.State.Contexts.RemoteBranches,

--- a/pkg/gui/controllers/status_controller.go
+++ b/pkg/gui/controllers/status_controller.go
@@ -60,7 +60,7 @@ func (self *StatusController) GetKeybindings(opts types.KeybindingsOpts) []*type
 		},
 		{
 			Key:         opts.GetKey(opts.Config.Status.AllBranchesLogGraph),
-			Handler:     func() error { self.showAllBranchLogs(); return nil },
+			Handler:     func() error { self.rotateAllBranchesLogs(); return nil },
 			Description: self.c.Tr.AllBranchesLogGraph,
 		},
 	}
@@ -178,7 +178,21 @@ func (self *StatusController) editConfig() error {
 }
 
 func (self *StatusController) showAllBranchLogs() {
-	cmdObj := self.c.Git().Branch.AllBranchesLogCmdObj()
+	cmdObj := self.c.Git().Branch.CurrentAllBranchesLogCmdObj()
+	task := types.NewRunPtyTask(cmdObj.GetCmd())
+
+	self.c.RenderToMainViews(types.RefreshMainOpts{
+		Pair: self.c.MainViewPairs().Normal,
+		Main: &types.ViewUpdateOpts{
+			Title: self.c.Tr.LogTitle,
+			Task:  task,
+		},
+	})
+}
+
+// Switches to the next branch command and renders it onto the screen
+func (self *StatusController) rotateAllBranchesLogs() {
+	cmdObj := self.c.Git().Branch.RotateAllBranchesLogCmdObj()
 	task := types.NewRunPtyTask(cmdObj.GetCmd())
 
 	self.c.RenderToMainViews(types.RefreshMainOpts{

--- a/pkg/integration/tests/status/log_cmd_status_panel_all_branches_log.go
+++ b/pkg/integration/tests/status/log_cmd_status_panel_all_branches_log.go
@@ -5,28 +5,28 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
-var LogCmd = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Cycle between two different log commands in the Status view",
+var LogCmdStatusPanelAllBranchesLog = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Cycle between two different log commands in the Status view when it has status panel AllBranchesLog",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
 		config.GetUserConfig().Git.AllBranchesLogCmds = []string{`echo "view1"`, `echo "view2"`}
+		config.GetUserConfig().Gui.StatusPanelView = "allBranchesLog"
 	},
 	SetupRepo: func(shell *Shell) {},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Status().
-			Focus().
-			Press(keys.Status.AllBranchesLogGraph)
-		t.Views().Main().Content(Contains("view2"))
-
-		t.Views().Status().
-			Focus().
-			Press(keys.Status.AllBranchesLogGraph)
-		t.Views().Main().Content(Contains("view1").DoesNotContain("view2"))
+			Focus()
+		t.Views().Main().Content(Contains("view1"))
 
 		t.Views().Status().
 			Focus().
 			Press(keys.Status.AllBranchesLogGraph)
 		t.Views().Main().Content(Contains("view2").DoesNotContain("view1"))
+
+		t.Views().Status().
+			Focus().
+			Press(keys.Status.AllBranchesLogGraph)
+		t.Views().Main().Content(Contains("view1").DoesNotContain("view2"))
 	},
 })

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -360,6 +360,7 @@ var tests = []*components.IntegrationTest{
 	status.ClickToFocus,
 	status.ClickWorkingTreeStateToOpenRebaseOptionsMenu,
 	status.LogCmd,
+	status.LogCmdStatusPanelAllBranchesLog,
 	status.ShowDivergenceFromBaseBranch,
 	submodule.Add,
 	submodule.Enter,


### PR DESCRIPTION
- **PR Description**

Currently the behaviors of pressing `1` to jump to the status panel (with `gui.StatusPanelView: allBranchesLogCmd`) and pressing `a` once in the status panel, are identical. This results in the bug described in  https://github.com/jesseduffield/lazygit/issues/4469, where the simple config:
```
git:
  allBranchesLogCmds:
    - echo "Hello 1"
    - echo "Hello 2"
gui:
  statusPanelView: allBranchesLog
```

rotates between the two commands as you press `1`, `2`, `1`, `2`.

This PR splits the behavior of `1` and `a` such that `1` just shows the current index without mutating anything, and `a` rotates the index, and then displays is. This latter behavior is not without controversy, as it changes existing behavior. See my long commit body for more details. The only way to "fix" this is to add additional understanding into the command as to what view is currently being rendered in the main view, which seemed to be non-trivial with how this view is implemented. If we wanted to fix this behavior, it might make sense to make more drastic changes and add an actual Tab for this allBranchesLog view.

Fixes https://github.com/jesseduffield/lazygit/issues/4469
- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [X] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc
