### PR TITLE
Don't assume remote name is origin

### DIFF
--- a/pkg/commands/hosting_service/hosting_service.go
+++ b/pkg/commands/hosting_service/hosting_service.go
@@ -166,17 +166,17 @@ type Service struct {
 }
 
 func (self *Service) getPullRequestURLIntoDefaultBranch(from string) string {
-	return self.resolveUrl(self.pullRequestURLIntoDefaultBranch, map[string]string{"From": from})
+	return self.resolveURL(self.pullRequestURLIntoDefaultBranch, map[string]string{"From": from})
 }
 
 func (self *Service) getPullRequestURLIntoTargetBranch(from string, to string) string {
-	return self.resolveUrl(self.pullRequestURLIntoTargetBranch, map[string]string{"From": from, "To": to})
+	return self.resolveURL(self.pullRequestURLIntoTargetBranch, map[string]string{"From": from, "To": to})
 }
 
 func (self *Service) getCommitURL(commitHash string) string {
-	return self.resolveUrl(self.commitURL, map[string]string{"CommitHash": commitHash})
+	return self.resolveURL(self.commitURL, map[string]string{"CommitHash": commitHash})
 }
 
-func (self *Service) resolveUrl(templateString string, args map[string]string) string {
+func (self *Service) resolveURL(templateString string, args map[string]string) string {
 	return self.repoURL + utils.ResolvePlaceholderString(templateString, args)
 }

--- a/pkg/commands/hosting_service/hosting_service_test.go
+++ b/pkg/commands/hosting_service/hosting_service_test.go
@@ -429,7 +429,7 @@ func TestGetPullRequestURL(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			tr := i18n.EnglishTranslationSet()
 			log := &fakes.FakeFieldLogger{}
-			hostingServiceMgr := NewHostingServiceMgr(log, tr, s.remoteUrl, s.configServiceDomains)
+			hostingServiceMgr := NewHostingServiceMgr(log, tr, s.remoteUrl, s.configServiceDomains, nil)
 			s.test(hostingServiceMgr.GetPullRequestURL(s.from, s.to))
 			log.AssertErrors(t, s.expectedLoggedErrors)
 		})

--- a/pkg/gui/controllers/basic_commits_controller.go
+++ b/pkg/gui/controllers/basic_commits_controller.go
@@ -198,7 +198,8 @@ func (self *BasicCommitsController) copyCommitAttribute(commit *models.Commit) e
 			Key: 'b',
 		},
 		{
-			Label: self.c.Tr.CommitURL,
+			Label:          self.c.Tr.CommitURL,
+			DisabledReason: self.canCopyCommitURL(commit),
 			OnPress: func() error {
 				return self.copyCommitURLToClipboard(commit)
 			},
@@ -380,6 +381,16 @@ func (self *BasicCommitsController) canCopyCommits(selectedCommits []*models.Com
 		}
 	}
 
+	return nil
+}
+
+func (self *BasicCommitsController) canCopyCommitURL(commit *models.Commit) *types.DisabledReason {
+	_, err := self.c.Helpers().Host.GetCommitURL(commit.Hash())
+	if err != nil {
+		return &types.DisabledReason{
+			Text: self.c.Tr.CommitHasNoURL,
+		}
+	}
 	return nil
 }
 

--- a/pkg/gui/controllers/basic_commits_controller.go
+++ b/pkg/gui/controllers/basic_commits_controller.go
@@ -161,6 +161,13 @@ func (self *BasicCommitsController) copyCommitAttribute(commit *models.Commit) e
 		}
 	}
 
+	var commitTagsDisabled *types.DisabledReason
+	if len(commit.Tags) == 0 {
+		commitTagsDisabled = &types.DisabledReason{
+			Text: self.c.Tr.CommitHasNoTags,
+		}
+	}
+
 	items := []*types.MenuItem{
 		{
 			Label: self.c.Tr.CommitHash,
@@ -211,21 +218,15 @@ func (self *BasicCommitsController) copyCommitAttribute(commit *models.Commit) e
 			},
 			Key: 'a',
 		},
-	}
-
-	commitTagsItem := types.MenuItem{
-		Label: self.c.Tr.CommitTags,
-		OnPress: func() error {
-			return self.copyCommitTagsToClipboard(commit)
+		{
+			Label:          self.c.Tr.CommitTags,
+			DisabledReason: commitTagsDisabled,
+			OnPress: func() error {
+				return self.copyCommitTagsToClipboard(commit)
+			},
+			Key: 't',
 		},
-		Key: 't',
 	}
-
-	if len(commit.Tags) == 0 {
-		commitTagsItem.DisabledReason = &types.DisabledReason{Text: self.c.Tr.CommitHasNoTags}
-	}
-
-	items = append(items, &commitTagsItem)
 
 	return self.c.Menu(types.CreateMenuOptions{
 		Title: self.c.Tr.Actions.CopyCommitAttributeToClipboard,

--- a/pkg/gui/controllers/helpers/host_helper.go
+++ b/pkg/gui/controllers/helpers/host_helper.go
@@ -42,5 +42,12 @@ func (self *HostHelper) getHostingServiceMgr() (*hosting_service.HostingServiceM
 		return nil, err
 	}
 	configServices := self.c.UserConfig().Services
-	return hosting_service.NewHostingServiceMgr(self.c.Log, self.c.Tr, remoteUrl, configServices), nil
+	hostingServiceMgr := hosting_service.NewHostingServiceMgr(
+		self.c.Log,
+		self.c.Tr,
+		remoteUrl,
+		configServices,
+		self.c.Git().Remote.CommitExistsOnRemote,
+	)
+	return hostingServiceMgr, nil
 }

--- a/pkg/gui/controllers/helpers/host_helper.go
+++ b/pkg/gui/controllers/helpers/host_helper.go
@@ -37,7 +37,7 @@ func (self *HostHelper) GetCommitURL(commitHash string) (string, error) {
 // getting this on every request rather than storing it in state in case our remoteURL changes
 // from one invocation to the next.
 func (self *HostHelper) getHostingServiceMgr() (*hosting_service.HostingServiceMgr, error) {
-	remoteUrl, err := self.c.Git().Remote.GetRemoteURL("origin")
+	remoteUrl, err := self.c.Git().Remote.GetRemoteURL()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -713,6 +713,7 @@ type TranslationSet struct {
 	CommitTagsCopiedToClipboard              string
 	CommitHasNoTags                          string
 	CommitHasNoMessageBody                   string
+	CommitHasNoURL                           string
 	PatchCopiedToClipboard                   string
 	CopiedToClipboard                        string
 	ErrCannotEditDirectory                   string
@@ -1766,6 +1767,7 @@ func EnglishTranslationSet() *TranslationSet {
 		CommitTagsCopiedToClipboard:              "Commit tags copied to clipboard",
 		CommitHasNoTags:                          "Commit has no tags",
 		CommitHasNoMessageBody:                   "Commit has no message body",
+		CommitHasNoURL:                           "Commit does not exist on remote",
 		PatchCopiedToClipboard:                   "Patch copied to clipboard",
 		CopiedToClipboard:                        "copied to clipboard",
 		ErrCannotEditDirectory:                   "Cannot edit directories: you can only edit individual files",


### PR DESCRIPTION
* **PR Description**
    - **Remove hardcoded assumption that the remote is named `origin`**
Previously, `lazygit `assumed the remote was always named origin, causing errors when repositories used a different remote name—even if a valid remote was available. This PR removes that assumption by delegating remote resolution to `RemoteCommands`, which now identifies the appropriate remote automatically (it one exists). As a result, [`HostingServiceMgr`](https://github.com/jesseduffield/lazygit/blob/master/pkg/gui/controllers/helpers/host_helper.go#L40-L40) can consistently be instantiated with a valid `repoURL`, regardless of the remote’s name.

    - **Disable the option to copy the URL for local-only commits**
While testing, I noticed that `lazygit `generates a URL for commits that exist only locally, which results in a 404 when opened. This portion of the PR disables the “Copy Commit URL” option for commits that are not present on any remote branch. I achieved this by adding a `commitExistsOnRemote func(string) bool` field to the `HostingServiceMgr` and populating it with a new `RemoteCommands.CommitExistsOnRemote` helper method at instantiation.

        I’m not fully satisfied with my current implementation—it feels clunky—so I’d welcome any suggestions for improvement.

    Resolves #4746.

* **Please check if the PR fulfills these requirements**

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
