### PR TITLE
Don't use "HEADLESS" environment variable for running tests

### DIFF
--- a/pkg/gui/test_mode.go
+++ b/pkg/gui/test_mode.go
@@ -61,5 +61,5 @@ func (gui *Gui) handleTestMode() {
 }
 
 func Headless() bool {
-	return os.Getenv("HEADLESS") != ""
+	return os.Getenv("LAZYGIT_HEADLESS") != ""
 }

--- a/pkg/integration/clients/go_test.go
+++ b/pkg/integration/clients/go_test.go
@@ -65,7 +65,7 @@ func TestIntegration(t *testing.T) {
 func runCmdHeadless(cmd *exec.Cmd) (int, error) {
 	cmd.Env = append(
 		cmd.Env,
-		"HEADLESS=true",
+		"LAZYGIT_HEADLESS=true",
 		"TERM=xterm",
 	)
 


### PR DESCRIPTION
It is a bit generic, it seems that users sometimes set it for other reasons (see https://github.com/jesseduffield/lazygit/issues/5030#issuecomment-3541000735), and then they are confused why they don't see anything. Use a more specific name instead.

