### PR TITLE
Update Fedora section of the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,14 +283,20 @@ and the git version which builds from the most recent commit.
 Instruction of how to install AUR content can be found here:
 <https://wiki.archlinux.org/index.php/Arch_User_Repository>
 
-### Fedora and RHEL
+### Fedora / Amazon Linux 2023 / CentOS Stream
 
-Packages for Fedora/RHEL and CentOS Stream are available via [Copr](https://copr.fedorainfracloud.org/coprs/atim/lazygit/) (Cool Other Package Repo).
+Packages for Fedora, Amazon Linux 2023 and CentOS Stream are available via
+[Copr](https://copr.fedorainfracloud.org/coprs/dejan/lazygit/) (Cool Other Package Repo).
 
 ```sh
-sudo dnf copr enable atim/lazygit -y
+sudo dnf copr enable dejan/lazygit
 sudo dnf install lazygit
 ```
+
+These packages are built using the RPM spec file located here: https://codeberg.org/dejan/rpm-lazygit
+
+You should be able to build RPMs for Fedora 41 or older, and other Fedora derivatives using the
+SRPM (Source RPM) file that you can grab from the latest COPR build.
 
 ### Solus Linux
 


### PR DESCRIPTION
After discussion from the following PR ( https://github.com/jesseduffield/lazygit/pull/4362 ) I have finally found time to make a PR to update the Fedora section of the README.md file. I actually use those instructions myself from few different Fedora and Amazon Linux 2023 machines.

Here is an example of installing lazygit from the Copr:

```
» sudo dnf install lazygit
Updating and loading repositories:
Repositories loaded.
Package                                                              Arch        Version                                                              Repository                                                  Size
Installing:
 lazygit                                                             x86_64      0.48.0-1.fc41                                                        copr:copr.fedorainfracloud.org:dejan:lazygit            21.5 MiB

Transaction Summary:
 Installing:         1 package

Total size of inbound packages is 6 MiB. Need to download 6 MiB.
After this operation, 22 MiB extra will be used (install 22 MiB, remove 0 B).
Is this ok [y/N]: y
[1/1] lazygit-0:0.48.0-1.fc41.x86_64                                                                                                                                          100% |   3.7 MiB/s |   5.7 MiB |  00m02s
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[1/1] Total                                                                                                                                                                   100% |   3.7 MiB/s |   5.7 MiB |  00m02s
Running transaction
[1/3] Verify package files                                                                                                                                                    100% |  52.0   B/s |   1.0   B |  00m00s
[2/3] Prepare transaction                                                                                                                                                     100% |   3.0   B/s |   1.0   B |  00m00s
[3/3] Installing lazygit-0:0.48.0-1.fc41.x86_64                                                                                                                               100% |  44.9 MiB/s |  21.5 MiB |  00m00s
Complete!
```