### PR TITLE
Kill background fetch when it requests a passphrase

### DIFF
--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-errors/errors"
-	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/sasha-s/go-deadlock"
 	"github.com/sirupsen/logrus"
@@ -340,7 +339,7 @@ func (self *cmdObjRunner) runAndDetectCredentialRequest(
 		tr := io.TeeReader(handler.stdoutPipe, cmdWriter)
 
 		go utils.Safe(func() {
-			self.processOutput(tr, handler.stdinPipe, promptUserForCredential, cmdObj.GetTask())
+			self.processOutput(tr, handler.stdinPipe, promptUserForCredential, cmdObj)
 		})
 	})
 }
@@ -349,9 +348,10 @@ func (self *cmdObjRunner) processOutput(
 	reader io.Reader,
 	writer io.Writer,
 	promptUserForCredential func(CredentialType) <-chan string,
-	task gocui.Task,
+	cmdObj *CmdObj,
 ) {
 	checkForCredentialRequest := self.getCheckForCredentialRequestFunc()
+	task := cmdObj.GetTask()
 
 	scanner := bufio.NewScanner(reader)
 	scanner.Split(bufio.ScanBytes)

--- a/pkg/commands/oscommands/cmd_obj_runner_test.go
+++ b/pkg/commands/oscommands/cmd_obj_runner_test.go
@@ -120,8 +120,8 @@ func TestProcessOutput(t *testing.T) {
 			reader := strings.NewReader(scenario.output)
 			writer := &strings.Builder{}
 
-			task := gocui.NewFakeTask()
-			runner.processOutput(reader, writer, toChanFn(scenario.promptUserForCredential), task)
+			cmdObj := &CmdObj{task: gocui.NewFakeTask()}
+			runner.processOutput(reader, writer, toChanFn(scenario.promptUserForCredential), cmdObj)
 
 			if writer.String() != scenario.expectedToWrite {
 				t.Errorf("expected to write '%s' but got '%s'", scenario.expectedToWrite, writer.String())


### PR DESCRIPTION
Previously we would enter a newline at the password prompt, which would cause the fetch to fail. The problem with this was that if you have many remotes, the fetch would sometimes hang for some reason; I don't totally understand how that happened, but I guess the many ssh processes requesting passwords would somehow interfere with each other. Avoid this by simply killing the git fetch process the moment it requests the first password.