### PR TITLE
feat: open file at revision in filtering mode

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -666,6 +666,7 @@ keybinding:
     openInBrowser: o
     viewBisectOptions: b
     startInteractiveRebase: i
+    openFileAtRevision: O
     selectCommitsOfCurrentBranch: '*'
   amendAttribute:
     resetAuthor: a

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -540,6 +540,7 @@ type KeybindingCommitsConfig struct {
 	OpenInBrowser                  string `yaml:"openInBrowser"`
 	ViewBisectOptions              string `yaml:"viewBisectOptions"`
 	StartInteractiveRebase         string `yaml:"startInteractiveRebase"`
+	OpenFileAtRevision             string `yaml:"openFileAtRevision"`
 	SelectCommitsOfCurrentBranch   string `yaml:"selectCommitsOfCurrentBranch"`
 }
 
@@ -555,7 +556,7 @@ type KeybindingStashConfig struct {
 }
 
 type KeybindingCommitFilesConfig struct {
-	CheckoutCommitFile string `yaml:"checkoutCommitFile"`
+	CheckoutCommitFile   string `yaml:"checkoutCommitFile"`
 }
 
 type KeybindingMainConfig struct {
@@ -999,6 +1000,7 @@ func GetDefaultConfig() *UserConfig {
 				OpenInBrowser:                  "o",
 				ViewBisectOptions:              "b",
 				StartInteractiveRebase:         "i",
+				OpenFileAtRevision:             "O",
 				SelectCommitsOfCurrentBranch:   "*",
 			},
 			AmendAttribute: KeybindingAmendAttributeConfig{
@@ -1011,7 +1013,7 @@ func GetDefaultConfig() *UserConfig {
 				RenameStash: "r",
 			},
 			CommitFiles: KeybindingCommitFilesConfig{
-				CheckoutCommitFile: "c",
+				CheckoutCommitFile:   "c",
 			},
 			Main: KeybindingMainConfig{
 				ToggleSelectHunk: "a",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -260,6 +260,8 @@ type TranslationSet struct {
 	GitconfigParseErr                     string
 	EditFile                              string
 	EditFileTooltip                       string
+	OpenFileAtRevision                    string
+	OpenFileAtRevisionTooltip             string
 	OpenFile                              string
 	OpenFileTooltip                       string
 	OpenInEditor                          string
@@ -978,6 +980,7 @@ type Actions struct {
 	Push                             string
 	Pull                             string
 	OpenFile                         string
+	OpenFileAtRevision               string
 	StashAllChanges                  string
 	StashAllChangesKeepIndex         string
 	StashStagedChanges               string
@@ -1306,6 +1309,8 @@ func EnglishTranslationSet() *TranslationSet {
 		GitconfigParseErr:                    `Gogit failed to parse your gitconfig file due to the presence of unquoted '\' characters. Removing these should fix the issue.`,
 		EditFile:                             `Edit file`,
 		EditFileTooltip:                      "Open file in external editor.",
+		OpenFileAtRevision:                   `Open file at revision`,
+		OpenFileAtRevisionTooltip:            "Open the file content from this commit revision in external editor (opens as temporary file).",
 		OpenFile:                             `Open file`,
 		OpenFileTooltip:                      "Open file in default application.",
 		OpenInEditor:                         "Open in editor",
@@ -1993,6 +1998,7 @@ func EnglishTranslationSet() *TranslationSet {
 			Push:                             "Push",
 			Pull:                             "Pull",
 			OpenFile:                         "Open file",
+			OpenFileAtRevision:               "Open file at revision",
 			StashAllChanges:                  "Stash all changes",
 			StashAllChangesKeepIndex:         "Stash all changes and keep index",
 			StashStagedChanges:               "Stash staged changes",

--- a/schema/config.json
+++ b/schema/config.json
@@ -1006,6 +1006,10 @@
           "type": "string",
           "default": "i"
         },
+        "openFileAtRevision": {
+          "type": "string",
+          "default": "O"
+        },
         "selectCommitsOfCurrentBranch": {
           "type": "string",
           "default": "*"


### PR DESCRIPTION
- **PR Description**

In the "file history mode" or "filtering mode", this allows to "Open file at revision" with configured EDITOR

helpful when you wan't to read the file content, copy and so on

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
