### PR TITLE
feat: warn user when unsupported 'delta --navigate' flag is used

### DIFF
--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -250,6 +250,8 @@ type TranslationSet struct {
 	IntroPopupMessage                     string
 	NonReloadableConfigWarningTitle       string
 	NonReloadableConfigWarning            string
+	DeltaNavigateWarningTitle             string
+	DeltaNavigateWarning                  string
 	GitconfigParseErr                     string
 	EditFile                              string
 	EditFileTooltip                       string
@@ -1344,6 +1346,8 @@ func EnglishTranslationSet() *TranslationSet {
 		IntroPopupMessage:                    englishIntroPopupMessage,
 		NonReloadableConfigWarningTitle:      "Config changed",
 		NonReloadableConfigWarning:           englishNonReloadableConfigWarning,
+		DeltaNavigateWarningTitle:            "Delta --navigate Not Supported",
+		DeltaNavigateWarning:                 "You have 'delta --navigate' configured as your pager.\n\nThe --navigate flag requires interactive keyboard input (n/N keys) that lazygit cannot forward to the subprocess.\n\nPlease remove '--navigate' from your pager configuration.",
 		GitconfigParseErr:                    `Gogit failed to parse your gitconfig file due to the presence of unquoted '\' characters. Removing these should fix the issue.`,
 		EditFile:                             `Edit file`,
 		EditFileTooltip:                      "Open file in external editor.",


### PR DESCRIPTION
Closes #5136

**The Issue**
Users attempting to use `delta --navigate` were finding that navigation keys (`n`/`N`) were unresponsive. This is because `lazygit` reads the pager's stdout via a PTY but does not forward `stdin` to the subprocess, making interactive features architecturally impossible in the current view.

**The Fix**
I added a startup check in `onInitialViewsCreation` (in `pkg/gui/layout.go`). If the user's config contains `delta` and `--navigate`, a modal dialog now appears explaining that this feature is not supported and advising them to remove the flag. The warning is also logged to the debug log for reference.

**Why This Happens**
Lazygit captures pager output via a PTY to display it in the TUI, but keyboard input goes through lazygit's own keybinding system rather than being forwarded to the subprocess. This architectural design means interactive pager features cannot work as intended.

**Validation**
I reproduced the issue with a local config and verified the dialog appears on startup:

<img width="1509" height="792" alt="Screenshot_20251225_000355" src="https://github.com/user-attachments/assets/1d52335e-61b9-420f-87ba-aabbef2851d2" />


### Please check if the PR fulfills these requirements

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc