### PR TITLE
Fix commit hash colors when filtering by path or aythor

### DIFF
--- a/pkg/commands/git_commands/commit_loader_test.go
+++ b/pkg/commands/git_commands/commit_loader_test.go
@@ -41,9 +41,9 @@ func TestGetCommits(t *testing.T) {
 		{
 			testName: "should return no commits if there are none",
 			logOrder: "topo-order",
-			opts:     GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: "mybranch", IncludeRebaseCommits: false},
+			opts:     GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: &models.Branch{Name: "mybranch"}, IncludeRebaseCommits: false},
 			runner: oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"merge-base", "mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"merge-base", "refs/heads/mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:+%H%x00%at%x00%aN%x00%ae%x00%P%x00%m%x00%D%x00%s", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
 
 			expectedCommitOpts: []models.NewCommitOpts{},
@@ -52,7 +52,7 @@ func TestGetCommits(t *testing.T) {
 		{
 			testName: "should use proper upstream name for branch",
 			logOrder: "topo-order",
-			opts:     GetCommitsOptions{RefName: "refs/heads/mybranch", RefForPushedStatus: "refs/heads/mybranch", IncludeRebaseCommits: false},
+			opts:     GetCommitsOptions{RefName: "refs/heads/mybranch", RefForPushedStatus: &models.Branch{Name: "mybranch"}, IncludeRebaseCommits: false},
 			runner: oscommands.NewFakeRunner(t).
 				ExpectGitArgs([]string{"merge-base", "refs/heads/mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				ExpectGitArgs([]string{"log", "refs/heads/mybranch", "--topo-order", "--oneline", "--pretty=format:+%H%x00%at%x00%aN%x00%ae%x00%P%x00%m%x00%D%x00%s", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
@@ -63,11 +63,11 @@ func TestGetCommits(t *testing.T) {
 		{
 			testName:     "should return commits if they are present",
 			logOrder:     "topo-order",
-			opts:         GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: "mybranch", IncludeRebaseCommits: false},
+			opts:         GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: &models.Branch{Name: "mybranch"}, IncludeRebaseCommits: false},
 			mainBranches: []string{"master", "main", "develop"},
 			runner: oscommands.NewFakeRunner(t).
 				// here it's seeing which commits are yet to be pushed
-				ExpectGitArgs([]string{"merge-base", "mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"merge-base", "refs/heads/mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
 				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:+%H%x00%at%x00%aN%x00%ae%x00%P%x00%m%x00%D%x00%s", "--abbrev=40", "--no-show-signature", "--"}, commitsOutput, nil).
 				// here it's testing which of the configured main branches have an upstream
@@ -199,11 +199,11 @@ func TestGetCommits(t *testing.T) {
 		{
 			testName:     "should not call merge-base for mainBranches if none exist",
 			logOrder:     "topo-order",
-			opts:         GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: "mybranch", IncludeRebaseCommits: false},
+			opts:         GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: &models.Branch{Name: "mybranch"}, IncludeRebaseCommits: false},
 			mainBranches: []string{"master", "main"},
 			runner: oscommands.NewFakeRunner(t).
 				// here it's seeing which commits are yet to be pushed
-				ExpectGitArgs([]string{"merge-base", "mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"merge-base", "refs/heads/mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
 				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:+%H%x00%at%x00%aN%x00%ae%x00%P%x00%m%x00%D%x00%s", "--abbrev=40", "--no-show-signature", "--"}, singleCommitOutput, nil).
 				// here it's testing which of the configured main branches exist; neither does
@@ -235,11 +235,11 @@ func TestGetCommits(t *testing.T) {
 		{
 			testName:     "should call merge-base for all main branches that exist",
 			logOrder:     "topo-order",
-			opts:         GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: "mybranch", IncludeRebaseCommits: false},
+			opts:         GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: &models.Branch{Name: "mybranch"}, IncludeRebaseCommits: false},
 			mainBranches: []string{"master", "main", "develop", "1.0-hotfixes"},
 			runner: oscommands.NewFakeRunner(t).
 				// here it's seeing which commits are yet to be pushed
-				ExpectGitArgs([]string{"merge-base", "mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"merge-base", "refs/heads/mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
 				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:+%H%x00%at%x00%aN%x00%ae%x00%P%x00%m%x00%D%x00%s", "--abbrev=40", "--no-show-signature", "--"}, singleCommitOutput, nil).
 				// here it's testing which of the configured main branches exist
@@ -273,9 +273,9 @@ func TestGetCommits(t *testing.T) {
 		{
 			testName: "should not specify order if `log.order` is `default`",
 			logOrder: "default",
-			opts:     GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: "mybranch", IncludeRebaseCommits: false},
+			opts:     GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: &models.Branch{Name: "mybranch"}, IncludeRebaseCommits: false},
 			runner: oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"merge-base", "mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"merge-base", "refs/heads/mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				ExpectGitArgs([]string{"log", "HEAD", "--oneline", "--pretty=format:+%H%x00%at%x00%aN%x00%ae%x00%P%x00%m%x00%D%x00%s", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
 
 			expectedCommitOpts: []models.NewCommitOpts{},
@@ -284,9 +284,9 @@ func TestGetCommits(t *testing.T) {
 		{
 			testName: "should set filter path",
 			logOrder: "default",
-			opts:     GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: "mybranch", FilterPath: "src"},
+			opts:     GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: &models.Branch{Name: "mybranch"}, FilterPath: "src"},
 			runner: oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"merge-base", "mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
+				ExpectGitArgs([]string{"merge-base", "refs/heads/mybranch", "mybranch@{u}"}, "b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164", nil).
 				ExpectGitArgs([]string{"log", "HEAD", "--oneline", "--pretty=format:+%H%x00%at%x00%aN%x00%ae%x00%P%x00%m%x00%D%x00%s", "--abbrev=40", "--follow", "--name-status", "--no-show-signature", "--", "src"}, "", nil),
 
 			expectedCommitOpts: []models.NewCommitOpts{},

--- a/pkg/commands/git_commands/main_branches.go
+++ b/pkg/commands/git_commands/main_branches.go
@@ -69,11 +69,11 @@ func (self *MainBranches) GetMergeBase(refName string) string {
 	// very rarely, users must quit and restart lazygit to fix it; the latter is
 	// also not very common, but can totally happen and is not an error.
 
-	output, _ := self.cmd.New(
+	output, _, _ := self.cmd.New(
 		NewGitCmd("merge-base").Arg(refName).Arg(mainBranches...).
 			ToArgv(),
-	).DontLog().RunWithOutput()
-	return ignoringWarnings(output)
+	).DontLog().RunWithOutputs()
+	return strings.TrimSpace(output)
 }
 
 func (self *MainBranches) determineMainBranches(configuredMainBranches []string) []string {

--- a/pkg/commands/models/ref.go
+++ b/pkg/commands/models/ref.go
@@ -1,4 +1,4 @@
-package types
+package models
 
 type Ref interface {
 	FullRefName() string
@@ -6,9 +6,4 @@ type Ref interface {
 	ShortRefName() string
 	ParentRefName() string
 	Description() string
-}
-
-type RefRange struct {
-	From Ref
-	To   Ref
 }

--- a/pkg/gui/context/branches_context.go
+++ b/pkg/gui/context/branches_context.go
@@ -59,7 +59,7 @@ func NewBranchesContext(c *ContextCommon) *BranchesContext {
 	return self
 }
 
-func (self *BranchesContext) GetSelectedRef() types.Ref {
+func (self *BranchesContext) GetSelectedRef() models.Ref {
 	branch := self.GetSelected()
 	if branch == nil {
 		return nil

--- a/pkg/gui/context/commit_files_context.go
+++ b/pkg/gui/context/commit_files_context.go
@@ -96,7 +96,7 @@ func (self *CommitFilesContext) ModelSearchResults(searchStr string, caseSensiti
 	return nil
 }
 
-func (self *CommitFilesContext) ReInit(ref types.Ref, refRange *types.RefRange) {
+func (self *CommitFilesContext) ReInit(ref models.Ref, refRange *types.RefRange) {
 	self.SetRef(ref)
 	self.SetRefRange(refRange)
 	if refRange != nil {

--- a/pkg/gui/context/local_commits_context.go
+++ b/pkg/gui/context/local_commits_context.go
@@ -164,7 +164,7 @@ func (self *LocalCommitsContext) CanRebase() bool {
 	return true
 }
 
-func (self *LocalCommitsContext) GetSelectedRef() types.Ref {
+func (self *LocalCommitsContext) GetSelectedRef() models.Ref {
 	commit := self.GetSelected()
 	if commit == nil {
 		return nil

--- a/pkg/gui/context/reflog_commits_context.go
+++ b/pkg/gui/context/reflog_commits_context.go
@@ -63,7 +63,7 @@ func (self *ReflogCommitsContext) CanRebase() bool {
 	return false
 }
 
-func (self *ReflogCommitsContext) GetSelectedRef() types.Ref {
+func (self *ReflogCommitsContext) GetSelectedRef() models.Ref {
 	commit := self.GetSelected()
 	if commit == nil {
 		return nil

--- a/pkg/gui/context/remote_branches_context.go
+++ b/pkg/gui/context/remote_branches_context.go
@@ -54,7 +54,7 @@ func NewRemoteBranchesContext(
 	}
 }
 
-func (self *RemoteBranchesContext) GetSelectedRef() types.Ref {
+func (self *RemoteBranchesContext) GetSelectedRef() models.Ref {
 	remoteBranch := self.GetSelected()
 	if remoteBranch == nil {
 		return nil
@@ -62,10 +62,10 @@ func (self *RemoteBranchesContext) GetSelectedRef() types.Ref {
 	return remoteBranch
 }
 
-func (self *RemoteBranchesContext) GetSelectedRefs() ([]types.Ref, int, int) {
+func (self *RemoteBranchesContext) GetSelectedRefs() ([]models.Ref, int, int) {
 	items, startIdx, endIdx := self.GetSelectedItems()
 
-	refs := lo.Map(items, func(item *models.RemoteBranch, _ int) types.Ref {
+	refs := lo.Map(items, func(item *models.RemoteBranch, _ int) models.Ref {
 		return item
 	})
 

--- a/pkg/gui/context/stash_context.go
+++ b/pkg/gui/context/stash_context.go
@@ -53,7 +53,7 @@ func (self *StashContext) CanRebase() bool {
 	return false
 }
 
-func (self *StashContext) GetSelectedRef() types.Ref {
+func (self *StashContext) GetSelectedRef() models.Ref {
 	stash := self.GetSelected()
 	if stash == nil {
 		return nil

--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -141,7 +141,7 @@ func NewSubCommitsContext(
 
 type SubCommitsViewModel struct {
 	// name of the ref that the sub-commits are shown for
-	ref                     types.Ref
+	ref                     models.Ref
 	refToShowDivergenceFrom string
 	*ListViewModel[*models.Commit]
 
@@ -149,11 +149,11 @@ type SubCommitsViewModel struct {
 	showBranchHeads bool
 }
 
-func (self *SubCommitsViewModel) SetRef(ref types.Ref) {
+func (self *SubCommitsViewModel) SetRef(ref models.Ref) {
 	self.ref = ref
 }
 
-func (self *SubCommitsViewModel) GetRef() types.Ref {
+func (self *SubCommitsViewModel) GetRef() models.Ref {
 	return self.ref
 }
 
@@ -177,7 +177,7 @@ func (self *SubCommitsContext) CanRebase() bool {
 	return false
 }
 
-func (self *SubCommitsContext) GetSelectedRef() types.Ref {
+func (self *SubCommitsContext) GetSelectedRef() models.Ref {
 	commit := self.GetSelected()
 	if commit == nil {
 		return nil

--- a/pkg/gui/context/tags_context.go
+++ b/pkg/gui/context/tags_context.go
@@ -52,7 +52,7 @@ func NewTagsContext(
 	}
 }
 
-func (self *TagsContext) GetSelectedRef() types.Ref {
+func (self *TagsContext) GetSelectedRef() models.Ref {
 	tag := self.GetSelected()
 	if tag == nil {
 		return nil

--- a/pkg/gui/controllers/helpers/diff_helper.go
+++ b/pkg/gui/controllers/helpers/diff_helper.go
@@ -174,7 +174,7 @@ func (self *DiffHelper) IgnoringWhitespaceSubTitle() string {
 	return ""
 }
 
-func (self *DiffHelper) OpenDiffToolForRef(selectedRef types.Ref) error {
+func (self *DiffHelper) OpenDiffToolForRef(selectedRef models.Ref) error {
 	to := selectedRef.RefName()
 	from, reverse := self.c.Modes().Diffing.GetFromAndReverseArgsForDiff("")
 	_, err := self.c.RunSubprocess(self.c.Git().Diff.OpenDiffToolCmdObj(

--- a/pkg/gui/controllers/helpers/sub_commits_helper.go
+++ b/pkg/gui/controllers/helpers/sub_commits_helper.go
@@ -24,7 +24,7 @@ func NewSubCommitsHelper(
 }
 
 type ViewSubCommitsOpts struct {
-	Ref                     types.Ref
+	Ref                     models.Ref
 	RefToShowDivergenceFrom string
 	TitleRef                string
 	Context                 types.Context

--- a/pkg/gui/controllers/helpers/sub_commits_helper.go
+++ b/pkg/gui/controllers/helpers/sub_commits_helper.go
@@ -39,7 +39,7 @@ func (self *SubCommitsHelper) ViewSubCommits(opts ViewSubCommitsOpts) error {
 			FilterAuthor:            self.c.Modes().Filtering.GetAuthor(),
 			IncludeRebaseCommits:    false,
 			RefName:                 opts.Ref.FullRefName(),
-			RefForPushedStatus:      opts.Ref.FullRefName(),
+			RefForPushedStatus:      opts.Ref,
 			RefToShowDivergenceFrom: opts.RefToShowDivergenceFrom,
 			MainBranches:            self.c.Model().MainBranches,
 			HashPool:                self.c.Model().HashPool,

--- a/pkg/gui/controllers/switch_to_diff_files_controller.go
+++ b/pkg/gui/controllers/switch_to_diff_files_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 )
 
@@ -11,7 +12,7 @@ var _ types.IController = &SwitchToDiffFilesController{}
 type CanSwitchToDiffFiles interface {
 	types.IListContext
 	CanRebase() bool
-	GetSelectedRef() types.Ref
+	GetSelectedRef() models.Ref
 	GetSelectedRefRangeForDiffFiles() *types.RefRange
 }
 

--- a/pkg/gui/controllers/switch_to_sub_commits_controller.go
+++ b/pkg/gui/controllers/switch_to_sub_commits_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/controllers/helpers"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 )
@@ -9,7 +10,7 @@ var _ types.IController = &SwitchToSubCommitsController{}
 
 type CanSwitchToSubCommits interface {
 	types.IListContext
-	GetSelectedRef() types.Ref
+	GetSelectedRef() models.Ref
 	ShowBranchHeadsInSubCommits() bool
 }
 
@@ -17,7 +18,7 @@ type CanSwitchToSubCommits interface {
 // but an attribute on it i.e. the ref of an item.
 type SwitchToSubCommitsController struct {
 	baseController
-	*ListControllerTrait[types.Ref]
+	*ListControllerTrait[models.Ref]
 	c       *ControllerCommon
 	context CanSwitchToSubCommits
 }
@@ -32,7 +33,7 @@ func NewSwitchToSubCommitsController(
 			c,
 			context,
 			context.GetSelectedRef,
-			func() ([]types.Ref, int, int) {
+			func() ([]models.Ref, int, int) {
 				panic("Not implemented")
 			},
 		),

--- a/pkg/gui/filetree/commit_file_tree_view_model.go
+++ b/pkg/gui/filetree/commit_file_tree_view_model.go
@@ -15,8 +15,8 @@ type ICommitFileTreeViewModel interface {
 	ICommitFileTree
 	types.IListCursor
 
-	GetRef() types.Ref
-	SetRef(types.Ref)
+	GetRef() models.Ref
+	SetRef(models.Ref)
 	GetRefRange() *types.RefRange // can be nil, in which case GetRef should be used
 	SetRefRange(*types.RefRange)  // should be set to nil when selection is not a range
 	GetCanRebase() bool
@@ -30,7 +30,7 @@ type CommitFileTreeViewModel struct {
 
 	// this is e.g. the commit for which we're viewing the files, if there is no
 	// range selection, or if the range selection can't be used for some reason
-	ref types.Ref
+	ref models.Ref
 
 	// this is a commit range for which we're viewing the files. Can be nil, in
 	// which case ref is used.
@@ -55,11 +55,11 @@ func NewCommitFileTreeViewModel(getFiles func() []*models.CommitFile, common *co
 	}
 }
 
-func (self *CommitFileTreeViewModel) GetRef() types.Ref {
+func (self *CommitFileTreeViewModel) GetRef() models.Ref {
 	return self.ref
 }
 
-func (self *CommitFileTreeViewModel) SetRef(ref types.Ref) {
+func (self *CommitFileTreeViewModel) SetRef(ref models.Ref) {
 	self.ref = ref
 }
 

--- a/pkg/gui/types/ref_range.go
+++ b/pkg/gui/types/ref_range.go
@@ -1,0 +1,8 @@
+package types
+
+import "github.com/jesseduffield/lazygit/pkg/commands/models"
+
+type RefRange struct {
+	From models.Ref
+	To   models.Ref
+}


### PR DESCRIPTION
- **PR Description**

Previously we would call git merge-base with the upstream branch to determine where unpushed commits end and pushed commits start, and also git merge-base with the main branch(es) to see where the merged commits start. This worked ok in normal cases, but it had two problems:
- when filtering by path or by author, those merge-base commits would usually not be part of the commit list, so we would miss the point where we should switch from unpushed to pushed, or from pushed to merged. The consequence was that in filtering mode, all commit hashes were always yellow.
- when main was merged into a feature branch, we would color all commits from that merge on down in green, even ones that are only part of the feature branch but not main. (See #3796)

To fix these problems, we switch our approach to one where we call git rev-list with the branch in question, with negative refspecs for the upstream branch and the main branches, respectively; this gives us the complete picture of which commits are pushed/unpushed/merged, so it also works in the cases described above.

And funnily, even though intuitively it feels more expensive, it actually performs better than the merge-base calls (for normal usage scenarios at least), so the commit-loading part of refresh is faster now in general. We are talking about differences like 300ms before, 140ms after, in some unscientific measurements I took (depends a lot on repo sizes, branch length, etc.). An exception are degenerate cases like feature branches with hundreds of thousands of commits, which are slower now; but I don't think we need to worry about those too much.

Fixes #3796.