### PR TITLE
Improve temp dir handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ test/git_server/data
 test/_results/**
 
 oryxBuildBinary
-__debug_bin
+__debug_bin*
 
 .worktrees
 demo/output/*

--- a/pkg/app/daemon/daemon.go
+++ b/pkg/app/daemon/daemon.go
@@ -76,8 +76,6 @@ func Handle(common *common.Common) {
 	if err := instruction.run(common); err != nil {
 		log.Fatal(err)
 	}
-
-	os.Exit(0)
 }
 
 func InDaemonMode() bool {

--- a/pkg/app/entry_point.go
+++ b/pkg/app/entry_point.go
@@ -124,7 +124,11 @@ func Start(buildInfo *BuildInfo, integrationTest integrationTypes.IntegrationTes
 		os.Exit(0)
 	}
 
-	tempDir, err := os.MkdirTemp("", "lazygit-*")
+	tmpDirBase := filepath.Join(os.TempDir(), "lazygit")
+	if err := os.MkdirAll(tmpDirBase, 0o700); err != nil {
+		log.Fatal(err.Error())
+	}
+	tempDir, err := os.MkdirTemp(tmpDirBase, "")
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
- Lazygit creates a temp dir at startup, and is supposed to clean it up after itself; however, this only worked for the main executable, not when lazygit was spawned as a helper daemon for interactive rebases, so we would leak a temp dir every time the user pressed `e` or `ctrl-j` or other similar commands.
- All these temp dirs were created at top level in `/tmp` and thus pollute it; now we create them inside a `/tmp/lazygit/` folder. This is no longer quite as important now that the first bug is fixed, but might still be useful when lazygit crashes, or when running many instances at once in different terminal tabs.

Resolves #4781.