### PR TITLE
Prevent lazygit crashing for some xcbuild metadata

### DIFF
--- a/pkg/integration/components/runner.go
+++ b/pkg/integration/components/runner.go
@@ -246,7 +246,11 @@ func getLazygitCommand(
 	cmdObj.AddEnvVars(fmt.Sprintf("GORACE=log_path=%s", raceDetectorLogsPath()))
 	if test.ExtraEnvVars() != nil {
 		for key, value := range test.ExtraEnvVars() {
-			cmdObj.AddEnvVars(fmt.Sprintf("%s=%s", key, value))
+			resolvedValue := utils.ResolvePlaceholderString(value, map[string]string{
+				"actualPath":     paths.Actual(),
+				"actualRepoPath": paths.ActualRepo(),
+			})
+			cmdObj.AddEnvVars(fmt.Sprintf("%s=%s", key, resolvedValue))
 		}
 	}
 

--- a/pkg/integration/tests/misc/git_warning.go
+++ b/pkg/integration/tests/misc/git_warning.go
@@ -1,0 +1,51 @@
+package misc
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var GitWarning = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Verify lazygit handles git warnings without crashing",
+	ExtraCmdArgs: []string{},
+	ExtraEnvVars: map[string]string{
+		"PATH": "{{actualRepoPath}}/bin:" + os.Getenv("PATH"),
+	},
+	Skip:        runtime.GOOS == "windows", // Shell wrapper won't work on Windows
+	SetupConfig: func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		// Create bin directory for our git wrapper
+		shell.CreateDir("bin")
+
+		// Create a git wrapper that outputs the warning then calls real git
+		shell.CreateFile("bin/git", `#!/bin/sh
+echo "warning: unhandled Platform key FamilyDisplayName" >&2
+exec /usr/bin/git "$@"
+`)
+		shell.MakeExecutable("bin/git")
+
+		// Create a simple repo with a commit
+		shell.CreateFileAndAdd("file.txt", "content").
+			Commit("initial commit")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		// Simply verify lazygit opens and shows the files view without crashing
+		// The git wrapper outputs the warning on every git command
+		t.Views().Files().IsFocused()
+
+		// Navigate to branches to trigger more git commands
+		t.Views().Branches().Focus()
+		t.Views().Branches().Lines(
+			Contains("master"),
+		)
+
+		// Navigate to commits to trigger git log
+		t.Views().Commits().Focus()
+		t.Views().Commits().Lines(
+			Contains("initial commit"),
+		)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -315,6 +315,7 @@ var tests = []*components.IntegrationTest{
 	misc.CopyConfirmationMessageToClipboard,
 	misc.CopyToClipboard,
 	misc.DisabledKeybindings,
+	misc.GitWarning,
 	misc.InitialOpen,
 	misc.RecentReposOnLaunch,
 	patch_building.Apply,


### PR DESCRIPTION
When nix brings in xcbuild as a transitive dependency on macOS, if there are new metadata tags that the nix-specific version of xcbuild doesn't support, then `git status` will write a warning to stderr like: `warning: unhandled Platform key FamilyDisplayName`. That stderr message causes lazygit to crash. My fix is to filter out the warnings and then redirect them to the lazygit log

Fixes #5013

### PR Description

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* ~~[ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))~~
  *  not needed, there are no user-facing changes
* ~~[ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))~~
* ~~[ ] Docs have been updated if necessary~~
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
