### PR TITLE
When pasting multi-line text into a prompt, don't treat the line feeds as "confirm"

### DIFF
--- a/pkg/gui/controllers/helpers/confirmation_helper.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper.go
@@ -26,6 +26,14 @@ func NewConfirmationHelper(c *HelperCommon) *ConfirmationHelper {
 
 func (self *ConfirmationHelper) wrappedConfirmationFunction(cancel goContext.CancelFunc, function func() error) func() error {
 	return func() error {
+		if self.c.GocuiGui().IsPasting {
+			// The user is pasting multi-line text into a prompt; we don't want to handle the
+			// line feeds as "confirm" keybindings. Simply ignoring them is the best we can do; this
+			// will cause the entire pasted text to appear as a single line in the prompt. Hopefully
+			// the user knows that ctrl-u allows them to delete it again...
+			return nil
+		}
+
 		cancel()
 
 		self.c.Context().Pop()


### PR DESCRIPTION
This is likely to do bad things; for example, if the prompt is the shell command prompt, then we would run into what looks like a deadlock bug in tcell. In other cases, the characters in the following lines might be treated as random keybindings after the prompt is confirmed; this is very similar to #4234.

In this case, it seems the best we can do is to simply swallow the line feeds. The entire pasted text will then appear as a single long line in the prompt, and hopefully the user knows that they can use ctrl-u to delete it again. If not, they will probably just hit esc to close the prompt.

Fixes #4954.