### PR TITLE
Add keys for command log menu items

### DIFF
--- a/pkg/gui/extras_panel.go
+++ b/pkg/gui/extras_panel.go
@@ -14,6 +14,7 @@ func (gui *Gui) handleCreateExtrasMenuPanel() error {
 		Items: []*types.MenuItem{
 			{
 				Label: gui.c.Tr.ToggleShowCommandLog,
+				Key:   't',
 				OnPress: func() error {
 					currentContext := gui.c.Context().CurrentStatic()
 					if gui.c.State().GetShowExtrasWindow() && currentContext.GetKey() == context.COMMAND_LOG_CONTEXT_KEY {
@@ -28,6 +29,7 @@ func (gui *Gui) handleCreateExtrasMenuPanel() error {
 			},
 			{
 				Label:   gui.c.Tr.FocusCommandLog,
+				Key:     'f',
 				OnPress: gui.handleFocusCommandLog,
 			},
 		},


### PR DESCRIPTION
### PR Description
Adds shortcut keys for the command log menu.

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
