### PR TITLE
Fix right-alignment of divergence from base branch for branch checked out in a worktree

### DIFF
--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -71,10 +71,11 @@ func getBranchDisplayStrings(
 	if showCommitHash {
 		availableWidth -= utils.COMMIT_HASH_SHORT_SIZE + 1
 	}
+	paddingNeededForDivergence := availableWidth
+
 	if checkedOutByWorkTree {
 		availableWidth -= utils.StringWidth(worktreeIcon) + 1
 	}
-	paddingNeededForDivergence := availableWidth
 
 	if len(branchStatus) > 0 {
 		availableWidth -= utils.StringWidth(utils.Decolorise(branchStatus)) + 1


### PR DESCRIPTION
- **PR Description**

We didn't take the worktree icon into account properly, so the divergence indication was offset to the left by two characters in this case.

I haven't used worktrees myself so far, so I didn't notice this before.