### PR TITLE
Run label check workflow only on label events and open pr event

### DIFF
--- a/.github/workflows/check-required-label.yml
+++ b/.github/workflows/check-required-label.yml
@@ -1,0 +1,16 @@
+name: Check Required Labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled]
+
+jobs:
+  check-required-label:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: "ignore-for-release, feature, enhancement, bug, maintenance, docs, i18n, performance"

--- a/.github/workflows/check-required-pr-label.yml
+++ b/.github/workflows/check-required-pr-label.yml
@@ -1,11 +1,11 @@
-name: Check Required Labels
+name: Check Required PR Labels
 
 on:
   pull_request:
     types: [opened, labeled, unlabeled]
 
 jobs:
-  check-required-label:
+  check-required-pr-label:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/master'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,15 +175,6 @@ jobs:
       - name: errors
         run: golangci-lint run
         if: ${{ failure() }}
-  check-required-label:
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - uses: mheap/github-action-required-labels@v5
-        with:
-          mode: exactly
-          count: 1
-          labels: "ignore-for-release, feature, enhancement, bug, maintenance, docs, i18n, performance"
   upload-coverage:
     # List all jobs that produce coverage files
     needs: [unit-tests, integration-tests]


### PR DESCRIPTION
## **PR Description**
- Currently, `check-required-label` only runs when commits are added to a PR, even if a maintainer has added labels, so the CI status remains red until a commit is pushed after labels are added by a maintainer.
- I updated the workflows to run `check-required-label` only on label events(add/remove) or open PR event.
- This will make PR status updates more accurate, so authors will be able to see that tests and lint are passing by just checking the PR status, and maintainers will easily know if the PR is ready for review.


## **Please check if the PR fulfills these requirements**

* [ ] ~~Cheatsheets are up-to-date (run `go generate ./...`)~~
* [ ] ~~Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))~~
* [ ] ~~Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)~~
* [ ] ~~Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))~~
* [ ] ~If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))~
* [ ] ~Docs have been updated if necessary~
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->

