### PR TITLE
When entering a commit in path filtering mode, select the filtered path

### DIFF
--- a/pkg/gui/controllers/switch_to_diff_files_controller.go
+++ b/pkg/gui/controllers/switch_to_diff_files_controller.go
@@ -90,6 +90,11 @@ func (self *SwitchToDiffFilesController) enter() error {
 		Scope: []types.RefreshableView{types.COMMIT_FILES},
 	})
 
+	if filterPath := self.c.Modes().Filtering.GetPath(); filterPath != "" {
+		commitFilesContext.CommitFileTreeViewModel.SelectPath(
+			filterPath, self.c.UserConfig().Gui.ShowRootItemInFileTree)
+	}
+
 	self.c.Context().Push(commitFilesContext, types.OnFocusOpts{})
 	return nil
 }

--- a/pkg/gui/filetree/build_tree.go
+++ b/pkg/gui/filetree/build_tree.go
@@ -162,9 +162,13 @@ func join(strs []string) string {
 }
 
 func SplitFileTreePath(path string, showRootItem bool) []string {
+	return split(InternalTreePathForFilePath(path, showRootItem))
+}
+
+func InternalTreePathForFilePath(path string, showRootItem bool) string {
 	if showRootItem {
-		return split("./" + path)
+		return "./" + path
 	}
 
-	return split(path)
+	return path
 }

--- a/pkg/gui/filetree/commit_file_tree_view_model.go
+++ b/pkg/gui/filetree/commit_file_tree_view_model.go
@@ -191,3 +191,13 @@ func (self *CommitFileTreeViewModel) ExpandAll() {
 		self.SetSelectedLineIdx(index)
 	}
 }
+
+// Try to select the given path if present. If it doesn't exist, or one of the parent directories is
+// collapsed, do nothing.
+// Note that filepath is an actual file path, not an internal tree path as with e.g. ToggleCollapsed.
+func (self *CommitFileTreeViewModel) SelectPath(filepath string, showRootItem bool) {
+	index, found := self.GetIndexForPath(InternalTreePathForFilePath(filepath, showRootItem))
+	if found {
+		self.SetSelection(index)
+	}
+}

--- a/pkg/integration/tests/filter_by_path/select_filtered_file_when_entering_commit.go
+++ b/pkg/integration/tests/filter_by_path/select_filtered_file_when_entering_commit.go
@@ -1,0 +1,47 @@
+package filter_by_path
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var SelectFilteredFileWhenEnteringCommit = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Filter commits by file path, then enter a commit and ensure the file is selected",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file1", "")
+		shell.CreateFileAndAdd("dir/file2", "")
+		shell.Commit("add files")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.GlobalPress(keys.Universal.FilteringMenu)
+		t.ExpectPopup().Menu().
+			Title(Equals("Filtering")).
+			Select(Contains("Enter path to filter by")).
+			Confirm()
+
+		t.ExpectPopup().Prompt().
+			Title(Equals("Enter path:")).
+			Type("dir/file2").
+			Confirm()
+
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("add files").IsSelected(),
+			).
+			PressEnter()
+
+		t.Views().CommitFiles().
+			IsFocused().
+			Lines(
+				Equals("▼ /"),
+				Equals("  ▼ dir"),
+				Equals("    A file2").IsSelected(),
+				Equals("  A file1"),
+			)
+	},
+})

--- a/pkg/integration/tests/filter_by_path/select_filtered_file_when_entering_commit_no_root_item.go
+++ b/pkg/integration/tests/filter_by_path/select_filtered_file_when_entering_commit_no_root_item.go
@@ -1,0 +1,47 @@
+package filter_by_path
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var SelectFilteredFileWhenEnteringCommitNoRootItem = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Filter commits by file path, then enter a commit and ensure the file is selected (with the show root item config off)",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Gui.ShowRootItemInFileTree = false
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file1", "")
+		shell.CreateFileAndAdd("dir/file2", "")
+		shell.Commit("add files")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.GlobalPress(keys.Universal.FilteringMenu)
+		t.ExpectPopup().Menu().
+			Title(Equals("Filtering")).
+			Select(Contains("Enter path to filter by")).
+			Confirm()
+
+		t.ExpectPopup().Prompt().
+			Title(Equals("Enter path:")).
+			Type("dir/file2").
+			Confirm()
+
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("add files").IsSelected(),
+			).
+			PressEnter()
+
+		t.Views().CommitFiles().
+			IsFocused().
+			Lines(
+				Equals("▼ dir"),
+				Equals("  A file2").IsSelected(),
+				Equals("A file1"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -239,6 +239,8 @@ var tests = []*components.IntegrationTest{
 	filter_by_path.KeepSameCommitSelectedOnExit,
 	filter_by_path.RewordCommitInFilteringMode,
 	filter_by_path.SelectFile,
+	filter_by_path.SelectFilteredFileWhenEnteringCommit,
+	filter_by_path.SelectFilteredFileWhenEnteringCommitNoRootItem,
 	filter_by_path.ShowDiffsForRenamedFile,
 	filter_by_path.TypeFile,
 	interactive_rebase.AdvancedInteractiveRebase,


### PR DESCRIPTION
This can be useful if you want to do some operation on the filtered file, e.g. check it out using `c`, or enter the file to make a custom patch from it.

Addresses #4935.