### PR TITLE
Don't log the git rev-list command that we use for IsBranchMerged

### DIFF
--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -288,7 +288,7 @@ func (self *BranchCommands) IsBranchMerged(branch *models.Branch, mainBranches *
 		Arg("--").
 		ToArgv()
 
-	stdout, _, err := self.cmd.New(cmdArgs).RunWithOutputs()
+	stdout, _, err := self.cmd.New(cmdArgs).DontLog().RunWithOutputs()
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
When you delete a branch, we call this function to determine whether we need to ask for confirmation of not. We don't want to log this, because it's not a command that a user would normally use as part of this operation.
