### PR TITLE
Remove the homebrew tap from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,17 +233,9 @@ For Windows, Mac OS(10.12+) or Linux, you can download a binary release [here](.
 
 ### Homebrew
 
-Normally the lazygit formula can be found in the Homebrew core but we suggest you tap our formula to get the frequently updated one. It works with Linux, too.
+It works with Linux, too.
 
-Tap:
-
-```
-brew install jesseduffield/lazygit/lazygit
-```
-
-Core:
-
-```
+```sh
 brew install lazygit
 ```
 


### PR DESCRIPTION
The core homebrew formular is usually up to date very quickly, so there's little reason to use the custom tap.

We still maintain the tap and update it for the benefit of users who already subscribed to it, but we no longer recommend it for new users.
