### PR TITLE
refactor: use strings.Builder and strings.Repeat to simplify code

### DIFF
--- a/pkg/cheatsheet/generate.go
+++ b/pkg/cheatsheet/generate.go
@@ -195,20 +195,21 @@ func getHeader(binding *types.Binding, tr *i18n.TranslationSet) header {
 }
 
 func formatSections(tr *i18n.TranslationSet, bindingSections []*bindingSection) string {
-	content := fmt.Sprintf("# Lazygit %s\n", tr.Keybindings)
+	var content strings.Builder
+	content.WriteString(fmt.Sprintf("# Lazygit %s\n", tr.Keybindings))
 
-	content += fmt.Sprintf("\n%s\n", italicize(tr.KeybindingsLegend))
+	content.WriteString(fmt.Sprintf("\n%s\n", italicize(tr.KeybindingsLegend)))
 
 	for _, section := range bindingSections {
-		content += formatTitle(section.title)
-		content += "| Key | Action | Info |\n"
-		content += "|-----|--------|-------------|\n"
+		content.WriteString(formatTitle(section.title))
+		content.WriteString("| Key | Action | Info |\n")
+		content.WriteString("|-----|--------|-------------|\n")
 		for _, binding := range section.bindings {
-			content += formatBinding(binding)
+			content.WriteString(formatBinding(binding))
 		}
 	}
 
-	return content
+	return content.String()
 }
 
 func formatTitle(title string) string {

--- a/pkg/commands/patch/patch_builder.go
+++ b/pkg/commands/patch/patch_builder.go
@@ -66,22 +66,22 @@ func (p *PatchBuilder) Start(from, to string, reverse bool, canRebase bool) {
 }
 
 func (p *PatchBuilder) PatchToApply(reverse bool, turnAddedFilesIntoDiffAgainstEmptyFile bool) string {
-	patch := ""
+	var patch strings.Builder
 
 	for filename, info := range p.fileInfoMap {
 		if info.mode == UNSELECTED {
 			continue
 		}
 
-		patch += p.RenderPatchForFile(RenderPatchForFileOpts{
+		patch.WriteString(p.RenderPatchForFile(RenderPatchForFileOpts{
 			Filename:                               filename,
 			Plain:                                  true,
 			Reverse:                                reverse,
 			TurnAddedFilesIntoDiffAgainstEmptyFile: turnAddedFilesIntoDiffAgainstEmptyFile,
-		})
+		}))
 	}
 
-	return patch
+	return patch.String()
 }
 
 func (p *PatchBuilder) addFileWhole(info *fileInfo) {

--- a/pkg/gui/presentation/submodules.go
+++ b/pkg/gui/presentation/submodules.go
@@ -1,6 +1,8 @@
 package presentation
 
 import (
+	"strings"
+
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/theme"
 	"github.com/samber/lo"
@@ -15,11 +17,11 @@ func GetSubmoduleListDisplayStrings(submodules []*models.SubmoduleConfig) [][]st
 func getSubmoduleDisplayStrings(s *models.SubmoduleConfig) []string {
 	name := s.Name
 	if s.ParentModule != nil {
-		indentation := ""
+		count := 0
 		for p := s.ParentModule; p != nil; p = p.ParentModule {
-			indentation += "  "
+			count++
 		}
-
+		indentation := strings.Repeat("  ", count)
 		name = indentation + "- " + s.Name
 	}
 


### PR DESCRIPTION
### PR Description

strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)



### Please check if the PR fulfills these requirements

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
