### PR TITLE
Add credential prompts for PKCS11-based SSH keys

### DIFF
--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -391,6 +391,7 @@ func (self *cmdObjRunner) getCheckForCredentialRequestFunc() func([]byte) (Crede
 		`Username\s*for\s*'.+':`:                 Username,
 		`Enter\s*passphrase\s*for\s*key\s*'.+':`: Passphrase,
 		`Enter\s*PIN\s*for\s*.+\s*key\s*.+:`:     PIN,
+		`Enter\s*PIN\s*for\s*'.+':`:              PIN,
 		`.*2FA Token.*`:                          Token,
 	}
 

--- a/pkg/commands/oscommands/cmd_obj_runner_test.go
+++ b/pkg/commands/oscommands/cmd_obj_runner_test.go
@@ -89,9 +89,15 @@ func TestProcessOutput(t *testing.T) {
 			expectedToWrite:         "passphrase",
 		},
 		{
-			name:                    "pin prompt",
+			name:                    "security key pin prompt",
 			promptUserForCredential: defaultPromptUserForCredential,
 			output:                  "Enter PIN for key '123':",
+			expectedToWrite:         "pin",
+		},
+		{
+			name:                    "pkcs11 key pin prompt",
+			promptUserForCredential: defaultPromptUserForCredential,
+			output:                  "Enter PIN for '123':",
 			expectedToWrite:         "pin",
 		},
 		{


### PR DESCRIPTION
- **PR Description**
Similar to #2239, add credential prompts for PKCS11-based SSH keys. OpenSSH code reference is [here](https://github.com/openssh/openssh-portable/blob/2827b6ac304ded8f99e8fbc12e7299133fadb2c2/ssh-pkcs11.c#L263).
- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
