### PR TITLE
Add installation with gah

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,14 @@ scoop bucket add extras
 scoop install lazygit
 ```
 
+### gah (Linux and Mac OS)
+
+You can install `lazygit` using [gah](https://github.com/marverix/gah/):
+
+```sh
+gah install lazygit
+```
+
 ### Arch Linux
 
 Packages for Arch Linux are available via pacman and AUR (Arch User Repository).


### PR DESCRIPTION
- **PR Description**

This PR adds to the documentation a way of installation using [gah](https://github.com/marverix/gah/).

> gah is an GitHub Releases app installer, that does not require sudo. It is a simple bash script that downloads the latest release of an app from GitHub and installs it in `~/.local/bin`. It is designed to be used with apps that are distributed as a single binary file.

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [X] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
