### PR TITLE
Add Codeberg as a supported git hosting service

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -1078,7 +1078,7 @@ services:
 Where:
 
 - `gitDomain` stands for the domain used by git itself (i.e. the one present on clone URLs), e.g. `git.work.com`
-- `provider` is one of `github`, `bitbucket`, `bitbucketServer`, `azuredevops`, `gitlab` or `gitea`
+- `provider` is one of `github`, `bitbucket`, `bitbucketServer`, `azuredevops`, `gitlab`, `gitea` or `codeberg`
 - `webDomain` is the URL where your git service exposes a web interface and APIs, e.g. `gitservice.work.com`
 
 ## Predefined commit message prefix

--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -75,6 +75,15 @@ var giteaServiceDef = ServiceDefinition{
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }
 
+var codebergServiceDef = ServiceDefinition{
+	provider:                        "codeberg",
+	pullRequestURLIntoDefaultBranch: "/compare/{{.From}}",
+	pullRequestURLIntoTargetBranch:  "/compare/{{.To}}...{{.From}}",
+	commitURL:                       "/commit/{{.CommitHash}}",
+	regexStrings:                    defaultUrlRegexStrings,
+	repoURLTemplate:                 defaultRepoURLTemplate,
+}
+
 var serviceDefinitions = []ServiceDefinition{
 	githubServiceDef,
 	bitbucketServiceDef,
@@ -82,6 +91,7 @@ var serviceDefinitions = []ServiceDefinition{
 	azdoServiceDef,
 	bitbucketServerServiceDef,
 	giteaServiceDef,
+	codebergServiceDef,
 }
 
 var defaultServiceDomains = []ServiceDomain{
@@ -109,5 +119,10 @@ var defaultServiceDomains = []ServiceDomain{
 		serviceDefinition: giteaServiceDef,
 		gitDomain:         "try.gitea.io",
 		webDomain:         "try.gitea.io",
+	},
+	{
+		serviceDefinition: codebergServiceDef,
+		gitDomain:         "codeberg.org",
+		webDomain:         "codeberg.org",
 	},
 }

--- a/pkg/commands/hosting_service/hosting_service_test.go
+++ b/pkg/commands/hosting_service/hosting_service_test.go
@@ -422,6 +422,44 @@ func TestGetPullRequestURL(t *testing.T) {
 			},
 		},
 		{
+			testName:  "Opens a link to new pull request on Codeberg (SSH)",
+			from:      "feature/new",
+			remoteUrl: "git@codeberg.org:johndoe/myrepo.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://codeberg.org/johndoe/myrepo/compare/feature%2Fnew", url)
+			},
+		},
+		{
+			testName:  "Opens a link to new pull request on Codeberg (SSH) with specific target",
+			from:      "feature/new",
+			to:        "dev",
+			remoteUrl: "git@codeberg.org:johndoe/myrepo.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://codeberg.org/johndoe/myrepo/compare/dev...feature%2Fnew", url)
+			},
+		},
+		{
+			testName:  "Opens a link to new pull request on Codeberg (HTTP)",
+			from:      "feature/new",
+			remoteUrl: "https://codeberg.org/johndoe/myrepo.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://codeberg.org/johndoe/myrepo/compare/feature%2Fnew", url)
+			},
+		},
+		{
+			testName:  "Opens a link to new pull request on Codeberg (HTTP) with specific target",
+			from:      "feature/new",
+			to:        "dev",
+			remoteUrl: "https://codeberg.org/johndoe/myrepo.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://codeberg.org/johndoe/myrepo/compare/dev...feature%2Fnew", url)
+			},
+		},
+		{
 			testName:  "Throws an error if git service is unsupported",
 			from:      "feature/divide-operation",
 			remoteUrl: "git@something.com:peter/calculator.git",
@@ -505,7 +543,7 @@ func TestGetPullRequestURL(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, "https://bitbucket.org/johndoe/social_network/pull-requests/new?source=feature%2Fprofile-page&t=1", url)
 			},
-			expectedLoggedErrors: []string{"Unknown git service type: 'noservice'. Expected one of github, bitbucket, gitlab, azuredevops, bitbucketServer, gitea"},
+			expectedLoggedErrors: []string{"Unknown git service type: 'noservice'. Expected one of github, bitbucket, gitlab, azuredevops, bitbucketServer, gitea, codeberg"},
 		},
 		{
 			testName:  "Escapes reserved URL characters in from branch name",


### PR DESCRIPTION
Thank you for an awesome tool. I wanted to add support for codeberg. Tested locally that opening pull-request works

### PR Description

Codeberg is a Gitea-based git hosting service that uses the same URL patterns for pull requests and commits but differs on its hostname

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
