### PR TITLE
Fix window arrangement when a popup or the search prompt is open

### DIFF
--- a/pkg/gui/controllers/helpers/window_arrangement_helper.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper.go
@@ -43,10 +43,9 @@ type WindowArrangementArgs struct {
 	Height int
 	// User config
 	UserConfig *config.UserConfig
-	// Name of the currently focused window
+	// Name of the currently focused window. (It's actually the current static window, meaning
+	// popups are ignored)
 	CurrentWindow string
-	// Name of the current static window (meaning popups are ignored)
-	CurrentStaticWindow string
 	// Name of the current side window (i.e. the current window in the left
 	// section of the UI)
 	CurrentSideWindow string
@@ -86,21 +85,20 @@ func (self *WindowArrangementHelper) GetWindowDimensions(informationStr string, 
 	}
 
 	args := WindowArrangementArgs{
-		Width:               width,
-		Height:              height,
-		UserConfig:          self.c.UserConfig(),
-		CurrentWindow:       self.windowHelper.CurrentWindow(),
-		CurrentSideWindow:   self.c.Context().CurrentSide().GetWindowName(),
-		CurrentStaticWindow: self.c.Context().CurrentStatic().GetWindowName(),
-		SplitMainPanel:      repoState.GetSplitMainPanel(),
-		ScreenMode:          repoState.GetScreenMode(),
-		AppStatus:           appStatus,
-		InformationStr:      informationStr,
-		ShowExtrasWindow:    self.c.State().GetShowExtrasWindow(),
-		InDemo:              self.c.InDemo(),
-		IsAnyModeActive:     self.modeHelper.IsAnyModeActive(),
-		InSearchPrompt:      repoState.InSearchPrompt(),
-		SearchPrefix:        searchPrefix,
+		Width:             width,
+		Height:            height,
+		UserConfig:        self.c.UserConfig(),
+		CurrentWindow:     self.c.Context().CurrentStatic().GetWindowName(),
+		CurrentSideWindow: self.c.Context().CurrentSide().GetWindowName(),
+		SplitMainPanel:    repoState.GetSplitMainPanel(),
+		ScreenMode:        repoState.GetScreenMode(),
+		AppStatus:         appStatus,
+		InformationStr:    informationStr,
+		ShowExtrasWindow:  self.c.State().GetShowExtrasWindow(),
+		InDemo:            self.c.InDemo(),
+		IsAnyModeActive:   self.modeHelper.IsAnyModeActive(),
+		InSearchPrompt:    repoState.InSearchPrompt(),
+		SearchPrefix:      searchPrefix,
 	}
 
 	return GetWindowDimensions(args)
@@ -393,7 +391,7 @@ func splitMainPanelSideBySide(args WindowArrangementArgs) bool {
 func getExtrasWindowSize(args WindowArrangementArgs) int {
 	var baseSize int
 	// The 'extras' window contains the command log context
-	if args.CurrentStaticWindow == "extras" {
+	if args.CurrentWindow == "extras" {
 		baseSize = 1000 // my way of saying 'fill the available space'
 	} else if args.Height < 40 {
 		baseSize = 1

--- a/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
@@ -19,21 +19,20 @@ import (
 func TestGetWindowDimensions(t *testing.T) {
 	getDefaultArgs := func() WindowArrangementArgs {
 		return WindowArrangementArgs{
-			Width:               75,
-			Height:              30,
-			UserConfig:          config.GetDefaultConfig(),
-			CurrentWindow:       "files",
-			CurrentSideWindow:   "files",
-			CurrentStaticWindow: "files",
-			SplitMainPanel:      false,
-			ScreenMode:          types.SCREEN_NORMAL,
-			AppStatus:           "",
-			InformationStr:      "information",
-			ShowExtrasWindow:    false,
-			InDemo:              false,
-			IsAnyModeActive:     false,
-			InSearchPrompt:      false,
-			SearchPrefix:        "",
+			Width:             75,
+			Height:            30,
+			UserConfig:        config.GetDefaultConfig(),
+			CurrentWindow:     "files",
+			CurrentSideWindow: "files",
+			SplitMainPanel:    false,
+			ScreenMode:        types.SCREEN_NORMAL,
+			AppStatus:         "",
+			InformationStr:    "information",
+			ShowExtrasWindow:  false,
+			InDemo:            false,
+			IsAnyModeActive:   false,
+			InSearchPrompt:    false,
+			SearchPrefix:      "",
 		}
 	}
 


### PR DESCRIPTION
When focusing the main view, going into full screen mode by pressing '+' twice, and then opening the search prompt ('/') or a menu (e.g. '?' or ':'), the full screen display would switch to the focused side panel.

Fix this by always excluding popups from the window arrangement logic. No popup should ever have any influence on how the views beneath it are laid out.

Addresses [this detail aspect](https://github.com/jesseduffield/lazygit/issues/1113#issuecomment-3206883422) of #1113.