### PR TITLE
feat: remove key from built-in commands taken by custom commands

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -340,7 +340,7 @@ initialValue: "username/{{ runCommand "date +\"%Y/%-m\"" }}/"
 
 ## Keybinding collisions
 
-If your custom keybinding collides with an inbuilt keybinding that is defined for the same context, only the custom keybinding will be executed. This also applies to the global context. However, one caveat is that if you have a custom keybinding defined on the global context for some key, and there is an in-built keybinding defined for the same key and for a specific context (say the 'files' context), then the in-built keybinding will take precedence. See how to change in-built keybindings [here](https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#keybindings)
+If your custom keybinding collides with a built-in keybinding in the same context, only the custom keybinding will run, and only that keybinding will have its key appear in the keybindings menu (press `?`); the built-in command's key will be hidden. This also applies to the global context. The exception is when you define a custom keybinding in the global context for a key that also has a built-in binding in a specific context (say the 'files' context): the built-in keybinding will take precedence in that specific context, and both bindings will have their keys displayed. See how to change built-in keybindings [here](https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#keybindings)
 
 ## Menus of custom commands
 

--- a/pkg/gui/controllers/options_menu_action.go
+++ b/pkg/gui/controllers/options_menu_action.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"github.com/jesseduffield/generics/set"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
@@ -75,7 +76,13 @@ func (self *OptionsMenuAction) getBindings(context types.Context) ([]*types.Bind
 		}
 	}
 
-	return uniqueBindings(bindingsPanel), uniqueBindings(bindingsGlobal), uniqueBindings(bindingsNavigation)
+	bindingsGlobal = uniqueBindings(bindingsGlobal)
+	deduplicateKey(bindingsGlobal)
+	bindingsPanel = uniqueBindings(bindingsPanel)
+	deduplicateKey(bindingsPanel)
+	bindingsNavigation = uniqueBindings(bindingsNavigation)
+	deduplicateKey(bindingsNavigation)
+	return bindingsPanel, bindingsGlobal, bindingsNavigation
 }
 
 // We shouldn't really need to do this. We should define alternative keys for the same
@@ -84,4 +91,14 @@ func uniqueBindings(bindings []*types.Binding) []*types.Binding {
 	return lo.UniqBy(bindings, func(binding *types.Binding) string {
 		return binding.GetDescription()
 	})
+}
+
+func deduplicateKey(bindings []*types.Binding) {
+	seen := set.New[types.Key]()
+	for _, binding := range bindings {
+		if seen.Includes(binding.Key) {
+			binding.Key = nil
+		}
+		seen.Add(binding.Key)
+	}
 }

--- a/pkg/integration/tests/custom_commands/keybindings.go
+++ b/pkg/integration/tests/custom_commands/keybindings.go
@@ -1,0 +1,47 @@
+package custom_commands
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var Keybindings = NewIntegrationTest(NewIntegrationTestArgs{
+	Description: "Display the keybindings with custom commands",
+	SetupRepo:   func(shell *Shell) {},
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.GetUserConfig().CustomCommands = []config.CustomCommand{
+			{
+				Key:     "a",
+				Context: "files",
+				Command: "touch myfile",
+			},
+			{
+				Key:     "p",
+				Context: "files",
+				Command: "fake pull",
+			},
+		}
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().Press("?")
+
+		t.ExpectPopup().Menu().
+			Title(Equals("Keybindings")).
+			ContainsLines(
+				Contains("a touch myfile"),
+				DoesNotContain("a Stage all"),
+			)
+
+		t.ExpectPopup().Menu().
+			Title(Equals("Keybindings")).
+			ContainsLines(
+				Contains("p fake pull"),
+			)
+
+		t.ExpectPopup().Menu().
+			Title(Equals("Keybindings")).
+			ContainsLines(
+				Contains("p Pull"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -172,6 +172,7 @@ var tests = []*components.IntegrationTest{
 	custom_commands.CustomCommandsSubmenu,
 	custom_commands.FormPrompts,
 	custom_commands.GlobalContext,
+	custom_commands.Keybindings,
 	custom_commands.MenuFromCommand,
 	custom_commands.MenuFromCommandsOutput,
 	custom_commands.MultipleContexts,


### PR DESCRIPTION
### PR Description

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

This PR aims to remove the key in keybindings for commands for which the key doesn't work because it is superseeded by a custom command.
Another possibility is to replace the key by the crossed version of the string.
