### PR TITLE
Fix to support creating MRs for repositories cloned with SSH alias

### DIFF
--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -4,7 +4,7 @@ package hosting_service
 // at https://regex101.com using the flavor Golang
 var defaultUrlRegexStrings = []string{
 	`^(?:https?|ssh)://[^/]+/(?P<owner>.*)/(?P<repo>.*?)(?:\.git)?$`,
-	`^.*?@.*:/*(?P<owner>.*)/(?P<repo>.*?)(?:\.git)?$`,
+	`^(.*?@)?.*:/*(?P<owner>.*)/(?P<repo>.*?)(?:\.git)?$`,
 }
 var defaultRepoURLTemplate = "https://{{.webDomain}}/{{.owner}}/{{.repo}}"
 

--- a/pkg/commands/hosting_service/hosting_service_test.go
+++ b/pkg/commands/hosting_service/hosting_service_test.go
@@ -57,6 +57,16 @@ func TestGetPullRequestURL(t *testing.T) {
 			},
 		},
 		{
+			testName:             "Opens a link to new pull request on github custom SSH config alias and a corresponding service config",
+			from:                 "feature/sum-operation",
+			remoteUrl:            "github:peter/calculator.git",
+			configServiceDomains: map[string]string{"github": "github:github.com"},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://github.com/peter/calculator/compare/feature%2Fsum-operation?expand=1", url)
+			},
+		},
+		{
 			testName:  "Opens a link to new pull request on github with extra slash removed",
 			from:      "feature/sum-operation",
 			remoteUrl: "git@github.com:/peter/calculator.git",
@@ -128,6 +138,16 @@ func TestGetPullRequestURL(t *testing.T) {
 			testName:  "Opens a link to new pull request on gitlab",
 			from:      "feature/ui",
 			remoteUrl: "git@gitlab.com:peter/calculator.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://gitlab.com/peter/calculator/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fui", url)
+			},
+		},
+		{
+			testName:             "Opens a link to new pull request on gitlab with custom SSH config alias and a corresponding service config",
+			from:                 "feature/ui",
+			remoteUrl:            "gitlab:peter/calculator.git",
+			configServiceDomains: map[string]string{"gitlab": "gitlab:gitlab.com"},
 			test: func(url string, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, "https://gitlab.com/peter/calculator/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fui", url)


### PR DESCRIPTION
### PR Description

Use case: some repositories are cloned with a full SSH alias (without a user). E.g. in `.ssh/config` you have

```
Host gitlab
    HostName gitlab.com
    User git
    IdentityFile ...
```

and then you clone with `git clone gitlab:foo/bar`

According to the docs, you can add a service to `config.yaml` and it should work:

```yaml
services:
  gitlab: 'gitlab:gitlab.com'
```

But currently it doesn't because lazygit expects all remote URLs to have a user. This can be fixed by the user by changing the URL to e.g. `git@gitlab:foo/bar`, but it breaks the user flow and is quite unexpected.

This PR changes `defaultUrlRegexStrings` and makes the `user@` part of the remote URL optional. Fixes the issue for Github and Gitlab which use the default regexes.

### Please check if the PR fulfills these requirements

* [*] Cheatsheets are up-to-date (run `go generate ./...`)
* [*] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [*] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [*] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [*] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [*] Docs have been updated if necessary
* [*] You've read through your own file changes for silly mistakes etc
