### PR TITLE
Add "Toggle full diff" checkbox to the filtering menu in filter-by-path mode

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -271,7 +271,7 @@ func (self *CommitCommands) ShowCmdObj(hash string, filterPath string) *oscomman
 		Arg(hash).
 		ArgIf(self.AppState.IgnoreWhitespaceInDiffView, "--ignore-all-space").
 		Arg(fmt.Sprintf("--find-renames=%d%%", self.AppState.RenameSimilarityThreshold)).
-		ArgIf(filterPath != "", "--", filterPath).
+		ArgIf(filterPath != "" && !self.AppState.ShowFullDiffInFilterByPathMode, "--", filterPath).
 		Dir(self.repoPaths.worktreePath).
 		ToArgv()
 

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -691,6 +691,8 @@ type AppState struct {
 	// This determines whether the git graph is rendered in the commits panel
 	// One of 'always' | 'never' | 'when-maximised'
 	GitLogShowGraph string
+
+	ShowFullDiffInFilterByPathMode bool
 }
 
 func getDefaultAppState() *AppState {

--- a/pkg/gui/controllers/filtering_menu_action.go
+++ b/pkg/gui/controllers/filtering_menu_action.go
@@ -92,6 +92,19 @@ func (self *FilteringMenuAction) Call() error {
 		Tooltip: tooltip,
 	})
 
+	if path := self.c.Modes().Filtering.GetPath(); path != "" {
+		menuItems = append(menuItems, &types.MenuItem{
+			Label: "Show full diff", // TODO: i18n (and tooltip?)
+			Key:   'f',
+			OnPress: func() error {
+				self.c.AppState.ShowFullDiffInFilterByPathMode = !self.c.AppState.ShowFullDiffInFilterByPathMode
+				self.c.SaveAppStateAndLogError()
+				return self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.COMMITS}})
+			},
+			Widget: types.MakeMenuCheckBox(self.c.AppState.ShowFullDiffInFilterByPathMode),
+		})
+	}
+
 	if self.c.Modes().Filtering.Active() {
 		menuItems = append(menuItems, &types.MenuItem{
 			Label:   self.c.Tr.ExitFilterMode,

--- a/pkg/gui/controllers/filtering_menu_action.go
+++ b/pkg/gui/controllers/filtering_menu_action.go
@@ -60,6 +60,7 @@ func (self *FilteringMenuAction) Call() error {
 
 	menuItems = append(menuItems, &types.MenuItem{
 		Label: self.c.Tr.FilterPathOption,
+		Key:   'p',
 		OnPress: func() error {
 			self.c.Prompt(types.PromptOpts{
 				FindSuggestionsFunc: self.c.Helpers().Suggestions.GetFilePathSuggestionsFunc(),
@@ -76,6 +77,7 @@ func (self *FilteringMenuAction) Call() error {
 
 	menuItems = append(menuItems, &types.MenuItem{
 		Label: self.c.Tr.FilterAuthorOption,
+		Key:   'a',
 		OnPress: func() error {
 			self.c.Prompt(types.PromptOpts{
 				FindSuggestionsFunc: self.c.Helpers().Suggestions.GetAuthorsSuggestionsFunc(),
@@ -93,6 +95,7 @@ func (self *FilteringMenuAction) Call() error {
 	if self.c.Modes().Filtering.Active() {
 		menuItems = append(menuItems, &types.MenuItem{
 			Label:   self.c.Tr.ExitFilterMode,
+			Key:     's',
 			OnPress: self.c.Helpers().Mode.ClearFiltering,
 		})
 	}

--- a/pkg/gui/controllers/helpers/diff_helper.go
+++ b/pkg/gui/controllers/helpers/diff_helper.go
@@ -57,7 +57,7 @@ func (self *DiffHelper) GetUpdateTaskForRenderingCommitsDiff(commit *models.Comm
 		from, to := refRange.From, refRange.To
 		args := []string{from.ParentRefName(), to.RefName(), "--stat", "-p"}
 		args = append(args, "--")
-		if path := self.c.Modes().Filtering.GetPath(); path != "" {
+		if path := self.c.Modes().Filtering.GetPath(); path != "" && !self.c.AppState.ShowFullDiffInFilterByPathMode {
 			args = append(args, path)
 		}
 		cmdObj := self.c.Git().Diff.DiffCmdObj(args)


### PR DESCRIPTION
- **PR Description**

Add a "Show full diff" checkbox to the filtering menu. This can be useful if you want to see the changes to the filtered file in context, and it can be used as a workaround in case the file was renamed, in which case the diff would be empty for all commits before the rename, because we would filter the diff by the path.