### PR TITLE
Log the hash of dropped stashes

### DIFF
--- a/pkg/commands/git_commands/stash_loader_test.go
+++ b/pkg/commands/git_commands/stash_loader_test.go
@@ -1,7 +1,9 @@
 package git_commands
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
@@ -17,6 +19,9 @@ func TestGetStashEntries(t *testing.T) {
 		expectedStashEntries []*models.StashEntry
 	}
 
+	hoursAgo := time.Now().Unix() - 3*3600 - 1800
+	daysAgo := time.Now().Unix() - 3*3600*24 - 3600*12
+
 	scenarios := []scenario{
 		{
 			"No stash entries found",
@@ -30,17 +35,20 @@ func TestGetStashEntries(t *testing.T) {
 			"",
 			oscommands.NewFakeRunner(t).
 				ExpectGitArgs([]string{"stash", "list", "-z", "--pretty=%ct|%gs"},
-					"WIP on add-pkg-commands-test: 55c6af2 increase parallel build\x00WIP on master: bb86a3f update github template\x00",
-					nil,
-				),
+					fmt.Sprintf("%d|WIP on add-pkg-commands-test: 55c6af2 increase parallel build\x00%d|WIP on master: bb86a3f update github template\x00",
+						hoursAgo,
+						daysAgo,
+					), nil),
 			[]*models.StashEntry{
 				{
-					Index: 0,
-					Name:  "WIP on add-pkg-commands-test: 55c6af2 increase parallel build",
+					Index:   0,
+					Name:    "WIP on add-pkg-commands-test: 55c6af2 increase parallel build",
+					Recency: "3h",
 				},
 				{
-					Index: 1,
-					Name:  "WIP on master: bb86a3f update github template",
+					Index:   1,
+					Name:    "WIP on master: bb86a3f update github template",
+					Recency: "3d",
 				},
 			},
 		},

--- a/pkg/commands/git_commands/stash_loader_test.go
+++ b/pkg/commands/git_commands/stash_loader_test.go
@@ -27,15 +27,15 @@ func TestGetStashEntries(t *testing.T) {
 			"No stash entries found",
 			"",
 			oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"stash", "list", "-z", "--pretty=%ct|%gs"}, "", nil),
+				ExpectGitArgs([]string{"stash", "list", "-z", "--pretty=%H|%ct|%gs"}, "", nil),
 			[]*models.StashEntry{},
 		},
 		{
 			"Several stash entries found",
 			"",
 			oscommands.NewFakeRunner(t).
-				ExpectGitArgs([]string{"stash", "list", "-z", "--pretty=%ct|%gs"},
-					fmt.Sprintf("%d|WIP on add-pkg-commands-test: 55c6af2 increase parallel build\x00%d|WIP on master: bb86a3f update github template\x00",
+				ExpectGitArgs([]string{"stash", "list", "-z", "--pretty=%H|%ct|%gs"},
+					fmt.Sprintf("fa1afe1|%d|WIP on add-pkg-commands-test: 55c6af2 increase parallel build\x00deadbeef|%d|WIP on master: bb86a3f update github template\x00",
 						hoursAgo,
 						daysAgo,
 					), nil),
@@ -44,11 +44,13 @@ func TestGetStashEntries(t *testing.T) {
 					Index:   0,
 					Name:    "WIP on add-pkg-commands-test: 55c6af2 increase parallel build",
 					Recency: "3h",
+					Hash:    "fa1afe1",
 				},
 				{
 					Index:   1,
 					Name:    "WIP on master: bb86a3f update github template",
 					Recency: "3d",
+					Hash:    "deadbeef",
 				},
 			},
 		},

--- a/pkg/commands/models/stash_entry.go
+++ b/pkg/commands/models/stash_entry.go
@@ -7,6 +7,7 @@ type StashEntry struct {
 	Index   int
 	Recency string
 	Name    string
+	Hash    string
 }
 
 func (s *StashEntry) FullRefName() string {

--- a/pkg/gui/controllers/stash_controller.go
+++ b/pkg/gui/controllers/stash_controller.go
@@ -129,6 +129,7 @@ func (self *StashController) handleStashApply(stashEntry *models.StashEntry) err
 func (self *StashController) handleStashPop(stashEntry *models.StashEntry) error {
 	pop := func() error {
 		self.c.LogAction(self.c.Tr.Actions.PopStash)
+		self.c.LogCommand("Popping stash "+stashEntry.Hash, false)
 		err := self.c.Git().Stash.Pop(stashEntry.Index)
 		self.postStashRefresh()
 		if err != nil {
@@ -162,6 +163,7 @@ func (self *StashController) handleStashDrop(stashEntries []*models.StashEntry) 
 		HandleConfirm: func() error {
 			self.c.LogAction(self.c.Tr.Actions.DropStash)
 			for i := len(stashEntries) - 1; i >= 0; i-- {
+				self.c.LogCommand("Dropping stash "+stashEntries[i].Hash, false)
 				err := self.c.Git().Stash.Drop(stashEntries[i].Index)
 				self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.STASH}})
 				if err != nil {

--- a/pkg/gui/controllers/stash_controller.go
+++ b/pkg/gui/controllers/stash_controller.go
@@ -112,7 +112,7 @@ func (self *StashController) handleStashApply(stashEntry *models.StashEntry) err
 			Title:  self.c.Tr.StashApply,
 			Prompt: self.c.Tr.SureApplyStashEntry,
 			HandleConfirm: func() error {
-				self.c.LogAction(self.c.Tr.Actions.Stash)
+				self.c.LogAction(self.c.Tr.Actions.ApplyStash)
 				err := self.c.Git().Stash.Apply(stashEntry.Index)
 				self.postStashRefresh()
 				if err != nil {
@@ -128,7 +128,7 @@ func (self *StashController) handleStashApply(stashEntry *models.StashEntry) err
 
 func (self *StashController) handleStashPop(stashEntry *models.StashEntry) error {
 	pop := func() error {
-		self.c.LogAction(self.c.Tr.Actions.Stash)
+		self.c.LogAction(self.c.Tr.Actions.PopStash)
 		err := self.c.Git().Stash.Pop(stashEntry.Index)
 		self.postStashRefresh()
 		if err != nil {
@@ -160,7 +160,7 @@ func (self *StashController) handleStashDrop(stashEntries []*models.StashEntry) 
 		Title:  self.c.Tr.StashDrop,
 		Prompt: self.c.Tr.SureDropStashEntry,
 		HandleConfirm: func() error {
-			self.c.LogAction(self.c.Tr.Actions.Stash)
+			self.c.LogAction(self.c.Tr.Actions.DropStash)
 			for i := len(stashEntries) - 1; i >= 0; i-- {
 				err := self.c.Git().Stash.Drop(stashEntries[i].Index)
 				self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.STASH}})

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1011,6 +1011,9 @@ type Actions struct {
 	UpdateRemote                     string
 	ApplyPatch                       string
 	Stash                            string
+	PopStash                         string
+	ApplyStash                       string
+	DropStash                        string
 	RenameStash                      string
 	RemoveSubmodule                  string
 	ResetSubmodule                   string
@@ -2050,6 +2053,9 @@ func EnglishTranslationSet() *TranslationSet {
 			UpdateRemote:                     "Update remote",
 			ApplyPatch:                       "Apply patch",
 			Stash:                            "Stash",
+			PopStash:                         "Pop stash",
+			ApplyStash:                       "Apply stash",
+			DropStash:                        "Drop stash",
 			RenameStash:                      "Rename stash",
 			RemoveSubmodule:                  "Remove submodule",
 			ResetSubmodule:                   "Reset submodule",


### PR DESCRIPTION
### PR Description

If you dropped/popped a stash accidentally, the logged hash can help recover it more easily.

Supersedes #4847.