### PR TITLE
fix: Cannot see branches or remotes when there is a branch with an empty name

### DIFF
--- a/pkg/commands/git_commands/config.go
+++ b/pkg/commands/git_commands/config.go
@@ -78,7 +78,16 @@ func (self *ConfigCommands) Branches() (map[string]*config.Branch, error) {
 		return nil, err
 	}
 
-	return conf.Branches, nil
+	// Filter out branches with empty names to handle edge cases where
+	// .git/config has [branch ""] sections
+	filteredBranches := make(map[string]*config.Branch)
+	for name, branch := range conf.Branches {
+		if name != "" {
+			filteredBranches[name] = branch
+		}
+	}
+
+	return filteredBranches, nil
 }
 
 func (self *ConfigCommands) GetGitFlowPrefixes() string {


### PR DESCRIPTION
## Summary
This PR fixes #5112

## Changes
- Added filtering in `ConfigCommands.Branches()` to exclude branches with empty names
- This prevents the issue where lazygit couldn't display branches or remotes when `.git/config` contains a `[branch ""]` section
- The fix is minimal and defensive, simply filtering out empty branch names from the configuration

## Testing
- All existing unit tests pass
- The fix handles the edge case without affecting normal branch operations

---
Generated with Claude Code