### PR TITLE
Log output of stash drop command(s)

### DIFF
--- a/pkg/commands/git_commands/stash.go
+++ b/pkg/commands/git_commands/stash.go
@@ -28,14 +28,14 @@ func NewStashCommands(
 func (self *StashCommands) DropNewest() error {
 	cmdArgs := NewGitCmd("stash").Arg("drop").ToArgv()
 
-	return self.cmd.New(cmdArgs).Run()
+	return self.cmd.New(cmdArgs).StreamOutput().Run()
 }
 
 func (self *StashCommands) Drop(index int) error {
 	cmdArgs := NewGitCmd("stash").Arg("drop", fmt.Sprintf("refs/stash@{%d}", index)).
 		ToArgv()
 
-	return self.cmd.New(cmdArgs).Run()
+	return self.cmd.New(cmdArgs).StreamOutput().Run()
 }
 
 func (self *StashCommands) Pop(index int) error {


### PR DESCRIPTION
It can be useful to see the reference hash of a stash after dropping it. This makes recovering the dropped stash a lot easier if the stash was dropped accidentally.
