### PR TITLE
feat: prompt to update tracking branches after remote rename

### DIFF
--- a/pkg/commands/git_commands/branch_loader.go
+++ b/pkg/commands/git_commands/branch_loader.go
@@ -386,3 +386,11 @@ func (self *BranchLoader) obtainReflogBranches(reflogCommits []*models.Commit) [
 	}
 	return reflogBranches
 }
+
+func (self *BranchLoader) GetRemoteBranchesByRemoteName(remoteName string) []*models.Branch {
+	branches := self.obtainBranches()
+
+	return lo.Filter(branches, func(branch *models.Branch, _ int) bool {
+		return branch.UpstreamRemote == remoteName
+	})
+}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -82,6 +82,8 @@ type TranslationSet struct {
 	NoContentToCopyError                  string
 	FileNameCopiedToast                   string
 	FilePathCopiedToast                   string
+	UpdateBranchesTrackingTitle           string
+	UpdateBranchesTrackingPrompt          string
 	FileDiffCopiedToast                   string
 	AllFilesDiffCopiedToast               string
 	FileContentCopiedToast                string
@@ -1197,6 +1199,8 @@ func EnglishTranslationSet() *TranslationSet {
 		DeleteBranchesTitle:                  "Delete selected branches?",
 		DeleteLocalBranch:                    "Delete local branch",
 		DeleteLocalBranches:                  "Delete local branches",
+		UpdateBranchesTrackingTitle:          "Update tracking branches?",
+		UpdateBranchesTrackingPrompt:         "Update branches tracking '{{.oldRemoteName}}' to track '{{.newRemoteName}}' instead?",
 		DeleteRemoteBranchPrompt:             "Are you sure you want to delete the remote branch '{{.selectedBranchName}}' from '{{.upstream}}'?",
 		DeleteRemoteBranchesPrompt:           "Are you sure you want to delete the remote branches of the selected branches from their respective remotes?",
 		DeleteLocalAndRemoteBranchPrompt:     "Are you sure you want to delete both '{{.localBranchName}}' from your machine, and '{{.remoteBranchName}}' from '{{.remoteName}}'?",


### PR DESCRIPTION
### PR Description
When a remote is renamed, lazygit now prompts to update local branches that were tracking the old remote so they continue tracking the new one.

## Demo

https://github.com/user-attachments/assets/fdf41229-12c9-4b03-bd14-276e21675164


### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
