### PR TITLE
Fix dropping range selection of filtered stashes

### DIFF
--- a/pkg/gui/controllers/stash_controller.go
+++ b/pkg/gui/controllers/stash_controller.go
@@ -161,9 +161,8 @@ func (self *StashController) handleStashDrop(stashEntries []*models.StashEntry) 
 		Prompt: self.c.Tr.SureDropStashEntry,
 		HandleConfirm: func() error {
 			self.c.LogAction(self.c.Tr.Actions.Stash)
-			startIndex := stashEntries[0].Index
-			for range stashEntries {
-				err := self.c.Git().Stash.Drop(startIndex)
+			for i := len(stashEntries) - 1; i >= 0; i-- {
+				err := self.c.Git().Stash.Drop(stashEntries[i].Index)
 				self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.STASH}})
 				if err != nil {
 					return err

--- a/pkg/integration/tests/stash/drop_multiple.go
+++ b/pkg/integration/tests/stash/drop_multiple.go
@@ -33,7 +33,6 @@ var DropMultiple = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("stash two"),
 				Contains("stash one"),
 			).
-			Press(keys.Universal.ToggleRangeSelect).
 			Press(keys.Universal.RangeSelectDown).
 			Press(keys.Universal.Remove).
 			Tap(func() {

--- a/pkg/integration/tests/stash/drop_multiple_in_filtered_mode.go
+++ b/pkg/integration/tests/stash/drop_multiple_in_filtered_mode.go
@@ -58,23 +58,13 @@ var DropMultipleInFilteredMode = NewIntegrationTest(NewIntegrationTestArgs{
 					Content(Contains("Are you sure you want to drop the selected stash entry(ies)?")).
 					Confirm()
 			}).
-			/* EXPECTED:
 			IsEmpty()
-			ACTUAL: */
-			Lines(
-				Contains("stash two-a"),
-			)
 
 		t.GlobalPress(keys.Universal.Return) // cancel filtering mode
 		t.Views().Stash().
 			Lines(
-				/* EXPECTED:
 				Contains("stash four"),
 				Contains("stash three"),
-				Contains("stash one"),
-				ACTUAL: */
-				Contains("stash four"),
-				Contains("stash two-a"),
 				Contains("stash one"),
 			)
 	},

--- a/pkg/integration/tests/stash/drop_multiple_in_filtered_mode.go
+++ b/pkg/integration/tests/stash/drop_multiple_in_filtered_mode.go
@@ -1,0 +1,81 @@
+package stash
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var DropMultipleInFilteredMode = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Drop multiple stash entries when filtering by path",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("initial commit")
+		shell.CreateFileAndAdd("file1", "content1")
+		shell.Stash("stash one")
+		shell.CreateFileAndAdd("file2", "content2a")
+		shell.Stash("stash two-a")
+		shell.CreateFileAndAdd("file3", "content3")
+		shell.Stash("stash three")
+		shell.CreateFileAndAdd("file2", "content2b")
+		shell.Stash("stash two-b")
+		shell.CreateFileAndAdd("file4", "content4")
+		shell.Stash("stash four")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Stash().
+			Lines(
+				Contains("stash four"),
+				Contains("stash two-b"),
+				Contains("stash three"),
+				Contains("stash two-a"),
+				Contains("stash one"),
+			)
+
+		t.GlobalPress(keys.Universal.FilteringMenu)
+		t.ExpectPopup().Menu().
+			Title(Equals("Filtering")).
+			Select(Contains("Enter path to filter by")).
+			Confirm()
+
+		t.ExpectPopup().Prompt().
+			Title(Equals("Enter path:")).
+			Type("file2").
+			Confirm()
+
+		t.Views().Stash().
+			Focus().
+			Lines(
+				Contains("stash two-b").IsSelected(),
+				Contains("stash two-a"),
+			).
+			Press(keys.Universal.RangeSelectDown).
+			Press(keys.Universal.Remove).
+			Tap(func() {
+				t.ExpectPopup().Confirmation().
+					Title(Equals("Stash drop")).
+					Content(Contains("Are you sure you want to drop the selected stash entry(ies)?")).
+					Confirm()
+			}).
+			/* EXPECTED:
+			IsEmpty()
+			ACTUAL: */
+			Lines(
+				Contains("stash two-a"),
+			)
+
+		t.GlobalPress(keys.Universal.Return) // cancel filtering mode
+		t.Views().Stash().
+			Lines(
+				/* EXPECTED:
+				Contains("stash four"),
+				Contains("stash three"),
+				Contains("stash one"),
+				ACTUAL: */
+				Contains("stash four"),
+				Contains("stash two-a"),
+				Contains("stash one"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -358,6 +358,7 @@ var tests = []*components.IntegrationTest{
 	stash.CreateBranch,
 	stash.Drop,
 	stash.DropMultiple,
+	stash.DropMultipleInFilteredMode,
 	stash.FilterByPath,
 	stash.Pop,
 	stash.PreventDiscardingFileChanges,


### PR DESCRIPTION
### PR Description

When filtering by file path, dropping a range selection of stashes would drop the wrong ones if those stashes would be noncontiguous in the unfiltered list.