### PR TITLE
fix: panic: runtime error: index out of range [0] with length 0

### DIFF
--- a/vendor/github.com/jesseduffield/gocui/view.go
+++ b/vendor/github.com/jesseduffield/gocui/view.go
@@ -1896,6 +1896,14 @@ func (v *View) onMouseMove(x int, y int) {
 }
 
 func (v *View) findHyperlinkAt(x, y int) *SearchPosition {
+	// Bounds check to prevent index out of range panic
+	if y < 0 || y >= len(v.viewLines) {
+		return nil
+	}
+	if x < 0 || x >= len(v.viewLines[y].line) {
+		return nil
+	}
+
 	linkStr := v.viewLines[y].line[x].hyperlink
 	if linkStr == "" {
 		return nil


### PR DESCRIPTION
Fixes #5148

## Changes
- Add bounds checking in `findHyperlinkAt()` to prevent panic when `viewLines` changes between caller's bounds check and access
- Return nil safely when x or y indices are out of range