### PR TITLE
Fix delay with flicking through files or commits when git diff is very slow

### DIFF
--- a/pkg/commands/oscommands/os.go
+++ b/pkg/commands/oscommands/os.go
@@ -1,7 +1,6 @@
 package oscommands
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -328,16 +327,4 @@ func GetLazygitPath() string {
 		ex = os.Args[0] // fallback to the first call argument if needed
 	}
 	return `"` + filepath.ToSlash(ex) + `"`
-}
-
-func (c *OSCommand) UpdateWindowTitle() error {
-	if c.Platform.OS != "windows" {
-		return nil
-	}
-	path, getWdErr := os.Getwd()
-	if getWdErr != nil {
-		return getWdErr
-	}
-	argString := fmt.Sprint("title ", filepath.Base(path), " - Lazygit")
-	return c.Cmd.NewShell(argString, c.UserConfig().OS.ShellFunctionsFile).Run()
 }

--- a/pkg/commands/oscommands/os_default_platform.go
+++ b/pkg/commands/oscommands/os_default_platform.go
@@ -5,8 +5,10 @@ package oscommands
 
 import (
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
+	"syscall"
 )
 
 func GetPlatform() *Platform {
@@ -37,4 +39,12 @@ func getUserShell() string {
 
 func (c *OSCommand) UpdateWindowTitle() error {
 	return nil
+}
+
+func TerminateProcessGracefully(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+
+	return cmd.Process.Signal(syscall.SIGTERM)
 }

--- a/pkg/commands/oscommands/os_default_platform.go
+++ b/pkg/commands/oscommands/os_default_platform.go
@@ -34,3 +34,7 @@ func getUserShell() string {
 
 	return "bash"
 }
+
+func (c *OSCommand) UpdateWindowTitle() error {
+	return nil
+}

--- a/pkg/commands/oscommands/os_windows.go
+++ b/pkg/commands/oscommands/os_windows.go
@@ -1,9 +1,24 @@
 package oscommands
 
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
 func GetPlatform() *Platform {
 	return &Platform{
 		OS:       "windows",
 		Shell:    "cmd",
 		ShellArg: "/c",
 	}
+}
+
+func (c *OSCommand) UpdateWindowTitle() error {
+	path, getWdErr := os.Getwd()
+	if getWdErr != nil {
+		return getWdErr
+	}
+	argString := fmt.Sprint("title ", filepath.Base(path), " - Lazygit")
+	return c.Cmd.NewShell(argString, c.UserConfig().OS.ShellFunctionsFile).Run()
 }

--- a/pkg/commands/oscommands/os_windows.go
+++ b/pkg/commands/oscommands/os_windows.go
@@ -3,6 +3,7 @@ package oscommands
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 )
 
@@ -21,4 +22,9 @@ func (c *OSCommand) UpdateWindowTitle() error {
 	}
 	argString := fmt.Sprint("title ", filepath.Base(path), " - Lazygit")
 	return c.Cmd.NewShell(argString, c.UserConfig().OS.ShellFunctionsFile).Run()
+}
+
+func TerminateProcessGracefully(cmd *exec.Cmd) error {
+	// Signals other than SIGKILL are not supported on Windows
+	return nil
 }


### PR DESCRIPTION
One reason why git diff can be very slow is when "diff.algorithm = histogram" is being used. In this case, showing a very long single-file diff can take seconds to load, and you'll see the "loading..." message in the main view until we got the first lines of the diff to show. There's nothing really we can do about this delay; however, when switching to another, shorter file (or commit) while the "loading..." message is still showing, this switch should be instantaneous. And it was before 0.54.0, but we broke this in 0.54.0 with 8d7740a5acab (#4782); now users have to wait for the slow git diff command to output more text before the switch occurs. To fix this, don't block waiting for the process to terminate if we just stopped it.

In addition, improve CPU usage by terminating git processes gracefully (by sending them a TERM signal); this helps keep CPU usage low when flicking through several of these huge diffs with "diff.algorithm = histogram", because it avoids having several git processes running in the background, calculating expensive diffs that we are never going to show. Unfortunately this is only possible on Linux and Mac, so Windows users will have to live with the higher CPU usage. The recommended workaround is to not use "diff.algorithm = histogram".

Fixes #4798.