### PR TITLE
Split behavior of rendering allBranchesLogCmd and switching to next cmd

### DIFF
--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -255,16 +255,22 @@ func (self *BranchCommands) Merge(branchName string, opts MergeOpts) error {
 	return self.cmd.New(cmdArgs).Run()
 }
 
-func (self *BranchCommands) AllBranchesLogCmdObj() *oscommands.CmdObj {
-	// Only choose between non-empty, non-identical commands
-	candidates := lo.Uniq(lo.WithoutEmpty(self.UserConfig().Git.AllBranchesLogCmds))
+// Only choose between non-empty, non-identical commands
+func (self *BranchCommands) allBranchesLogCandidates() []string {
+	return lo.Uniq(lo.WithoutEmpty(self.UserConfig().Git.AllBranchesLogCmds))
+}
 
-	n := len(candidates)
+func (self *BranchCommands) AllBranchesLogCmdObj() *oscommands.CmdObj {
+	candidates := self.allBranchesLogCandidates()
 
 	i := self.allBranchesLogCmdIndex
-	self.allBranchesLogCmdIndex = uint8((int(i) + 1) % n)
-
 	return self.cmd.New(str.ToArgv(candidates[i])).DontLog()
+}
+
+func (self *BranchCommands) RotateAllBranchesLogIdx() {
+	n := len(self.allBranchesLogCandidates())
+	i := self.allBranchesLogCmdIndex
+	self.allBranchesLogCmdIndex = uint8((int(i) + 1) % n)
 }
 
 func (self *BranchCommands) IsBranchMerged(branch *models.Branch, mainBranches *MainBranches) (bool, error) {

--- a/pkg/gui/controllers/status_controller.go
+++ b/pkg/gui/controllers/status_controller.go
@@ -60,7 +60,7 @@ func (self *StatusController) GetKeybindings(opts types.KeybindingsOpts) []*type
 		},
 		{
 			Key:         opts.GetKey(opts.Config.Status.AllBranchesLogGraph),
-			Handler:     func() error { self.showAllBranchLogs(); return nil },
+			Handler:     func() error { self.switchToOrRotateAllBranchesLogs(); return nil },
 			Description: self.c.Tr.AllBranchesLogGraph,
 		},
 	}
@@ -188,6 +188,18 @@ func (self *StatusController) showAllBranchLogs() {
 			Task:  task,
 		},
 	})
+}
+
+// Switches to the all branches view, or, if already on that view,
+// rotates to the next command in the list, and then renders it.
+func (self *StatusController) switchToOrRotateAllBranchesLogs() {
+	// A bit of a hack to ensure we only rotate to the next branch log command
+	// if we currently are looking at a branch log. Otherwise, we should just show
+	// the current index (if we are coming from the dashboard).
+	if self.c.Views().Main.Title == self.c.Tr.LogTitle {
+		self.c.Git().Branch.RotateAllBranchesLogIdx()
+	}
+	self.showAllBranchLogs()
 }
 
 func (self *StatusController) showDashboard() {

--- a/pkg/integration/tests/status/log_cmd_status_panel_all_branches_log.go
+++ b/pkg/integration/tests/status/log_cmd_status_panel_all_branches_log.go
@@ -1,0 +1,38 @@
+package status
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var LogCmdStatusPanelAllBranchesLog = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Cycle between two different log commands in the Status view when it has status panel AllBranchesLog",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Git.AllBranchesLogCmds = []string{`echo "view1"`, `echo "view2"`}
+		config.GetUserConfig().Gui.StatusPanelView = "allBranchesLog"
+	},
+	SetupRepo: func(shell *Shell) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Status().
+			Focus()
+		t.Views().Main().Content(Contains("view1"))
+
+		// We head to the branches view and return
+		t.Views().Branches().
+			Focus()
+		t.Views().Status().
+			Focus()
+
+		t.Views().Main().Content(Contains("view1").DoesNotContain("view2"))
+
+		t.Views().Status().
+			Press(keys.Status.AllBranchesLogGraph)
+		t.Views().Main().Content(Contains("view2").DoesNotContain("view1"))
+
+		t.Views().Status().
+			Press(keys.Status.AllBranchesLogGraph)
+		t.Views().Main().Content(Contains("view1").DoesNotContain("view2"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -360,6 +360,7 @@ var tests = []*components.IntegrationTest{
 	status.ClickToFocus,
 	status.ClickWorkingTreeStateToOpenRebaseOptionsMenu,
 	status.LogCmd,
+	status.LogCmdStatusPanelAllBranchesLog,
 	status.ShowDivergenceFromBaseBranch,
 	submodule.Add,
 	submodule.Enter,


### PR DESCRIPTION
- **PR Description**

This is a recreation of https://github.com/jesseduffield/lazygit/pull/4556.

Compared to that PR description, this has actually solved the problem that repeated attempts to `1` `a` when `gui.statusPanelView: dashboard`. Now we only rotate logs on the 2nd `a` press. While this does differ from current behavior, I believe it is better, and I have more details in my commit description.

Fixes https://github.com/jesseduffield/lazygit/issues/4469

- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc