### PR TITLE
Fix wrong inactive highlight when switching between repos

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -523,6 +523,13 @@ func (gui *Gui) checkForChangedConfigsThatDontAutoReload(oldConfig *config.UserC
 // resetState reuses the repo state from our repo state map, if the repo was
 // open before; otherwise it creates a new one.
 func (gui *Gui) resetState(startArgs appTypes.StartArgs) types.Context {
+	// Un-highlight the current view if there is one. The reason we do this is
+	// that the repo we are switching to might have a different view focused,
+	// and would then show an inactive highlight for the previous view.
+	if oldCurrentView := gui.g.CurrentView(); oldCurrentView != nil {
+		oldCurrentView.Highlight = false
+	}
+
 	worktreePath := gui.git.RepoPaths.WorktreePath()
 
 	if state := gui.RepoStateMap[Repo(worktreePath)]; state != nil {


### PR DESCRIPTION
- **PR Description**

When switching between repos, each repo might have a different focused panel; in this case, the previously focused panel would show the "inactive" highlight. By default this is only bold text, so it's barely noticeable, but it becomes more pronounced when setting e.g.

```yml
gui:
  theme:
    inactiveViewSelectedLineBgColor:
      - "#666666"
```

I noticed this especially when entering or leaving submodules; for example, enter a submodule by pressing enter in the Files panel, then switch to the Commits panel in the submodule, then press Esc to go back to the parent repo. This would put the focus back into the Files panel, but keep the inactive highlight in the Commits panel.
