### PR TITLE
Remove the git.paging.useConfig option

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -303,9 +303,6 @@ git:
     # ydiff -p cat -s --wrap --width={{columnWidth}}
     pager: ""
 
-    # If true, Lazygit will use whatever pager is specified in `$GIT_PAGER`, `$PAGER`, or your *git config*. If the pager ends with something like ` | less` we will strip that part out, because less doesn't play nice with our rendering approach. If the custom pager uses less under the hood, that will also break rendering (hence the `--paging=never` flag for the `delta` pager).
-    useConfig: false
-
     # e.g. 'difft --color=always'
     externalDiffCommand: ""
 

--- a/docs/Custom_Pagers.md
+++ b/docs/Custom_Pagers.md
@@ -10,7 +10,6 @@ Support does not extend to Windows users, because we're making use of a package 
 git:
   paging:
     colorArg: always
-    useConfig: false
 ```
 
 the `colorArg` key is for whether you want the `--color=always` arg in your `git diff` command. Some pagers want it set to `always`, others want it set to `never`.
@@ -54,17 +53,6 @@ git:
 
 Be careful with this one, I think the homebrew and pip versions are behind master. I needed to directly download the ydiff script to get the no-pager functionality working.
 
-## Using git config
-
-```yaml
-git:
-  paging:
-    colorArg: always
-    useConfig: true
-```
-
-If you set `useConfig: true`, lazygit will use whatever pager is specified in `$GIT_PAGER`, `$PAGER`, or your *git config*. If the pager ends with something like ` | less` we will strip that part out, because less doesn't play nice with our rendering approach. If the custom pager uses less under the hood, that will also break rendering (hence the `--paging=never` flag for the `delta` pager).
-
 ## Using external diff commands
 
 Some diff tools can't work as a simple pager like the ones above do, because they need access to the entire diff, so just post-processing git's diff is not enough for them. The most notable example is probably [difftastic](https://difftastic.wilfred.me.uk).
@@ -77,7 +65,7 @@ git:
     externalDiffCommand: difft --color=always
 ```
 
-The `colorArg`, `pager`, and `useConfig` options are not used in this case.
+The `colorArg` and `pager` options are not used in this case.
 
 You can add whatever extra arguments you prefer for your difftool; for instance
 

--- a/pkg/commands/git_commands/config.go
+++ b/pkg/commands/git_commands/config.go
@@ -43,12 +43,6 @@ func (self *ConfigCommands) ConfiguredPager() string {
 }
 
 func (self *ConfigCommands) GetPager(width int) string {
-	useConfig := self.UserConfig().Git.Paging.UseConfig
-	if useConfig {
-		pager := self.ConfiguredPager()
-		return strings.Split(pager, "| less")[0]
-	}
-
 	templateValues := map[string]string{
 		"columnWidth": strconv.Itoa(width/2 - 6),
 	}

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -316,8 +316,6 @@ type PagingConfig struct {
 	// delta --dark --paging=never
 	// ydiff -p cat -s --wrap --width={{columnWidth}}
 	Pager PagerType `yaml:"pager"`
-	// If true, Lazygit will use whatever pager is specified in `$GIT_PAGER`, `$PAGER`, or your *git config*. If the pager ends with something like ` | less` we will strip that part out, because less doesn't play nice with our rendering approach. If the custom pager uses less under the hood, that will also break rendering (hence the `--paging=never` flag for the `delta` pager).
-	UseConfig bool `yaml:"useConfig"`
 	// e.g. 'difft --color=always'
 	ExternalDiffCommand string `yaml:"externalDiffCommand"`
 }
@@ -797,7 +795,6 @@ func GetDefaultConfig() *UserConfig {
 			Paging: PagingConfig{
 				ColorArg:            "always",
 				Pager:               "",
-				UseConfig:           false,
 				ExternalDiffCommand: "",
 			},
 			Commit: CommitConfig{

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -2169,6 +2169,8 @@ keybinding:
   universal:
     suspendApp: <disabled>
 	redo: <c-z>
+
+- The 'git.paging.useConfig' option has been removed. If you were relying on it to configure your pager, you'll have to explicitly set the pager again using the git.paging.pager' option.
 `,
 		},
 	}

--- a/schema/config.json
+++ b/schema/config.json
@@ -1672,11 +1672,6 @@
             "ydiff -p cat -s --wrap --width={{columnWidth}}"
           ]
         },
-        "useConfig": {
-          "type": "boolean",
-          "description": "If true, Lazygit will use whatever pager is specified in `$GIT_PAGER`, `$PAGER`, or your *git config*. If the pager ends with something like ` | less` we will strip that part out, because less doesn't play nice with our rendering approach. If the custom pager uses less under the hood, that will also break rendering (hence the `--paging=never` flag for the `delta` pager).",
-          "default": false
-        },
         "externalDiffCommand": {
           "type": "string",
           "description": "e.g. 'difft --color=always'"


### PR DESCRIPTION
### PR Description

Many people don't understand what this means, which is apparent from the amount of issues that got filed because of this. Let's get rid of it to avoid this confusion. People will have to configure their pager twice if they want to use it both on the command line and in lazygit, which I think is not a big deal.

See [here](https://github.com/jesseduffield/lazygit/issues/3704#issuecomment-2330772344) for more rationale.

Closes #3704.