### PR TITLE
Allow using SelectedSubmodule in CustomCommands

### DIFF
--- a/docs-master/Custom_Command_Keybindings.md
+++ b/docs-master/Custom_Command_Keybindings.md
@@ -299,6 +299,7 @@ SelectedCommit
 SelectedCommitRange
 SelectedFile
 SelectedPath
+SelectedSubmodule
 SelectedLocalBranch
 SelectedRemoteBranch
 SelectedRemote

--- a/pkg/gui/services/custom_commands/models.go
+++ b/pkg/gui/services/custom_commands/models.go
@@ -43,6 +43,12 @@ type File struct {
 	IsWorktree              bool
 }
 
+type Submodule struct {
+	Name string
+	Path string
+	Url  string
+}
+
 type Branch struct {
 	Name           string
 	DisplayName    string

--- a/pkg/gui/services/custom_commands/session_state_loader.go
+++ b/pkg/gui/services/custom_commands/session_state_loader.go
@@ -62,6 +62,18 @@ func fileShimFromModelFile(file *models.File) *File {
 	}
 }
 
+func submoduleShimFromModelSubmodule(submodule *models.SubmoduleConfig) *Submodule {
+	if submodule == nil {
+		return nil
+	}
+
+	return &Submodule{
+		Name: submodule.Name,
+		Path: submodule.Path,
+		Url:  submodule.Url,
+	}
+}
+
 func branchShimFromModelBranch(branch *models.Branch) *Branch {
 	if branch == nil {
 		return nil
@@ -186,6 +198,7 @@ type SessionState struct {
 	SelectedCommit         *Commit
 	SelectedCommitRange    *CommitRange
 	SelectedFile           *File
+	SelectedSubmodule      *Submodule
 	SelectedPath           string
 	SelectedLocalBranch    *Branch
 	SelectedRemoteBranch   *RemoteBranch
@@ -225,6 +238,7 @@ func (self *SessionStateLoader) call() *SessionState {
 
 	return &SessionState{
 		SelectedFile:           fileShimFromModelFile(self.c.Contexts().Files.GetSelectedFile()),
+		SelectedSubmodule:      submoduleShimFromModelSubmodule(self.c.Contexts().Submodules.GetSelected()),
 		SelectedPath:           selectedPath,
 		SelectedLocalCommit:    selectedLocalCommit,
 		SelectedReflogCommit:   selectedReflogCommit,

--- a/pkg/integration/tests/custom_commands/selected_submodule.go
+++ b/pkg/integration/tests/custom_commands/selected_submodule.go
@@ -1,0 +1,52 @@
+package custom_commands
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var SelectedSubmodule = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Use the {{ .SelectedSubmodule }} template variable",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo: func(shell *Shell) {
+		shell.EmptyCommit("Initial commit")
+		shell.CloneIntoSubmodule("submodule", "path/submodule")
+		shell.Commit("Add submodule")
+	},
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.GetUserConfig().CustomCommands = []config.CustomCommand{
+			{
+				Key:     "X",
+				Context: "submodules",
+				Command: "printf '%s' '{{ .SelectedSubmodule.Path }}' > file.txt",
+			},
+			{
+				Key:     "U",
+				Context: "submodules",
+				Command: "printf '%s' '{{ .SelectedSubmodule.Url }}' > file.txt",
+			},
+			{
+				Key:     "N",
+				Context: "submodules",
+				Command: "printf '%s' '{{ .SelectedSubmodule.Name }}' > file.txt",
+			},
+		}
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Submodules().
+			Focus().
+			Lines(
+				Contains("submodule").IsSelected(),
+			)
+
+		t.Views().Submodules().Press("X")
+		t.FileSystem().FileContent("file.txt", Equals("path/submodule"))
+
+		t.Views().Submodules().Press("U")
+		t.FileSystem().FileContent("file.txt", Equals("../submodule"))
+
+		t.Views().Submodules().Press("N")
+		t.FileSystem().FileContent("file.txt", Equals("submodule"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -178,6 +178,7 @@ var tests = []*components.IntegrationTest{
 	custom_commands.SelectedCommit,
 	custom_commands.SelectedCommitRange,
 	custom_commands.SelectedPath,
+	custom_commands.SelectedSubmodule,
 	custom_commands.ShowOutputInPanel,
 	custom_commands.SuggestionsCommand,
 	custom_commands.SuggestionsPreset,


### PR DESCRIPTION
### PR Description

This PR allows the use of `{{ SelectedSubmodule.Path }}`, `{{ SelectedSubmodule.Name }}` and `{{ SelectedSubmodule.Url }}` in custom commands.

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
