### PR TITLE
feat: batch file remove actions

### DIFF
--- a/pkg/commands/git_commands/working_tree_test.go
+++ b/pkg/commands/git_commands/working_tree_test.go
@@ -70,7 +70,7 @@ func TestWorkingTreeUnstageFile(t *testing.T) {
 // these tests don't cover everything, in part because we already have an integration
 // test which does cover everything. I don't want to unnecessarily assert on the 'how'
 // when the 'what' is what matters
-func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
+func TestWorkingTreeDiscardAllFilesChanges(t *testing.T) {
 	type scenario struct {
 		testName      string
 		file          *models.File
@@ -190,7 +190,7 @@ func TestWorkingTreeDiscardAllFileChanges(t *testing.T) {
 	for _, s := range scenarios {
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildWorkingTreeCommands(commonDeps{runner: s.runner, removeFile: s.removeFile})
-			err := instance.DiscardAllFileChanges(s.file)
+			err := instance.DiscardAllFilesChanges([]*models.File{s.file})
 
 			if s.expectedError == "" {
 				assert.Nil(t, err)
@@ -476,7 +476,7 @@ func TestWorkingTreeDiscardUnstagedFileChanges(t *testing.T) {
 	for _, s := range scenarios {
 		t.Run(s.testName, func(t *testing.T) {
 			instance := buildWorkingTreeCommands(commonDeps{runner: s.runner})
-			s.test(instance.DiscardUnstagedFileChanges(s.file))
+			s.test(instance.DiscardUnstagedFilesChanges([]*models.File{s.file}))
 			s.runner.CheckForMissingCalls()
 		})
 	}

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -1382,10 +1382,20 @@ func (self *FilesController) remove(selectedNodes []*filetree.FileNode) error {
 				defer self.context().CancelRangeSelect()
 			}
 
+			// Collect all files from the selected nodes
+			var files []*models.File
 			for _, node := range selectedNodes {
-				if err := self.c.Git().WorkingTree.DiscardAllDirChanges(node); err != nil {
+				if err := node.ForEachFile(func(file *models.File) error {
+					files = append(files, file)
+					return nil
+				}); err != nil {
 					return err
 				}
+			}
+
+			// TODO: Send all nodes to delete untracked directories
+			if err := self.c.Git().WorkingTree.DiscardAllFilesChanges(files); err != nil {
+				return err
 			}
 
 			self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES, types.WORKTREES}})
@@ -1409,10 +1419,20 @@ func (self *FilesController) remove(selectedNodes []*filetree.FileNode) error {
 				defer self.context().CancelRangeSelect()
 			}
 
+			// Collect all files from the selected nodes
+			var files []*models.File
 			for _, node := range selectedNodes {
-				if err := self.c.Git().WorkingTree.DiscardUnstagedDirChanges(node); err != nil {
+				if err := node.ForEachFile(func(file *models.File) error {
+					files = append(files, file)
+					return nil
+				}); err != nil {
 					return err
 				}
+			}
+
+			// TODO: Send all nodes to delete untracked directories
+			if err := self.c.Git().WorkingTree.DiscardUnstagedFilesChanges(files); err != nil {
+				return err
 			}
 
 			self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.FILES, types.WORKTREES}})


### PR DESCRIPTION
### PR Description

closes #4581

when pressing the remove keymap for files, we now group them up by the action we will perform on them, and then execute each action in bulk for all the files. This is a much faster approach than executing for each file.

some notes:
- was initially fully generated by ai, but i edited it a decent amount
- the discard unstaged files logic can be a separate change if need be, ai went ahead and did both to begin with so figured i'd go with it
- trusting that existing integration tests and unit tests are good enough since this is not new behavior, but open to adding more

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc