### PR TITLE
When pressing `a` to stage all files, don't include untracked files when showing only tracked files

### DIFF
--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -49,8 +49,10 @@ func (self *WorkingTreeCommands) StageFiles(paths []string, extraArgs []string) 
 }
 
 // StageAll stages all files
-func (self *WorkingTreeCommands) StageAll() error {
-	cmdArgs := NewGitCmd("add").Arg("-A").ToArgv()
+func (self *WorkingTreeCommands) StageAll(onlyTrackedFiles bool) error {
+	cmdArgs := NewGitCmd("add").
+		ArgIfElse(onlyTrackedFiles, "-u", "-A").
+		ToArgv()
 
 	return self.cmd.New(cmdArgs).Run()
 }

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -634,7 +634,8 @@ func (self *FilesController) toggleStagedAllWithLock() error {
 			return err
 		}
 
-		if err := self.c.Git().WorkingTree.StageAll(); err != nil {
+		onlyTrackedFiles := self.context().GetFilter() == filetree.DisplayTracked
+		if err := self.c.Git().WorkingTree.StageAll(onlyTrackedFiles); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/gui/controllers/helpers/fixup_helper.go
+++ b/pkg/gui/controllers/helpers/fixup_helper.go
@@ -133,7 +133,7 @@ func (self *FixupHelper) HandleFindBaseCommitForFixupPress() error {
 		Prompt: self.c.Tr.HunksWithOnlyAddedLinesWarning,
 		HandleConfirm: func() error {
 			if !hasStagedChanges {
-				if err := self.c.Git().WorkingTree.StageAll(); err != nil {
+				if err := self.c.Git().WorkingTree.StageAll(true); err != nil {
 					return err
 				}
 				self.c.Refresh(types.RefreshOptions{Mode: types.SYNC, Scope: []types.RefreshableView{types.FILES}})

--- a/pkg/gui/controllers/helpers/merge_and_rebase_helper.go
+++ b/pkg/gui/controllers/helpers/merge_and_rebase_helper.go
@@ -244,7 +244,7 @@ func (self *MergeAndRebaseHelper) PromptToContinueRebase() error {
 					Prompt: self.c.Tr.UnstagedFilesAfterConflictsResolved,
 					HandleConfirm: func() error {
 						self.c.LogAction(self.c.Tr.Actions.StageAllFiles)
-						if err := self.c.Git().WorkingTree.StageAll(); err != nil {
+						if err := self.c.Git().WorkingTree.StageAll(true); err != nil {
 							return err
 						}
 

--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -207,7 +207,7 @@ func (self *WorkingTreeHelper) promptToStageAllAndRetry(retry func() error) erro
 		Prompt: self.c.Tr.NoFilesStagedPrompt,
 		HandleConfirm: func() error {
 			self.c.LogAction(self.c.Tr.Actions.StageAllFiles)
-			if err := self.c.Git().WorkingTree.StageAll(); err != nil {
+			if err := self.c.Git().WorkingTree.StageAll(false); err != nil {
 				return err
 			}
 			self.syncRefresh()
@@ -228,7 +228,7 @@ func (self *WorkingTreeHelper) prepareFilesForCommit() error {
 	noStagedFiles := !self.AnyStagedFiles()
 	if noStagedFiles && self.c.UserConfig().Gui.SkipNoStagedFilesWarning {
 		self.c.LogAction(self.c.Tr.Actions.StageAllFiles)
-		err := self.c.Git().WorkingTree.StageAll()
+		err := self.c.Git().WorkingTree.StageAll(false)
 		if err != nil {
 			return err
 		}

--- a/pkg/integration/tests/filter_and_search/stage_all_stages_only_tracked_files_in_tracked_only_filter.go
+++ b/pkg/integration/tests/filter_and_search/stage_all_stages_only_tracked_files_in_tracked_only_filter.go
@@ -48,10 +48,7 @@ var StageAllStagesOnlyTrackedFilesInTrackedOnlyFilter = NewIntegrationTest(NewIn
 			Lines(
 				Equals("▼ /").IsSelected(),
 				Equals("  M  file-tracked"), // 'M' is now in the left column, so file is staged
-				/* EXPECTED:
 				Equals("  ?? file-untracked"),
-				ACTUAL: */
-				Equals("  A  file-untracked"),
 			)
 	},
 })

--- a/pkg/integration/tests/filter_and_search/stage_all_stages_only_tracked_files_in_tracked_only_filter.go
+++ b/pkg/integration/tests/filter_and_search/stage_all_stages_only_tracked_files_in_tracked_only_filter.go
@@ -1,0 +1,57 @@
+package filter_and_search
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var StageAllStagesOnlyTrackedFilesInTrackedOnlyFilter = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Staging all files in tracked only view should stage only tracked files",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file-tracked", "foo")
+
+		shell.Commit("first commit")
+
+		shell.CreateFile("file-untracked", "bar")
+		shell.UpdateFile("file-tracked", "baz")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			Focus().
+			Lines(
+				Equals("▼ /").IsSelected(),
+				Equals("   M file-tracked"),
+				Equals("  ?? file-untracked"),
+			).
+			Press(keys.Files.OpenStatusFilter).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Filtering")).
+					Select(Contains("Show only tracked files")).
+					Confirm()
+			}).
+			Lines(
+				Equals(" M file-tracked"),
+			).
+			Press(keys.Files.ToggleStagedAll).
+			Press(keys.Files.OpenStatusFilter).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Filtering")).
+					Select(Contains("No filter")).
+					Confirm()
+			}).
+			Lines(
+				Equals("▼ /").IsSelected(),
+				Equals("  M  file-tracked"), // 'M' is now in the left column, so file is staged
+				/* EXPECTED:
+				Equals("  ?? file-untracked"),
+				ACTUAL: */
+				Equals("  A  file-untracked"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -229,6 +229,7 @@ var tests = []*components.IntegrationTest{
 	filter_and_search.NestedFilter,
 	filter_and_search.NestedFilterTransient,
 	filter_and_search.NewSearch,
+	filter_and_search.StageAllStagesOnlyTrackedFilesInTrackedOnlyFilter,
 	filter_and_search.StagingFolderStagesOnlyTrackedFilesInTrackedOnlyFilter,
 	filter_by_author.SelectAuthor,
 	filter_by_author.TypeAuthor,


### PR DESCRIPTION
- **PR Description**

This is very similar to what we did for pressing space in #4386; we forgot that the "stage all" command has the same issue.

Also, fix two other commands that stage all files under the hood:
- when continuing a rebase after resolving conflicts, we auto-stage all files, but in this case we never want to include untracked files, regardless of the filter
- likewise, pressing ctrl-f to find a base commit for fixup stages all files for convenience, but again, this should only stage files that are already tracked