### PR TITLE
Don't depend on en_US locale to be installed

### DIFF
--- a/pkg/commands/git_commands/rebase.go
+++ b/pkg/commands/git_commands/rebase.go
@@ -244,8 +244,9 @@ func (self *RebaseCommands) PrepareInteractiveRebaseCommand(opts PrepareInteract
 
 	cmdObj.AddEnvVars(
 		"DEBUG="+debug,
-		"LANG=C",   // Force using English language
-		"LC_ALL=C", // Force using English language
+		"LANG=C",        // Force using English language
+		"LC_ALL=C",      // Force using English language
+		"LC_MESSAGES=C", // Force using English language
 		"GIT_SEQUENCE_EDITOR="+gitSequenceEditor,
 	)
 
@@ -277,8 +278,9 @@ func (self *RebaseCommands) GitRebaseEditTodo(todosFileContent []byte) error {
 
 	cmdObj.AddEnvVars(
 		"DEBUG="+debug,
-		"LANG=C",   // Force using English language
-		"LC_ALL=C", // Force using English language
+		"LANG=C",        // Force using English language
+		"LC_ALL=C",      // Force using English language
+		"LC_MESSAGES=C", // Force using English language
 		"GIT_EDITOR="+ex,
 		"GIT_SEQUENCE_EDITOR="+ex,
 	)

--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -330,7 +330,7 @@ func (self *cmdObjRunner) runAndDetectCredentialRequest(
 	promptUserForCredential func(CredentialType) <-chan string,
 ) error {
 	// setting the output to english so we can parse it for a username/password request
-	cmdObj.AddEnvVars("LANG=C", "LC_ALL=C")
+	cmdObj.AddEnvVars("LANG=C", "LC_ALL=C", "LC_MESSAGES=C")
 
 	return self.runAndStreamAux(cmdObj, func(handler *cmdHandler, cmdWriter io.Writer) {
 		tr := io.TeeReader(handler.stdoutPipe, cmdWriter)


### PR DESCRIPTION
For some of the git commands that lazygit uses, it needs to force the language to English because it parses git's output and needs to react to certain things. It used to do this by setting the locale to `en_US.UTF-8`; some users reported that this locale isn't available on their systems. Use the "C" locale instead, which achieves the same result and is guaranteed to be available everywhere.

Fixes #4731.