### PR TITLE
Fix support for Git copy status when status.renames=copies

### DIFF
--- a/pkg/commands/git_commands/file_loader.go
+++ b/pkg/commands/git_commands/file_loader.go
@@ -201,8 +201,8 @@ func (self *FileLoader) gitStatus(opts GitStatusOptions) ([]FileStatus, error) {
 			PreviousPath: "",
 		}
 
-		if strings.HasPrefix(status.Change, "R") {
-			// if a line starts with 'R' then the next line is the original file.
+		if strings.HasPrefix(status.Change, "R") || strings.HasPrefix(status.Change, "C") {
+			// if a line starts with 'R' (rename) or 'C' (copy) then the next line is the original file.
 			status.PreviousPath = splitLines[i+1]
 			status.StatusString = fmt.Sprintf("%s %s -> %s", status.Change, status.PreviousPath, status.Path)
 			i++

--- a/pkg/commands/git_commands/file_loader_test.go
+++ b/pkg/commands/git_commands/file_loader_test.go
@@ -192,6 +192,43 @@ func TestFileGetStatusFiles(t *testing.T) {
 				},
 			},
 		},
+		{
+			testName:            "Copied files",
+			similarityThreshold: 50,
+			runner: oscommands.NewFakeRunner(t).
+				ExpectGitArgs([]string{"status", "--untracked-files=yes", "--porcelain", "-z", "--find-renames=50%"},
+					"C  copy1.txt\x00original.txt\x00CM copy2.txt\x00original.txt",
+					nil,
+				),
+			expectedFiles: []*models.File{
+				{
+					Path:                    "copy1.txt",
+					PreviousPath:            "original.txt",
+					HasStagedChanges:        true,
+					HasUnstagedChanges:      false,
+					Tracked:                 true,
+					Added:                   false,
+					Deleted:                 false,
+					HasMergeConflicts:       false,
+					HasInlineMergeConflicts: false,
+					DisplayString:           "C  original.txt -> copy1.txt",
+					ShortStatus:             "C ",
+				},
+				{
+					Path:                    "copy2.txt",
+					PreviousPath:            "original.txt",
+					HasStagedChanges:        true,
+					HasUnstagedChanges:      true,
+					Tracked:                 true,
+					Added:                   false,
+					Deleted:                 false,
+					HasMergeConflicts:       false,
+					HasInlineMergeConflicts: false,
+					DisplayString:           "CM original.txt -> copy2.txt",
+					ShortStatus:             "CM",
+				},
+			},
+		},
 	}
 
 	for _, s := range scenarios {


### PR DESCRIPTION
Fixes: #4890

- Fix file status parsing to handle Git copy operations when `status.renames=copies` is configured
- Extend status parser to recognize both "R" (rename) and "C" (copy) prefixes 
- Add comprehensive test coverage for copy status codes

The same issue from #4890 
now is fixed

<img width="602" height="453" alt="image" src="https://github.com/user-attachments/assets/faaf5c41-59a7-4297-9d9e-5de4a552009e" />
