### PR TITLE
Fix branch selection jumping back on background fetch

### DIFF
--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -448,8 +448,6 @@ func (self *RefreshHelper) refreshBranches(refreshWorktrees bool, keepBranchSele
 	self.c.Mutexes().RefreshingBranchesMutex.Lock()
 	defer self.c.Mutexes().RefreshingBranchesMutex.Unlock()
 
-	prevSelectedBranch := self.c.Contexts().Branches.GetSelected()
-
 	reflogCommits := self.c.Model().FilteredReflogCommits
 	if self.c.Modes().Filtering.Active() && self.c.AppState.LocalBranchSortOrder == "recency" {
 		// in filter mode we filter our reflog commits to just those containing the path
@@ -483,6 +481,8 @@ func (self *RefreshHelper) refreshBranches(refreshWorktrees bool, keepBranchSele
 	if err != nil {
 		self.c.Log.Error(err)
 	}
+
+	prevSelectedBranch := self.c.Contexts().Branches.GetSelected()
 
 	self.c.Model().Branches = branches
 


### PR DESCRIPTION
- **PR Description**

When refreshing the branches list, we have code to keep the same branch selected even when the refresh changes the sort order; this code remembers the selected branch before the refresh, and then tries to select it again afterwards (looking it up by name) if it is still there.

However, we stored the previously selected branch too early, before even obtaining the branches list; if the user moved the selection between that point and the end of the refresh, it would jump back. Fix this by remembering the previous selection only at the last moment, right before assigning the new branches slice.

We still have a race condition here between the UI code that manages the selection as the user presses arrow keys, and the background thread doing the refresh that reads and restores the selection; however, the race was there before, and we make it neither better nor worse with this PR. It doesn't seem to be a problem in practice.

Fixes #4116.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
