### PR TITLE
Update go to 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 
 env:
-  GO_VERSION: 1.24
+  GO_VERSION: 1.25
 
 on:
   push:
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Test code
         # we're passing -short so that we skip the integration tests, which will be run in parallel below
         run: |
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Print git version
         run: git --version
       - name: Test code
@@ -113,7 +113,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Build linux binary
         run: |
           GOOS=linux go build
@@ -140,7 +140,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Check Vendor Directory
         # ensure our vendor directory matches up with our go modules
         run: |
@@ -166,7 +166,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Lint
         uses: golangci/golangci-lint-action@v8
         with:
@@ -187,7 +187,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
 
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           # If you change this, make sure to also update scripts/golangci-lint-shim.sh
-          version: v2.2.1
+          version: v2.4.0
       - name: errors
         run: golangci-lint run
         if: ${{ failure() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
 
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.24"
+  go: "1.25"
 linters:
   enable:
     - copyloopvar

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # docker build -t lazygit .
 # docker run -it lazygit:latest /bin/sh
 
-FROM golang:1.24 as build
+FROM golang:1.25 as build
 WORKDIR /go/src/github.com/jesseduffield/lazygit/
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jesseduffield/lazygit
 
-go 1.24.0
+go 1.25.0
 
 require (
 	dario.cat/mergo v1.0.1

--- a/scripts/golangci-lint-shim.sh
+++ b/scripts/golangci-lint-shim.sh
@@ -3,6 +3,6 @@
 set -e
 
 # Must be kept in sync with the version in .github/workflows/ci.yml
-version="v2.2.1"
+version="v2.4.0"
 
 go run "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$version" "$@"


### PR DESCRIPTION
### PR Description
This PR includes 2 changes:
1. Bump golangci-lint version to `v2.4.0` from  `v.2.2.1`
1. Bump Go version to `1.25.0`:
	- Bump Go version to `1.25` in `go.mod`
	- Bump Go version to  `1.25` in `ci.yml`
	- Bump base image to `golang:1.25`  in `Dockerfile`

### Reference
- [Go 1.25 release note](https://tip.golang.org/doc/go1.25)

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] ~If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))~
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
