### PR TITLE
Config option to always create annotated tags

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -332,6 +332,11 @@ git:
     # The commit message to use for a squash merge commit. Can contain "{{selectedRef}}" and "{{currentBranch}}" placeholders.
     squashMergeMessage: Squash merge {{selectedRef}} into {{currentBranch}}
 
+  # Config relating to tagging
+  tag:
+    # If true, always create annotated tags (even if the tag message is empty)
+    alwaysAnnotate: false
+
   # list of branches that are considered 'main' branches, used when displaying commits
   mainBranches:
     - master

--- a/pkg/config/app_config_test.go
+++ b/pkg/config/app_config_test.go
@@ -640,6 +640,11 @@ git:
     # The commit message to use for a squash merge commit. Can contain "{{selectedRef}}" and "{{currentBranch}}" placeholders.
     squashMergeMessage: Squash merge {{selectedRef}} into {{currentBranch}}
 
+  # Config relating to tagging
+  tag:
+    # If true, always create annotated tags (even if the tag message is empty)
+    alwaysAnnotate: false
+
   # list of branches that are considered 'main' branches, used when displaying commits
   mainBranches:
     - master

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -242,6 +242,8 @@ type GitConfig struct {
 	Commit CommitConfig `yaml:"commit"`
 	// Config relating to merging
 	Merging MergingConfig `yaml:"merging"`
+	// Config relating to tagging
+	Tag TagConfig `yaml:"tag"`
 	// list of branches that are considered 'main' branches, used when displaying commits
 	MainBranches []string `yaml:"mainBranches" jsonschema:"uniqueItems=true"`
 	// Prefix to use when skipping hooks. E.g. if set to 'WIP', then pre-commit hooks will be skipped when the commit message starts with 'WIP'
@@ -339,6 +341,11 @@ type MergingConfig struct {
 	Args string `yaml:"args" jsonschema:"example=--no-ff"`
 	// The commit message to use for a squash merge commit. Can contain "{{selectedRef}}" and "{{currentBranch}}" placeholders.
 	SquashMergeMessage string `yaml:"squashMergeMessage"`
+}
+
+type TagConfig struct {
+	// If true, always create annotated tags (even if the tag message is empty)
+	AlwaysAnnotate bool `yaml:"alwaysAnnotate"`
 }
 
 type LogConfig struct {
@@ -808,6 +815,9 @@ func GetDefaultConfig() *UserConfig {
 				ManualCommit:       false,
 				Args:               "",
 				SquashMergeMessage: "Squash merge {{selectedRef}} into {{currentBranch}}",
+			},
+			Tag: TagConfig{
+				AlwaysAnnotate: false,
 			},
 			Log: LogConfig{
 				Order:          "topo-order",

--- a/pkg/gui/controllers/helpers/tags_helper.go
+++ b/pkg/gui/controllers/helpers/tags_helper.go
@@ -38,7 +38,7 @@ func (self *TagsHelper) OpenCreateTagPrompt(ref string, onCreate func()) error {
 			Prompt: prompt,
 			HandleConfirm: func() error {
 				var command *oscommands.CmdObj
-				if description != "" || self.c.Git().Config.GetGpgTagSign() {
+				if description != "" || self.c.Git().Config.GetGpgTagSign() || self.c.UserConfig().Git.Tag.AlwaysAnnotate {
 					self.c.LogAction(self.c.Tr.Actions.CreateAnnotatedTag)
 					command = self.c.Git().Tag.CreateAnnotatedObj(tagName, ref, description, force)
 				} else {

--- a/pkg/integration/components/git.go
+++ b/pkg/integration/components/git.go
@@ -21,6 +21,17 @@ func (self *Git) TagNamesAt(ref string, expectedNames []string) *Git {
 	return self.assert([]string{"git", "tag", "--sort=v:refname", "--points-at", ref}, strings.Join(expectedNames, "\n"))
 }
 
+func (self *Git) TagIsAnnotated(tagName string) *Git {
+	cmdArgs := []string{"git", "cat-file", "-t", tagName}
+	expectedOutput := "tag"
+
+	return self.expect(cmdArgs, func(output string) (bool, string) {
+		isAnnotated := output == expectedOutput
+		failureMessage := fmt.Sprintf("Expected tag '%s' to be an annotated tag (output 'tag'), but got '%s'", tagName, output)
+		return isAnnotated, failureMessage
+	})
+}
+
 func (self *Git) RemoteTagDeleted(ref string, tagName string) *Git {
 	return self.expect([]string{"git", "ls-remote", ref, fmt.Sprintf("refs/tags/%s", tagName)}, func(s string) (bool, string) {
 		return len(s) == 0, fmt.Sprintf("Expected tag %s to have been removed from %s", tagName, ref)

--- a/pkg/integration/tests/tag/create_annotated_with_config.go
+++ b/pkg/integration/tests/tag/create_annotated_with_config.go
@@ -1,0 +1,37 @@
+package tag
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CreateAnnotatedWithConfig = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Create an annotated tag when the alwaysAnnotate config option is enabled",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Git.Tag.AlwaysAnnotate = true
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("initial commit")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Tags().
+			Focus().
+			IsEmpty().
+			Press(keys.Universal.New).
+			Tap(func() {
+				t.ExpectPopup().CommitMessagePanel().
+					Title(Equals("Tag name")).
+					Type("new-tag").
+					Confirm()
+			}).
+			Lines(
+				MatchesRegexp(`new-tag.*`).IsSelected(),
+			).
+			PressEnter().
+			Tap(func() {
+				t.Git().TagIsAnnotated("new-tag")
+			})
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -405,6 +405,7 @@ var tests = []*components.IntegrationTest{
 	tag.Checkout,
 	tag.CheckoutWhenBranchWithSameNameExists,
 	tag.CopyToClipboard,
+	tag.CreateAnnotatedWithConfig,
 	tag.CreateWhileCommitting,
 	tag.CrudAnnotated,
 	tag.CrudLightweight,

--- a/schema/config.json
+++ b/schema/config.json
@@ -297,6 +297,10 @@
           "$ref": "#/$defs/MergingConfig",
           "description": "Config relating to merging"
         },
+        "tag": {
+          "$ref": "#/$defs/TagConfig",
+          "description": "Config relating to tagging"
+        },
         "mainBranches": {
           "items": {
             "type": "string"
@@ -1726,6 +1730,18 @@
       "additionalProperties": false,
       "type": "object",
       "description": "Config relating to the spinner."
+    },
+    "TagConfig": {
+      "properties": {
+        "alwaysAnnotate": {
+          "type": "boolean",
+          "description": "If true, always create annotated tags (even if the tag message is empty)",
+          "default": false
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Config relating to tagging"
     },
     "ThemeConfig": {
       "properties": {


### PR DESCRIPTION
- **PR Description**

Adds a new configuration setting `git.tag.alwaysAnnotate`.

When set to `true`, creating a tag in the tags panel will always create an annotated tag, even if the tag message is empty.

- **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation)) <!-- You may need to check if the "Tag message" prompt is internationalised -->
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary <!-- Be sure to add the new key to the configuration docs! -->
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->