### PR TITLE
Add git config menu with scope switching

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -615,6 +615,7 @@ keybinding:
     startSearch: /
     optionMenu: <disabled>
     optionMenu-alt1: '?'
+    gitConfig: ;
     select: <space>
     goInto: <enter>
     confirm: <enter>

--- a/docs-master/keybindings/Keybindings_en.md
+++ b/docs-master/keybindings/Keybindings_en.md
@@ -18,6 +18,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Increase diff context size | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
 | `` { `` | Decrease diff context size | Decrease the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
+| `` ; `` | Git config |  |
 | `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | View custom patch options |  |
 | `` m `` | View merge/rebase options | View options to abort/continue/skip the current merge/rebase. |

--- a/docs-master/keybindings/Keybindings_ja.md
+++ b/docs-master/keybindings/Keybindings_ja.md
@@ -18,6 +18,7 @@ _凡例：`＜c-b＞` はctrl+b、`＜a-b＞` はalt+b、`B` はshift+bを意味
 | `` ( `` | リネーム検出の類似度しきい値を下げる | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | 差分コンテキストサイズを増やす | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
 | `` { `` | 差分コンテキストサイズを減らす | Decrease the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
+| `` ; `` | Git config |  |
 | `` : `` | シェルコマンドを実行 | 実行するシェルコマンドを入力するプロンプトを表示します。 |
 | `` <c-p> `` | カスタムパッチオプションを表示 |  |
 | `` m `` | マージ/リベースオプションを表示 | 現在のマージ/リベースを中止/継続/スキップするオプションを表示します。 |

--- a/docs-master/keybindings/Keybindings_ko.md
+++ b/docs-master/keybindings/Keybindings_ko.md
@@ -18,6 +18,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Diff 보기의 변경 사항 주위에 표시되는 컨텍스트의 크기를 늘리기 | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
 | `` { `` | Diff 보기의 변경 사항 주위에 표시되는 컨텍스트 크기 줄이기 | Decrease the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
+| `` ; `` | Git config |  |
 | `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | 커스텀 Patch 옵션 보기 |  |
 | `` m `` | View merge/rebase options | View options to abort/continue/skip the current merge/rebase. |

--- a/docs-master/keybindings/Keybindings_nl.md
+++ b/docs-master/keybindings/Keybindings_nl.md
@@ -18,6 +18,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Increase diff context size | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
 | `` { `` | Decrease diff context size | Decrease the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
+| `` ; `` | Git config |  |
 | `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | Bekijk aangepaste patch opties |  |
 | `` m `` | Bekijk merge/rebase opties | View options to abort/continue/skip the current merge/rebase. |

--- a/docs-master/keybindings/Keybindings_pl.md
+++ b/docs-master/keybindings/Keybindings_pl.md
@@ -18,6 +18,7 @@ _Legenda: `<c-b>` oznacza ctrl+b, `<a-b>` oznacza alt+b, `B` oznacza shift+b_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Zwiększ rozmiar kontekstu w widoku różnic | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
 | `` { `` | Zmniejsz rozmiar kontekstu w widoku różnic | Decrease the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
+| `` ; `` | Git config |  |
 | `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | Wyświetl opcje niestandardowej łatki |  |
 | `` m `` | Pokaż opcje scalania/rebase | Pokaż opcje do przerwania/kontynuowania/pominięcia bieżącego scalania/rebase. |

--- a/docs-master/keybindings/Keybindings_pt.md
+++ b/docs-master/keybindings/Keybindings_pt.md
@@ -18,6 +18,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Increase diff context size | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
 | `` { `` | Decrease diff context size | Decrease the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
+| `` ; `` | Git config |  |
 | `` : `` | Executar comando da shell | Traga um prompt onde você pode digitar um comando shell para executar. |
 | `` <c-p> `` | Ver opções de patch personalizadas |  |
 | `` m `` | Ver opções de mesclar/rebase | Ver opções para abortar/continuar/pular o merge/rebase atual. |

--- a/docs-master/keybindings/Keybindings_ru.md
+++ b/docs-master/keybindings/Keybindings_ru.md
@@ -18,6 +18,7 @@ _Связки клавиш_
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Увеличить размер контекста, отображаемого вокруг изменений в просмотрщике сравнении | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
 | `` { `` | Уменьшите размер контекста, отображаемого вокруг изменений в просмотрщике сравнении | Decrease the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
+| `` ; `` | Git config |  |
 | `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | Просмотреть пользовательские параметры патча |  |
 | `` m `` | Просмотреть параметры слияния/перебазирования | View options to abort/continue/skip the current merge/rebase. |

--- a/docs-master/keybindings/Keybindings_zh-CN.md
+++ b/docs-master/keybindings/Keybindings_zh-CN.md
@@ -18,6 +18,7 @@ _图例：`<c-b>` 意味着ctrl+b, `<a-b>意味着Alt+b, `B` 意味着shift+b_
 | `` ( `` | 降低重命名相似度阈值 | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | 扩大差异视图中显示的上下文范围 | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
 | `` { `` | 缩小差异视图中显示的上下文范围 | Decrease the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
+| `` ; `` | Git config |  |
 | `` : `` | 执行 Shell 命令 | 调出可输入shell命令执行的提示符。 |
 | `` <c-p> `` | 查看自定义补丁选项 |  |
 | `` m `` | 查看合并/变基选项 | 查看当前合并或变基的中止、继续、跳过选项 |

--- a/docs-master/keybindings/Keybindings_zh-TW.md
+++ b/docs-master/keybindings/Keybindings_zh-TW.md
@@ -18,6 +18,7 @@ _說明：`<c-b>` 表示 Ctrl＋B、`<a-b>` 表示 Alt＋B，`B`表示 Shift＋B
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | 增加差異檢視中顯示變更周圍上下文的大小 | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
 | `` { `` | 減小差異檢視中顯示變更周圍上下文的大小 | Decrease the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |
+| `` ; `` | Git config |  |
 | `` : `` | Execute shell command | Bring up a prompt where you can enter a shell command to execute. |
 | `` <c-p> `` | 檢視自訂補丁選項 |  |
 | `` m `` | 查看合併/變基選項 | View options to abort/continue/skip the current merge/rebase. |

--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -110,7 +110,7 @@ func NewGitCommandAux(
 	// and allows for better namespacing when compared to having every method living
 	// on the one struct.
 	// common ones are: cmn, osCommand, dotGitDir, configCommands
-	configCommands := git_commands.NewConfigCommands(cmn, gitConfig, repo)
+	configCommands := git_commands.NewConfigCommands(cmn, gitConfig, repo, cmd)
 
 	gitCommon := git_commands.NewGitCommon(cmn, version, cmd, osCommand, repoPaths, repo, configCommands, pagerConfig)
 

--- a/pkg/commands/git_commands/deps_test.go
+++ b/pkg/commands/git_commands/deps_test.go
@@ -76,7 +76,7 @@ func buildGitCommon(deps commonDeps) *GitCommon {
 	}
 
 	gitCommon.repo = buildRepo()
-	gitCommon.config = NewConfigCommands(gitCommon.Common, gitConfig, gitCommon.repo)
+	gitCommon.config = NewConfigCommands(gitCommon.Common, gitConfig, gitCommon.repo, gitCommon.cmd)
 
 	getenv := deps.getenv
 	if getenv == nil {

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -693,11 +693,12 @@ func (c *AppConfig) SaveGlobalUserConfig() {
 // AppState stores data between runs of the app like when the last update check
 // was performed and which other repos have been checked out
 type AppState struct {
-	LastUpdateCheck        int64
-	RecentRepos            []string
-	StartupPopupVersion    int
-	DidShowHunkStagingHint bool
-	LastVersion            string // this is the last version the user was using, for the purpose of showing release notes
+	LastUpdateCheck           int64
+	RecentRepos               []string
+	StartupPopupVersion       int
+	DidShowHunkStagingHint    bool
+	LastVersion               string   // this is the last version the user was using, for the purpose of showing release notes
+	GitConfigExpandedSections []string `yaml:"gitConfigExpandedSections"`
 
 	// these are for shell commands typed in directly, not for custom commands in the lazygit config.
 	// For backwards compatibility we keep the old name in yaml files.

--- a/pkg/config/app_config_test.go
+++ b/pkg/config/app_config_test.go
@@ -836,6 +836,7 @@ keybinding:
     startSearch: /
     optionMenu: <disabled>
     optionMenu-alt1: '?'
+    gitConfig: ';'
     select: <space>
     goInto: <enter>
     confirm: <enter>

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -447,6 +447,7 @@ type KeybindingUniversalConfig struct {
 	StartSearch                       string   `yaml:"startSearch"`
 	OptionMenu                        string   `yaml:"optionMenu"`
 	OptionMenuAlt1                    string   `yaml:"optionMenu-alt1"`
+	GitConfig                         string   `yaml:"gitConfig"`
 	Select                            string   `yaml:"select"`
 	GoInto                            string   `yaml:"goInto"`
 	Confirm                           string   `yaml:"confirm"`
@@ -909,6 +910,7 @@ func GetDefaultConfig() *UserConfig {
 				StartSearch:                       "/",
 				OptionMenu:                        "<disabled>",
 				OptionMenuAlt1:                    "?",
+				GitConfig:                         ";",
 				Select:                            "<space>",
 				GoInto:                            "<enter>",
 				Confirm:                           "<enter>",

--- a/pkg/gui/context/menu_context.go
+++ b/pkg/gui/context/menu_context.go
@@ -17,6 +17,7 @@ type MenuContext struct {
 
 	*MenuViewModel
 	*ListContextTrait
+	extraKeybindings []*types.Binding
 }
 
 var _ types.IListContext = (*MenuContext)(nil)
@@ -216,14 +217,14 @@ func (self *MenuContext) GetKeybindings(opts types.KeybindingsOpts) []*types.Bin
 		// allows assigning a keybinding to a menu item that overrides a non-essential binding such
 		// as 'j', 'k', 'H', 'L', etc. This is safe to do because the essential bindings such as
 		// confirm and return have already been removed from the menu items in this case.
-		return append(menuItemBindings, basicBindings...)
+		return append(append(menuItemBindings, self.extraKeybindings...), basicBindings...)
 	}
 
 	// For the keybindings menu we didn't remove the essential bindings from the menu items, because
 	// it is important to see all bindings (as a cheat sheet for what the keys are when the menu is
 	// not open). Therefore we want the essential bindings to have higher precedence than the menu
 	// item bindings.
-	return append(basicBindings, menuItemBindings...)
+	return append(append(basicBindings, menuItemBindings...), self.extraKeybindings...)
 }
 
 func (self *MenuContext) OnMenuPress(selectedItem *types.MenuItem) error {
@@ -260,4 +261,8 @@ func (self *MenuContext) FilterPrefix(tr *i18n.TranslationSet) string {
 	}
 
 	return self.FilteredListViewModel.FilterPrefix(tr)
+}
+
+func (self *MenuContext) SetExtraKeybindings(bindings []*types.Binding) {
+	self.extraKeybindings = bindings
 }

--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -89,6 +89,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 		func() *status.StatusManager { return gui.statusManager },
 		modeHelper,
 	)
+	gitConfigHelper := helpers.NewGitConfigHelper(helperCommon)
 
 	gui.helpers = &helpers.Helpers{
 		Refs:            refsHelper,
@@ -115,6 +116,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 		Repos:           reposHelper,
 		RecordDirectory: recordDirectoryHelper,
 		Update:          helpers.NewUpdateHelper(helperCommon, gui.Updater),
+		GitConfig:       gitConfigHelper,
 		Window:          windowHelper,
 		View:            viewHelper,
 		Refresh:         refreshHelper,

--- a/pkg/gui/controllers/global_controller.go
+++ b/pkg/gui/controllers/global_controller.go
@@ -24,6 +24,14 @@ func NewGlobalController(
 func (self *GlobalController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
 	return []*types.Binding{
 		{
+			Key:             opts.GetKey(opts.Config.Universal.GitConfig),
+			Handler:         opts.Guards.NoPopupPanel(self.c.Helpers().GitConfig.OpenMenu),
+			Description:     self.c.Tr.GitConfigTitle,
+			DisplayOnScreen: true,
+			OpensMenu:       true,
+			GetDisabledReason: self.gitConfigDisabledReason,
+		},
+		{
 			Key:         opts.GetKey(opts.Config.Universal.ExecuteShellCommand),
 			Handler:     self.shellCommand,
 			Description: self.c.Tr.ExecuteShellCommand,
@@ -211,6 +219,14 @@ func (self *GlobalController) optionsMenuDisabledReason() *types.DisabledReason 
 	if ctx.GetKind() == types.PERSISTENT_POPUP || ctx.GetKind() == types.TEMPORARY_POPUP {
 		// The empty error text is intentional. We don't want to show an error
 		// toast for this, but only hide it from the options map.
+		return &types.DisabledReason{Text: ""}
+	}
+	return nil
+}
+
+func (self *GlobalController) gitConfigDisabledReason() *types.DisabledReason {
+	ctx := self.c.Context().Current()
+	if ctx.GetKind() == types.PERSISTENT_POPUP || ctx.GetKind() == types.TEMPORARY_POPUP {
 		return &types.DisabledReason{Text: ""}
 	}
 	return nil

--- a/pkg/gui/controllers/helpers/git_config_helper.go
+++ b/pkg/gui/controllers/helpers/git_config_helper.go
@@ -1,0 +1,508 @@
+package helpers
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazygit/pkg/gui/style"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/i18n"
+	"github.com/jesseduffield/lazygit/pkg/utils"
+	"github.com/samber/lo"
+)
+
+type GitConfigHelper struct {
+	c                *HelperCommon
+	displayScope     gitConfigDisplayScope
+	expandedSections map[string]bool
+}
+
+func NewGitConfigHelper(c *HelperCommon) *GitConfigHelper {
+	expandedSections := map[string]bool{}
+	for _, section := range c.GetAppState().GitConfigExpandedSections {
+		expandedSections[section] = true
+	}
+	return &GitConfigHelper{
+		c:                c,
+		displayScope:     gitConfigDisplayScopeGlobal,
+		expandedSections: expandedSections,
+	}
+}
+
+func (self *GitConfigHelper) OpenMenu() error {
+	return self.openMenuWithSelection(self.currentMenuSelectionID())
+}
+
+func (self *GitConfigHelper) openMenuWithSelection(selectionID string) error {
+	localConfig := self.c.Git().Config.ListLocalConfig()
+	globalConfig := self.c.Git().Config.ListGlobalConfig()
+	systemConfig := self.c.Git().Config.ListSystemConfig()
+
+	displayValues := self.displayScopeValues(localConfig, globalConfig, systemConfig)
+	keys := keysForScope(displayValues, defaultGitConfigKeysForScope(self.displayScope))
+	configSection := &types.MenuSection{
+		Title: utils.ResolvePlaceholderString(
+			self.c.Tr.GitConfigConfigSectionWithScope,
+			map[string]string{"scope": self.displayScopeLabel()},
+		),
+		Column: 0,
+	}
+	menuItems := []*types.MenuItem{}
+
+	menuItems = append(menuItems, self.sectionMenuItems(configSection, keys, displayValues)...)
+
+	self.c.Contexts().Menu.SetExtraKeybindings(self.scopeKeybindings())
+
+	if err := self.c.Menu(types.CreateMenuOptions{
+		Title:           self.c.Tr.GitConfigTitle,
+		Items:           menuItems,
+		ColumnAlignment: []utils.Alignment{utils.AlignLeft, utils.AlignLeft},
+	}); err != nil {
+		return err
+	}
+	self.restoreSelection(menuItems, selectionID)
+	return nil
+}
+
+func (self *GitConfigHelper) openGitConfigEntryMenu(key string) error {
+	localValue := self.c.Git().Config.GetLocalConfigValue(key)
+	globalValue := self.c.Git().Config.GetGlobalConfigValue(key)
+	notSetReason := &types.DisabledReason{Text: self.c.Tr.GitConfigNotSet}
+
+	menuItems := []*types.MenuItem{
+		{
+			LabelColumns: []string{
+				self.c.Tr.GitConfigSetLocal,
+				self.formatGitConfigValue(localValue, style.FgGreen),
+			},
+			OnPress: func() error {
+				return self.promptSetGitConfigValue(key, gitConfigScopeLocal, localValue)
+			},
+		},
+		{
+			LabelColumns: []string{
+				self.c.Tr.GitConfigSetGlobal,
+				self.formatGitConfigValue(globalValue, style.FgYellow),
+			},
+			OnPress: func() error {
+				return self.promptSetGitConfigValue(key, gitConfigScopeGlobal, globalValue)
+			},
+		},
+		{
+			Label:          self.c.Tr.GitConfigUnsetLocal,
+			OnPress:        func() error { return self.unsetGitConfigValue(key, gitConfigScopeLocal) },
+			DisabledReason: lo.Ternary(localValue == "", notSetReason, nil),
+		},
+		{
+			Label:          self.c.Tr.GitConfigUnsetGlobal,
+			OnPress:        func() error { return self.unsetGitConfigValue(key, gitConfigScopeGlobal) },
+			DisabledReason: lo.Ternary(globalValue == "", notSetReason, nil),
+		},
+	}
+
+	return self.c.Menu(types.CreateMenuOptions{
+		Title:           key,
+		Items:           menuItems,
+		ColumnAlignment: []utils.Alignment{utils.AlignLeft, utils.AlignLeft},
+	})
+}
+
+type gitConfigScope struct {
+	name string
+}
+
+var (
+	gitConfigScopeLocal  = gitConfigScope{name: "local"}
+	gitConfigScopeGlobal = gitConfigScope{name: "global"}
+)
+
+func (self *GitConfigHelper) promptSetGitConfigValue(key string, scope gitConfigScope, currentValue string) error {
+	title := utils.ResolvePlaceholderString(
+		self.c.Tr.GitConfigSetPromptTitle,
+		map[string]string{
+			"key":   key,
+			"scope": self.gitConfigScopeLabel(scope),
+		},
+	)
+	self.c.Prompt(types.PromptOpts{
+		Title:              title,
+		InitialContent:     currentValue,
+		AllowEmptyInput:    false,
+		PreserveWhitespace: true,
+		HandleConfirm: func(value string) error {
+			if err := self.setGitConfigValue(key, scope, value); err != nil {
+				return err
+			}
+			self.c.Toast(utils.ResolvePlaceholderString(self.c.Tr.GitConfigUpdatedToast, map[string]string{
+				"key":   key,
+				"scope": self.gitConfigScopeLabel(scope),
+			}))
+			return self.OpenMenu()
+		},
+	})
+	return nil
+}
+
+func (self *GitConfigHelper) setGitConfigValue(key string, scope gitConfigScope, value string) error {
+	var err error
+	switch scope.name {
+	case "local":
+		err = self.c.Git().Config.SetLocalConfigValue(key, value)
+	case "global":
+		err = self.c.Git().Config.SetGlobalConfigValue(key, value)
+	default:
+		return errors.New("unknown git config scope")
+	}
+
+	if err != nil {
+		return err
+	}
+
+	self.c.Git().Config.DropConfigCache()
+	return nil
+}
+
+func (self *GitConfigHelper) unsetGitConfigValue(key string, scope gitConfigScope) error {
+	var err error
+	switch scope.name {
+	case "local":
+		err = self.c.Git().Config.UnsetLocalConfigValue(key)
+	case "global":
+		err = self.c.Git().Config.UnsetGlobalConfigValue(key)
+	default:
+		return errors.New("unknown git config scope")
+	}
+
+	if err != nil {
+		return err
+	}
+
+	self.c.Git().Config.DropConfigCache()
+	self.c.Toast(utils.ResolvePlaceholderString(self.c.Tr.GitConfigUpdatedToast, map[string]string{
+		"key":   key,
+		"scope": self.gitConfigScopeLabel(scope),
+	}))
+	return self.OpenMenu()
+}
+
+func (self *GitConfigHelper) formatGitConfigValue(value string, color style.TextStyle) string {
+	if value == "" {
+		return style.FgBlackLighter.Sprint(self.c.Tr.GitConfigNotSet)
+	}
+	return color.Sprint(value)
+}
+
+func (self *GitConfigHelper) gitConfigScopeLabel(scope gitConfigScope) string {
+	switch scope.name {
+	case "local":
+		return self.c.Tr.GitConfigScopeLocal
+	case "global":
+		return self.c.Tr.GitConfigScopeGlobal
+	default:
+		return scope.name
+	}
+}
+
+type gitConfigDisplayScope struct {
+	name string
+}
+
+var (
+	gitConfigDisplayScopeLocal  = gitConfigDisplayScope{name: "local"}
+	gitConfigDisplayScopeGlobal = gitConfigDisplayScope{name: "global"}
+	gitConfigDisplayScopeSystem = gitConfigDisplayScope{name: "system"}
+)
+
+func (self gitConfigDisplayScope) label(tr *i18n.TranslationSet) string {
+	switch self.name {
+	case "local":
+		return tr.GitConfigLocalColumn
+	case "global":
+		return tr.GitConfigGlobalColumn
+	case "system":
+		return tr.GitConfigSystemColumn
+	default:
+		return self.name
+	}
+}
+
+func (self gitConfigDisplayScope) keybinding() types.Key {
+	switch self.name {
+	case "local":
+		return 'l'
+	case "global":
+		return 'g'
+	case "system":
+		return 's'
+	default:
+		return nil
+	}
+}
+
+func (self *GitConfigHelper) displayScopeValues(localConfig map[string]string, globalConfig map[string]string, systemConfig map[string]string) map[string]string {
+	switch self.displayScope.name {
+	case "local":
+		return localConfig
+	case "global":
+		return globalConfig
+	case "system":
+		return systemConfig
+	default:
+		return map[string]string{}
+	}
+}
+
+func (self *GitConfigHelper) sectionMenuItems(sectionHeader *types.MenuSection, keys []string, values map[string]string) []*types.MenuItem {
+	sections := map[string][]string{}
+	leafKeys := []string{}
+	for _, key := range keys {
+		parts := strings.SplitN(key, ".", 2)
+		if len(parts) == 1 {
+			leafKeys = append(leafKeys, key)
+			continue
+		}
+		sections[parts[0]] = append(sections[parts[0]], parts[1])
+	}
+
+	sectionNames := make([]string, 0, len(sections))
+	for sectionName := range sections {
+		sectionNames = append(sectionNames, sectionName)
+	}
+	sort.Strings(sectionNames)
+	sort.Strings(leafKeys)
+
+	menuItems := make([]*types.MenuItem, 0, len(keys))
+	for _, section := range sectionNames {
+		isExpanded := self.isSectionExpanded(section)
+		prefix := "+ "
+		if isExpanded {
+			prefix = "- "
+		}
+		menuItems = append(menuItems, &types.MenuItem{
+			Label:        "section:" + section,
+			LabelColumns: []string{prefix + section},
+			Section:      sectionHeader,
+			OnPress: func() error {
+				self.toggleSection(section)
+				return self.openMenuWithSelection("section:" + section)
+			},
+		})
+
+		if !isExpanded {
+			continue
+		}
+
+		children := sections[section]
+		sort.Strings(children)
+		for i, child := range children {
+			isLast := i == len(children)-1
+			branch := "  |- "
+			if isLast {
+				branch = "  `- "
+			}
+			fullKey := section + "." + child
+			menuItems = append(menuItems, &types.MenuItem{
+				Label: "key:" + fullKey,
+				LabelColumns: []string{
+					branch + child,
+					self.formatGitConfigValue(values[fullKey], self.displayScopeColor()),
+				},
+				Section: sectionHeader,
+				OnPress: func() error {
+					return self.openGitConfigEntryMenu(fullKey)
+				},
+			})
+		}
+	}
+
+	for _, key := range leafKeys {
+		menuItems = append(menuItems, &types.MenuItem{
+			Label: "key:" + key,
+			LabelColumns: []string{
+				key,
+				self.formatGitConfigValue(values[key], self.displayScopeColor()),
+			},
+			Section: sectionHeader,
+			OnPress: func() error {
+				return self.openGitConfigEntryMenu(key)
+			},
+		})
+	}
+
+	return menuItems
+}
+
+func (self *GitConfigHelper) displayScopeColor() style.TextStyle {
+	switch self.displayScope.name {
+	case "local":
+		return style.FgGreen
+	case "global":
+		return style.FgYellow
+	case "system":
+		return style.FgBlue
+	default:
+		return style.FgDefault
+	}
+}
+
+func (self *GitConfigHelper) isSectionExpanded(section string) bool {
+	expanded, ok := self.expandedSections[section]
+	return ok && expanded
+}
+
+func (self *GitConfigHelper) toggleSection(section string) {
+	self.expandedSections[section] = !self.isSectionExpanded(section)
+	self.persistExpandedSections()
+}
+
+func (self *GitConfigHelper) persistExpandedSections() {
+	expanded := []string{}
+	for section, isExpanded := range self.expandedSections {
+		if isExpanded {
+			expanded = append(expanded, section)
+		}
+	}
+	sort.Strings(expanded)
+	self.c.GetAppState().GitConfigExpandedSections = expanded
+	self.c.SaveAppStateAndLogError()
+}
+
+func (self *GitConfigHelper) currentMenuSelectionID() string {
+	if self.c.Contexts().Menu == nil {
+		return ""
+	}
+	return self.c.Contexts().Menu.GetSelectedItemId()
+}
+
+func (self *GitConfigHelper) restoreSelection(items []*types.MenuItem, selectionID string) {
+	if selectionID == "" {
+		return
+	}
+	for i, item := range items {
+		if item != nil && item.ID() == selectionID {
+			self.c.Contexts().Menu.GetList().SetSelection(i)
+			self.c.Contexts().Menu.FocusLine(true)
+			return
+		}
+	}
+}
+
+func (self *GitConfigHelper) scopeKeybindings() []*types.Binding {
+	return []*types.Binding{
+		{
+			Key:     gitConfigDisplayScopeLocal.keybinding(),
+			Handler: func() error { return self.setDisplayScope(gitConfigDisplayScopeLocal) },
+		},
+		{
+			Key:     gitConfigDisplayScopeGlobal.keybinding(),
+			Handler: func() error { return self.setDisplayScope(gitConfigDisplayScopeGlobal) },
+		},
+		{
+			Key:     gitConfigDisplayScopeSystem.keybinding(),
+			Handler: func() error { return self.setDisplayScope(gitConfigDisplayScopeSystem) },
+		},
+		{
+			Key:     gocui.KeyArrowLeft,
+			Handler: self.selectPreviousScope,
+		},
+		{
+			Key:     gocui.KeyArrowRight,
+			Handler: self.selectNextScope,
+		},
+	}
+}
+
+func (self *GitConfigHelper) setDisplayScope(scope gitConfigDisplayScope) error {
+	if self.displayScope.name == scope.name {
+		return nil
+	}
+	self.displayScope = scope
+	return self.openMenuWithSelection(self.currentMenuSelectionID())
+}
+
+func (self *GitConfigHelper) selectPreviousScope() error {
+	return self.selectScopeOffset(-1)
+}
+
+func (self *GitConfigHelper) selectNextScope() error {
+	return self.selectScopeOffset(1)
+}
+
+func (self *GitConfigHelper) selectScopeOffset(offset int) error {
+	scopes := []gitConfigDisplayScope{
+		gitConfigDisplayScopeLocal,
+		gitConfigDisplayScopeGlobal,
+		gitConfigDisplayScopeSystem,
+	}
+	currentIdx := 0
+	for i, scope := range scopes {
+		if scope.name == self.displayScope.name {
+			currentIdx = i
+			break
+		}
+	}
+	nextIdx := (currentIdx + offset) % len(scopes)
+	if nextIdx < 0 {
+		nextIdx += len(scopes)
+	}
+	return self.setDisplayScope(scopes[nextIdx])
+}
+
+func (self *GitConfigHelper) displayScopeLabel() string {
+	return fmt.Sprintf("< %s >", self.displayScope.label(self.c.Tr))
+}
+
+func keysForScope(values map[string]string, defaults []string) []string {
+	keySet := make(map[string]struct{}, len(values)+len(defaults))
+	for key := range values {
+		keySet[key] = struct{}{}
+	}
+	for _, key := range defaults {
+		keySet[key] = struct{}{}
+	}
+	result := make([]string, 0, len(keySet))
+	for key := range keySet {
+		result = append(result, key)
+	}
+	sort.Strings(result)
+	return result
+}
+
+type defaultGitConfigKey struct {
+	key    string
+	scopes map[string]bool
+}
+
+func defaultGitConfigKeysForScope(scope gitConfigDisplayScope) []string {
+	keys := []defaultGitConfigKey{
+		{key: "user.name", scopes: map[string]bool{"local": true, "global": true}},
+		{key: "user.email", scopes: map[string]bool{"local": true, "global": true}},
+		{key: "core.editor", scopes: map[string]bool{"local": true, "global": true, "system": true}},
+		{key: "core.autocrlf", scopes: map[string]bool{"local": true, "global": true, "system": true}},
+		{key: "core.ignorecase", scopes: map[string]bool{"local": true, "global": true, "system": true}},
+		{key: "init.defaultBranch", scopes: map[string]bool{"global": true, "system": true}},
+		{key: "pull.rebase", scopes: map[string]bool{"local": true, "global": true}},
+		{key: "pull.ff", scopes: map[string]bool{"local": true, "global": true}},
+		{key: "merge.ff", scopes: map[string]bool{"local": true, "global": true}},
+		{key: "push.default", scopes: map[string]bool{"local": true, "global": true}},
+		{key: "fetch.prune", scopes: map[string]bool{"local": true, "global": true}},
+		{key: "commit.gpgSign", scopes: map[string]bool{"local": true, "global": true}},
+		{key: "tag.gpgSign", scopes: map[string]bool{"local": true, "global": true}},
+		{key: "gpg.program", scopes: map[string]bool{"global": true, "system": true}},
+		{key: "rebase.autostash", scopes: map[string]bool{"local": true, "global": true}},
+		{key: "rerere.enabled", scopes: map[string]bool{"local": true, "global": true}},
+		{key: "diff.tool", scopes: map[string]bool{"local": true, "global": true}},
+		{key: "merge.tool", scopes: map[string]bool{"local": true, "global": true}},
+	}
+	result := []string{}
+	for _, entry := range keys {
+		if entry.scopes[scope.name] {
+			result = append(result, entry.key)
+		}
+	}
+	sort.Strings(result)
+	return result
+}

--- a/pkg/gui/controllers/helpers/helpers.go
+++ b/pkg/gui/controllers/helpers/helpers.go
@@ -42,6 +42,7 @@ type Helpers struct {
 	Repos             *ReposHelper
 	RecordDirectory   *RecordDirectoryHelper
 	Update            *UpdateHelper
+	GitConfig         *GitConfigHelper
 	Window            *WindowHelper
 	View              *ViewHelper
 	Refresh           *RefreshHelper
@@ -79,6 +80,7 @@ func NewStubHelpers() *Helpers {
 		Repos:             &ReposHelper{},
 		RecordDirectory:   &RecordDirectoryHelper{},
 		Update:            &UpdateHelper{},
+		GitConfig:         &GitConfigHelper{},
 		Window:            &WindowHelper{},
 		View:              &ViewHelper{},
 		Refresh:           &RefreshHelper{},

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -11,6 +11,9 @@ import (
 
 // note: items option is mutated by this function
 func (gui *Gui) createMenu(opts types.CreateMenuOptions) error {
+	if opts.Title != gui.c.Tr.GitConfigTitle {
+		gui.State.Contexts.Menu.SetExtraKeybindings(nil)
+	}
 	if !opts.HideCancel {
 		// this is mutative but I'm okay with that for now
 		opts.Items = append(opts.Items, &types.MenuItem{

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -228,6 +228,22 @@ type TranslationSet struct {
 	RenameStashPrompt                     string
 	OpenConfig                            string
 	EditConfig                            string
+	GitConfigTitle                        string
+	GitConfigKeyColumn                    string
+	GitConfigLocalColumn                  string
+	GitConfigGlobalColumn                 string
+	GitConfigSystemColumn                 string
+	GitConfigValueColumn                  string
+	GitConfigSetLocal                     string
+	GitConfigSetGlobal                    string
+	GitConfigUnsetLocal                   string
+	GitConfigUnsetGlobal                  string
+	GitConfigSetPromptTitle               string
+	GitConfigUpdatedToast                 string
+	GitConfigNotSet                       string
+	GitConfigScopeLocal                   string
+	GitConfigScopeGlobal                  string
+	GitConfigConfigSectionWithScope       string
 	ForcePush                             string
 	ForcePushPrompt                       string
 	ForcePushDisabled                     string
@@ -1322,6 +1338,22 @@ func EnglishTranslationSet() *TranslationSet {
 		RenameStashPrompt:                    "Rename stash: {{.stashName}}",
 		OpenConfig:                           "Open config file",
 		EditConfig:                           "Edit config file",
+		GitConfigTitle:                       "Git config",
+		GitConfigKeyColumn:                   "Key",
+		GitConfigLocalColumn:                 "Local",
+		GitConfigGlobalColumn:                "Global",
+		GitConfigSystemColumn:                "System",
+		GitConfigValueColumn:                 "Value ({{.scope}})",
+		GitConfigSetLocal:                    "Set local value",
+		GitConfigSetGlobal:                   "Set global value",
+		GitConfigUnsetLocal:                  "Unset local value",
+		GitConfigUnsetGlobal:                 "Unset global value",
+		GitConfigSetPromptTitle:              "Set {{.scope}} {{.key}}",
+		GitConfigUpdatedToast:                "Updated {{.scope}} {{.key}}",
+		GitConfigNotSet:                      "not set",
+		GitConfigScopeLocal:                  "local",
+		GitConfigScopeGlobal:                 "global",
+		GitConfigConfigSectionWithScope:      "Config {{.scope}}",
 		ForcePush:                            "Force push",
 		ForcePushPrompt:                      "Your branch has diverged from the remote branch. Press {{.cancelKey}} to cancel, or {{.confirmKey}} to force push.",
 		ForcePushDisabled:                    "Your branch has diverged from the remote branch and you've disabled force pushing",

--- a/pkg/integration/tests/ui/keybinding_suggestions_when_switching_repos.go
+++ b/pkg/integration/tests/ui/keybinding_suggestions_when_switching_repos.go
@@ -31,12 +31,12 @@ var KeybindingSuggestionsWhenSwitchingRepos = NewIntegrationTest(NewIntegrationT
 
 		t.Views().Files().Focus()
 		t.Views().Options().Content(
-			Equals("Commit: c | Stash: s | Reset: D | Keybindings: ?"))
+			Equals("Commit: c | Stash: s | Reset: D | Git config: ; | Keybindings: ?"))
 
 		switchToRepo("other")
 		switchToRepo("repo")
 
 		t.Views().Options().Content(
-			Equals("Commit: c | Stash: s | Reset: D | Keybindings: ?"))
+			Equals("Commit: c | Stash: s | Reset: D | Git config: ; | Keybindings: ?"))
 	},
 })

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -1370,6 +1370,10 @@
           "type": "string",
           "default": "?"
         },
+        "gitConfig": {
+          "type": "string",
+          "default": ";"
+        },
         "select": {
           "type": "string",
           "default": "\u003cspace\u003e"


### PR DESCRIPTION
### PR Description

  Adds a Git config menu (global keybinding ;) for viewing and editing git config values in a tree view. Supports
  switching scope (local/global/system) via l/g/s or ←/→, shows the active scope in the header, persists expanded
  sections, and includes common keys even when unset.

### Notes

  - Future idea (after approval): when committing without user.name/user.email, prompt to open this menu.
  - Observation: Integration tests need global user.name/user.email; I prefer per‑repo settings. It’d be nice
    if tests could set these locally or reuse the repo’s local config.

### Please check if the PR fulfills these requirements

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [X] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [X] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [X] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
