### PR TITLE
Fix DEFAULT_REMOTE_ICON character code

### DIFF
--- a/pkg/gui/presentation/icons/git_icons.go
+++ b/pkg/gui/presentation/icons/git_icons.go
@@ -12,7 +12,7 @@ var (
 	TAG_ICON                     = "\uf02b"     // 
 	COMMIT_ICON                  = "\U000f0718" // 󰜘
 	MERGE_COMMIT_ICON            = "\U000f062d" // 󰘭
-	DEFAULT_REMOTE_ICON          = "\uf02a2"    // 󰊢
+	DEFAULT_REMOTE_ICON          = "\U000f02a2" // 󰊢
 	STASH_ICON                   = "\uf01c"     // 
 	LINKED_WORKTREE_ICON         = "\U000f0339" // 󰌹
 	MISSING_LINKED_WORKTREE_ICON = "\U000f033a" // 󰌺


### PR DESCRIPTION
Unicode characters with code longer than 4 digits should be written as `\Uffffffff` (8 digits)

Fixes #4652 

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
