### PR TITLE
Add option to disable warning when amending last commit

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -72,6 +72,9 @@ gui:
   # When mouse events are captured, it's a little harder to select text: e.g. requiring you to hold the option key when on macOS.
   mouseEvents: true
 
+  # If true, do not show a warning when amending a commit.
+  skipAmendWarning: false
+
   # If true, do not show a warning when discarding changes in the staging view.
   skipDiscardChangeWarning: false
 

--- a/pkg/config/app_config_test.go
+++ b/pkg/config/app_config_test.go
@@ -384,6 +384,9 @@ gui:
   # When mouse events are captured, it's a little harder to select text: e.g. requiring you to hold the option key when on macOS.
   mouseEvents: true
 
+  # If true, do not show a warning when amending a commit.
+  skipAmendWarning: false
+
   # If true, do not show a warning when discarding changes in the staging view.
   skipDiscardChangeWarning: false
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -74,6 +74,8 @@ type GuiConfig struct {
 	// If true, capture mouse events.
 	// When mouse events are captured, it's a little harder to select text: e.g. requiring you to hold the option key when on macOS.
 	MouseEvents bool `yaml:"mouseEvents"`
+	// If true, do not show a warning when amending a commit.
+	SkipAmendWarning bool `yaml:"skipAmendWarning"`
 	// If true, do not show a warning when discarding changes in the staging view.
 	SkipDiscardChangeWarning bool `yaml:"skipDiscardChangeWarning"`
 	// If true, do not show warning when applying/popping the stash
@@ -734,6 +736,7 @@ func GetDefaultConfig() *UserConfig {
 			ScrollOffBehavior:        "margin",
 			TabWidth:                 4,
 			MouseEvents:              true,
+			SkipAmendWarning:         false,
 			SkipDiscardChangeWarning: false,
 			SkipStashWarning:         false,
 			SidePanelWidth:           0.3333,

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -795,7 +795,7 @@ func (self *FilesController) handleAmendCommitPress() error {
 				},
 			},
 		})
-	} else {
+	} else if !self.c.UserConfig().Gui.SkipAmendWarning {
 		self.c.Confirm(types.ConfirmOpts{
 			Title:  self.c.Tr.AmendLastCommitTitle,
 			Prompt: self.c.Tr.SureToAmend,
@@ -803,9 +803,11 @@ func (self *FilesController) handleAmendCommitPress() error {
 				return doAmend()
 			},
 		})
+
+		return nil
 	}
 
-	return nil
+	return doAmend()
 }
 
 func (self *FilesController) isResolvingConflicts() bool {

--- a/schema/config.json
+++ b/schema/config.json
@@ -468,6 +468,11 @@
           "description": "If true, capture mouse events.\nWhen mouse events are captured, it's a little harder to select text: e.g. requiring you to hold the option key when on macOS.",
           "default": true
         },
+        "skipAmendWarning": {
+          "type": "boolean",
+          "description": "If true, do not show a warning when amending a commit.",
+          "default": false
+        },
         "skipDiscardChangeWarning": {
           "type": "boolean",
           "description": "If true, do not show a warning when discarding changes in the staging view.",


### PR DESCRIPTION
- **PR Description**
Add an option in the User Config to disable the warning message when amending the last commit.

Fixes #4636 

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
