### PR TITLE
Enable hunk staging mode by default

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -117,7 +117,7 @@ gui:
   wrapLinesInStagingView: true
 
   # If true, hunk selection mode will be enabled by default when entering the staging view.
-  useHunkModeInStagingView: false
+  useHunkModeInStagingView: true
 
   # One of 'auto' (default) | 'en' | 'zh-CN' | 'zh-TW' | 'pl' | 'nl' | 'ja' | 'ko' | 'ru'
   language: auto

--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -221,7 +221,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <left> `` | Go to previous hunk |  |
 | `` <right> `` | Go to next hunk |  |
 | `` v `` | Toggle range select |  |
-| `` a `` | Select hunk | Toggle hunk selection mode. |
+| `` a `` | Toggle hunk selection | Toggle line-by-line vs. hunk selection mode. |
 | `` <c-o> `` | Copy selected text to clipboard |  |
 | `` o `` | Open file | Open file in default application. |
 | `` e `` | Edit file | Open file in external editor. |
@@ -236,7 +236,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <left> `` | Go to previous hunk |  |
 | `` <right> `` | Go to next hunk |  |
 | `` v `` | Toggle range select |  |
-| `` a `` | Select hunk | Toggle hunk selection mode. |
+| `` a `` | Toggle hunk selection | Toggle line-by-line vs. hunk selection mode. |
 | `` <c-o> `` | Copy selected text to clipboard |  |
 | `` <space> `` | Stage | Toggle selection staged / unstaged. |
 | `` d `` | Discard | When unstaged change is selected, discard the change using `git reset`. When staged change is selected, unstage the change. |

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -164,7 +164,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <left> `` | 이전 hunk를 선택 |  |
 | `` <right> `` | 다음 hunk를 선택 |  |
 | `` v `` | 드래그 선택 전환 |  |
-| `` a `` | Toggle select hunk | Toggle hunk selection mode. |
+| `` a `` | Toggle select hunk | Toggle line-by-line vs. hunk selection mode. |
 | `` <c-o> `` | 선택한 텍스트를 클립보드에 복사 |  |
 | `` o `` | 파일 닫기 | Open file in default application. |
 | `` e `` | 파일 편집 | Open file in external editor. |
@@ -179,7 +179,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <left> `` | 이전 hunk를 선택 |  |
 | `` <right> `` | 다음 hunk를 선택 |  |
 | `` v `` | 드래그 선택 전환 |  |
-| `` a `` | Toggle select hunk | Toggle hunk selection mode. |
+| `` a `` | Toggle select hunk | Toggle line-by-line vs. hunk selection mode. |
 | `` <c-o> `` | 선택한 텍스트를 클립보드에 복사 |  |
 | `` <space> `` | Staged 전환 | 선택한 행을 staged / unstaged |
 | `` d `` | 변경을 삭제 (git reset) | When unstaged change is selected, discard the change using `git reset`. When staged change is selected, unstage the change. |

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -229,7 +229,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <left> `` | Selecteer de vorige hunk |  |
 | `` <right> `` | Selecteer de volgende hunk |  |
 | `` v `` | Toggle drag selecteer |  |
-| `` a `` | Toggle selecteer hunk | Toggle hunk selection mode. |
+| `` a `` | Toggle selecteer hunk | Toggle line-by-line vs. hunk selection mode. |
 | `` <c-o> `` | Copy selected text to clipboard |  |
 | `` o `` | Open bestand | Open file in default application. |
 | `` e `` | Verander bestand | Open file in external editor. |
@@ -302,7 +302,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` <left> `` | Selecteer de vorige hunk |  |
 | `` <right> `` | Selecteer de volgende hunk |  |
 | `` v `` | Toggle drag selecteer |  |
-| `` a `` | Toggle selecteer hunk | Toggle hunk selection mode. |
+| `` a `` | Toggle selecteer hunk | Toggle line-by-line vs. hunk selection mode. |
 | `` <c-o> `` | Copy selected text to clipboard |  |
 | `` <space> `` | Toggle staged | Toggle lijnen staged / unstaged |
 | `` d `` | Verwijdert change (git reset) | When unstaged change is selected, discard the change using `git reset`. When staged change is selected, unstage the change. |

--- a/docs/keybindings/Keybindings_ru.md
+++ b/docs/keybindings/Keybindings_ru.md
@@ -76,7 +76,7 @@ _Связки клавиш_
 | `` <left> `` | Выбрать предыдущую часть |  |
 | `` <right> `` | Выбрать следующую часть |  |
 | `` v `` | Переключить выборку перетаскивания |  |
-| `` a `` | Переключить выборку частей | Toggle hunk selection mode. |
+| `` a `` | Переключить выборку частей | Toggle line-by-line vs. hunk selection mode. |
 | `` <c-o> `` | Скопировать выделенный текст в буфер обмена |  |
 | `` <space> `` | Переключить индекс | Переключить строку в проиндексированные / непроиндексированные |
 | `` d `` | Отменить изменение (git reset) | When unstaged change is selected, discard the change using `git reset`. When staged change is selected, unstage the change. |
@@ -124,7 +124,7 @@ _Связки клавиш_
 | `` <left> `` | Выбрать предыдущую часть |  |
 | `` <right> `` | Выбрать следующую часть |  |
 | `` v `` | Переключить выборку перетаскивания |  |
-| `` a `` | Переключить выборку частей | Toggle hunk selection mode. |
+| `` a `` | Переключить выборку частей | Toggle line-by-line vs. hunk selection mode. |
 | `` <c-o> `` | Скопировать выделенный текст в буфер обмена |  |
 | `` o `` | Открыть файл | Open file in default application. |
 | `` e `` | Редактировать файл | Open file in external editor. |

--- a/docs/keybindings/Keybindings_zh-TW.md
+++ b/docs/keybindings/Keybindings_zh-TW.md
@@ -58,7 +58,7 @@ _說明：`<c-b>` 表示 Ctrl＋B、`<a-b>` 表示 Alt＋B，`B`表示 Shift＋B
 | `` <left> `` | 選擇上一段 |  |
 | `` <right> `` | 選擇下一段 |  |
 | `` v `` | 切換拖曳選擇 |  |
-| `` a `` | 切換選擇程式碼塊 | Toggle hunk selection mode. |
+| `` a `` | 切換選擇程式碼塊 | Toggle line-by-line vs. hunk selection mode. |
 | `` <c-o> `` | 複製所選文本至剪貼簿 |  |
 | `` o `` | 開啟檔案 | 使用預設軟體開啟 |
 | `` e `` | 編輯檔案 | 使用外部編輯器開啟 |
@@ -99,7 +99,7 @@ _說明：`<c-b>` 表示 Ctrl＋B、`<a-b>` 表示 Alt＋B，`B`表示 Shift＋B
 | `` <left> `` | 選擇上一段 |  |
 | `` <right> `` | 選擇下一段 |  |
 | `` v `` | 切換拖曳選擇 |  |
-| `` a `` | 切換選擇程式碼塊 | Toggle hunk selection mode. |
+| `` a `` | 切換選擇程式碼塊 | Toggle line-by-line vs. hunk selection mode. |
 | `` <c-o> `` | 複製所選文本至剪貼簿 |  |
 | `` <space> `` | 切換預存 | 切換現有行的狀態 (已預存/未預存) |
 | `` d `` | 刪除變更 (git reset) | When unstaged change is selected, discard the change using `git reset`. When staged change is selected, unstage the change. |

--- a/pkg/app/entry_point.go
+++ b/pkg/app/entry_point.go
@@ -141,6 +141,9 @@ func Start(buildInfo *BuildInfo, integrationTest integrationTypes.IntegrationTes
 
 	if integrationTest != nil {
 		integrationTest.SetupConfig(appConfig)
+		// Set this to true so that integration tests don't have to explicitly deal with the hunk
+		// staging hint:
+		appConfig.GetAppState().DidShowHunkStagingHint = true
 
 		// Preserve the changes that the test setup just made to the config, so
 		// they don't get lost when we reload the config while running the test

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -669,12 +669,7 @@ type AppState struct {
 }
 
 func getDefaultAppState() *AppState {
-	return &AppState{
-		LastUpdateCheck:     0,
-		RecentRepos:         []string{},
-		StartupPopupVersion: 0,
-		LastVersion:         "",
-	}
+	return &AppState{}
 }
 
 func LogPath() (string, error) {

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -656,10 +656,11 @@ func (c *AppConfig) SaveGlobalUserConfig() {
 // AppState stores data between runs of the app like when the last update check
 // was performed and which other repos have been checked out
 type AppState struct {
-	LastUpdateCheck     int64
-	RecentRepos         []string
-	StartupPopupVersion int
-	LastVersion         string // this is the last version the user was using, for the purpose of showing release notes
+	LastUpdateCheck        int64
+	RecentRepos            []string
+	StartupPopupVersion    int
+	DidShowHunkStagingHint bool
+	LastVersion            string // this is the last version the user was using, for the purpose of showing release notes
 
 	// these are for shell commands typed in directly, not for custom commands in the lazygit config.
 	// For backwards compatibility we keep the old name in yaml files.

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -739,7 +739,7 @@ func GetDefaultConfig() *UserConfig {
 			MainPanelSplitMode:       "flexible",
 			EnlargedSideViewLocation: "left",
 			WrapLinesInStagingView:   true,
-			UseHunkModeInStagingView: false,
+			UseHunkModeInStagingView: true,
 			Language:                 "auto",
 			TimeFormat:               "02 Jan 06",
 			ShortTimeFormat:          time.Kitchen,

--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -494,6 +494,8 @@ func (self *CommitFilesController) enterCommitFile(node *filetree.CommitFileNode
 			}
 
 			self.c.Context().Push(self.c.Contexts().CustomPatchBuilder, opts)
+			self.c.Helpers().PatchBuilding.ShowHunkStagingHint()
+
 			return nil
 		},
 	})

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -554,6 +554,8 @@ func (self *FilesController) EnterFile(opts types.OnFocusOpts) error {
 
 	context := lo.Ternary(opts.ClickedWindowName == "secondary", self.c.Contexts().StagingSecondary, self.c.Contexts().Staging)
 	self.c.Context().Push(context, opts)
+	self.c.Helpers().PatchBuilding.ShowHunkStagingHint()
+
 	return nil
 }
 

--- a/pkg/gui/controllers/helpers/patch_building_helper.go
+++ b/pkg/gui/controllers/helpers/patch_building_helper.go
@@ -2,8 +2,10 @@ package helpers
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/jesseduffield/lazygit/pkg/commands/patch"
+	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/patch_exploring"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 )
@@ -25,6 +27,19 @@ func (self *PatchBuildingHelper) ValidateNormalWorkingTreeState() (bool, error) 
 		return false, errors.New(self.c.Tr.CantPatchWhileRebasingError)
 	}
 	return true, nil
+}
+
+func (self *PatchBuildingHelper) ShowHunkStagingHint() {
+	if !self.c.AppState.DidShowHunkStagingHint && self.c.UserConfig().Gui.UseHunkModeInStagingView {
+		self.c.AppState.DidShowHunkStagingHint = true
+		self.c.SaveAppStateAndLogError()
+
+		message := fmt.Sprintf(self.c.Tr.HunkStagingHint,
+			keybindings.Label(self.c.UserConfig().Keybinding.Main.ToggleSelectHunk))
+		self.c.Confirm(types.ConfirmOpts{
+			Prompt: message,
+		})
+	}
 }
 
 // takes us from the patch building panel back to the commit files panel

--- a/pkg/gui/controllers/options_menu_action.go
+++ b/pkg/gui/controllers/options_menu_action.go
@@ -25,7 +25,7 @@ func (self *OptionsMenuAction) Call() error {
 				}
 				return &types.MenuItem{
 					OpensMenu: binding.OpensMenu,
-					Label:     binding.Description,
+					Label:     binding.GetDescription(),
 					OnPress: func() error {
 						if binding.Handler == nil {
 							return nil
@@ -60,7 +60,7 @@ func (self *OptionsMenuAction) getBindings(context types.Context) ([]*types.Bind
 	bindings, _ := self.c.GetInitialKeybindingsWithCustomCommands()
 
 	for _, binding := range bindings {
-		if binding.Description != "" {
+		if binding.GetDescription() != "" {
 			if binding.ViewName == "" || binding.Tag == "global" {
 				bindingsGlobal = append(bindingsGlobal, binding)
 			} else if binding.ViewName == context.GetViewName() {
@@ -80,6 +80,6 @@ func (self *OptionsMenuAction) getBindings(context types.Context) ([]*types.Bind
 // handler in the keybinding struct.
 func uniqueBindings(bindings []*types.Binding) []*types.Binding {
 	return lo.UniqBy(bindings, func(binding *types.Binding) string {
-		return binding.Description
+		return binding.GetDescription()
 	})
 }

--- a/pkg/gui/controllers/patch_explorer_controller.go
+++ b/pkg/gui/controllers/patch_explorer_controller.go
@@ -95,9 +95,15 @@ func (self *PatchExplorerController) GetKeybindings(opts types.KeybindingsOpts) 
 			Description: self.c.Tr.ToggleRangeSelect,
 		},
 		{
-			Key:             opts.GetKey(opts.Config.Main.ToggleSelectHunk),
-			Handler:         self.withRenderAndFocus(self.HandleToggleSelectHunk),
-			Description:     self.c.Tr.ToggleSelectHunk,
+			Key:         opts.GetKey(opts.Config.Main.ToggleSelectHunk),
+			Handler:     self.withRenderAndFocus(self.HandleToggleSelectHunk),
+			Description: self.c.Tr.ToggleSelectHunk,
+			DescriptionFunc: func() string {
+				if state := self.context.GetState(); state != nil && state.SelectingHunk() {
+					return self.c.Tr.SelectLineByLine
+				}
+				return self.c.Tr.SelectHunk
+			},
 			Tooltip:         self.c.Tr.ToggleSelectHunkTooltip,
 			DisplayOnScreen: true,
 		},

--- a/pkg/gui/options_map.go
+++ b/pkg/gui/options_map.go
@@ -50,14 +50,9 @@ func (self *OptionsMapMgr) renderContextOptionsMap() {
 			displayStyle = *binding.DisplayStyle
 		}
 
-		description := binding.Description
-		if binding.ShortDescription != "" {
-			description = binding.ShortDescription
-		}
-
 		return bindingInfo{
 			key:         keybindings.LabelFromKey(binding.Key),
-			description: description,
+			description: binding.GetShortDescription(),
 			style:       displayStyle,
 		}
 	})

--- a/pkg/gui/types/keybindings.go
+++ b/pkg/gui/types/keybindings.go
@@ -47,6 +47,13 @@ func (b *Binding) IsDisabled() bool {
 	return b.GetDisabledReason != nil && b.GetDisabledReason() != nil
 }
 
+func (b *Binding) GetShortDescription() string {
+	if b.ShortDescription != "" {
+		return b.ShortDescription
+	}
+	return b.Description
+}
+
 // A guard is a decorator which checks something before executing a handler
 // and potentially early-exits if some precondition hasn't been met.
 type Guard func(func() error) func() error

--- a/pkg/gui/types/keybindings.go
+++ b/pkg/gui/types/keybindings.go
@@ -16,12 +16,20 @@ type Binding struct {
 	Key         Key
 	Modifier    gocui.Modifier
 	Description string
+	// DescriptionFunc is used instead of Description if non-nil, and is useful for dynamic
+	// descriptions that change depending on context. Important: this must not be an expensive call.
+	// Note that you should still provide a generic, non-dynamic description in the Description field,
+	// as this is used in the cheatsheet.
+	DescriptionFunc func() string
 	// If defined, this is used in place of Description when showing the keybinding
 	// in the options view at the bottom left of the screen.
 	ShortDescription string
-	Alternative      string
-	Tag              string // e.g. 'navigation'. Used for grouping things in the cheatsheet
-	OpensMenu        bool
+	// ShortDescriptionFunc is used instead of ShortDescription if non-nil, and is useful for dynamic
+	// descriptions that change depending on context. Important: this must not be an expensive call.
+	ShortDescriptionFunc func() string
+	Alternative          string
+	Tag                  string // e.g. 'navigation'. Used for grouping things in the cheatsheet
+	OpensMenu            bool
 
 	// If true, the keybinding will appear at the bottom of the screen.
 	// Even if set to true, the keybinding will not be displayed if it is currently
@@ -47,11 +55,21 @@ func (b *Binding) IsDisabled() bool {
 	return b.GetDisabledReason != nil && b.GetDisabledReason() != nil
 }
 
+func (b *Binding) GetDescription() string {
+	if b.DescriptionFunc != nil {
+		return b.DescriptionFunc()
+	}
+	return b.Description
+}
+
 func (b *Binding) GetShortDescription() string {
+	if b.ShortDescriptionFunc != nil {
+		return b.ShortDescriptionFunc()
+	}
 	if b.ShortDescription != "" {
 		return b.ShortDescription
 	}
-	return b.Description
+	return b.GetDescription()
 }
 
 // A guard is a decorator which checks something before executing a handler

--- a/pkg/gui/types/keybindings.go
+++ b/pkg/gui/types/keybindings.go
@@ -43,8 +43,8 @@ type Binding struct {
 	GetDisabledReason func() *DisabledReason
 }
 
-func (Binding *Binding) IsDisabled() bool {
-	return Binding.GetDisabledReason != nil && Binding.GetDisabledReason() != nil
+func (b *Binding) IsDisabled() bool {
+	return b.GetDisabledReason != nil && b.GetDisabledReason() != nil
 }
 
 // A guard is a decorator which checks something before executing a handler

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -2119,7 +2119,7 @@ keybinding:
 
 gui:
   filterMode: 'fuzzy'
-	  `,
+`,
 			"0.44.0": `- The gui.branchColors config option is deprecated; it will be removed in a future version. Please use gui.branchColorPatterns instead.
 - The automatic coloring of branches starting with "feature/", "bugfix/", or "hotfix/" has been removed; if you want this, it's easy to set up using the new gui.branchColorPatterns option.`,
 			"0.49.0": `- Executing shell commands (with the ':' prompt) no longer uses an interactive shell, which means that if you want to use your shell aliases in this prompt, you need to do a little bit of setup work. See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#using-aliases-or-functions-in-shell-commands for details.`,

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -289,6 +289,8 @@ type TranslationSet struct {
 	DiscardSelection                      string
 	DiscardSelectionTooltip               string
 	ToggleSelectHunk                      string
+	SelectHunk                            string
+	SelectLineByLine                      string
 	ToggleSelectHunkTooltip               string
 	ToggleSelectionForPatch               string
 	EditHunk                              string
@@ -1336,8 +1338,10 @@ func EnglishTranslationSet() *TranslationSet {
 		DiscardSelection:                     `Discard`,
 		DiscardSelectionTooltip:              "When unstaged change is selected, discard the change using `git reset`. When staged change is selected, unstage the change.",
 		ToggleRangeSelect:                    "Toggle range select",
-		ToggleSelectHunk:                     "Select hunk",
-		ToggleSelectHunkTooltip:              "Toggle hunk selection mode.",
+		ToggleSelectHunk:                     "Toggle hunk selection",
+		SelectHunk:                           "Select hunks",
+		SelectLineByLine:                     "Select line-by-line",
+		ToggleSelectHunkTooltip:              "Toggle line-by-line vs. hunk selection mode.",
 		ToggleSelectionForPatch:              `Toggle lines in patch`,
 		EditHunk:                             `Edit hunk`,
 		EditHunkTooltip:                      "Edit selected hunk in external editor.",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -2134,7 +2134,13 @@ If, on the other hand, you want this even for feature branches, you can set it t
 
 git:
   localBranchSortOrder: recency
-  remoteBranchSortOrder: alphabetical`,
+  remoteBranchSortOrder: alphabetical
+
+- The default selection mode in the staging and custom patch building views has been changed to hunk mode. This is the more useful mode in most cases, as it usually saves a lot of keystrokes. If you want to switch back to the old line mode default, you can do so by adding the following to your config:
+
+gui:
+  useHunkSelectionMode: false
+`,
 		},
 	}
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -292,6 +292,7 @@ type TranslationSet struct {
 	SelectHunk                            string
 	SelectLineByLine                      string
 	ToggleSelectHunkTooltip               string
+	HunkStagingHint                       string
 	ToggleSelectionForPatch               string
 	EditHunk                              string
 	EditHunkTooltip                       string
@@ -1059,6 +1060,15 @@ const englishNonReloadableConfigWarning = `The following config settings were ch
 
 {{configs}}`
 
+const englishHunkStagingHint = `Hunk selection mode is now the default for staging. If you want to stage individual lines, press '%s' to switch to line-by-line mode.
+
+If you prefer to use line-by-line mode by default (like in earlier lazygit versions), add
+
+gui:
+  useHunkModeInStagingView: false
+
+to your lazygit config.`
+
 // exporting this so we can use it in tests
 func EnglishTranslationSet() *TranslationSet {
 	return &TranslationSet{
@@ -1342,6 +1352,7 @@ func EnglishTranslationSet() *TranslationSet {
 		SelectHunk:                           "Select hunks",
 		SelectLineByLine:                     "Select line-by-line",
 		ToggleSelectHunkTooltip:              "Toggle line-by-line vs. hunk selection mode.",
+		HunkStagingHint:                      englishHunkStagingHint,
 		ToggleSelectionForPatch:              `Toggle lines in patch`,
 		EditHunk:                             `Edit hunk`,
 		EditHunkTooltip:                      "Edit selected hunk in external editor.",

--- a/pkg/integration/tests/commit/stage_range_of_lines.go
+++ b/pkg/integration/tests/commit/stage_range_of_lines.go
@@ -9,7 +9,9 @@ var StageRangeOfLines = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Staging a range of lines",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
-	SetupConfig:  func(config *config.AppConfig) {},
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Gui.UseHunkModeInStagingView = false
+	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateFileAndAdd("myfile", "1st\n2nd\n3rd\n4th\n5th\n6th\n")
 		shell.Commit("Add file")

--- a/pkg/integration/tests/demo/custom_patch.go
+++ b/pkg/integration/tests/demo/custom_patch.go
@@ -22,6 +22,7 @@ var CustomPatch = NewIntegrationTest(NewIntegrationTestArgs{
 	IsDemo:       true,
 	SetupConfig: func(cfg *config.AppConfig) {
 		setDefaultDemoConfig(cfg)
+		cfg.GetUserConfig().Gui.UseHunkModeInStagingView = false
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateNCommitsWithRandomMessages(30)

--- a/pkg/integration/tests/patch_building/move_to_index_partial.go
+++ b/pkg/integration/tests/patch_building/move_to_index_partial.go
@@ -48,7 +48,6 @@ var MoveToIndexPartial = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains(`+third line2`),
 			).
 			PressPrimaryAction().
-			PressPrimaryAction().
 			Tap(func() {
 				t.Views().Information().Content(Contains("Building patch"))
 

--- a/pkg/integration/tests/patch_building/specific_selection.go
+++ b/pkg/integration/tests/patch_building/specific_selection.go
@@ -9,7 +9,9 @@ var SpecificSelection = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Build a custom patch with a specific selection of lines, adding individual lines, as well as a range and hunk, and adding a file directly",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
-	SetupConfig:  func(config *config.AppConfig) {},
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Gui.UseHunkModeInStagingView = false
+	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateFileAndAdd("hunk-file", "1a\n1b\n1c\n1d\n1e\n1f\n1g\n1h\n1i\n1j\n1k\n1l\n1m\n1n\n1o\n1p\n1q\n1r\n1s\n1t\n1u\n1v\n1w\n1x\n1y\n1z\n")
 		shell.Commit("first commit")

--- a/pkg/integration/tests/staging/diff_context_change.go
+++ b/pkg/integration/tests/staging/diff_context_change.go
@@ -50,7 +50,6 @@ var DiffContextChange = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Staging().
 			IsFocused().
-			Press(keys.Main.ToggleSelectHunk).
 			SelectedLines(
 				Contains(`-3a`),
 				Contains(`+3b`),
@@ -92,7 +91,6 @@ var DiffContextChange = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().StagingSecondary().
 			IsFocused().
-			Press(keys.Main.ToggleSelectHunk).
 			SelectedLines(
 				Contains(`-3a`),
 				Contains(`+3b`),

--- a/pkg/integration/tests/staging/discard_all_changes.go
+++ b/pkg/integration/tests/staging/discard_all_changes.go
@@ -31,6 +31,7 @@ var DiscardAllChanges = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Staging().
 			IsFocused().
+			Press(keys.Main.ToggleSelectHunk).
 			SelectedLines(Contains("+three")).
 			// discard the line
 			Press(keys.Universal.Remove).

--- a/pkg/integration/tests/staging/stage_hunks.go
+++ b/pkg/integration/tests/staging/stage_hunks.go
@@ -9,7 +9,9 @@ var StageHunks = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Stage and unstage various hunks of a file in the staging panel",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
-	SetupConfig:  func(config *config.AppConfig) {},
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Gui.UseHunkModeInStagingView = false
+	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateFileAndAdd("file1", "1a\n2a\n3a\n4a\n5a\n6a\n7a\n8a")
 		shell.Commit("one")

--- a/pkg/integration/tests/staging/stage_lines.go
+++ b/pkg/integration/tests/staging/stage_lines.go
@@ -9,7 +9,9 @@ var StageLines = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Stage and unstage various lines of a file in the staging panel",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
-	SetupConfig:  func(config *config.AppConfig) {},
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Gui.UseHunkModeInStagingView = false
+	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateFileAndAdd("file1", "one\ntwo\n")
 		shell.Commit("one")

--- a/pkg/integration/tests/staging/stage_ranges.go
+++ b/pkg/integration/tests/staging/stage_ranges.go
@@ -9,7 +9,9 @@ var StageRanges = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Stage and unstage various ranges of a file in the staging panel",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
-	SetupConfig:  func(config *config.AppConfig) {},
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Gui.UseHunkModeInStagingView = false
+	},
 	SetupRepo: func(shell *Shell) {
 		shell.CreateFileAndAdd("file1", "one\ntwo\n")
 		shell.Commit("one")

--- a/pkg/integration/tests/stash/stash_staged_partial_file.go
+++ b/pkg/integration/tests/stash/stash_staged_partial_file.go
@@ -26,7 +26,6 @@ var StashStagedPartialFile = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains(" line1\n-line2\n+line2 mod\n line3\n-line4\n+line4 mod"),
 			).
 			PressPrimaryAction().
-			PressPrimaryAction().
 			Content(
 				Contains(" line1\n line2 mod\n line3\n-line4\n+line4 mod"),
 			).

--- a/pkg/integration/tests/ui/range_select.go
+++ b/pkg/integration/tests/ui/range_select.go
@@ -31,7 +31,9 @@ var RangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 	Description:  "Verify range select works as expected in list views and in patch explorer views",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
-	SetupConfig:  func(config *config.AppConfig) {},
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Gui.UseHunkModeInStagingView = false
+	},
 	SetupRepo: func(shell *Shell) {
 		// We're testing the commits view as our representative list context,
 		// as well as the staging view, and we're using the exact same code to test

--- a/schema/config.json
+++ b/schema/config.json
@@ -569,7 +569,7 @@
         "useHunkModeInStagingView": {
           "type": "boolean",
           "description": "If true, hunk selection mode will be enabled by default when entering the staging view.",
-          "default": false
+          "default": true
         },
         "language": {
           "type": "string",


### PR DESCRIPTION
- **PR Description**

In #4684 we improved the hunk selection behavior to work on blocks of changes instead of actual hunks, and I find this so useful that I wanted to use it by default. In #4685 I added a user config to make hunk selection the default, but I made it an opt-in config because I was worried that users might not find out how to switch back to line selection if needed.

To address this concern, in this PR I add a popup that explains this the first time the user enters staging; there is also a breaking changes notice at startup, and we improve the options display at the bottom of the screen to be clearer about this. Hopefully these measures are enough to not confuse people.

Closes #4759.