### PR TITLE
Enhance PR/Issue templates readability

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,10 +6,10 @@ labels: bug
 assignees: ''
 ---
 
-**Describe the bug**
+## Describe the bug
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+## To Reproduce
 Steps to reproduce the behavior:
 
 1. Go to '...'
@@ -17,20 +17,22 @@ Steps to reproduce the behavior:
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+## Screenshots
 If applicable, add screenshots to help explain your problem.
 
-**Version info:**
-_Run `lazygit --version` and paste the result here_
-_Run `git --version` and paste the result here_
+## Version info:
 
-**Additional context**
+* _Run `lazygit --version` and paste the result here_
+* _Run `git --version` and paste the result here_
+
+## Additional context
 Add any other context about the problem here.
 
-**Note:** please try updating to the latest version or [manually building](https://github.com/jesseduffield/lazygit/#manual) the latest `master` to see if the issue still occurs.
+> [!NOTE]
+> Please try updating to the latest version or [manually building](https://github.com/jesseduffield/lazygit/#manual) the latest `master` to see if the issue still occurs.
 
 <!--
 If you want to try and debug this issue yourself, you can run `lazygit --debug` in one terminal panel and `lazygit --logs` in another to view the logs.

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-**Topic**
-A clear and concise description of what you want to discuss
+## Topic
+A clear and concise description of what you want to discuss.
 
-**Your thoughts**
-What you have to say about the topic
+## Your thoughts
+What you have to say about the topic.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,16 +6,16 @@ labels: enhancement
 assignees: ''
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional context
 Add any other context or screenshots about the feature request here.
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-- **PR Description**
+## PR Description
 
-- **Please check if the PR fulfills these requirements**
+## Please check if the PR fulfills these requirements
 
 * [ ] Cheatsheets are up-to-date (run `go generate ./...`)
 * [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))


### PR DESCRIPTION
## PR Description
- I updated PR/Issue templates to enhance their readability.
- I hope this change can reduce the maintainer's burden to read PR/Issue, even a little bit.
- Of course, it is most important how the maintainers feel about this change, so if you don't need this, I have no objection to closing this PR.
- By the way, I use the template I changed for this PR. How do you feel?

## Please check if the PR fulfills these requirements

* [ ] ~Cheatsheets are up-to-date (run `go generate ./...`)~
* [ ] ~Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))~
* [ ] ~Tests have been added/updated (see [here]~(https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] ~Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))~
* [ ] ~If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here]~(https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] ~Docs have been updated if necessary~
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
