### PR TITLE
Fix main panel not updating during search navigation

### DIFF
--- a/pkg/gui/context/list_context_trait.go
+++ b/pkg/gui/context/list_context_trait.go
@@ -117,6 +117,7 @@ func (self *ListContextTrait) HandleRender() {
 func (self *ListContextTrait) OnSearchSelect(selectedLineIdx int) error {
 	self.GetList().SetSelection(self.ViewIndexToModelIndex(selectedLineIdx))
 	self.HandleFocus(types.OnFocusOpts{})
+	self.Context.HandleRenderToMain()
 	return nil
 }
 


### PR DESCRIPTION
### PR Description

Fixes the bug where navigating search results with `n` (next) or `N` (previous) in list contexts (e.g., commits panel) correctly updates the selection in the side panel but does not refresh the main panel to show the newly selected item's details.

### Changes Made

- Added `self.Context.HandleRenderToMain()` call in `OnSearchSelect()` function in `pkg/gui/context/list_context_trait.go:120`
- This ensures the main panel explicitly refreshes when navigating search results, matching the behavior of normal arrow key navigation

### Testing

Manually tested:
1. Opened lazygit in a git repository
2. Navigated to commits panel
3. Pressed `/` to start search
4. Typed search term matching multiple commits
5. Pressed `n` to navigate to next match
6. Verified main panel now updates to show the diff for the newly selected commit

### Checklist

* [x] Code has been formatted (gofumpt)
* [x] Cheatsheets are up-to-date (no keybinding changes)
* [x] Tests have been added/updated (N/A - simple one-line fix)
* [x] Text is internationalised (no new text added)
* [x] Docs have been updated if necessary (no docs changes needed)
* [x] You've read through your own file changes for silly mistakes etc