### PR TITLE
Fix branch head icon appearing at head commit when a remote or tag exists with the same name as the current branch

### DIFF
--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -102,12 +102,10 @@ func (self *BranchCommands) CurrentBranchInfo() (BranchInfo, error) {
 	}, nil
 }
 
-// CurrentBranchName get name of current branch
+// CurrentBranchName get name of current branch. Returns empty string if HEAD is detached.
 func (self *BranchCommands) CurrentBranchName() (string, error) {
-	cmdArgs := NewGitCmd("rev-parse").
-		Arg("--abbrev-ref").
-		Arg("--verify").
-		Arg("HEAD").
+	cmdArgs := NewGitCmd("branch").
+		Arg("--show-current").
 		ToArgv()
 
 	output, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()

--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -111,10 +111,11 @@ func (self *BranchCommands) CurrentBranchName() (string, error) {
 		ToArgv()
 
 	output, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
-	if err == nil {
-		return strings.TrimSpace(output), nil
+	if err != nil {
+		return "", err
 	}
-	return "", err
+
+	return strings.TrimSpace(output), nil
 }
 
 // LocalDelete delete branch locally

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -308,7 +308,7 @@ func (self *RefreshHelper) determineCheckedOutBranchName() string {
 	// In all other cases, get the branch name by asking git what branch is
 	// checked out. Note that if we're on a detached head (for reasons other
 	// than rebasing or bisecting, i.e. it was explicitly checked out), then
-	// this will return its hash.
+	// this will return an empty string.
 	if branchName, err := self.c.Git().Branch.CurrentBranchName(); err == nil {
 		return branchName
 	}

--- a/pkg/integration/tests/commit/do_not_show_branch_marker_for_head_commit.go
+++ b/pkg/integration/tests/commit/do_not_show_branch_marker_for_head_commit.go
@@ -1,0 +1,34 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var DoNotShowBranchMarkerForHeadCommit = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Verify that no branch heads are shown for the branch head if there is a tag with the same name as the branch",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	GitVersion:   AtLeast("2.38.0"),
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetAppState().GitLogShowGraph = "never"
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("one")
+		shell.NewBranch("branch1")
+		shell.EmptyCommit("two")
+		shell.EmptyCommit("three")
+		shell.CreateLightweightTag("branch1", "master")
+
+		shell.SetConfig("rebase.updateRefs", "true")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		// Check that the local commits view does show a branch marker for the head commit
+		t.Views().Commits().
+			Lines(
+				Contains("CI * three"), // don't want the star here
+				Contains("CI two"),
+				Contains("CI branch1 one"),
+			)
+	},
+})

--- a/pkg/integration/tests/commit/do_not_show_branch_marker_for_head_commit.go
+++ b/pkg/integration/tests/commit/do_not_show_branch_marker_for_head_commit.go
@@ -26,7 +26,7 @@ var DoNotShowBranchMarkerForHeadCommit = NewIntegrationTest(NewIntegrationTestAr
 		// Check that the local commits view does show a branch marker for the head commit
 		t.Views().Commits().
 			Lines(
-				Contains("CI * three"), // don't want the star here
+				Contains("CI three"),
 				Contains("CI two"),
 				Contains("CI branch1 one"),
 			)

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -118,6 +118,7 @@ var tests = []*components.IntegrationTest{
 	commit.CreateTag,
 	commit.DisableCopyCommitMessageBody,
 	commit.DiscardOldFileChanges,
+	commit.DoNotShowBranchMarkerForHeadCommit,
 	commit.FailHooksThenCommitNoHooks,
 	commit.FindBaseCommitForFixup,
 	commit.FindBaseCommitForFixupDisregardMainBranch,


### PR DESCRIPTION
- **PR Description**

Fix the problem that if the `rebase.updateRefs` git config is on, a branch icon would appear in the commits list for the head commit as soon as a remote or tag exists whose name is the same as the name of the current branch.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
