### PR TITLE
Fix stash operations when branch named 'stash' exists

### DIFF
--- a/pkg/commands/git_commands/stash.go
+++ b/pkg/commands/git_commands/stash.go
@@ -32,21 +32,21 @@ func (self *StashCommands) DropNewest() error {
 }
 
 func (self *StashCommands) Drop(index int) error {
-	cmdArgs := NewGitCmd("stash").Arg("drop", fmt.Sprintf("stash@{%d}", index)).
+	cmdArgs := NewGitCmd("stash").Arg("drop", fmt.Sprintf("refs/stash@{%d}", index)).
 		ToArgv()
 
 	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *StashCommands) Pop(index int) error {
-	cmdArgs := NewGitCmd("stash").Arg("pop", fmt.Sprintf("stash@{%d}", index)).
+	cmdArgs := NewGitCmd("stash").Arg("pop", fmt.Sprintf("refs/stash@{%d}", index)).
 		ToArgv()
 
 	return self.cmd.New(cmdArgs).Run()
 }
 
 func (self *StashCommands) Apply(index int) error {
-	cmdArgs := NewGitCmd("stash").Arg("apply", fmt.Sprintf("stash@{%d}", index)).
+	cmdArgs := NewGitCmd("stash").Arg("apply", fmt.Sprintf("refs/stash@{%d}", index)).
 		ToArgv()
 
 	return self.cmd.New(cmdArgs).Run()
@@ -90,7 +90,7 @@ func (self *StashCommands) ShowStashEntryCmdObj(index int) *oscommands.CmdObj {
 		Arg(fmt.Sprintf("--unified=%d", self.AppState.DiffContextSize)).
 		ArgIf(self.AppState.IgnoreWhitespaceInDiffView, "--ignore-all-space").
 		Arg(fmt.Sprintf("--find-renames=%d%%", self.AppState.RenameSimilarityThreshold)).
-		Arg(fmt.Sprintf("stash@{%d}", index)).
+		Arg(fmt.Sprintf("refs/stash@{%d}", index)).
 		Dir(self.repoPaths.worktreePath).
 		ToArgv()
 
@@ -152,7 +152,7 @@ func (self *StashCommands) SaveStagedChanges(message string) error {
 	}
 
 	if err := self.cmd.New(
-		NewGitCmd("stash").Arg("apply", "stash@{1}").ToArgv(),
+		NewGitCmd("stash").Arg("apply", "refs/stash@{1}").ToArgv(),
 	).Run(); err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func (self *StashCommands) SaveStagedChanges(message string) error {
 	}
 
 	if err := self.cmd.New(
-		NewGitCmd("stash").Arg("drop", "stash@{1}").ToArgv(),
+		NewGitCmd("stash").Arg("drop", "refs/stash@{1}").ToArgv(),
 	).Run(); err != nil {
 		return err
 	}

--- a/pkg/commands/git_commands/stash_test.go
+++ b/pkg/commands/git_commands/stash_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestStashDrop(t *testing.T) {
 	runner := oscommands.NewFakeRunner(t).
-		ExpectGitArgs([]string{"stash", "drop", "stash@{1}"}, "Dropped refs/stash@{1} (98e9cca532c37c766107093010c72e26f2c24c04)\n", nil)
+		ExpectGitArgs([]string{"stash", "drop", "refs/stash@{1}"}, "Dropped refs/stash@{1} (98e9cca532c37c766107093010c72e26f2c24c04)\n", nil)
 	instance := buildStashCommands(commonDeps{runner: runner})
 
 	assert.NoError(t, instance.Drop(1))
@@ -19,7 +19,7 @@ func TestStashDrop(t *testing.T) {
 
 func TestStashApply(t *testing.T) {
 	runner := oscommands.NewFakeRunner(t).
-		ExpectGitArgs([]string{"stash", "apply", "stash@{1}"}, "", nil)
+		ExpectGitArgs([]string{"stash", "apply", "refs/stash@{1}"}, "", nil)
 	instance := buildStashCommands(commonDeps{runner: runner})
 
 	assert.NoError(t, instance.Apply(1))
@@ -28,7 +28,7 @@ func TestStashApply(t *testing.T) {
 
 func TestStashPop(t *testing.T) {
 	runner := oscommands.NewFakeRunner(t).
-		ExpectGitArgs([]string{"stash", "pop", "stash@{1}"}, "", nil)
+		ExpectGitArgs([]string{"stash", "pop", "refs/stash@{1}"}, "", nil)
 	instance := buildStashCommands(commonDeps{runner: runner})
 
 	assert.NoError(t, instance.Pop(1))
@@ -113,7 +113,7 @@ func TestStashStashEntryCmdObj(t *testing.T) {
 			contextSize:         3,
 			similarityThreshold: 50,
 			ignoreWhitespace:    false,
-			expected:            []string{"git", "-C", "/path/to/worktree", "stash", "show", "-p", "--stat", "-u", "--color=always", "--unified=3", "--find-renames=50%", "stash@{5}"},
+			expected:            []string{"git", "-C", "/path/to/worktree", "stash", "show", "-p", "--stat", "-u", "--color=always", "--unified=3", "--find-renames=50%", "refs/stash@{5}"},
 		},
 		{
 			testName:            "Show diff with custom context size",
@@ -121,7 +121,7 @@ func TestStashStashEntryCmdObj(t *testing.T) {
 			contextSize:         77,
 			similarityThreshold: 50,
 			ignoreWhitespace:    false,
-			expected:            []string{"git", "-C", "/path/to/worktree", "stash", "show", "-p", "--stat", "-u", "--color=always", "--unified=77", "--find-renames=50%", "stash@{5}"},
+			expected:            []string{"git", "-C", "/path/to/worktree", "stash", "show", "-p", "--stat", "-u", "--color=always", "--unified=77", "--find-renames=50%", "refs/stash@{5}"},
 		},
 		{
 			testName:            "Show diff with custom similarity threshold",
@@ -129,7 +129,7 @@ func TestStashStashEntryCmdObj(t *testing.T) {
 			contextSize:         3,
 			similarityThreshold: 33,
 			ignoreWhitespace:    false,
-			expected:            []string{"git", "-C", "/path/to/worktree", "stash", "show", "-p", "--stat", "-u", "--color=always", "--unified=3", "--find-renames=33%", "stash@{5}"},
+			expected:            []string{"git", "-C", "/path/to/worktree", "stash", "show", "-p", "--stat", "-u", "--color=always", "--unified=3", "--find-renames=33%", "refs/stash@{5}"},
 		},
 		{
 			testName:            "Default case",
@@ -137,7 +137,7 @@ func TestStashStashEntryCmdObj(t *testing.T) {
 			contextSize:         3,
 			similarityThreshold: 50,
 			ignoreWhitespace:    true,
-			expected:            []string{"git", "-C", "/path/to/worktree", "stash", "show", "-p", "--stat", "-u", "--color=always", "--unified=3", "--ignore-all-space", "--find-renames=50%", "stash@{5}"},
+			expected:            []string{"git", "-C", "/path/to/worktree", "stash", "show", "-p", "--stat", "-u", "--color=always", "--unified=3", "--ignore-all-space", "--find-renames=50%", "refs/stash@{5}"},
 		},
 	}
 
@@ -177,7 +177,7 @@ func TestStashRename(t *testing.T) {
 			message:          "New message",
 			expectedHashCmd:  []string{"rev-parse", "refs/stash@{3}"},
 			hashResult:       "f0d0f20f2f61ffd6d6bfe0752deffa38845a3edd\n",
-			expectedDropCmd:  []string{"stash", "drop", "stash@{3}"},
+			expectedDropCmd:  []string{"stash", "drop", "refs/stash@{3}"},
 			expectedStoreCmd: []string{"stash", "store", "-m", "New message", "f0d0f20f2f61ffd6d6bfe0752deffa38845a3edd"},
 		},
 		{
@@ -186,7 +186,7 @@ func TestStashRename(t *testing.T) {
 			message:          "",
 			expectedHashCmd:  []string{"rev-parse", "refs/stash@{4}"},
 			hashResult:       "f0d0f20f2f61ffd6d6bfe0752deffa38845a3edd\n",
-			expectedDropCmd:  []string{"stash", "drop", "stash@{4}"},
+			expectedDropCmd:  []string{"stash", "drop", "refs/stash@{4}"},
 			expectedStoreCmd: []string{"stash", "store", "f0d0f20f2f61ffd6d6bfe0752deffa38845a3edd"},
 		},
 	}

--- a/pkg/commands/models/stash_entry.go
+++ b/pkg/commands/models/stash_entry.go
@@ -10,7 +10,7 @@ type StashEntry struct {
 }
 
 func (s *StashEntry) FullRefName() string {
-	return s.RefName()
+	return "refs/" + s.RefName()
 }
 
 func (s *StashEntry) RefName() string {

--- a/pkg/gui/controllers/stash_controller.go
+++ b/pkg/gui/controllers/stash_controller.go
@@ -187,7 +187,7 @@ func (self *StashController) postStashRefresh() error {
 }
 
 func (self *StashController) handleNewBranchOffStashEntry(stashEntry *models.StashEntry) error {
-	return self.c.Helpers().Refs.NewBranch(stashEntry.RefName(), stashEntry.Description(), "")
+	return self.c.Helpers().Refs.NewBranch(stashEntry.FullRefName(), stashEntry.Description(), "")
 }
 
 func (self *StashController) handleRenameStashEntry(stashEntry *models.StashEntry) error {

--- a/pkg/integration/tests/stash/apply.go
+++ b/pkg/integration/tests/stash/apply.go
@@ -12,6 +12,8 @@ var Apply = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("initial commit")
+		shell.NewBranch("stash")
+		shell.Checkout("master")
 		shell.CreateFile("file", "content")
 		shell.GitAddAll()
 		shell.Stash("stash one")

--- a/pkg/integration/tests/stash/create_branch.go
+++ b/pkg/integration/tests/stash/create_branch.go
@@ -12,6 +12,8 @@ var CreateBranch = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("initial commit")
+		shell.NewBranch("stash")
+		shell.Checkout("master")
 		shell.CreateFile("myfile", "content")
 		shell.GitAddAll()
 		shell.Stash("stash one")
@@ -39,6 +41,7 @@ var CreateBranch = NewIntegrationTest(NewIntegrationTestArgs{
 			Lines(
 				Contains("new_branch").IsSelected(),
 				Contains("master"),
+				Contains("stash"),
 			).
 			PressEnter()
 

--- a/pkg/integration/tests/stash/drop.go
+++ b/pkg/integration/tests/stash/drop.go
@@ -12,6 +12,8 @@ var Drop = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("initial commit")
+		shell.NewBranch("stash")
+		shell.Checkout("master")
 		shell.CreateFile("file", "content")
 		shell.GitAddAll()
 		shell.Stash("stash one")

--- a/pkg/integration/tests/stash/rename.go
+++ b/pkg/integration/tests/stash/rename.go
@@ -13,6 +13,8 @@ var Rename = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupRepo: func(shell *Shell) {
 		shell.
 			EmptyCommit("blah").
+			NewBranch("stash").
+			Checkout("master").
 			CreateFileAndAdd("file-1", "change to stash1").
 			Stash("foo").
 			CreateFileAndAdd("file-2", "change to stash2").

--- a/pkg/integration/tests/stash/show_with_branch_named_stash.go
+++ b/pkg/integration/tests/stash/show_with_branch_named_stash.go
@@ -5,40 +5,39 @@ import (
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
 
-var Pop = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Pop a stash entry",
+var ShowWithBranchNamedStash = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "View stash when there is a branch also named 'stash'",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("initial commit")
-		shell.NewBranch("stash")
-		shell.Checkout("master")
 		shell.CreateFile("file", "content")
 		shell.GitAddAll()
-		shell.Stash("stash one")
+
+		shell.NewBranch("stash")
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
-		t.Views().Files().IsEmpty()
-
 		t.Views().Stash().
-			Focus().
-			Lines(
-				Contains("stash one").IsSelected(),
-			).
-			Press(keys.Stash.PopStash).
-			Tap(func() {
-				t.ExpectPopup().Confirmation().
-					Title(Equals("Stash pop")).
-					Content(Contains("Are you sure you want to pop this stash entry?")).
-					Confirm()
-			}).
 			IsEmpty()
 
 		t.Views().Files().
-			IsFocused().
 			Lines(
 				Contains("file"),
+			).
+			Press(keys.Files.StashAllChanges)
+
+		t.ExpectPopup().Prompt().Title(Equals("Stash changes")).Type("my stashed file").Confirm()
+
+		t.Views().Stash().
+			Lines(
+				MatchesRegexp(`\ds .* my stashed file`),
 			)
+
+		t.Views().Files().
+			IsEmpty()
+
+		t.Views().Stash().Focus()
+		t.Views().Main().ContainsLines(Equals(" file | 1 +"))
 	},
 })

--- a/pkg/integration/tests/stash/stash.go
+++ b/pkg/integration/tests/stash/stash.go
@@ -12,6 +12,8 @@ var Stash = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupConfig:  func(config *config.AppConfig) {},
 	SetupRepo: func(shell *Shell) {
 		shell.EmptyCommit("initial commit")
+		shell.NewBranch("stash")
+		shell.Checkout("master")
 		shell.CreateFile("file", "content")
 		shell.GitAddAll()
 	},

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -352,6 +352,7 @@ var tests = []*components.IntegrationTest{
 	stash.Pop,
 	stash.PreventDiscardingFileChanges,
 	stash.Rename,
+	stash.ShowWithBranchNamedStash,
 	stash.Stash,
 	stash.StashAll,
 	stash.StashAndKeepIndex,


### PR DESCRIPTION
- **PR Description**

Pretty basic fix, didn't seem to have any complications. I basically just grepped for `stash{` and all of the references seemed like they could benefit from the addition. I only added the refs/ prefix to the FullRefName() method to align with other similar methods, and to make this change not impact any user facing modals. I added one integration test for the super obvious failure behavior. I didn't feel that it was worth it to create duplicate integration tests for the other behaviors of drop, apply, pop, etc. I did manually test them though. If interested, I could add the creation of the `stash` branch to all the existing tests of stash behavior, just to prove they continue to work under those conditions. I just didn't do that on the first pass cause I could see how that could take away from the core behavior the tests are trying to demonstrate.

Fixes: https://github.com/jesseduffield/lazygit/issues/4634

- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc
