### PR TITLE
Fix staging when using the new useExternalDiffGitConfig config

### DIFF
--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -267,7 +267,7 @@ func (self *WorkingTreeCommands) WorktreeFileDiffCmdObj(node models.IFile, plain
 	noIndex := !node.GetIsTracked() && !node.GetHasStagedChanges() && !cached && node.GetIsFile()
 	extDiffCmd := self.UserConfig().Git.Paging.ExternalDiffCommand
 	useExtDiff := extDiffCmd != "" && !plain
-	useExtDiffGitConfig := self.UserConfig().Git.Paging.UseExternalDiffGitConfig
+	useExtDiffGitConfig := self.UserConfig().Git.Paging.UseExternalDiffGitConfig && !plain
 
 	cmdArgs := NewGitCmd("diff").
 		ConfigIf(useExtDiff, "diff.external="+extDiffCmd).
@@ -305,7 +305,7 @@ func (self *WorkingTreeCommands) ShowFileDiffCmdObj(from string, to string, reve
 
 	extDiffCmd := self.UserConfig().Git.Paging.ExternalDiffCommand
 	useExtDiff := extDiffCmd != "" && !plain
-	useExtDiffGitConfig := self.UserConfig().Git.Paging.UseExternalDiffGitConfig
+	useExtDiffGitConfig := self.UserConfig().Git.Paging.UseExternalDiffGitConfig && !plain
 
 	cmdArgs := NewGitCmd("diff").
 		Config("diff.noprefix=false").


### PR DESCRIPTION
This new config was introduced in 0.55, but it made it impossible to enter the staging view or custom patch building view.

Fixes https://github.com/jesseduffield/lazygit/pull/4832#issuecomment-3289371491.