### PR TITLE
Don't hide keybindings that match the confirmMenu key in the keybindings menu

### DIFF
--- a/pkg/gui/controllers/options_menu_action.go
+++ b/pkg/gui/controllers/options_menu_action.go
@@ -51,6 +51,7 @@ func (self *OptionsMenuAction) Call() error {
 		HideCancel:                true,
 		ColumnAlignment:           []utils.Alignment{utils.AlignRight, utils.AlignLeft},
 		AllowFilteringKeybindings: true,
+		KeepConfirmKeybindings:    true,
 	})
 }
 

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -35,7 +35,7 @@ func (gui *Gui) createMenu(opts types.CreateMenuOptions) error {
 		maxColumnSize = max(maxColumnSize, len(item.LabelColumns))
 
 		// Remove all item keybindings that are the same as the confirm binding
-		if item.Key == confirmKey {
+		if item.Key == confirmKey && !opts.KeepConfirmKeybindings {
 			item.Key = nil
 		}
 	}

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -156,6 +156,7 @@ type CreateMenuOptions struct {
 	HideCancel                bool
 	ColumnAlignment           []utils.Alignment
 	AllowFilteringKeybindings bool
+	KeepConfirmKeybindings    bool // if true, the keybindings that match the confirm binding will not be removed from menu items
 }
 
 type CreatePopupPanelOpts struct {


### PR DESCRIPTION
In all other menus besides the keybindings menu it makes sense to hide keybindings that match the confirmMenu binding. This is important to make it clear which action will be triggered when you press the key.

In the keybindings menu this is different; the main purpose of that menu is not to allow triggering commands by their key while the menu is open, but to serve as a reference for what the keybindings are when it is not open. Because of this, it is more important to show all bindings in this menu, even if they conflict with the confirmMenu key.

This fixes a regression introduced in b3a3410a1a98.
