### PR TITLE
Add configuration for overriding hardcoded icon settings

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -52,6 +52,12 @@ gui:
     # Map of file extensions (including the dot) to icon properties (icon and color)
     extensions: {}
 
+    # Map of vcs icons to string (icon only)
+    vcsIcons: {}
+
+    # Map of file icons to string (icon only)
+    fileIcons: {}
+
   # The number of lines you scroll by when scrolling the main window
   scrollHeight: 2
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -717,6 +717,8 @@ type CustomIconsConfig struct {
 	Filenames map[string]IconProperties `yaml:"filenames"`
 	// Map of file extensions (including the dot) to icon properties (icon and color)
 	Extensions map[string]IconProperties `yaml:"extensions"`
+	VCSIcons   map[string]string         `yaml:"vcsIcons"`
+	FileIcons  map[string]IconProperties `yaml:"fileIcons"`
 }
 
 type IconProperties struct {

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -717,8 +717,10 @@ type CustomIconsConfig struct {
 	Filenames map[string]IconProperties `yaml:"filenames"`
 	// Map of file extensions (including the dot) to icon properties (icon and color)
 	Extensions map[string]IconProperties `yaml:"extensions"`
-	VCSIcons   map[string]string         `yaml:"vcsIcons"`
-	FileIcons  map[string]IconProperties `yaml:"fileIcons"`
+	// Map of vcs icons to string (icon only)
+	VCSIcons map[string]string `yaml:"vcsIcons"`
+	// Map of file icons to string (icon only)
+	FileIcons map[string]IconProperties `yaml:"fileIcons"`
 }
 
 type IconProperties struct {

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -450,8 +450,12 @@ func (gui *Gui) onUserConfigLoaded() error {
 	authors.SetCustomAuthors(userConfig.Gui.AuthorColors)
 	if userConfig.Gui.NerdFontsVersion != "" {
 		icons.SetNerdFontsVersion(userConfig.Gui.NerdFontsVersion)
+
+		icons.PatchHardcodedIcons(userConfig.Gui.CustomIcons)
 	} else if userConfig.Gui.ShowIcons {
 		icons.SetNerdFontsVersion("2")
+
+		icons.PatchHardcodedIcons(userConfig.Gui.CustomIcons)
 	}
 
 	if len(userConfig.Gui.BranchColorPatterns) > 0 {

--- a/pkg/gui/presentation/icons/patch.go
+++ b/pkg/gui/presentation/icons/patch.go
@@ -1,0 +1,55 @@
+package icons
+
+import "github.com/jesseduffield/lazygit/pkg/config"
+
+func PatchHardcodedIcons(customIcons config.CustomIconsConfig) {
+	patchFileIconFromConfig(customIcons.FileIcons)
+	patchVCSIconFromConfig(customIcons.VCSIcons)
+}
+
+func patchVCSIconFromConfig(vcsIcons map[string]string) {
+	for name, icon := range vcsIcons {
+		// replace Variables(e.x: SOME_UPPER_SNAKECASE_VARIABLE)
+		switch name {
+		case "branch":
+			BRANCH_ICON = icon
+		case "detached-head":
+			DETACHED_HEAD_ICON = icon
+		case "tag":
+			TAG_ICON = icon
+		case "commit":
+			COMMIT_ICON = icon
+		case "merge-commit":
+			MERGE_COMMIT_ICON = icon
+		case "remote":
+			DEFAULT_REMOTE_ICON = icon
+		case "stash":
+			STASH_ICON = icon
+		case "linked-worktree":
+			LINKED_WORKTREE_ICON = icon
+		case "missing-linked-worktree":
+			MISSING_LINKED_WORKTREE_ICON = icon
+		}
+		// replace value in remoteIconsMap if the key exists.
+		if _, ok := remoteIcons[name]; ok {
+			remoteIcons[name] = icon
+		}
+	}
+}
+
+func changeStruct(p config.IconProperties) IconProperties {
+	return IconProperties{Icon: p.Icon, Color: p.Color}
+}
+
+func patchFileIconFromConfig(fileIcons map[string]config.IconProperties) {
+	for name, icon := range fileIcons {
+		switch name {
+		case "file":
+			DEFAULT_FILE_ICON = changeStruct(icon)
+		case "submodule":
+			DEFAULT_SUBMODULE_ICON = changeStruct(icon)
+		case "directory":
+			DEFAULT_DIRECTORY_ICON = changeStruct(icon)
+		}
+	}
+}

--- a/schema/config.json
+++ b/schema/config.json
@@ -277,6 +277,20 @@
           },
           "type": "object",
           "description": "Map of file extensions (including the dot) to icon properties (icon and color)"
+        },
+        "vcsIcons": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Map of vcs icons to string (icon only)"
+        },
+        "fileIcons": {
+          "additionalProperties": {
+            "$ref": "#/$defs/IconProperties"
+          },
+          "type": "object",
+          "description": "Map of file icons to string (icon only)"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
### PR Description
Added a patcher to the function in pkg/gui/gui.go thet loads icons, allowing VCS and file icons to be customized via Lazygit's config instead of being hardcoded.
### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
