### PR TITLE
fix: use Files-specific keybinding for reset-to-upstream in files view

### DIFF
--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -499,25 +499,26 @@ type KeybindingStatusConfig struct {
 }
 
 type KeybindingFilesConfig struct {
-	CommitChanges            string `yaml:"commitChanges"`
-	CommitChangesWithoutHook string `yaml:"commitChangesWithoutHook"`
-	AmendLastCommit          string `yaml:"amendLastCommit"`
-	CommitChangesWithEditor  string `yaml:"commitChangesWithEditor"`
-	FindBaseCommitForFixup   string `yaml:"findBaseCommitForFixup"`
-	ConfirmDiscard           string `yaml:"confirmDiscard"`
-	IgnoreFile               string `yaml:"ignoreFile"`
-	RefreshFiles             string `yaml:"refreshFiles"`
-	StashAllChanges          string `yaml:"stashAllChanges"`
-	ViewStashOptions         string `yaml:"viewStashOptions"`
-	ToggleStagedAll          string `yaml:"toggleStagedAll"`
-	ViewResetOptions         string `yaml:"viewResetOptions"`
-	Fetch                    string `yaml:"fetch"`
-	ToggleTreeView           string `yaml:"toggleTreeView"`
-	OpenMergeOptions         string `yaml:"openMergeOptions"`
-	OpenStatusFilter         string `yaml:"openStatusFilter"`
-	CopyFileInfoToClipboard  string `yaml:"copyFileInfoToClipboard"`
-	CollapseAll              string `yaml:"collapseAll"`
-	ExpandAll                string `yaml:"expandAll"`
+	CommitChanges              string `yaml:"commitChanges"`
+	CommitChangesWithoutHook   string `yaml:"commitChangesWithoutHook"`
+	AmendLastCommit            string `yaml:"amendLastCommit"`
+	CommitChangesWithEditor    string `yaml:"commitChangesWithEditor"`
+	FindBaseCommitForFixup     string `yaml:"findBaseCommitForFixup"`
+	ConfirmDiscard             string `yaml:"confirmDiscard"`
+	IgnoreFile                 string `yaml:"ignoreFile"`
+	RefreshFiles               string `yaml:"refreshFiles"`
+	StashAllChanges            string `yaml:"stashAllChanges"`
+	ViewStashOptions           string `yaml:"viewStashOptions"`
+	ToggleStagedAll            string `yaml:"toggleStagedAll"`
+	ViewResetOptions           string `yaml:"viewResetOptions"`
+	ViewResetToUpstreamOptions string `yaml:"viewResetToUpstreamOptions"`
+	Fetch                      string `yaml:"fetch"`
+	ToggleTreeView             string `yaml:"toggleTreeView"`
+	OpenMergeOptions           string `yaml:"openMergeOptions"`
+	OpenStatusFilter           string `yaml:"openStatusFilter"`
+	CopyFileInfoToClipboard    string `yaml:"copyFileInfoToClipboard"`
+	CollapseAll                string `yaml:"collapseAll"`
+	ExpandAll                  string `yaml:"expandAll"`
 }
 
 type KeybindingBranchesConfig struct {
@@ -959,25 +960,26 @@ func GetDefaultConfig() *UserConfig {
 				AllBranchesLogGraph: "a",
 			},
 			Files: KeybindingFilesConfig{
-				CommitChanges:            "c",
-				CommitChangesWithoutHook: "w",
-				AmendLastCommit:          "A",
-				CommitChangesWithEditor:  "C",
-				FindBaseCommitForFixup:   "<c-f>",
-				IgnoreFile:               "i",
-				RefreshFiles:             "r",
-				StashAllChanges:          "s",
-				ViewStashOptions:         "S",
-				ToggleStagedAll:          "a",
-				ViewResetOptions:         "D",
-				Fetch:                    "f",
-				ToggleTreeView:           "`",
-				OpenMergeOptions:         "M",
-				OpenStatusFilter:         "<c-b>",
-				ConfirmDiscard:           "x",
-				CopyFileInfoToClipboard:  "y",
-				CollapseAll:              "-",
-				ExpandAll:                "=",
+				CommitChanges:              "c",
+				CommitChangesWithoutHook:   "w",
+				AmendLastCommit:            "A",
+				CommitChangesWithEditor:    "C",
+				FindBaseCommitForFixup:     "<c-f>",
+				IgnoreFile:                 "i",
+				RefreshFiles:               "r",
+				StashAllChanges:            "s",
+				ViewStashOptions:           "S",
+				ToggleStagedAll:            "a",
+				ViewResetOptions:           "D",
+				ViewResetToUpstreamOptions: "U",
+				Fetch:                      "f",
+				ToggleTreeView:             "`",
+				OpenMergeOptions:           "M",
+				OpenStatusFilter:           "<c-b>",
+				ConfirmDiscard:             "x",
+				CopyFileInfoToClipboard:    "y",
+				CollapseAll:                "-",
+				ExpandAll:                  "=",
 			},
 			Branches: KeybindingBranchesConfig{
 				CopyPullRequestURL:     "<c-y>",

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -152,7 +152,7 @@ func (self *FilesController) GetKeybindings(opts types.KeybindingsOpts) []*types
 			DisplayOnScreen:   true,
 		},
 		{
-			Key:         opts.GetKey(opts.Config.Commits.ViewResetOptions),
+			Key:         opts.GetKey(opts.Config.Files.ViewResetToUpstreamOptions),
 			Handler:     self.createResetToUpstreamMenu,
 			Description: self.c.Tr.ViewResetToUpstreamOptions,
 			OpensMenu:   true,


### PR DESCRIPTION
Fixes #5150

## Changes
- Added `ViewResetToUpstreamOptions` to `KeybindingFilesConfig` with default key `U`
- Fixed `files_controller.go` to use the Files-specific keybinding instead of `opts.Config.Commits.ViewResetOptions`

The bug was caused by the reset-to-upstream action in the files view incorrectly using `opts.Config.Commits.ViewResetOptions` (the commits view config), which caused the commits view keybinding to "bleed" into the files view.