### PR TITLE
Fix scrolling hunk into view when selecting next hunk

### DIFF
--- a/pkg/gui/context/list_context_trait.go
+++ b/pkg/gui/context/list_context_trait.go
@@ -30,7 +30,7 @@ func (self *ListContextTrait) FocusLine() {
 
 	// Doing this at the end of the layout function because we need the view to be
 	// resized before we focus the line, otherwise if we're in accordion mode
-	// the view could be squashed and won't how to adjust the cursor/origin.
+	// the view could be squashed and won't know how to adjust the cursor/origin.
 	// Also, refreshing the viewport needs to happen after the view has been resized.
 	self.c.AfterLayout(func() error {
 		oldOrigin, _ := self.GetViewTrait().ViewPortYBounds()

--- a/pkg/gui/context/patch_explorer_context.go
+++ b/pkg/gui/context/patch_explorer_context.go
@@ -94,11 +94,6 @@ func (self *PatchExplorerContext) Render() {
 	self.c.Render()
 }
 
-func (self *PatchExplorerContext) Focus() {
-	self.FocusSelection()
-	self.c.Render()
-}
-
 func (self *PatchExplorerContext) setContent() {
 	self.GetView().SetContent(self.GetContentToRender())
 }

--- a/pkg/gui/patch_exploring/focus.go
+++ b/pkg/gui/patch_exploring/focus.go
@@ -22,7 +22,7 @@ func calculateNewOriginWithNeededAndWantedIdx(currentOrigin int, bufferHeight in
 		allowedChange := bottom - needToSeeIdx
 		return origin - min(requiredChange, allowedChange)
 	} else if wantToSeeIdx >= bottom {
-		requiredChange := wantToSeeIdx - bottom
+		requiredChange := wantToSeeIdx + 1 - bottom
 		allowedChange := needToSeeIdx - origin
 		return origin + min(requiredChange, allowedChange)
 	}

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -192,7 +192,6 @@ type IPatchExplorerContext interface {
 	GetIncludedLineIndices() []int
 	RenderAndFocus()
 	Render()
-	Focus()
 	GetContentToRender() string
 	NavigateTo(selectedLineIdx int)
 	GetMutex() *deadlock.Mutex


### PR DESCRIPTION
- **PR Description**

If the hunk to be selected was partially scrolled offscreen, the view wouldn't
scroll enough to make it completely visible (the last line of the hunk was still
offscreen).
