### PR TITLE
Fix normalisedSelectedNodes function

### DIFF
--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -1221,14 +1221,14 @@ func normalisedSelectedNodes(selectedNodes []*filetree.FileNode) []*filetree.Fil
 }
 
 func isDescendentOfSelectedNodes(node *filetree.FileNode, selectedNodes []*filetree.FileNode) bool {
-	nodePath := node.GetPath()
+	nodePath := node.GetInternalPath()
 
 	for _, selectedNode := range selectedNodes {
 		if selectedNode.IsFile() {
 			continue
 		}
 
-		selectedNodePath := selectedNode.GetPath()
+		selectedNodePath := selectedNode.GetInternalPath()
 
 		if strings.HasPrefix(nodePath, selectedNodePath+"/") {
 			return true

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -1221,13 +1221,14 @@ func normalisedSelectedNodes(selectedNodes []*filetree.FileNode) []*filetree.Fil
 }
 
 func isDescendentOfSelectedNodes(node *filetree.FileNode, selectedNodes []*filetree.FileNode) bool {
+	nodePath := node.GetPath()
+
 	for _, selectedNode := range selectedNodes {
 		if selectedNode.IsFile() {
 			continue
 		}
 
 		selectedNodePath := selectedNode.GetPath()
-		nodePath := node.GetPath()
 
 		if strings.HasPrefix(nodePath, selectedNodePath+"/") {
 			return true


### PR DESCRIPTION
The `normalisedSelectedNodes` function in `files_controller.go` had a bug where it didn't work correctly for the root item (`/`). This PR fixes that.

We don't have any tests for this bug. Apparently, the functions that use this (staging and discarding files) also work correctly when they work on a directory and then on the contained file again, that's why nobody has noticed yet. I briefly looked into adding unit tests for the function, but it was more work than I was willing to put into this right now.