### PR TITLE
Collapse selection after deleting a range of branches or stashes

### DIFF
--- a/pkg/gui/context/traits/list_cursor.go
+++ b/pkg/gui/context/traits/list_cursor.go
@@ -133,8 +133,17 @@ func (self *ListCursor) GetRangeStartIdx() (int, bool) {
 	return 0, false
 }
 
+// Cancel range select mode, but keep the "moving end" of the range selected.
+// Used when pressing 'v' or escape to toggle range select mode, for example.
 func (self *ListCursor) CancelRangeSelect() {
 	self.rangeSelectMode = RangeSelectModeNone
+}
+
+// Cancel range select mode, but keep the top of the range selected. Note that
+// this is different from CancelRangeSelect. Useful after deleting a range of items.
+func (self *ListCursor) CollapseRangeSelectionToTop() {
+	start, _ := self.GetSelectionRange()
+	self.SetSelection(start)
 }
 
 // Returns true if we are in range select mode. Note that we may be in range select

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -535,7 +535,7 @@ func (self *BranchesController) remoteDelete(branches []*models.Branch) error {
 	remoteBranches := lo.Map(branches, func(branch *models.Branch, _ int) *models.RemoteBranch {
 		return &models.RemoteBranch{Name: branch.UpstreamBranch, RemoteName: branch.UpstreamRemote}
 	})
-	return self.c.Helpers().BranchesHelper.ConfirmDeleteRemote(remoteBranches)
+	return self.c.Helpers().BranchesHelper.ConfirmDeleteRemote(remoteBranches, false)
 }
 
 func (self *BranchesController) localAndRemoteDelete(branches []*models.Branch) error {

--- a/pkg/gui/controllers/helpers/branches_helper.go
+++ b/pkg/gui/controllers/helpers/branches_helper.go
@@ -47,8 +47,8 @@ func (self *BranchesHelper) ConfirmLocalDelete(branches []*models.Branch) error 
 			if err := self.c.Git().Branch.LocalDelete(branchNames, true); err != nil {
 				return err
 			}
-			selectionStart, _ := self.c.Contexts().Branches.GetSelectionRange()
-			self.c.Contexts().Branches.SetSelectedLineIdx(selectionStart)
+
+			self.c.Contexts().Branches.CollapseRangeSelectionToTop()
 			self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.BRANCHES}})
 			return nil
 		})
@@ -180,9 +180,7 @@ func (self *BranchesHelper) ConfirmLocalAndRemoteDelete(branches []*models.Branc
 					return err
 				}
 
-				selectionStart, _ := self.c.Contexts().Branches.GetSelectionRange()
-				self.c.Contexts().Branches.SetSelectedLineIdx(selectionStart)
-
+				self.c.Contexts().Branches.CollapseRangeSelectionToTop()
 				self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.BRANCHES, types.REMOTES}})
 				return nil
 			})

--- a/pkg/gui/controllers/helpers/branches_helper.go
+++ b/pkg/gui/controllers/helpers/branches_helper.go
@@ -82,7 +82,7 @@ func (self *BranchesHelper) ConfirmLocalDelete(branches []*models.Branch) error 
 	return nil
 }
 
-func (self *BranchesHelper) ConfirmDeleteRemote(remoteBranches []*models.RemoteBranch) error {
+func (self *BranchesHelper) ConfirmDeleteRemote(remoteBranches []*models.RemoteBranch, resetRemoteBranchesSelection bool) error {
 	var title string
 	if len(remoteBranches) == 1 {
 		title = utils.ResolvePlaceholderString(
@@ -115,6 +115,9 @@ func (self *BranchesHelper) ConfirmDeleteRemote(remoteBranches []*models.RemoteB
 					return err
 				}
 				self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.BRANCHES, types.REMOTES}})
+				if resetRemoteBranchesSelection {
+					self.c.Contexts().RemoteBranches.CollapseRangeSelectionToTop()
+				}
 				return nil
 			})
 		},

--- a/pkg/gui/controllers/remote_branches_controller.go
+++ b/pkg/gui/controllers/remote_branches_controller.go
@@ -133,7 +133,7 @@ func (self *RemoteBranchesController) context() *context.RemoteBranchesContext {
 }
 
 func (self *RemoteBranchesController) delete(selectedBranches []*models.RemoteBranch) error {
-	return self.c.Helpers().BranchesHelper.ConfirmDeleteRemote(selectedBranches)
+	return self.c.Helpers().BranchesHelper.ConfirmDeleteRemote(selectedBranches, true)
 }
 
 func (self *RemoteBranchesController) merge(selectedBranch *models.RemoteBranch) error {

--- a/pkg/gui/controllers/stash_controller.go
+++ b/pkg/gui/controllers/stash_controller.go
@@ -178,6 +178,7 @@ func (self *StashController) handleStashDrop(stashEntries []*models.StashEntry) 
 					return err
 				}
 			}
+			self.context().CollapseRangeSelectionToTop()
 			return nil
 		},
 	})


### PR DESCRIPTION
- **PR Description**

Fixes selection state persistence after deletion by resetting selection mode.  
Resolves [#4612](https://github.com/jesseduffield/lazygit/issues/4612)

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
