### PR TITLE
Change keybinding of "keep" item in Merge Conflict menu back to 'k'

### DIFF
--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -585,7 +585,7 @@ func (self *FilesController) handleNonInlineConflict(file *models.File) error {
 		OnPress: func() error {
 			return handle(self.c.Git().WorkingTree.StageFile, self.c.Tr.Actions.ResolveConflictByKeepingFile)
 		},
-		Key: 'p',
+		Key: 'k',
 	}
 	deleteItem := &types.MenuItem{
 		Label: self.c.Tr.MergeConflictDeleteFile,


### PR DESCRIPTION
Now that we can use 'k' as a menu item binding (this was fixed in #5131), use it for the "keep" entry in the merge menu. I don't think this will be a problem for people's muscle memory, given that this menu is not encountered every day; and it's simply the better keybinding.

This reverts commit b32b55201e0b392c777846de75eae3a2183aada6.
