### PR TITLE
Add bold style for border

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -248,7 +248,7 @@ gui:
   screenMode: normal
 
   # Window border style.
-  # One of 'rounded' (default) | 'single' | 'double' | 'hidden'
+  # One of 'rounded' (default) | 'single' | 'double' | 'hidden' | 'bold'
   border: rounded
 
   # If true, show a seriously epic explosion animation when nuking the working tree.

--- a/pkg/config/app_config_test.go
+++ b/pkg/config/app_config_test.go
@@ -560,7 +560,7 @@ gui:
   screenMode: normal
 
   # Window border style.
-  # One of 'rounded' (default) | 'single' | 'double' | 'hidden'
+  # One of 'rounded' (default) | 'single' | 'double' | 'hidden' | 'bold'
   border: rounded
 
   # If true, show a seriously epic explosion animation when nuking the working tree.

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -166,8 +166,8 @@ type GuiConfig struct {
 	// One of: 'normal' (default) | 'half' | 'full'
 	ScreenMode string `yaml:"screenMode" jsonschema:"enum=normal,enum=half,enum=full"`
 	// Window border style.
-	// One of 'rounded' (default) | 'single' | 'double' | 'hidden'
-	Border string `yaml:"border" jsonschema:"enum=single,enum=double,enum=rounded,enum=hidden"`
+	// One of 'rounded' (default) | 'single' | 'double' | 'hidden' | 'bold'
+	Border string `yaml:"border" jsonschema:"enum=single,enum=double,enum=rounded,enum=hidden,enum=bold"`
 	// If true, show a seriously epic explosion animation when nuking the working tree.
 	AnimateExplosion bool `yaml:"animateExplosion"`
 	// Whether to stack UI components on top of each other.

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -159,6 +159,8 @@ func (gui *Gui) configureViewProperties() {
 		frameRunes = []rune{'─', '│', '╭', '╮', '╰', '╯'}
 	case "hidden":
 		frameRunes = []rune{' ', ' ', ' ', ' ', ' ', ' '}
+	case "bold":
+		frameRunes = []rune{'━', '┃', '┏', '┓', '┗', '┛'}
 	}
 
 	for _, mapping := range gui.orderedViewNameMappings() {

--- a/schema/config.json
+++ b/schema/config.json
@@ -685,9 +685,10 @@
             "single",
             "double",
             "rounded",
-            "hidden"
+            "hidden",
+            "bold"
           ],
-          "description": "Window border style.\nOne of 'rounded' (default) | 'single' | 'double' | 'hidden'",
+          "description": "Window border style.\nOne of 'rounded' (default) | 'single' | 'double' | 'hidden' | 'bold'",
           "default": "rounded"
         },
         "animateExplosion": {


### PR DESCRIPTION
- **PR Description**

bold border looks great and makes it easy to notice the color change

screen shot:

![20250614-171448-275767295](https://github.com/user-attachments/assets/d05840a0-e8d3-4948-aabd-5d1074d5eee4)


- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
