### PR TITLE
Fix lazygit's UI becoming unresponsive when a background fetch asks for a passphrase

### DIFF
--- a/pkg/commands/oscommands/cmd_obj.go
+++ b/pkg/commands/oscommands/cmd_obj.go
@@ -196,6 +196,7 @@ func (self *CmdObj) PromptOnCredentialRequest(task gocui.Task) *CmdObj {
 
 func (self *CmdObj) FailOnCredentialRequest() *CmdObj {
 	self.credentialStrategy = FAIL
+	self.usePty = true
 
 	return self
 }


### PR DESCRIPTION
Fix a regression introduced with #4525.

This fixes the problem that background fetching makes lazygit hang when the fetch request needs to prompt for a passphrase. For Mac users who use the keychain to store their ssh passphrases, this can happen when lazygit is running while the machine goes to sleep, because macOS looks the keychain in that case.
