### PR TITLE
feat: add keybinding to toggle first-parent-only mode in commits panel

### DIFF
--- a/docs-master/keybindings/Keybindings_en.md
+++ b/docs-master/keybindings/Keybindings_en.md
@@ -106,6 +106,7 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` t `` | Revert | Create a revert commit for the selected commit, which applies the selected commit's changes in reverse. |
 | `` T `` | Tag commit | Create a new tag pointing at the selected commit. You'll be prompted to enter a tag name and optional description. |
 | `` <c-l> `` | View log options | View options for commit log e.g. changing sort order, hiding the git graph, showing the whole git graph. |
+| `` z `` | Toggle first-parent only (flat view) | Show only first-parent commits, hiding all commits from merged branches. This gives a flat view of the main branch history. |
 | `` <space> `` | Checkout | Checkout the selected commit as a detached HEAD. |
 | `` y `` | Copy commit attribute to clipboard | Copy commit attribute to clipboard (e.g. hash, URL, diff, message, author). |
 | `` o `` | Open commit in browser |  |

--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -64,6 +64,8 @@ type GetCommitsOptions struct {
 	RefForPushedStatus   models.Ref // the ref to use for determining pushed/unpushed status
 	// determines if we show the whole git graph i.e. pass the '--all' flag
 	All bool
+	// determines if we show only first-parent commits (flat view)
+	FirstParentOnly bool
 	// If non-empty, show divergence from this ref (left-right log)
 	RefToShowDivergenceFrom string
 	MainBranches            *MainBranches
@@ -588,6 +590,7 @@ func (self *CommitLoader) getLogCmd(opts GetCommitsOptions) *oscommands.CmdObj {
 		Arg(refSpec).
 		ArgIf(gitLogOrder != "default", "--"+gitLogOrder).
 		ArgIf(opts.All, "--all").
+		ArgIf(opts.FirstParentOnly, "--first-parent").
 		Arg("--oneline").
 		Arg(prettyFormat).
 		Arg("--abbrev=40").

--- a/pkg/gui/context/local_commits_context.go
+++ b/pkg/gui/context/local_commits_context.go
@@ -148,6 +148,9 @@ type LocalCommitsViewModel struct {
 
 	// If this is true we'll use git log --all when fetching the commits.
 	showWholeGitGraph bool
+
+	// If this is true we'll use git log --first-parent for a flat view.
+	showFirstParentOnly bool
 }
 
 func NewLocalCommitsViewModel(getModel func() []*models.Commit, c *ContextCommon) *LocalCommitsViewModel {
@@ -240,6 +243,14 @@ func (self *LocalCommitsViewModel) SetShowWholeGitGraph(value bool) {
 
 func (self *LocalCommitsViewModel) GetShowWholeGitGraph() bool {
 	return self.showWholeGitGraph
+}
+
+func (self *LocalCommitsViewModel) SetShowFirstParentOnly(value bool) {
+	self.showFirstParentOnly = value
+}
+
+func (self *LocalCommitsViewModel) GetShowFirstParentOnly() bool {
+	return self.showFirstParentOnly
 }
 
 func (self *LocalCommitsViewModel) GetCommits() []*models.Commit {

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -328,6 +328,7 @@ func (self *RefreshHelper) refreshCommitsWithLimit() error {
 			RefName:              self.refForLog(),
 			RefForPushedStatus:   checkedOutRef,
 			All:                  self.c.Contexts().LocalCommits.GetShowWholeGitGraph(),
+			FirstParentOnly:      self.c.Contexts().LocalCommits.GetShowFirstParentOnly(),
 			MainBranches:         self.c.Model().MainBranches,
 			HashPool:             self.c.Model().HashPool,
 		},

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -244,6 +244,12 @@ func (self *LocalCommitsController) GetKeybindings(opts types.KeybindingsOpts) [
 			Tooltip:     self.c.Tr.OpenLogMenuTooltip,
 			OpensMenu:   true,
 		},
+		{
+			Key:         'z',
+			Handler:     self.toggleFirstParentOnly,
+			Description: self.c.Tr.ToggleFirstParentOnly,
+			Tooltip:     self.c.Tr.ToggleFirstParentOnlyTooltip,
+		},
 	}
 
 	return bindings
@@ -1484,4 +1490,10 @@ func (self *LocalCommitsController) pickEnabled(selectedCommits []*models.Commit
 	}
 
 	return self.midRebaseCommandEnabled(selectedCommits, startIdx, endIdx)
+}
+
+func (self *LocalCommitsController) toggleFirstParentOnly() error {
+	self.context().SetShowFirstParentOnly(!self.context().GetShowFirstParentOnly())
+	self.c.Refresh(types.RefreshOptions{Scope: []types.RefreshableView{types.COMMITS}})
+	return nil
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -778,6 +778,8 @@ type TranslationSet struct {
 	OpenLogMenu                              string
 	OpenLogMenuTooltip                       string
 	LogMenuTitle                             string
+	ToggleFirstParentOnly                    string
+	ToggleFirstParentOnlyTooltip             string
 	ToggleShowGitGraphAll                    string
 	ShowGitGraph                             string
 	ShowGitGraphTooltip                      string
@@ -1876,6 +1878,8 @@ func EnglishTranslationSet() *TranslationSet {
 		OpenLogMenu:                              "View log options",
 		OpenLogMenuTooltip:                       "View options for commit log e.g. changing sort order, hiding the git graph, showing the whole git graph.",
 		LogMenuTitle:                             "Commit Log Options",
+		ToggleFirstParentOnly:                    "Toggle first-parent only (flat view)",
+		ToggleFirstParentOnlyTooltip:             "Show only first-parent commits, hiding all commits from merged branches. This gives a flat view of the main branch history.",
 		ToggleShowGitGraphAll:                    "Toggle show whole git graph (pass the `--all` flag to `git log`)",
 		ShowGitGraph:                             "Show git graph",
 		ShowGitGraphTooltip:                      "Show or hide the git graph in the commit log.\n\nThe default can be changed in the config file with the key 'git.log.showGraph'.",


### PR DESCRIPTION
Add a keybinding (z) to toggle first-parent-only mode, which shows only commits on the main branch line by passing --first-parent to git log. This provides a cleaner, flatter view for repositories with many merge commits.

Changes:
- Add FirstParentOnly option to GetCommitsOptions
- Add --first-parent flag to git log command
- Add showFirstParentOnly state to LocalCommitsViewModel
- Add z keybinding to toggle the mode
- Add i18n translations

### PR Description

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
