### PR TITLE
Fix the main view display after reverting a commit

### DIFF
--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -869,7 +869,7 @@ func (self *LocalCommitsController) revert(commits []*models.Commit, start, end 
 					return err
 				}
 				self.context().MoveSelection(len(commits))
-				self.context().FocusLine()
+				self.context().HandleFocus(types.OnFocusOpts{})
 
 				if mustStash {
 					if err := self.c.Git().Stash.Pop(0); err != nil {

--- a/pkg/integration/tests/commit/revert.go
+++ b/pkg/integration/tests/commit/revert.go
@@ -33,10 +33,7 @@ var Revert = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("first commit").IsSelected(),
 			).
 			Tap(func() {
-				/* EXPECTED:
 				t.Views().Main().Content(Contains("+myfile content"))
-				ACTUAL: */
-				t.Views().Main().Content(Contains("-myfile content"))
 			}).
 			SelectPreviousItem()
 


### PR DESCRIPTION
After reverting a commit, the main view would show the diff of a commit that is not the selected one.