### PR TITLE
Instantiate mutexes by value

### DIFF
--- a/pkg/commands/git_commands/main_branches.go
+++ b/pkg/commands/git_commands/main_branches.go
@@ -21,7 +21,7 @@ type MainBranches struct {
 	previousMainBranches []string
 
 	cmd   oscommands.ICmdObjBuilder
-	mutex *deadlock.Mutex
+	mutex deadlock.Mutex
 }
 
 func NewMainBranches(
@@ -32,7 +32,6 @@ func NewMainBranches(
 		c:                    cmn,
 		existingMainBranches: nil,
 		cmd:                  cmd,
-		mutex:                &deadlock.Mutex{},
 	}
 }
 

--- a/pkg/gui/context/filtered_list.go
+++ b/pkg/gui/context/filtered_list.go
@@ -16,14 +16,13 @@ type FilteredList[T any] struct {
 	getFilterFields func(T) []string
 	filter          string
 
-	mutex *deadlock.Mutex
+	mutex deadlock.Mutex
 }
 
 func NewFilteredList[T any](getList func() []T, getFilterFields func(T) []string) *FilteredList[T] {
 	return &FilteredList[T]{
 		getList:         getList,
 		getFilterFields: getFilterFields,
-		mutex:           &deadlock.Mutex{},
 	}
 }
 

--- a/pkg/gui/context/merge_conflicts_context.go
+++ b/pkg/gui/context/merge_conflicts_context.go
@@ -12,7 +12,7 @@ type MergeConflictsContext struct {
 	types.Context
 	viewModel *ConflictsViewModel
 	c         *ContextCommon
-	mutex     *deadlock.Mutex
+	mutex     deadlock.Mutex
 }
 
 type ConflictsViewModel struct {
@@ -33,7 +33,6 @@ func NewMergeConflictsContext(
 
 	return &MergeConflictsContext{
 		viewModel: viewModel,
-		mutex:     &deadlock.Mutex{},
 		Context: NewSimpleContext(
 			NewBaseContext(NewBaseContextOpts{
 				Kind:             types.MAIN_CONTEXT,
@@ -57,7 +56,7 @@ func (self *MergeConflictsContext) SetState(state *mergeconflicts.State) {
 }
 
 func (self *MergeConflictsContext) GetMutex() *deadlock.Mutex {
-	return self.mutex
+	return &self.mutex
 }
 
 func (self *MergeConflictsContext) SetUserScrolling(isScrolling bool) {

--- a/pkg/gui/context/patch_explorer_context.go
+++ b/pkg/gui/context/patch_explorer_context.go
@@ -15,7 +15,7 @@ type PatchExplorerContext struct {
 	viewTrait              *ViewTrait
 	getIncludedLineIndices func() []int
 	c                      *ContextCommon
-	mutex                  *deadlock.Mutex
+	mutex                  deadlock.Mutex
 }
 
 var (
@@ -36,7 +36,6 @@ func NewPatchExplorerContext(
 		state:                  nil,
 		viewTrait:              NewViewTrait(view),
 		c:                      c,
-		mutex:                  &deadlock.Mutex{},
 		getIncludedLineIndices: getIncludedLineIndices,
 		SimpleContext: NewSimpleContext(NewBaseContext(NewBaseContextOpts{
 			View:                       view,
@@ -137,7 +136,7 @@ func (self *PatchExplorerContext) NavigateTo(selectedLineIdx int) {
 }
 
 func (self *PatchExplorerContext) GetMutex() *deadlock.Mutex {
-	return self.mutex
+	return &self.mutex
 }
 
 func (self *PatchExplorerContext) ModelSearchResults(searchStr string, caseSensitive bool) []gocui.SearchPosition {

--- a/pkg/gui/controllers/helpers/inline_status_helper.go
+++ b/pkg/gui/controllers/helpers/inline_status_helper.go
@@ -15,7 +15,7 @@ type InlineStatusHelper struct {
 
 	windowHelper             *WindowHelper
 	contextsWithInlineStatus map[types.ContextKey]*inlineStatusInfo
-	mutex                    *deadlock.Mutex
+	mutex                    deadlock.Mutex
 }
 
 func NewInlineStatusHelper(c *HelperCommon, windowHelper *WindowHelper) *InlineStatusHelper {
@@ -23,7 +23,6 @@ func NewInlineStatusHelper(c *HelperCommon, windowHelper *WindowHelper) *InlineS
 		c:                        c,
 		windowHelper:             windowHelper,
 		contextsWithInlineStatus: make(map[types.ContextKey]*inlineStatusInfo),
-		mutex:                    &deadlock.Mutex{},
 	}
 }
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -681,17 +681,6 @@ func NewGui(
 		// real value after loading the user config:
 		ShowExtrasWindow: true,
 
-		Mutexes: types.Mutexes{
-			RefreshingFilesMutex:    &deadlock.Mutex{},
-			RefreshingBranchesMutex: &deadlock.Mutex{},
-			RefreshingStatusMutex:   &deadlock.Mutex{},
-			LocalCommitsMutex:       &deadlock.Mutex{},
-			SubCommitsMutex:         &deadlock.Mutex{},
-			AuthorsMutex:            &deadlock.Mutex{},
-			SubprocessMutex:         &deadlock.Mutex{},
-			PopupMutex:              &deadlock.Mutex{},
-			PtyMutex:                &deadlock.Mutex{},
-		},
 		InitialDir:       initialDir,
 		afterLayoutFuncs: make(chan func() error, 1000),
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -118,7 +118,7 @@ type Gui struct {
 	// is being pushed). At the moment the rule is to use an item operation when
 	// we need to talk to the remote.
 	itemOperations      map[string]types.ItemOperation
-	itemOperationsMutex *deadlock.Mutex
+	itemOperationsMutex deadlock.Mutex
 
 	PrevLayout PrevLayout
 
@@ -684,8 +684,7 @@ func NewGui(
 		InitialDir:       initialDir,
 		afterLayoutFuncs: make(chan func() error, 1000),
 
-		itemOperations:      make(map[string]types.ItemOperation),
-		itemOperationsMutex: &deadlock.Mutex{},
+		itemOperations: make(map[string]types.ItemOperation),
 	}
 
 	gui.PopupHandler = popup.NewPopupHandler(

--- a/pkg/gui/gui_common.go
+++ b/pkg/gui/gui_common.go
@@ -100,8 +100,8 @@ func (self *guiCommon) Model() *types.Model {
 	return self.gui.State.Model
 }
 
-func (self *guiCommon) Mutexes() types.Mutexes {
-	return self.gui.Mutexes
+func (self *guiCommon) Mutexes() *types.Mutexes {
+	return &self.gui.Mutexes
 }
 
 func (self *guiCommon) GocuiGui() *gocui.Gui {

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -94,7 +94,7 @@ type IGuiCommon interface {
 
 	Modes() *Modes
 
-	Mutexes() Mutexes
+	Mutexes() *Mutexes
 
 	State() IStateAccessor
 
@@ -313,18 +313,16 @@ type Model struct {
 	HashPool *utils.StringPool
 }
 
-// if you add a new mutex here be sure to instantiate it. We're using pointers to
-// mutexes so that we can pass the mutexes to controllers.
 type Mutexes struct {
-	RefreshingFilesMutex    *deadlock.Mutex
-	RefreshingBranchesMutex *deadlock.Mutex
-	RefreshingStatusMutex   *deadlock.Mutex
-	LocalCommitsMutex       *deadlock.Mutex
-	SubCommitsMutex         *deadlock.Mutex
-	AuthorsMutex            *deadlock.Mutex
-	SubprocessMutex         *deadlock.Mutex
-	PopupMutex              *deadlock.Mutex
-	PtyMutex                *deadlock.Mutex
+	RefreshingFilesMutex    deadlock.Mutex
+	RefreshingBranchesMutex deadlock.Mutex
+	RefreshingStatusMutex   deadlock.Mutex
+	LocalCommitsMutex       deadlock.Mutex
+	SubCommitsMutex         deadlock.Mutex
+	AuthorsMutex            deadlock.Mutex
+	SubprocessMutex         deadlock.Mutex
+	PopupMutex              deadlock.Mutex
+	PtyMutex                deadlock.Mutex
 }
 
 // A long-running operation associated with an item. For example, we'll show


### PR DESCRIPTION
- **PR Description**

Here's a minor cleanup: instantiate mutexes by value so that they don't have to be initialized explicitly. It is always preferable for structs to have a valid zero value, and this is one small step in that direction.

I read this recommendation in the [Uber style guide](https://github.com/uber-go/guide/blob/master/style.md#zero-value-mutexes-are-valid), and it makes a lot of sense to me. I find most of the rest of this style guide to be a very good read, too.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
