### PR TITLE
Error Handling when TERM variable is invalid

### DIFF
--- a/pkg/app/errors.go
+++ b/pkg/app/errors.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/jesseduffield/lazygit/pkg/i18n"
@@ -30,6 +32,14 @@ func knownError(tr *i18n.TranslationSet, err error) (string, bool) {
 		{
 			originalError: "getwd: no such file or directory",
 			newError:      tr.WorkingDirectoryDoesNotExist,
+		},
+		{
+			originalError: "terminal entry not found: term not set",
+			newError:      tr.TermNotSet,
+		},
+		{
+			originalError: "$TERM Not Found",
+			newError:      fmt.Sprintf(tr.TermNotFound, os.Getenv("TERM")),
 		},
 	}
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -758,6 +758,9 @@ func (gui *Gui) initGocui(headless bool, test integrationTypes.IntegrationTest) 
 		Height:           height,
 	})
 	if err != nil {
+		if err.Error() == "exit status 1" {
+			err = errors.New("$TERM Not Found")
+		}
 		return nil, err
 	}
 

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -499,6 +499,8 @@ type TranslationSet struct {
 	StashOptions                          string
 	NotARepository                        string
 	WorkingDirectoryDoesNotExist          string
+	TermNotSet                            string
+	TermNotFound                          string
 	ScrollLeft                            string
 	ScrollRight                           string
 	DiscardPatch                          string
@@ -1583,6 +1585,8 @@ func EnglishTranslationSet() *TranslationSet {
 		StashOptions:                         "Stash options",
 		NotARepository:                       "Error: must be run inside a git repository",
 		WorkingDirectoryDoesNotExist:         "Error: the current working directory does not exist",
+		TermNotSet:                           "Error: TERM environment variable not set.",
+		TermNotFound:                         "Error: could not find terminal info for $TERM '%s'. Please check your TERM variable is set correctly.",
 		ScrollLeft:                           "Scroll left",
 		ScrollRight:                          "Scroll right",
 		DiscardPatch:                         "Discard patch",


### PR DESCRIPTION
### PR Description

Resolves #4868 

The root cause stems from running an external command `infocmp` in `setupterm` function from tcell dependency.

https://github.com/jesseduffield/lazygit/blob/0d5a410114036e2151087e6a8cf5295cca317c16/vendor/github.com/gdamore/tcell/v2/terminfo/dynamic/dynamic.go#L119-L130

The error returns 'exit status 1' which will be propagate all the way up to `app.go`.

#### Unset Term Variable

**Before**
```bash
> unset TERM
> lazygit
Not in a git repository. Create a new git repository? (y/N): N
2025/09/07 18:52:22 An error occurred! Please create an issue at: https://github.com/jesseduffield/lazygit/issues

*fmt.wrapError terminal entry not found: term not set
/home/runner/work/lazygit/lazygit/pkg/app/app.go:55 (0xc9d2bf)
/home/runner/work/lazygit/lazygit/pkg/app/entry_point.go:172 (0xc9f486)
/home/runner/work/lazygit/lazygit/main.go:23 (0xca0838)
/opt/hostedtoolcache/go/1.24.5/x64/src/internal/runtime/atomic/types.go:194 (0x443f6b)
/opt/hostedtoolcache/go/1.24.5/x64/src/runtime/asm_amd64.s:1700 (0x480ca1)
```
**After**
```bash
> unset TERM
> lazygit
Not in a git repository. Create a new git repository? (y/N): N
2025/09/07 20:58:03 Error: TERM environment variable not set.
exit status 1
```

#### Invalid Term Variable

**Before**
```bash
> export TERM=skibidi
> lazygit
Not in a git repository. Create a new git repository? (y/N): N
2025/09/07 18:49:56 An error occurred! Please create an issue at: https://github.com/jesseduffield/lazygit/issues

*exec.ExitError exit status 1
/home/runner/work/lazygit/lazygit/pkg/app/app.go:55 (0xc9d2bf)
/home/runner/work/lazygit/lazygit/pkg/app/entry_point.go:172 (0xc9f486)
/home/runner/work/lazygit/lazygit/main.go:23 (0xca0838)
/opt/hostedtoolcache/go/1.24.5/x64/src/internal/runtime/atomic/types.go:194 (0x443f6b)
/opt/hostedtoolcache/go/1.24.5/x64/src/runtime/asm_amd64.s:1700 (0x480ca1)
```
**After**
```bash
> export TERM=skibidi
> lazygit
2025/09/07 21:00:01 Error: could not find terminal info for $TERM 'skibidi'. Please check your TERM variable is set correctly.
exit status 1
```

### Please check if the PR fulfills these requirements

* [ ] Cheatsheets are up-to-date (run go generate ./...)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->