### PR TITLE
Clamp maxY in patch explorer and merge conflicts to allow large hunks

### DIFF
--- a/pkg/commands/patch/format.go
+++ b/pkg/commands/patch/format.go
@@ -128,7 +128,6 @@ func (self *patchPresenter) formatLine(str string, textStyle style.TextStyle, in
 	return self.formatLineAux(str, textStyle, included)
 }
 
-// 'selected' means you've got it highlighted with your cursor
 // 'included' means the line has been included in the patch (only applicable when
 // building a patch)
 func (self *patchPresenter) formatLineAux(str string, textStyle style.TextStyle, included bool) string {

--- a/pkg/gui/context/merge_conflicts_context.go
+++ b/pkg/gui/context/merge_conflicts_context.go
@@ -109,7 +109,8 @@ func (self *MergeConflictsContext) SetSelectedLineRange() {
 	originY := view.OriginY()
 	// As far as the view is concerned, we are always selecting a range
 	view.SetRangeSelectStart(startIdx)
-	view.SetCursorY(endIdx - originY)
+	cursorY := min(endIdx-originY, view.InnerHeight()-1)
+	view.SetCursorY(cursorY)
 }
 
 func (self *MergeConflictsContext) GetOriginY() int {

--- a/pkg/gui/context/patch_explorer_context.go
+++ b/pkg/gui/context/patch_explorer_context.go
@@ -118,7 +118,8 @@ func (self *PatchExplorerContext) FocusSelection() {
 	startIdx, endIdx := state.SelectedViewRange()
 	// As far as the view is concerned, we are always selecting a range
 	view.SetRangeSelectStart(startIdx)
-	view.SetCursorY(endIdx - newOriginY)
+	cursorY := min(endIdx-newOriginY, bufferHeight-1)
+	view.SetCursorY(cursorY)
 }
 
 func (self *PatchExplorerContext) GetContentToRender() string {


### PR DESCRIPTION
- **PR Description**

Did a git bisect and found that https://github.com/jesseduffield/lazygit/issues/4470 was introduced by https://github.com/jesseduffield/lazygit/commit/f3eb180f75496637719895902abf76af10b8425f.

Our problem comes down to the implementation of `SetCursorY` in gocui, which was throwing out the y value we provided it, since it was higher than the inner height of the view.
https://github.com/jesseduffield/lazygit/blob/a0ec22c251c67b40f2df9a61226f3bd514789e15/vendor/github.com/jesseduffield/gocui/view.go#L583-L589

We only had 2 callsites to `SetCursorY`, both of which I tested manually and updated in this PR. We _could_ put this clamping logic into gocui, but the name `Set` doesn't imply that it does any clamping. I'm open to renaming the function and making the PR there, if we would want.


Fixes https://github.com/jesseduffield/lazygit/issues/4470
- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
