### PR TITLE
Support Alt+Backspace for word deletion in text areas

### DIFF
--- a/pkg/gui/editors.go
+++ b/pkg/gui/editors.go
@@ -8,6 +8,9 @@ import (
 
 func (gui *Gui) handleEditorKeypress(textArea *gocui.TextArea, key gocui.Key, ch rune, mod gocui.Modifier, allowMultiline bool) bool {
 	switch {
+	case (key == gocui.KeyBackspace || key == gocui.KeyBackspace2) && (mod&gocui.ModAlt) != 0,
+		key == gocui.KeyCtrlW:
+		textArea.BackSpaceWord()
 	case key == gocui.KeyBackspace || key == gocui.KeyBackspace2:
 		textArea.BackSpaceChar()
 	case key == gocui.KeyCtrlD || key == gocui.KeyDelete:
@@ -42,8 +45,6 @@ func (gui *Gui) handleEditorKeypress(textArea *gocui.TextArea, key gocui.Key, ch
 		textArea.GoToStartOfLine()
 	case key == gocui.KeyCtrlE || key == gocui.KeyEnd:
 		textArea.GoToEndOfLine()
-	case key == gocui.KeyCtrlW:
-		textArea.BackSpaceWord()
 	case key == gocui.KeyCtrlY:
 		textArea.Yank()
 


### PR DESCRIPTION
- **PR Description**
Add support for Alt+Backspace (Option+Backspace on macOS) to delete entire words in text input areas, matching common text editor behavior.

- **Please check if the PR fulfills these requirements**
  * [x] Cheatsheets are up-to-date (run `go generate ./...`)
  * [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
  * [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
  * [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
  * [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
  * [x] Docs have been updated if necessary
  * [x] You've read through your own file changes for silly mistakes etc