### PR TITLE
Add config value for skipping "Recent repositories" prompt

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -473,7 +473,8 @@ services: {}
 # What to do when opening Lazygit outside of a git repo.
 # - 'prompt': (default) ask whether to initialize a new repo or open in the most recent repo
 # - 'create': initialize a new repo
-# - 'skip': open most recent repo
+# - 'recent': open most recent repo
+# - 'skip': open most recent repo and skip the modal
 # - 'quit': exit Lazygit
 notARepository: prompt
 
@@ -1079,6 +1080,11 @@ notARepository: 'prompt'
 ```yaml
 # to skip and initialize a new repo
 notARepository: 'create'
+```
+
+```yaml
+# to select from recent repositories
+notARepository: 'recent'
 ```
 
 ```yaml

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -209,6 +209,8 @@ func (app *App) setupRepo(
 			}
 		case "create":
 			shouldInitRepo = true
+		case "recent":
+			shouldInitRepo = false
 		case "skip":
 			shouldInitRepo = false
 		case "quit":

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -31,9 +31,10 @@ type UserConfig struct {
 	// What to do when opening Lazygit outside of a git repo.
 	// - 'prompt': (default) ask whether to initialize a new repo or open in the most recent repo
 	// - 'create': initialize a new repo
-	// - 'skip': open most recent repo
+	// - 'recent': open most recent repo
+	// - 'skip': open most recent repo and skip the modal
 	// - 'quit': exit Lazygit
-	NotARepository string `yaml:"notARepository" jsonschema:"enum=prompt,enum=create,enum=skip,enum=quit"`
+	NotARepository string `yaml:"notARepository" jsonschema:"enum=prompt,enum=create,enum=recent,enum=skip,enum=quit"`
 	// If true, display a confirmation when subprocess terminates. This allows you to view the output of the subprocess before returning to Lazygit.
 	PromptToReturnFromSubprocess bool `yaml:"promptToReturnFromSubprocess"`
 	// Keybindings

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -260,7 +260,7 @@ func (gui *Gui) onInitialViewsCreation() error {
 	gui.c.GetAppState().LastVersion = gui.Config.GetVersion()
 	gui.c.SaveAppStateAndLogError()
 
-	if gui.showRecentRepos {
+	if gui.showRecentRepos && gui.c.UserConfig().NotARepository != "skip" {
 		if err := gui.helpers.Repos.CreateRecentReposMenu(); err != nil {
 			return err
 		}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1475,7 +1475,7 @@ func EnglishTranslationSet() *TranslationSet {
 		BareRepo:                             "You've attempted to open Lazygit in a bare repo but Lazygit does not yet support bare repos. Open most recent repo? (y/n) ",
 		InitialBranch:                        "Branch name? (leave empty for git's default): ",
 		NoRecentRepositories:                 "Must open lazygit in a git repository. No valid recent repositories. Exiting.",
-		IncorrectNotARepository:              "The value of 'notARepository' is incorrect. It should be one of 'prompt', 'create', 'skip', or 'quit'.",
+		IncorrectNotARepository:              "The value of 'notARepository' is incorrect. It should be one of 'prompt', 'create', 'recent', 'skip', or 'quit'.",
 		AutoStashTitle:                       "Autostash?",
 		AutoStashPrompt:                      "You must stash and pop your changes to bring them across. Do this automatically? (enter/esc)",
 		AutoStashForUndo:                     "Auto-stashing changes for undoing to %s",

--- a/pkg/i18n/translations/pl.json
+++ b/pkg/i18n/translations/pl.json
@@ -323,7 +323,7 @@
   "BareRepo": "Próbujesz otworzyć Lazygit w gołym repozytorium, ale Lazygit jeszcze nie obsługuje gołych repozytoriów. Otworzyć najnowsze repozytorium? (t/n) ",
   "InitialBranch": "Nazwa gałęzi? (pozostaw puste dla domyślnej gita): ",
   "NoRecentRepositories": "Musisz otworzyć lazygit w repozytorium git. Brak ważnych ostatnich repozytoriów. Wyjście.",
-  "IncorrectNotARepository": "Wartość 'notARepository' jest nieprawidłowa. Powinna być jedną z 'prompt', 'create', 'skip', lub 'quit'.",
+  "IncorrectNotARepository": "Wartość 'notARepository' jest nieprawidłowa. Powinna być jedną z 'prompt', 'create', 'recent', 'skip', lub 'quit'.",
   "AutoStashPrompt": "Musisz schować i wyciągnąć swoje zmiany, aby je przenieść. Zrobić to automatycznie? (enter/esc)",
   "Discard": "Odrzuć",
   "DiscardChangesTitle": "Odrzuć zmiany",

--- a/pkg/i18n/translations/pt.json
+++ b/pkg/i18n/translations/pt.json
@@ -391,7 +391,7 @@
   "BareRepo": "Você tentou abrir Lazygit em um repositório puro, mas Lazygit ainda não suporta repositórios vazios. Abrir os repositórios mais recentes? (y/n) ",
   "InitialBranch": "Nome da branch? (deixe vazio para o padrão do git): ",
   "NoRecentRepositories": "É necessário abrir lazygit em um repositório git. Nenhum repositório recente válido. Saindo do sistema.",
-  "IncorrectNotARepository": "O valor de 'notARepository' está incorreto. Deve ser um dos 'prompt', 'create', 'sk', ou 'quit'.",
+  "IncorrectNotARepository": "O valor de 'notARepository' está incorreto. Deve ser um dos 'prompt', 'create', 'recent', 'skip', ou 'quit'.",
   "AutoStashTitle": "Autoarmazenar?",
   "AutoStashPrompt": "Você deve esconder e mostrar suas alterações para que elas passem. Quer fazer isso automaticamente? (enter/esc)",
   "Discard": "Descartar",

--- a/pkg/i18n/translations/ru.json
+++ b/pkg/i18n/translations/ru.json
@@ -244,7 +244,7 @@
   "BareRepo": "Вы пытались открыть Lazygit в пустом репозитории, но Lazygit ещё не поддерживает пустые репозитории. Открыть последний репозиторий? (y/n)",
   "InitialBranch": "Название ветки? (оставьте пустым для git по умолчанию):",
   "NoRecentRepositories": "Необходимо открыть lazygit в git репозитории. Нет валидных последних репозиториев. Выход.",
-  "IncorrectNotARepository": "Неверное значение 'notARepository'. Это должно быть одним из 'prompt', 'create', 'skip', или 'quit'.",
+  "IncorrectNotARepository": "Неверное значение 'notARepository'. Это должно быть одним из 'prompt', 'create', 'recent', 'skip', или 'quit'.",
   "AutoStashTitle": "Автосохранить изменения?",
   "AutoStashPrompt": "Чтобы перенести изменения, их нужно сохранить и вынуть. Сделать это автоматически? (enter/esc)",
   "Discard": "Просмотреть параметры «отмены изменении»",

--- a/pkg/i18n/translations/zh-CN.json
+++ b/pkg/i18n/translations/zh-CN.json
@@ -403,7 +403,7 @@
   "BareRepo": "您已经尝试在空仓库中打开Lazygit，但是Lazygit还不支持空仓库。打开最近的仓库吗？(y / n) ",
   "InitialBranch": "分支名称? (git的默认值为空): ",
   "NoRecentRepositories": "必须在git存储库中打开lazygit。没有有效的最近存储库。即将退出...",
-  "IncorrectNotARepository": "'notARepository'的值不正确。它应该是“prompt”，“create”，“skip”或“quit”中的一个。",
+  "IncorrectNotARepository": "'notARepository'的值不正确。它应该是“prompt”，“create”，“recent”，“skip”或“quit”中的一个。",
   "AutoStashTitle": "自动存储？",
   "AutoStashPrompt": "您必须隐藏并弹出变更以使变更生效。自动执行？(enter/esc)",
   "Discard": "查看'放弃变更'选项",

--- a/pkg/i18n/translations/zh-TW.json
+++ b/pkg/i18n/translations/zh-TW.json
@@ -281,7 +281,7 @@
   "BareRepo": "你嘗試在裸版本庫中開啟 Lazygit，但 Lazygit 尚未支援裸版本庫。是否開啟最新版本庫？ (y/n) ",
   "InitialBranch": "分支名稱？（留空使用 git 的預設值）：",
   "NoRecentRepositories": "必須在 git 版本庫中開啟 lazygit。沒有有效的最近版本庫。退出。",
-  "IncorrectNotARepository": "無效 `notARepository` 輸入。輸入應為「prompt」、「create」、「skip」、或「quit」。",
+  "IncorrectNotARepository": "無效 `notARepository` 輸入。輸入應為「prompt」、「create」、「recent」、「skip」、或「quit」。",
   "AutoStashTitle": "是否自動收藏？",
   "AutoStashPrompt": "必須收藏並拾起變更才得以繼續操作。是否自動執行？（Enter/Esc）",
   "Discard": "捨棄",

--- a/schema/config.json
+++ b/schema/config.json
@@ -1916,10 +1916,11 @@
           "enum": [
             "prompt",
             "create",
+            "recent",
             "skip",
             "quit"
           ],
-          "description": "What to do when opening Lazygit outside of a git repo.\n- 'prompt': (default) ask whether to initialize a new repo or open in the most recent repo\n- 'create': initialize a new repo\n- 'skip': open most recent repo\n- 'quit': exit Lazygit",
+          "description": "What to do when opening Lazygit outside of a git repo.\n- 'prompt': (default) ask whether to initialize a new repo or open in the most recent repo\n- 'create': initialize a new repo\n- 'recent': open most recent repo\n- 'skip': open most recent repo and skip the modal\n- 'quit': exit Lazygit",
           "default": "prompt"
         },
         "promptToReturnFromSubprocess": {


### PR DESCRIPTION
- **PR Description**
The configuration key `notARepository` configures the action to be taken when opening Lazygit outside of a git repo.

Current possible values are
- 'prompt': (default) ask whether to initialize a new repo or open in the most recent repo
- 'create': initialize a new repo
- 'skip': open most recent repo
- 'quit': exit Lazygit

With `notARepository: skip`, the most recent repository is selected, but a "Recent repositories" prompt is still opened.

Proposed change:
- `notARepository: recent` open most recent repo and the "Recent repositories" prompt
- `notARepository: skip` open most recent repo and skip the prompt

Related issue: https://github.com/jesseduffield/lazygit/issues/3129

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
