### PR TITLE
Use a PTY when using external diff command from git config

### DIFF
--- a/pkg/gui/pty.go
+++ b/pkg/gui/pty.go
@@ -47,9 +47,10 @@ func (gui *Gui) newPtyTask(view *gocui.View, cmd *exec.Cmd, prefix string) error
 	width := view.InnerWidth()
 	pager := gui.stateAccessor.GetPagerConfig().GetPagerCommand(width)
 	externalDiffCommand := gui.stateAccessor.GetPagerConfig().GetExternalDiffCommand()
+	useExtDiffGitConfig := gui.stateAccessor.GetPagerConfig().GetUseExternalDiffGitConfig()
 
-	if pager == "" && externalDiffCommand == "" {
-		// if we're not using a custom pager we don't need to use a pty
+	if pager == "" && externalDiffCommand == "" && !useExtDiffGitConfig {
+		// If we're not using a custom pager nor external diff command, then we don't need to use a pty
 		return gui.newCmdTask(view, cmd, prefix)
 	}
 


### PR DESCRIPTION
### PR Description

I hit the same issue as https://github.com/jesseduffield/lazygit/issues/3119 when setting `useExtDiffGitConfig` to true and using `difftastic` side-by-side comparison in my git config.

The same fix in https://github.com/jesseduffield/lazygit/pull/3120 needs to be applied for the newer config option.

### Please check if the PR fulfills these requirements

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
