### PR TITLE
Add fallback to detecting main branches for fresh repositories

### DIFF
--- a/pkg/commands/git_commands/main_branches.go
+++ b/pkg/commands/git_commands/main_branches.go
@@ -113,6 +113,18 @@ func (self *MainBranches) determineMainBranches(configuredMainBranches []string)
 				NewGitCmd("rev-parse").Arg("--verify", "--quiet", ref).ToArgv(),
 			).DontLog().Run(); err == nil {
 				existingBranches[i] = ref
+				return
+			}
+
+			// If this is a brand new repository with no commits, then the current branch would be the default
+			desiredRef := "refs/heads/" + branchName
+			if ref, err := self.cmd.New(
+				NewGitCmd("symbolic-ref").Arg("HEAD").ToArgv(),
+			).DontLog().RunWithOutput(); err == nil {
+				if strings.TrimSpace(ref) == desiredRef {
+					existingBranches[i] = desiredRef
+					return
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### PR Description
All other attempts to determine the main branch fail on a fresh repository right after `git init` because there are no actual commits that these branches point to.

Fixes https://github.com/jesseduffield/lazygit/issues/5058
### Please check if the PR fulfills these requirements

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc
