### PR TITLE
Stop bumping our homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,10 +149,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{secrets.LAZYGIT_RELEASE_PAT}}
-
-      - name: Bump Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@v3
-        with:
-          token: ${{secrets.LAZYGIT_RELEASE_PAT}}
-          formula: lazygit
-          tag: ${{env.new_tag}}


### PR DESCRIPTION
It is being auto-bumped by homebrew, like most formulae these days, so no reason for us to do that explicitly; and it actually fails with an error message, so stop trying.
