### PR TITLE
Decrease minimum required git version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         git-version:
-          - 2.32.0 # oldest supported version
+          - 2.30.0 # oldest supported version
           - 2.38.2 # first version that supports the rebase.updateRefs config
           - 2.44.0
           - latest # We rely on github to have the latest version installed on their VMs

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -140,7 +140,7 @@ func NewApp(config config.AppConfigurer, test integrationTypes.IntegrationTest, 
 	return app, nil
 }
 
-const minGitVersionStr = "2.32.0"
+const minGitVersionStr = "2.30.0"
 
 func minGitVersionErrorMessage(tr *i18n.TranslationSet) string {
 	return fmt.Sprintf(tr.MinGitVersionError, minGitVersionStr)

--- a/pkg/commands/git_commands/repo_paths.go
+++ b/pkg/commands/git_commands/repo_paths.go
@@ -21,6 +21,8 @@ type RepoPaths struct {
 	isBareRepo         bool
 }
 
+var gitPathFormatVersion = GitVersion{2, 31, 0, ""}
+
 // Path to the current worktree. If we're in the main worktree, this will
 // be the same as RepoPath()
 func (self *RepoPaths) WorktreePath() string {
@@ -77,14 +79,15 @@ func GetRepoPaths(
 	if err != nil {
 		return nil, err
 	}
-	return GetRepoPathsForDir(cwd, cmd)
+	return GetRepoPathsForDir(cwd, cmd, version)
 }
 
 func GetRepoPathsForDir(
 	dir string,
 	cmd oscommands.ICmdObjBuilder,
+	version *GitVersion,
 ) (*RepoPaths, error) {
-	gitDirOutput, err := callGitRevParseWithDir(cmd, dir, "--show-toplevel", "--absolute-git-dir", "--git-common-dir", "--is-bare-repository", "--show-superproject-working-tree")
+	gitDirOutput, err := callGitRevParseWithDir(cmd, version, dir, "--show-toplevel", "--absolute-git-dir", "--git-common-dir", "--is-bare-repository", "--show-superproject-working-tree")
 	if err != nil {
 		return nil, err
 	}
@@ -93,6 +96,12 @@ func GetRepoPathsForDir(
 	worktreePath := gitDirResults[0]
 	worktreeGitDirPath := gitDirResults[1]
 	repoGitDirPath := gitDirResults[2]
+	if version.IsOlderThanVersion(&gitPathFormatVersion) {
+		repoGitDirPath, err = filepath.Abs(repoGitDirPath)
+		if err != nil {
+			return nil, err
+		}
+	}
 	isBareRepo := gitDirResults[3] == "true"
 
 	// If we're in a submodule, --show-superproject-working-tree will return
@@ -122,10 +131,11 @@ func GetRepoPathsForDir(
 
 func callGitRevParseWithDir(
 	cmd oscommands.ICmdObjBuilder,
+	version *GitVersion,
 	dir string,
 	gitRevArgs ...string,
 ) (string, error) {
-	gitRevParse := NewGitCmd("rev-parse").Arg("--path-format=absolute").Arg(gitRevArgs...)
+	gitRevParse := NewGitCmd("rev-parse").ArgIf(version.IsAtLeastVersion(&gitPathFormatVersion), "--path-format=absolute").Arg(gitRevArgs...)
 	if dir != "" {
 		gitRevParse.Dir(dir)
 	}

--- a/pkg/commands/git_commands/repo_paths_test.go
+++ b/pkg/commands/git_commands/repo_paths_test.go
@@ -194,13 +194,22 @@ func TestGetRepoPaths(t *testing.T) {
 			runner := oscommands.NewFakeRunner(t)
 			cmd := oscommands.NewDummyCmdObjBuilder(runner)
 
+			version, err := GetGitVersion(oscommands.NewDummyOSCommand())
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			getRevParseArgs := func() []string {
-				return []string{"rev-parse", "--path-format=absolute"}
+				args := []string{"rev-parse"}
+				if version.IsAtLeast(2, 31, 0) {
+					args = append(args, "--path-format=absolute")
+				}
+				return args
 			}
 			// prepare the filesystem for the scenario
 			s.BeforeFunc(runner, getRevParseArgs)
 
-			repoPaths, err := GetRepoPathsForDir("", cmd)
+			repoPaths, err := GetRepoPathsForDir("", cmd, version)
 
 			// check the error and the paths
 			if s.Err != nil {

--- a/pkg/commands/git_commands/worktree_loader.go
+++ b/pkg/commands/git_commands/worktree_loader.go
@@ -82,7 +82,7 @@ func (self *WorktreeLoader) GetWorktrees() ([]*models.Worktree, error) {
 			if worktree.IsPathMissing {
 				return
 			}
-			gitDir, err := callGitRevParseWithDir(self.cmd, worktree.Path, "--absolute-git-dir")
+			gitDir, err := callGitRevParseWithDir(self.cmd, self.version, worktree.Path, "--absolute-git-dir")
 			if err != nil {
 				self.Log.Warnf("Could not find git dir for worktree %s: %v", worktree.Path, err)
 				return

--- a/pkg/commands/git_commands/worktree_loader_test.go
+++ b/pkg/commands/git_commands/worktree_loader_test.go
@@ -190,7 +190,11 @@ branch refs/heads/mybranch-worktree
 			}
 
 			getRevParseArgs := func() []string {
-				return []string{"rev-parse", "--path-format=absolute"}
+				args := []string{"rev-parse"}
+				if version.IsAtLeast(2, 31, 0) {
+					args = append(args, "--path-format=absolute")
+				}
+				return args
 			}
 
 			s.before(runner, fs, getRevParseArgs)

--- a/pkg/integration/tests/commit/create_amend_commit.go
+++ b/pkg/integration/tests/commit/create_amend_commit.go
@@ -41,18 +41,20 @@ var CreateAmendCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("commit 01"),
 			)
 
-		t.Views().Commits().
-			Press(keys.Commits.SquashAboveCommits).
-			Tap(func() {
-				t.ExpectPopup().Menu().
-					Title(Equals("Apply fixup commits")).
-					Select(Contains("Above the selected commit")).
-					Confirm()
-			}).
-			Lines(
-				Contains("commit 03"),
-				Contains("commit 02 amended").IsSelected(),
-				Contains("commit 01"),
-			)
+		if t.Git().Version().IsAtLeast(2, 32, 0) { // Support for auto-squashing "amend!" commits was added in git 2.32.0
+			t.Views().Commits().
+				Press(keys.Commits.SquashAboveCommits).
+				Tap(func() {
+					t.ExpectPopup().Menu().
+						Title(Equals("Apply fixup commits")).
+						Select(Contains("Above the selected commit")).
+						Confirm()
+				}).
+				Lines(
+					Contains("commit 03"),
+					Contains("commit 02 amended").IsSelected(),
+					Contains("commit 01"),
+				)
+		}
 	},
 })


### PR DESCRIPTION
### PR Description

Decrease minimum required git version to 2.30

It was previously updated to 2.32 here: https://github.com/jesseduffield/lazygit/pull/4718. Per its description, the version choice was arbitrary as long as it was at least 2.27.

The reason why I'm updating the version is that the server I remote into for work uses git v2.30.

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
