### PR TITLE
Stop updating Jesse's homebrew tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,26 +36,3 @@ snapshot:
 changelog:
   use: github-native
   sort: asc
-brews:
-  -
-    # Repository to push the tap to.
-    repository:
-      owner: jesseduffield
-      name: homebrew-lazygit
-
-    # Your app's homepage.
-    # Default is empty.
-    homepage: 'https://github.com/jesseduffield/lazygit/'
-
-    # Your app's description.
-    # Default is empty.
-    description: 'A simple terminal UI for git commands, written in Go'
-
-    # # Packages your package depends on.
-    # dependencies:
-    #   - git
-    #   - zsh
-    # # Packages that conflict with your package.
-    # conflicts:
-    #   - svn
-    #   - bash


### PR DESCRIPTION
The tap is being retired, see https://github.com/jesseduffield/homebrew-lazygit/pull/3.
