### PR TITLE
Remove confirmation for opening the merge tool

### DIFF
--- a/pkg/gui/controllers/helpers/working_tree_helper.go
+++ b/pkg/gui/controllers/helpers/working_tree_helper.go
@@ -90,18 +90,10 @@ func (self *WorkingTreeHelper) FileForSubmodule(submodule *models.SubmoduleConfi
 }
 
 func (self *WorkingTreeHelper) OpenMergeTool() error {
-	self.c.Confirm(types.ConfirmOpts{
-		Title:  self.c.Tr.MergeToolTitle,
-		Prompt: self.c.Tr.MergeToolPrompt,
-		HandleConfirm: func() error {
-			self.c.LogAction(self.c.Tr.Actions.OpenMergeTool)
-			return self.c.RunSubprocessAndRefresh(
-				self.c.Git().WorkingTree.OpenMergeToolCmdObj(),
-			)
-		},
-	})
-
-	return nil
+	self.c.LogAction(self.c.Tr.Actions.OpenMergeTool)
+	return self.c.RunSubprocessAndRefresh(
+		self.c.Git().WorkingTree.OpenMergeToolCmdObj(),
+	)
 }
 
 func (self *WorkingTreeHelper) HandleCommitPressWithMessage(initialMessage string, forceSkipHooks bool) error {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -247,8 +247,6 @@ type TranslationSet struct {
 	UpdateFailedErr                       string
 	ConfirmQuitDuringUpdateTitle          string
 	ConfirmQuitDuringUpdate               string
-	MergeToolTitle                        string
-	MergeToolPrompt                       string
 	IntroPopupMessage                     string
 	NonReloadableConfigWarningTitle       string
 	NonReloadableConfigWarning            string
@@ -1343,8 +1341,6 @@ func EnglishTranslationSet() *TranslationSet {
 		UpdateFailedErr:                      "Update failed: {{.errMessage}}",
 		ConfirmQuitDuringUpdateTitle:         "Currently updating",
 		ConfirmQuitDuringUpdate:              "An update is in progress. Are you sure you want to quit?",
-		MergeToolTitle:                       "Merge tool",
-		MergeToolPrompt:                      "Are you sure you want to open `git mergetool`?",
 		IntroPopupMessage:                    englishIntroPopupMessage,
 		NonReloadableConfigWarningTitle:      "Config changed",
 		NonReloadableConfigWarning:           englishNonReloadableConfigWarning,


### PR DESCRIPTION
The confirmation used to make sense back when the Open MergeTool command was its own top-level command; however, that command was changed in #4889 to open a menu instead, and Open MergeTool is now just a submenu entry in that menu, so it no longer needs a confirmation.

Fixes #5093.