### PR TITLE
Do not display recent repo list when it would be empty

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -129,11 +129,9 @@ func NewApp(config config.AppConfigurer, test integrationTypes.IntegrationTest, 
 	}
 
 	// used for testing purposes
-	if os.Getenv("SHOW_RECENT_REPOS") == "true" {
-		showRecentRepos = true
-	}
+	forceRecentRepos := os.Getenv("SHOW_RECENT_REPOS") == "true"
 
-	app.Gui, err = gui.NewGui(common, config, gitVersion, updater, showRecentRepos, dirName, test)
+	app.Gui, err = gui.NewGui(common, config, gitVersion, updater, showRecentRepos, forceRecentRepos, dirName, test)
 	if err != nil {
 		return app, err
 	}

--- a/pkg/gui/controllers/helpers/repos_helper.go
+++ b/pkg/gui/controllers/helpers/repos_helper.go
@@ -94,12 +94,16 @@ func (self *ReposHelper) getCurrentBranch(path string) string {
 	return self.c.Tr.BranchUnknown
 }
 
-func (self *ReposHelper) CreateRecentReposMenu() error {
-	// we'll show an empty panel if there are no recent repos
+func (self *ReposHelper) CreateRecentReposMenu(force bool) error {
 	recentRepoPaths := []string{}
 	if len(self.c.GetAppState().RecentRepos) > 0 {
 		// we skip the first one because we're currently in it
 		recentRepoPaths = self.c.GetAppState().RecentRepos[1:]
+	}
+
+	// we'll skip the panel if there are no recent repos, and we are not forcing this via a test
+	if len(recentRepoPaths) == 0 && !force {
+		return nil
 	}
 
 	currentBranches := sync.Map{}

--- a/pkg/gui/controllers/status_controller.go
+++ b/pkg/gui/controllers/status_controller.go
@@ -54,7 +54,7 @@ func (self *StatusController) GetKeybindings(opts types.KeybindingsOpts) []*type
 		},
 		{
 			Key:             opts.GetKey(opts.Config.Status.RecentRepos),
-			Handler:         self.c.Helpers().Repos.CreateRecentReposMenu,
+			Handler:         func() error { return self.c.Helpers().Repos.CreateRecentReposMenu(true) },
 			Description:     self.c.Tr.SwitchRepo,
 			DisplayOnScreen: true,
 		},
@@ -114,10 +114,10 @@ func (self *StatusController) onClick(opts gocui.ViewMouseBindingOpts) error {
 			return self.c.Helpers().MergeAndRebase.CreateRebaseOptionsMenu()
 		}
 		if cursorInSubstring(opts.X, upstreamStatus+" "+workingTreeStatus+" ", repoName) {
-			return self.c.Helpers().Repos.CreateRecentReposMenu()
+			return self.c.Helpers().Repos.CreateRecentReposMenu(false)
 		}
 	} else if cursorInSubstring(opts.X, upstreamStatus+" ", repoName) {
-		return self.c.Helpers().Repos.CreateRecentReposMenu()
+		return self.c.Helpers().Repos.CreateRecentReposMenu(false)
 	}
 
 	return nil

--- a/pkg/gui/dummies.go
+++ b/pkg/gui/dummies.go
@@ -17,6 +17,6 @@ func NewDummyUpdater() *updates.Updater {
 // NewDummyGui creates a new dummy GUI for testing
 func NewDummyGui() *Gui {
 	newAppConfig := config.NewDummyAppConfig()
-	dummyGui, _ := NewGui(common.NewDummyCommon(), newAppConfig, &git_commands.GitVersion{Major: 2, Minor: 0, Patch: 0}, NewDummyUpdater(), false, "", nil)
+	dummyGui, _ := NewGui(common.NewDummyCommon(), newAppConfig, &git_commands.GitVersion{Major: 2, Minor: 0, Patch: 0}, NewDummyUpdater(), false, false, "", nil)
 	return dummyGui
 }

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -89,6 +89,9 @@ type Gui struct {
 	// recent repo with the recent repos popup showing
 	showRecentRepos bool
 
+	// Used for testing purposes
+	forceRecentRepos bool
+
 	Mutexes types.Mutexes
 
 	// when you enter into a submodule we'll append the superproject's path to this array
@@ -661,6 +664,7 @@ func NewGui(
 	gitVersion *git_commands.GitVersion,
 	updater *updates.Updater,
 	showRecentRepos bool,
+	forceRecentRepos bool,
 	initialDir string,
 	test integrationTypes.IntegrationTest,
 ) (*Gui, error) {
@@ -673,6 +677,7 @@ func NewGui(
 		viewBufferManagerMap: map[string]*tasks.ViewBufferManager{},
 		viewPtmxMap:          map[string]*os.File{},
 		showRecentRepos:      showRecentRepos,
+		forceRecentRepos:     forceRecentRepos,
 		RepoPathStack:        &utils.StringStack{},
 		RepoStateMap:         map[Repo]*GuiRepoState{},
 		GuiLog:               []string{},

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -261,7 +261,7 @@ func (gui *Gui) onInitialViewsCreation() error {
 	gui.c.SaveAppStateAndLogError()
 
 	if gui.showRecentRepos {
-		if err := gui.helpers.Repos.CreateRecentReposMenu(); err != nil {
+		if err := gui.helpers.Repos.CreateRecentReposMenu(gui.forceRecentRepos); err != nil {
 			return err
 		}
 		gui.showRecentRepos = false

--- a/pkg/integration/tests/status/click_repo_name_to_open_repos_menu.go
+++ b/pkg/integration/tests/status/click_repo_name_to_open_repos_menu.go
@@ -1,6 +1,8 @@
 package status
 
 import (
+	"path/filepath"
+
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
 )
@@ -10,9 +12,40 @@ var ClickRepoNameToOpenReposMenu = NewIntegrationTest(NewIntegrationTestArgs{
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
-	SetupRepo:    func(shell *Shell) {},
+	SetupRepo: func(shell *Shell) {
+		// Create another repo that we can switch to
+		shell.CloneIntoRemote("other_repo")
+		shell.CreateFileAndAdd("other_repo/README.md", "# other_repo")
+		shell.Commit("initial commit")
+
+		// Create a third repo
+		shell.CloneIntoRemote("third_repo")
+		shell.CreateFileAndAdd("third_repo/README.md", "# third_repo")
+		shell.Commit("initial commit")
+
+		// Add these repos to the recent repos list
+		otherRepoPath, err := filepath.Abs("other_repo")
+		if err != nil {
+			panic(err)
+		}
+		thirdRepoPath, err := filepath.Abs("third_repo")
+		if err != nil {
+			panic(err)
+		}
+
+		// Switch to the other repo and back to add it to the recent repos list
+		shell.RunCommand([]string{"cd", otherRepoPath})
+		shell.RunCommand([]string{"cd", "-"})
+		shell.RunCommand([]string{"cd", thirdRepoPath})
+		shell.RunCommand([]string{"cd", "-"})
+	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Status().Click(1, 0)
-		t.ExpectPopup().Menu().Title(Equals("Recent repositories"))
+		t.ExpectPopup().Menu().Title(Equals("Recent repositories")).
+			Lines(
+				Contains("other_repo").IsSelected(),
+				Contains("third_repo"),
+				Contains("Cancel"),
+			)
 	},
 })


### PR DESCRIPTION
- **PR Description**

I'm not happy about the inelegance of this solution, and I'm not entirely sure it works. Creating as a draft because I don't plan on closing this work out to completion right now.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
