### PR TITLE
Hide the cursor when the password prompt is showing

### DIFF
--- a/pkg/gui/context.go
+++ b/pkg/gui/context.go
@@ -196,7 +196,7 @@ func (self *ContextMgr) Activate(c types.Context, opts types.OnFocusOpts) {
 
 	v.Visible = true
 
-	self.gui.c.GocuiGui().Cursor = v.Editable
+	self.gui.c.GocuiGui().Cursor = v.Editable && v.Mask == 0
 
 	c.HandleFocus(opts)
 }


### PR DESCRIPTION
The cursor is a bit of a security concern, because it reveals the length (and typing pattern) of the password.

Resolves #4877.