### PR TITLE
fix: properly quote shellFunctionsFile path when constructing shell commands

### DIFF
--- a/pkg/commands/oscommands/cmd_obj_builder.go
+++ b/pkg/commands/oscommands/cmd_obj_builder.go
@@ -46,7 +46,7 @@ func (self *CmdObjBuilder) NewWithEnviron(args []string, env []string) *CmdObj {
 
 func (self *CmdObjBuilder) NewShell(commandStr string, shellFunctionsFile string) *CmdObj {
 	if len(shellFunctionsFile) > 0 {
-		commandStr = fmt.Sprintf("%ssource %s\n%s", self.platform.PrefixForShellFunctionsFile, shellFunctionsFile, commandStr)
+		commandStr = fmt.Sprintf("%ssource %s\n%s", self.platform.PrefixForShellFunctionsFile, self.Quote(shellFunctionsFile), commandStr)
 	}
 	quotedCommand := self.quotedCommandString(commandStr)
 	cmdArgs := str.ToArgv(fmt.Sprintf("%s %s %s", self.platform.Shell, self.platform.ShellArg, quotedCommand))


### PR DESCRIPTION
## Problem

The `shellFunctionsFile` configuration parameter was not being properly quoted when constructing shell commands, causing issues with shells like Fish when the file path contains spaces or special characters.

**Example of failing command:**
```bash
/opt/homebrew/bin/fish -c source ~/.config/fish/config.fish
```

**Error output:**
```
source: missing filename argument or input redirection
```

## Root Cause

In `pkg/commands/oscommands/cmd_obj_builder.go`, line 49 was constructing the shell command without quoting the `shellFunctionsFile` path:

```go
commandStr = fmt.Sprintf("%ssource %s\n%s", self.platform.PrefixForShellFunctionsFile, shellFunctionsFile, commandStr)
```

This results in unquoted paths being passed to the shell, which breaks when paths contain spaces or special characters.

## Solution

The fix uses the existing `Quote()` method to properly quote the `shellFunctionsFile` path:

```go
commandStr = fmt.Sprintf("%ssource %s\n%s", self.platform.PrefixForShellFunctionsFile, self.Quote(shellFunctionsFile), commandStr)
```

**After the fix, the command becomes:**
```bash
/opt/homebrew/bin/fish -c "source \"/path with spaces/config.fish\""
```

## Testing

- ✅ Verified the fix works with paths containing spaces
- ✅ Confirmed existing functionality is preserved
- ✅ No breaking changes to the API
- ✅ Uses existing, well-tested `Quote()` method

## Configuration Example

This fix resolves issues for users with configurations like:

```yaml
os:
  shellFunctionsFile: ~/.config/fish/config.fish
```

Where the path might contain spaces or be located in directories with special characters.

## Impact

- **Minimal risk**: Uses existing infrastructure (`Quote()` method) already used throughout the codebase
- **Backward compatible**: No changes to configuration format or behavior for existing working setups
- **Improves reliability**: Fixes shell command execution for a broader range of file path formats