### PR TITLE
Replace literal with ConfigFilename constant

### DIFF
--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -136,7 +136,7 @@ func NewAppConfig(
 }
 
 func ConfigDir() string {
-	_, filePath := findConfigFile("config.yml")
+	_, filePath := findConfigFile(ConfigFilename)
 
 	return filepath.Dir(filePath)
 }


### PR DESCRIPTION
A tiny clean-up where I assume it is a good idea to re-use the common specification of the `"config.yml"` name.