### PR TITLE
Pass only Git-tracked Go files to gofumpt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,11 @@ test: unit-test integration-test-all
 generate:
 	go generate ./...
 
+# If you execute `gofumpt -l -w .`, it will format all Go files in the current directory, including `test/_results/*` files.
+# We pass only Git-tracked Go files to gofumpt because we don't want to format the test results or get errors from it.
 .PHONY: format
 format:
-	gofumpt -l -w .
+	git ls-files '*.go' ':!vendor' | xargs gofumpt -l -w
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
## **PR Description**
The below error message is shown when executing `make format` when `test/_results/demo/worktree_create_from_branches/actual/repo/src/shims.go` exists (maybe executing integration test produces this file?).

```sh
$ make format
gofumpt -l -w .
test/_results/demo/worktree_create_from_branches/actual/repo/src/shims.go:1:20: expected 'package', found 'EOF'
make: *** [format] Error 2
```

I have confirmed it works without above error when I run `make format` on this PR's branch.

## **Please check if the PR fulfills these requirements**

* [ ] ~Cheatsheets are up-to-date (run `go generate ./...`)~
* [ ] ~Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))~
* [ ] ~Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)~
* [ ] ~Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))~
* [ ] ~If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))~
* [ ] ~Docs have been updated if necessary~
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->

