### PR TITLE
Switch to branches view when checking out a commit

### DIFF
--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -61,6 +61,10 @@ func (self *RefsHelper) CheckoutRef(ref string, options types.CheckoutRefOptions
 		return self.c.WithWaitingStatus(waitingStatus, f)
 	}
 
+	// Switch to the branches context _before_ starting to check out the branch, so that we see the
+	// inline status. This is a no-op if the branches panel is already focused.
+	self.c.Context().Push(self.c.Contexts().Branches, types.OnFocusOpts{})
+
 	return withCheckoutStatus(func(gocui.Task) error {
 		if err := self.c.Git().Branch.Checkout(ref, cmdOptions); err != nil {
 			// note, this will only work for english-language git commands. If we force git to use english, and the error isn't this one, then the user will receive an english command they may not understand. I'm not sure what the best solution to this is. Running the command once in english and a second time in the native language is one option
@@ -109,11 +113,6 @@ func (self *RefsHelper) CheckoutRef(ref string, options types.CheckoutRefOptions
 // Shows a prompt to choose between creating a new branch or checking out a detached head
 func (self *RefsHelper) CheckoutRemoteBranch(fullBranchName string, localBranchName string) error {
 	checkout := func(branchName string) error {
-		// Switch to the branches context _before_ starting to check out the
-		// branch, so that we see the inline status
-		if self.c.Context().Current() != self.c.Contexts().Branches {
-			self.c.Context().Push(self.c.Contexts().Branches, types.OnFocusOpts{})
-		}
 		return self.CheckoutRef(branchName, types.CheckoutRefOptions{})
 	}
 

--- a/pkg/gui/controllers/tags_controller.go
+++ b/pkg/gui/controllers/tags_controller.go
@@ -155,7 +155,6 @@ func (self *TagsController) checkout(tag *models.Tag) error {
 	if err := self.c.Helpers().Refs.CheckoutRef(tag.FullRefName(), types.CheckoutRefOptions{}); err != nil {
 		return err
 	}
-	self.c.Context().Push(self.c.Contexts().Branches, types.OnFocusOpts{})
 	return nil
 }
 

--- a/pkg/integration/tests/commit/checkout.go
+++ b/pkg/integration/tests/commit/checkout.go
@@ -43,14 +43,16 @@ var Checkout = NewIntegrationTest(NewIntegrationTestArgs{
 			Select(MatchesRegexp("Checkout commit [a-f0-9]+ as detached head")).
 			Confirm()
 		t.Views().Branches().
+			IsFocused().
 			Lines(
-				Contains("* (HEAD detached at"),
+				Contains("* (HEAD detached at").IsSelected(),
 				Contains("branch1"),
 				Contains("branch2"),
 				Contains("master"),
 			)
 
 		t.Views().Commits().
+			Focus().
 			NavigateToLine(Contains("two")).
 			PressPrimaryAction()
 
@@ -65,8 +67,9 @@ var Checkout = NewIntegrationTest(NewIntegrationTestArgs{
 			Select(Contains("Checkout branch 'master'")).
 			Confirm()
 		t.Views().Branches().
+			IsFocused().
 			Lines(
-				Contains("master"),
+				Contains("master").IsSelected(),
 				Contains("branch1"),
 				Contains("branch2"),
 			)

--- a/pkg/integration/tests/undo/undo_checkout_and_drop.go
+++ b/pkg/integration/tests/undo/undo_checkout_and_drop.go
@@ -102,11 +102,13 @@ var UndoCheckoutAndDrop = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 
 				t.Views().Branches().
+					IsFocused().
 					Lines(
 						Contains("master").IsSelected(),
 						Contains("other_branch"),
 					)
 			}).
+			Focus().
 			Lines(
 				Contains("three").IsSelected(),
 				Contains("two"),
@@ -135,11 +137,13 @@ var UndoCheckoutAndDrop = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 
 				t.Views().Branches().
+					IsFocused().
 					Lines(
 						Contains("other_branch").IsSelected(),
 						Contains("master"),
 					)
 			}).
+			Focus().
 			Press(keys.Universal.Redo).
 			Tap(confirmRedoDrop).
 			Lines(


### PR DESCRIPTION
We move the code to push the branches context into CheckoutRef, this way it works consistently no matter where we call it from. Previously, checking out remote branches or tags would switch to the branches view, but checking out a commit did not.

Note that it now also takes effect for undoing or redoing a checkout, which may be a bit questionable; but I still think it makes sense for this, too.