### PR TITLE
Fix scrollbar in certain popup panels (e.g. the intro message for new users)

### DIFF
--- a/pkg/gui/controllers/helpers/confirmation_helper.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	goContext "context"
 	"fmt"
+	"strings"
 
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
@@ -168,7 +169,7 @@ func (self *ConfirmationHelper) CreatePopupPanel(ctx goContext.Context, opts typ
 		confirmationView.RenderTextArea()
 	} else {
 		self.c.ResetViewOrigin(confirmationView)
-		self.c.SetViewContent(confirmationView, style.AttrBold.Sprint(opts.Prompt))
+		self.c.SetViewContent(confirmationView, style.AttrBold.Sprint(strings.TrimSpace(opts.Prompt)))
 	}
 
 	self.setKeyBindings(cancel, opts)

--- a/pkg/utils/lines_test.go
+++ b/pkg/utils/lines_test.go
@@ -406,20 +406,6 @@ func TestWrapViewLinesToWidth(t *testing.T) {
 			expectedOriginalLinesIndices: []int{0, 1, 2},
 		},
 		{
-			name:     "Avoid blank line at end if not editable",
-			wrap:     true,
-			editable: false,
-			text:     "First\nSecond\nThird\n",
-			width:    10,
-			expectedWrappedLines: []string{
-				"First",
-				"Second",
-				"Third",
-			},
-			expectedWrappedLinesIndices:  []int{0, 1, 2},
-			expectedOriginalLinesIndices: []int{0, 1, 2},
-		},
-		{
 			name:     "Keep blank line at end if editable",
 			wrap:     true,
 			editable: true,


### PR DESCRIPTION
When showing a confirmation whose text ends with a line feed, we would make the popup panel one line less tall than it needs to be, so it would show a scroll bar. One example where this occurred is the very first popup that users ever see (the "seriously you rock" message for new users); that's a pretty bad first impression.

This happens because our code to suppress trailing newlines in views doesn't work for styled text, and the text in confirmations is bold. This code checks if the last character of the text is a line feed, and in this case it isn't; the escape sequence for turning bold off comes after it.

We should really fix this by improving that mechanism, but this would require some tricky logic, so as a quick fix, trim trailing (and leading) linefeeds from the text that we display in a confirmation, before making it bold.