### PR TITLE
Remove reference to rtx in README

### DIFF
--- a/pkg/integration/README.md
+++ b/pkg/integration/README.md
@@ -96,9 +96,4 @@ If you're testing different pieces of functionality, it's better to test them in
 
 ## Testing against old git versions
 
-Our CI tests against multiple git versions. If your test fails on an old version, then to troubleshoot you'll need to install the failing git version. One option is to use [rtx](https://github.com/jdxcode/rtx) (see installation steps in the readme) with the git plugin like so:
-```sh
-rtx plugin add git
-rtx install git 2.20.0
-rtx local git 2.20.0
-```
+Our CI tests against multiple git versions. If your test fails on an old version, then to troubleshoot you'll need to install the failing git version.


### PR DESCRIPTION
- **PR Description**


 rtx has since been renamed to mise https://mise.jdx.dev/rtx.html and the creator says that it shouldn't be used to manage git. https://github.com/jdx/mise/pull/4694#issuecomment-2747820332

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [X] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

