### PR TITLE
Show a better error message if the temp directory is not writeable

### DIFF
--- a/pkg/app/entry_point.go
+++ b/pkg/app/entry_point.go
@@ -125,8 +125,13 @@ func Start(buildInfo *BuildInfo, integrationTest integrationTypes.IntegrationTes
 		os.Exit(0)
 	}
 
-	tempDir, err := os.MkdirTemp(getTempDirBase(), "lazygit-*")
+	tempDirBase := getTempDirBase()
+	tempDir, err := os.MkdirTemp(tempDirBase, "lazygit-*")
 	if err != nil {
+		if os.IsPermission(err) {
+			log.Fatalf("Your temp directory (%s) is not writeable. Try if rebooting your machine fixes this.", tempDirBase)
+		}
+
 		log.Fatal(err.Error())
 	}
 	defer os.RemoveAll(tempDir)


### PR DESCRIPTION
This happened to a few users after updating macOS to version 15.7.1, and apparently a reboot fixes it, so suggest this in the error message.

Closes #4924