### PR TITLE
Add confirmation for nuking the working tree

### DIFF
--- a/pkg/gui/controllers/workspace_reset_controller.go
+++ b/pkg/gui/controllers/workspace_reset_controller.go
@@ -31,18 +31,26 @@ func (self *FilesController) createResetMenu() error {
 				red.Sprint(nukeStr),
 			},
 			OnPress: func() error {
-				self.c.LogAction(self.c.Tr.Actions.NukeWorkingTree)
-				if err := self.c.Git().WorkingTree.ResetAndClean(); err != nil {
-					return err
-				}
+				self.c.Confirm(
+					types.ConfirmOpts{
+						Title:  self.c.Tr.Actions.NukeWorkingTree,
+						Prompt: self.c.Tr.NukeTreeConfirmation,
+						HandleConfirm: func() error {
+							self.c.LogAction(self.c.Tr.Actions.NukeWorkingTree)
+							if err := self.c.Git().WorkingTree.ResetAndClean(); err != nil {
+								return err
+							}
 
-				if self.c.UserConfig().Gui.AnimateExplosion {
-					self.animateExplosion()
-				}
+							if self.c.UserConfig().Gui.AnimateExplosion {
+								self.animateExplosion()
+							}
 
-				self.c.Refresh(
-					types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}},
-				)
+							self.c.Refresh(
+								types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES}},
+							)
+							return nil
+						},
+					})
 				return nil
 			},
 			Key:     'x',

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -782,6 +782,7 @@ type TranslationSet struct {
 	SoftResetPrompt                          string
 	UpstreamGone                             string
 	NukeDescription                          string
+	NukeTreeConfirmation                     string
 	DiscardStagedChangesDescription          string
 	EmptyOutput                              string
 	Patch                                    string
@@ -1832,6 +1833,7 @@ func EnglishTranslationSet() *TranslationSet {
 		CheckoutAutostashPrompt:                  "Are you sure you want to checkout '%s'? An auto-stash will be performed if necessary.",
 		UpstreamGone:                             "(upstream gone)",
 		NukeDescription:                          "If you want to make all the changes in the worktree go away, this is the way to do it. If there are dirty submodule changes this will stash those changes in the submodule(s).",
+		NukeTreeConfirmation:                     "Are you sure you want to nuke the working tree? This will discard all changes in the worktree (staged, unstaged and untracked), which is not undoable.",
 		DiscardStagedChangesDescription:          "This will create a new stash entry containing only staged files and then drop it, so that the working tree is left with only unstaged changes",
 		EmptyOutput:                              "<Empty output>",
 		Patch:                                    "Patch",


### PR DESCRIPTION

- **PR Description**

This is a small PR that extends the logic added in https://github.com/jesseduffield/lazygit/pull/4704

There were many reports of users accidentally resetting the working tree using the reset commands and a nice change was added by @stefanhaller to prompt for confirmation on those actions but the "Nuke working tree" option was not covered by the PR.

I believe this one is actually one of the most important options to prompt because it's by default the first one on the list. I myself triggered it once when trying to discard a single file while unknowingly having caps-lock enabled as I thought I was confirming the single file discard option.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
