### PR TITLE
Kill git processes more gracefully on Linux/Mac

### DIFF
--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -264,14 +264,9 @@ func (c *OSCommand) PipeCommands(cmdObjs ...*CmdObj) error {
 	return nil
 }
 
-// Kill kills a process. If the process has Setpgid == true, then we have anticipated that it might spawn its own child processes, so we've given it a process group ID (PGID) equal to its process id (PID) and given its child processes will inherit the PGID, we can kill that group, rather than killing the process itself.
+// Kill kills a process.
 func Kill(cmd *exec.Cmd) error {
 	return kill.Kill(cmd)
-}
-
-// PrepareForChildren sets Setpgid to true on the cmd, so that when we run it as a subprocess, we can kill its group rather than the process itself. This is because some commands, like `docker-compose logs` spawn multiple children processes, and killing the parent process isn't sufficient for killing those child processes. We set the group id here, and then in subprocess.go we check if the group id is set and if so, we kill the whole group rather than just the one process.
-func PrepareForChildren(cmd *exec.Cmd) {
-	kill.PrepareForChildren(cmd)
 }
 
 func (c *OSCommand) CopyToClipboard(str string) error {

--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -13,7 +13,6 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/atotto/clipboard"
-	"github.com/jesseduffield/kill"
 	"github.com/jesseduffield/lazygit/pkg/common"
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/utils"
@@ -262,11 +261,6 @@ func (c *OSCommand) PipeCommands(cmdObjs ...*CmdObj) error {
 		return errors.New(strings.Join(finalErrors, "\n"))
 	}
 	return nil
-}
-
-// Kill kills a process.
-func Kill(cmd *exec.Cmd) error {
-	return kill.Kill(cmd)
 }
 
 func (c *OSCommand) CopyToClipboard(str string) error {

--- a/pkg/commands/oscommands/os_default_platform.go
+++ b/pkg/commands/oscommands/os_default_platform.go
@@ -5,8 +5,10 @@ package oscommands
 
 import (
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
+	"syscall"
 )
 
 func GetPlatform() *Platform {
@@ -33,4 +35,17 @@ func getUserShell() string {
 	}
 
 	return "bash"
+}
+
+func Kill(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		// You can't kill a person with no body
+		return nil
+	}
+
+	// Terminate the process gracefully, and hope that it handles the signal properly. We use it
+	// only for git, and we know that git is well-behaved in this regard. If we were to use this for
+	// other commands, we may need to implement a more robust solution, e.g. waiting for a while and
+	// then killing the process forcefully if it didn't terminate.
+	return cmd.Process.Signal(syscall.SIGTERM)
 }

--- a/pkg/commands/oscommands/os_default_platform.go
+++ b/pkg/commands/oscommands/os_default_platform.go
@@ -43,6 +43,11 @@ func Kill(cmd *exec.Cmd) error {
 		return nil
 	}
 
+	if cmd.ProcessState != nil {
+		// The process has already exited
+		return nil
+	}
+
 	// Terminate the process gracefully, and hope that it handles the signal properly. We use it
 	// only for git, and we know that git is well-behaved in this regard. If we were to use this for
 	// other commands, we may need to implement a more robust solution, e.g. waiting for a while and

--- a/pkg/commands/oscommands/os_windows.go
+++ b/pkg/commands/oscommands/os_windows.go
@@ -1,9 +1,20 @@
 package oscommands
 
+import (
+	"os/exec"
+
+	"github.com/jesseduffield/kill"
+)
+
 func GetPlatform() *Platform {
 	return &Platform{
 		OS:       "windows",
 		Shell:    "cmd",
 		ShellArg: "/c",
 	}
+}
+
+// Kill kills a process.
+func Kill(cmd *exec.Cmd) error {
+	return kill.Kill(cmd)
 }


### PR DESCRIPTION
- **PR Description**

The kill.Kill() function uses SIGKILL to forcefully terminate processes. This is not a good idea with git, since it might hit it at a time where it created an index.lock file, which will then not be cleaned up. Improve this by sending the command a SIGTERM signal instead.

I'm not changing the kill package here, because it is used by other projects which might have different requirements than lazygit; so I'm fixing this locally here. Also, I'm not changing Windows, it continues to use the kill.Kill code, which forcefully terminates. This could still be a problem with regards to the index.lock issue, but I'm just not sure if there's anything we can do, since Windows doesn't support signals.

Resolves #2050, at least on Linux and Mac.