### PR TITLE
Updated checkout verb for portuguese

### DIFF
--- a/pkg/i18n/translations/pt.json
+++ b/pkg/i18n/translations/pt.json
@@ -87,7 +87,7 @@
   "MergeConflictPressEnterToResolve": "Pressione %s para resolver.",
   "MergeConflictKeepFile": "Manter arquivo",
   "MergeConflictDeleteFile": "Excluir arquivo",
-  "Checkout": "Verificar",
+  "Checkout": "Trocar(Checkout)",
   "CheckoutTooltip": "Checar item selecionado",
   "CantCheckoutBranchWhilePulling": "Você não pode hecar outra branch enquanto puxa a branch atual",
   "TagCheckoutTooltip": "Checar a tag selecionada como um HEAD, desanexado",


### PR DESCRIPTION
### PR Description

I made a small change to make the "checkout" action more self-explained

the way it was set up sounded more like "verify" rather than the "checkout" action from git, and I kept the English version, we are used to it here as well :3

### Please check if the PR fulfills these requirements

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
