### PR TITLE
Use branchPrefix when moving commits to new branch

### DIFF
--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -325,13 +325,10 @@ func (self *RefsHelper) NewBranch(from string, fromFormattedName string, suggest
 	if suggestedBranchName == "" {
 		var err error
 
-		suggestedBranchName, err = utils.ResolveTemplate(self.c.UserConfig().Git.BranchPrefix, nil, template.FuncMap{
-			"runCommand": self.c.Git().Custom.TemplateFunctionRunCommand,
-		})
+		suggestedBranchName, err = self.getSuggestedBranchName()
 		if err != nil {
 			return err
 		}
-		suggestedBranchName = strings.ReplaceAll(suggestedBranchName, "\t", " ")
 	}
 
 	refresh := func() error {
@@ -586,4 +583,15 @@ func (self *RefsHelper) ParseRemoteBranchName(fullBranchName string) (string, st
 
 func IsSwitchBranchUncommittedChangesError(err error) bool {
 	return strings.Contains(err.Error(), "Please commit your changes or stash them before you switch branch")
+}
+
+func (self *RefsHelper) getSuggestedBranchName() (string, error) {
+	suggestedBranchName, err := utils.ResolveTemplate(self.c.UserConfig().Git.BranchPrefix, nil, template.FuncMap{
+		"runCommand": self.c.Git().Custom.TemplateFunctionRunCommand,
+	})
+	if err != nil {
+		return suggestedBranchName, err
+	}
+	suggestedBranchName = strings.ReplaceAll(suggestedBranchName, "\t", " ")
+	return suggestedBranchName, nil
 }

--- a/pkg/integration/tests/branch/move_commits_to_new_branch_keep_stacked.go
+++ b/pkg/integration/tests/branch/move_commits_to_new_branch_keep_stacked.go
@@ -9,7 +9,9 @@ var MoveCommitsToNewBranchKeepStacked = NewIntegrationTest(NewIntegrationTestArg
 	Description:  "Create a new branch from the commits that you accidentally made on the wrong branch; choosing stacked on current branch",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
-	SetupConfig:  func(config *config.AppConfig) {},
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Git.BranchPrefix = "myprefix/"
+	},
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("initial commit")
 		shell.CloneIntoRemote("origin")
@@ -42,12 +44,13 @@ var MoveCommitsToNewBranchKeepStacked = NewIntegrationTest(NewIntegrationTestArg
 
 		t.ExpectPopup().Prompt().
 			Title(Equals("New branch name (branch is off of 'feature')")).
+			InitialText(Equals("myprefix/")).
 			Type("new branch").
 			Confirm()
 
 		t.Views().Branches().
 			Lines(
-				Contains("new-branch").DoesNotContain("↑").IsSelected(),
+				Contains("myprefix/new-branch").DoesNotContain("↑").IsSelected(),
 				Contains("feature ✓"),
 				Contains("master ✓"),
 			)


### PR DESCRIPTION
- **PR Description**

When pressing N to move new commits to a new branch we get greeted with an empty prompt, this PR makes it so we fill the empty prompt with a suggestion taken from branchPrefix, similar to the good old create a new branch.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
