### PR TITLE
Clear preserved commit message when entering CommitEditorPanel

### DIFF
--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -157,8 +157,7 @@ func (self *CommitsHelper) OpenCommitMessagePanel(opts *OpenCommitMessagePanelOp
 	self.c.Context().Push(self.c.Contexts().CommitMessage, types.OnFocusOpts{})
 }
 
-func (self *CommitsHelper) OnCommitSuccess() {
-	// if we have a preserved message we want to clear it on success
+func (self *CommitsHelper) ClearPreservedCommitMessage() {
 	self.c.Contexts().CommitMessage.SetPreservedMessageAndLogError("")
 }
 

--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -159,9 +159,7 @@ func (self *CommitsHelper) OpenCommitMessagePanel(opts *OpenCommitMessagePanelOp
 
 func (self *CommitsHelper) OnCommitSuccess() {
 	// if we have a preserved message we want to clear it on success
-	if self.c.Contexts().CommitMessage.GetPreserveMessage() {
-		self.c.Contexts().CommitMessage.SetPreservedMessageAndLogError("")
-	}
+	self.c.Contexts().CommitMessage.SetPreservedMessageAndLogError("")
 }
 
 func (self *CommitsHelper) HandleCommitConfirm() error {

--- a/pkg/gui/controllers/helpers/tags_helper.go
+++ b/pkg/gui/controllers/helpers/tags_helper.go
@@ -34,7 +34,6 @@ func (self *TagsHelper) OpenCreateTagPrompt(ref string, onCreate func()) error {
 		}
 
 		return self.gpg.WithGpgHandling(command, git_commands.TagGpgSign, self.c.Tr.CreatingTag, func() error {
-			self.commitsHelper.OnCommitSuccess()
 			return nil
 		}, []types.RefreshableView{types.COMMITS, types.TAGS})
 	}

--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -136,6 +136,10 @@ func (self *WorkingTreeHelper) switchFromCommitMessagePanelToEditor(filepath str
 // their editor rather than via the popup panel
 func (self *WorkingTreeHelper) HandleCommitEditorPress() error {
 	return self.WithEnsureCommittableFiles(func() error {
+		// See reasoning in switchFromCommitMessagePanelToEditor for why it makes sense
+		// to clear this message before calling into the editor
+		self.commitsHelper.ClearPreservedCommitMessage()
+
 		self.c.LogAction(self.c.Tr.Actions.Commit)
 		return self.c.RunSubprocessAndRefresh(
 			self.c.Git().Commit.CommitEditorCmdObj(),

--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -112,7 +112,7 @@ func (self *WorkingTreeHelper) handleCommit(summary string, description string, 
 	self.c.LogAction(self.c.Tr.Actions.Commit)
 	return self.gpgHelper.WithGpgHandling(cmdObj, git_commands.CommitGpgSign, self.c.Tr.CommittingStatus,
 		func() error {
-			self.commitsHelper.OnCommitSuccess()
+			self.commitsHelper.ClearPreservedCommitMessage()
 			return nil
 		}, nil)
 }
@@ -124,7 +124,7 @@ func (self *WorkingTreeHelper) switchFromCommitMessagePanelToEditor(filepath str
 	// access to the last message that the user typed, and it might be very
 	// different from what was last in the commit panel. So the best we can do
 	// here is to always clear the remembered commit message.
-	self.commitsHelper.OnCommitSuccess()
+	self.commitsHelper.ClearPreservedCommitMessage()
 
 	self.c.LogAction(self.c.Tr.Actions.Commit)
 	return self.c.RunSubprocessAndRefresh(


### PR DESCRIPTION
- **PR Description**

Fixes the problem described in #4557:

I often find myself initiating a commit message with `c`, but then halfway through typing the message, realize that is is likely to be more substantial than I thought. I press `<esc>`  and then `C` to launch my editor where I can edit a larger commit body more effectively. I finish my commit message, close my editor, return to LazyGit and all is well.

Unfortunately, the next time I press `c`, creating a totally new commit, my partially completed message is still present. It no longer is relevant, so I have to delete the few words I typed before.

- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc
