### PR TITLE
Make the minimum required git version a placeholder in the error text

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -140,15 +140,22 @@ func NewApp(config config.AppConfigurer, test integrationTypes.IntegrationTest, 
 	return app, nil
 }
 
+const minGitVersionStr = "2.32.0"
+
+func minGitVersionErrorMessage(tr *i18n.TranslationSet) string {
+	return fmt.Sprintf(tr.MinGitVersionError, minGitVersionStr)
+}
+
 func (app *App) validateGitVersion() (*git_commands.GitVersion, error) {
 	version, err := git_commands.GetGitVersion(app.OSCommand)
 	// if we get an error anywhere here we'll show the same status
-	minVersionError := errors.New(app.Tr.MinGitVersionError)
+	minVersionError := errors.New(minGitVersionErrorMessage(app.Tr))
 	if err != nil {
 		return nil, minVersionError
 	}
 
-	if version.IsOlderThan(2, 32, 0) {
+	minRequiredVersion, _ := git_commands.ParseGitVersion(minGitVersionStr)
+	if version.IsOlderThanVersion(minRequiredVersion) {
 		return nil, minVersionError
 	}
 

--- a/pkg/app/errors.go
+++ b/pkg/app/errors.go
@@ -16,7 +16,7 @@ type errorMapping struct {
 func knownError(tr *i18n.TranslationSet, err error) (string, bool) {
 	errorMessage := err.Error()
 
-	knownErrorMessages := []string{tr.MinGitVersionError}
+	knownErrorMessages := []string{minGitVersionErrorMessage(tr)}
 
 	if lo.Contains(knownErrorMessages, errorMessage) {
 		return errorMessage, true

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1717,7 +1717,7 @@ func EnglishTranslationSet() *TranslationSet {
 		CreateNewBranchFromCommit:                "Create new branch off of commit",
 		BuildingPatch:                            "Building patch",
 		ViewCommits:                              "View commits",
-		MinGitVersionError:                       "Git version must be at least 2.32 (i.e. from 2021 onwards). Please upgrade your git version. Alternatively raise an issue at https://github.com/jesseduffield/lazygit/issues for lazygit to be more backwards compatible.",
+		MinGitVersionError:                       "Git version must be at least %s. Please upgrade your git version.",
 		RunningCustomCommandStatus:               "Running custom command",
 		SubmoduleStashAndReset:                   "Stash uncommitted submodule changes and update",
 		AndResetSubmodules:                       "And reset submodules",


### PR DESCRIPTION
- **PR Description**

This way we don't have to update the text and all translations every time we bump the version.

Remove the year from the error text, it's cumbersome to update and I don't find it very important to have in the message.

Also remove the invitation to file an issue; I don't find it very likely that we are going to relax the minimum git requirement again.

