### PR TITLE
Fix possible crash with auto-forwarding branches

### DIFF
--- a/pkg/gui/controllers/helpers/branches_helper.go
+++ b/pkg/gui/controllers/helpers/branches_helper.go
@@ -270,8 +270,12 @@ func (self *BranchesHelper) AutoForwardBranches() error {
 		return nil
 	}
 
-	allBranches := self.c.UserConfig().Git.AutoForwardBranches == "allBranches"
 	branches := self.c.Model().Branches
+	if len(branches) == 0 {
+		return nil
+	}
+
+	allBranches := self.c.UserConfig().Git.AutoForwardBranches == "allBranches"
 	updateCommands := ""
 	// The first branch is the currently checked out branch; skip it
 	for _, branch := range branches[1:] {


### PR DESCRIPTION
- **PR Description**

Fix crash in AutoForwardBranches when the branches slice is empty.

I'm not aware of any real scenario where this can happen, but we have seen one stack trace where it crashed with an out-of-bounds error in the range expression below, so there must be a way. And it seems better to guard against it anyway, rather than assuming it can't happen.

(Hopefully) fixes #4564.
