### PR TITLE
Add user config to use hunk mode by default when entering staging view

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -116,6 +116,9 @@ gui:
   # paragraphs of markdown text.
   wrapLinesInStagingView: true
 
+  # If true, hunk selection mode will be enabled by default when entering the staging view.
+  useHunkModeInStagingView: false
+
   # One of 'auto' (default) | 'en' | 'zh-CN' | 'zh-TW' | 'pl' | 'nl' | 'ja' | 'ko' | 'ru'
   language: auto
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -107,6 +107,8 @@ type GuiConfig struct {
 	// makes it much easier to work with diffs that have long lines, e.g.
 	// paragraphs of markdown text.
 	WrapLinesInStagingView bool `yaml:"wrapLinesInStagingView"`
+	// If true, hunk selection mode will be enabled by default when entering the staging view.
+	UseHunkModeInStagingView bool `yaml:"useHunkModeInStagingView"`
 	// One of 'auto' (default) | 'en' | 'zh-CN' | 'zh-TW' | 'pl' | 'nl' | 'ja' | 'ko' | 'ru'
 	Language string `yaml:"language" jsonschema:"enum=auto,enum=en,enum=zh-TW,enum=zh-CN,enum=pl,enum=nl,enum=ja,enum=ko,enum=ru"`
 	// Format used when displaying time e.g. commit time.
@@ -745,6 +747,7 @@ func GetDefaultConfig() *UserConfig {
 			MainPanelSplitMode:       "flexible",
 			EnlargedSideViewLocation: "left",
 			WrapLinesInStagingView:   true,
+			UseHunkModeInStagingView: false,
 			Language:                 "auto",
 			TimeFormat:               "02 Jan 06",
 			ShortTimeFormat:          time.Kitchen,

--- a/pkg/gui/controllers/helpers/patch_building_helper.go
+++ b/pkg/gui/controllers/helpers/patch_building_helper.go
@@ -84,7 +84,7 @@ func (self *PatchBuildingHelper) RefreshPatchBuildingPanel(opts types.OnFocusOpt
 
 	oldState := context.GetState()
 
-	state := patch_exploring.NewState(diff, selectedLineIdx, context.GetView(), oldState)
+	state := patch_exploring.NewState(diff, selectedLineIdx, context.GetView(), oldState, self.c.UserConfig().Gui.UseHunkModeInStagingView)
 	context.SetState(state)
 	if state == nil {
 		self.Escape()

--- a/pkg/gui/controllers/helpers/staging_helper.go
+++ b/pkg/gui/controllers/helpers/staging_helper.go
@@ -62,12 +62,13 @@ func (self *StagingHelper) RefreshStagingPanel(focusOpts types.OnFocusOpts) {
 	mainContext.GetMutex().Lock()
 	secondaryContext.GetMutex().Lock()
 
+	hunkMode := self.c.UserConfig().Gui.UseHunkModeInStagingView
 	mainContext.SetState(
-		patch_exploring.NewState(mainDiff, mainSelectedLineIdx, mainContext.GetView(), mainContext.GetState()),
+		patch_exploring.NewState(mainDiff, mainSelectedLineIdx, mainContext.GetView(), mainContext.GetState(), hunkMode),
 	)
 
 	secondaryContext.SetState(
-		patch_exploring.NewState(secondaryDiff, secondarySelectedLineIdx, secondaryContext.GetView(), secondaryContext.GetState()),
+		patch_exploring.NewState(secondaryDiff, secondarySelectedLineIdx, secondaryContext.GetView(), secondaryContext.GetState(), hunkMode),
 	)
 
 	mainState := mainContext.GetState()

--- a/pkg/gui/controllers/patch_building_controller.go
+++ b/pkg/gui/controllers/patch_building_controller.go
@@ -170,7 +170,7 @@ func (self *PatchBuildingController) Escape() error {
 	context := self.c.Contexts().CustomPatchBuilder
 	state := context.GetState()
 
-	if state.SelectingRange() || state.SelectingHunk() {
+	if state.SelectingRange() || state.SelectingHunkEnabledByUser() {
 		state.SetLineSelectMode()
 		self.c.PostRefreshUpdate(context)
 		return nil

--- a/pkg/gui/controllers/patch_building_controller.go
+++ b/pkg/gui/controllers/patch_building_controller.go
@@ -134,7 +134,7 @@ func (self *PatchBuildingController) toggleSelection() error {
 	state := self.context().GetState()
 
 	// Get added/deleted lines in the selected patch range
-	lineIndicesToToggle := state.ChangeLinesInSelectedPatchRange()
+	lineIndicesToToggle := state.LineIndicesOfAddedOrDeletedLinesInSelectedPatchRange()
 	if len(lineIndicesToToggle) == 0 {
 		// Only context lines or header lines selected, so nothing to do
 		return nil

--- a/pkg/gui/controllers/staging_controller.go
+++ b/pkg/gui/controllers/staging_controller.go
@@ -168,7 +168,7 @@ func (self *StagingController) EditFile() error {
 }
 
 func (self *StagingController) Escape() error {
-	if self.context.GetState().SelectingRange() || self.context.GetState().SelectingHunk() {
+	if self.context.GetState().SelectingRange() || self.context.GetState().SelectingHunkEnabledByUser() {
 		self.context.GetState().SetLineSelectMode()
 		self.c.PostRefreshUpdate(self.context)
 		return nil

--- a/pkg/gui/patch_exploring/state.go
+++ b/pkg/gui/patch_exploring/state.go
@@ -335,7 +335,7 @@ func (s *State) SelectedPatchRange() (int, int) {
 }
 
 // Returns the line indices of the selected patch range that are changes (i.e. additions or deletions)
-func (s *State) ChangeLinesInSelectedPatchRange() []int {
+func (s *State) LineIndicesOfAddedOrDeletedLinesInSelectedPatchRange() []int {
 	viewStart, viewEnd := s.SelectedViewRange()
 	patchStart, patchEnd := s.patchLineIndices[viewStart], s.patchLineIndices[viewEnd]
 	lines := s.patch.Lines()

--- a/pkg/gui/patch_exploring/state.go
+++ b/pkg/gui/patch_exploring/state.go
@@ -39,7 +39,7 @@ const (
 	HUNK
 )
 
-func NewState(diff string, selectedLineIdx int, view *gocui.View, oldState *State) *State {
+func NewState(diff string, selectedLineIdx int, view *gocui.View, oldState *State, useHunkModeByDefault bool) *State {
 	if oldState != nil && diff == oldState.diff && selectedLineIdx == -1 {
 		// if we're here then we can return the old state. If selectedLineIdx was not -1
 		// then that would mean we were trying to click and potentially drag a range, which
@@ -61,6 +61,10 @@ func NewState(diff string, selectedLineIdx int, view *gocui.View, oldState *Stat
 	}
 
 	selectMode := LINE
+	if useHunkModeByDefault {
+		selectMode = HUNK
+	}
+
 	// if we have clicked from the outside to focus the main view we'll pass in a non-negative line index so that we can instantly select that line
 	if selectedLineIdx >= 0 {
 		// Clamp to the number of wrapped view lines; index might be out of
@@ -70,9 +74,9 @@ func NewState(diff string, selectedLineIdx int, view *gocui.View, oldState *Stat
 		selectMode = RANGE
 		rangeStartLineIdx = selectedLineIdx
 	} else if oldState != nil {
-		// if we previously had a selectMode of RANGE, we want that to now be line again
-		if oldState.selectMode == HUNK {
-			selectMode = HUNK
+		// if we previously had a selectMode of RANGE, we want that to now be line again (or hunk, if that's the default)
+		if oldState.selectMode != RANGE {
+			selectMode = oldState.selectMode
 		}
 		selectedLineIdx = viewLineIndices[patch.GetNextChangeIdx(oldState.patchLineIndices[oldState.selectedLineIdx])]
 	} else {

--- a/schema/config.json
+++ b/schema/config.json
@@ -530,6 +530,11 @@
           "description": "If true, wrap lines in the staging view to the width of the view. This\nmakes it much easier to work with diffs that have long lines, e.g.\nparagraphs of markdown text.",
           "default": true
         },
+        "useHunkModeInStagingView": {
+          "type": "boolean",
+          "description": "If true, hunk selection mode will be enabled by default when entering the staging view.",
+          "default": false
+        },
         "language": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
- **PR Description**

As of #4684, hunk mode has become so useful that I prefer it over line mode now. This PR adds a config that lets you use hunk mode by default in the staging view.

I'm not enabling this by default yet, although I do think it's the more useful mode for most people. The biggest issue that I still have with this is that _if_ you need to switch to line mode for some reason, then it's very non-obvious how to do that. New users might not find out at all, and think that lazygit doesn't allow staging individual lines.