### PR TITLE
Show stash name for selected stash

### DIFF
--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -262,15 +262,14 @@ func (self *FilesController) GetOnRenderToMain() func() {
 				}
 				if node.File.ShortStatus == "DU" || node.File.ShortStatus == "UD" {
 					cmdObj := self.c.Git().Diff.DiffCmdObj([]string{"--base", "--", node.GetPath()})
-					task := types.NewRunPtyTask(cmdObj.GetCmd())
-					task.Prefix = message + "\n\n"
+					prefix := message + "\n\n"
 					if node.File.ShortStatus == "DU" {
-						task.Prefix += self.c.Tr.MergeConflictIncomingDiff
+						prefix += self.c.Tr.MergeConflictIncomingDiff
 					} else {
-						task.Prefix += self.c.Tr.MergeConflictCurrentDiff
+						prefix += self.c.Tr.MergeConflictCurrentDiff
 					}
-					task.Prefix += "\n\n"
-					opts.Main.Task = task
+					prefix += "\n\n"
+					opts.Main.Task = types.NewRunPtyTaskWithPrefix(cmdObj.GetCmd(), prefix)
 				} else {
 					opts.Main.Task = types.NewRenderStringTask(message)
 				}

--- a/pkg/gui/controllers/helpers/diff_helper.go
+++ b/pkg/gui/controllers/helpers/diff_helper.go
@@ -61,9 +61,8 @@ func (self *DiffHelper) GetUpdateTaskForRenderingCommitsDiff(commit *models.Comm
 			args = append(args, path)
 		}
 		cmdObj := self.c.Git().Diff.DiffCmdObj(args)
-		task := types.NewRunPtyTask(cmdObj.GetCmd())
-		task.Prefix = style.FgYellow.Sprintf("%s %s-%s\n\n", self.c.Tr.ShowingDiffForRange, from.ShortRefName(), to.ShortRefName())
-		return task
+		prefix := style.FgYellow.Sprintf("%s %s-%s\n\n", self.c.Tr.ShowingDiffForRange, from.ShortRefName(), to.ShortRefName())
+		return types.NewRunPtyTaskWithPrefix(cmdObj.GetCmd(), prefix)
 	}
 
 	cmdObj := self.c.Git().Commit.ShowCmdObj(commit.Hash(), self.c.Modes().Filtering.GetPath())
@@ -79,12 +78,12 @@ func (self *DiffHelper) ExitDiffMode() error {
 func (self *DiffHelper) RenderDiff() {
 	args := self.DiffArgs()
 	cmdObj := self.c.Git().Diff.DiffCmdObj(args)
-	task := types.NewRunPtyTask(cmdObj.GetCmd())
-	task.Prefix = style.FgMagenta.Sprintf(
+	prefix := style.FgMagenta.Sprintf(
 		"%s %s\n\n",
 		self.c.Tr.ShowingGitDiff,
 		"git diff "+strings.Join(args, " "),
 	)
+	task := types.NewRunPtyTaskWithPrefix(cmdObj.GetCmd(), prefix)
 
 	self.c.RenderToMainViews(types.RefreshMainOpts{
 		Pair: self.c.MainViewPairs().Normal,

--- a/pkg/gui/controllers/stash_controller.go
+++ b/pkg/gui/controllers/stash_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
+	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
@@ -82,8 +83,10 @@ func (self *StashController) GetOnRenderToMain() func() {
 			if stashEntry == nil {
 				task = types.NewRenderStringTask(self.c.Tr.NoStashEntries)
 			} else {
-				task = types.NewRunPtyTask(
+				prefix := style.FgYellow.Sprintf("%s\n\n", stashEntry.Description())
+				task = types.NewRunPtyTaskWithPrefix(
 					self.c.Git().Stash.ShowStashEntryCmdObj(stashEntry.Index).GetCmd(),
+					prefix,
 				)
 			}
 

--- a/pkg/gui/types/rendering.go
+++ b/pkg/gui/types/rendering.go
@@ -94,3 +94,7 @@ func (t *RunPtyTask) IsUpdateTask() {}
 func NewRunPtyTask(cmd *exec.Cmd) *RunPtyTask {
 	return &RunPtyTask{Cmd: cmd}
 }
+
+func NewRunPtyTaskWithPrefix(cmd *exec.Cmd, prefix string) *RunPtyTask {
+	return &RunPtyTask{Cmd: cmd, Prefix: prefix}
+}


### PR DESCRIPTION
- **PR Description**

In the Stash panel, show information about the selected stash above the diff of the stash in the main view. This is useful for stash entries with very long names that are not fully visible in the Stash panel.

Fixes #4662.
