### PR TITLE
Fix fixup's false filename detection in hunks containing dashed lines

### DIFF
--- a/pkg/gui/controllers/helpers/fixup_helper.go
+++ b/pkg/gui/controllers/helpers/fixup_helper.go
@@ -194,7 +194,7 @@ func parseDiff(diff string) ([]*hunk, []*hunk) {
 		if strings.HasPrefix(line, "diff --git") {
 			finishHunk()
 			currentHunk = nil
-		} else if strings.HasPrefix(line, "--- ") {
+		} else if currentHunk == nil && strings.HasPrefix(line, "--- ") {
 			// For some reason, the line ends with a tab character if the file
 			// name contains spaces
 			filename = strings.TrimRight(line[6:], "\t")

--- a/pkg/gui/controllers/helpers/fixup_helper_test.go
+++ b/pkg/gui/controllers/helpers/fixup_helper_test.go
@@ -79,6 +79,26 @@ index 9ce8efb33..fb5e469e7 100644
 			},
 		},
 		{
+			name: "hunk with dashed lines",
+			diff: `
+diff --git a/file1.txt b/file1.txt
+index 9ce8efb33..fb5e469e7 100644
+--- a/file1.txt
++++ b/file1.txt
+@@ -3,1 +3,1 @@
+--- xxx
++-- yyy
+`,
+			expectedDeletedLineHunks: []*hunk{
+				{
+					filename:     "file1.txt",
+					startLineIdx: 3,
+					numLines:     1,
+				},
+			},
+			expectedAddedLineHunks: []*hunk{},
+		},
+		{
 			name: "several hunks in different files",
 			diff: `
 diff --git a/file1.txt b/file1.txt


### PR DESCRIPTION
### PR Description

The existing diff parser incorrectly treated subsequent lines beginning with `---` as filename headers while processing hunks.  This caused corruption when dashed lines appeared within diffs themselves.

Restrict filename detection to only occur between hunks.

This repository https://github.com/abobov/lazygit-fixup-issue demonstrates the issue:

- clone repository
- run `git reset --soft HEAD~`
- try `<c-f>` Find base commit for fixup 
- `fatal: no such path ...` error


### Please check if the PR fulfills these requirements

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
