### PR TITLE
fix: Redesign the `git log` half-screen view

### DIFF
--- a/pkg/gui/context/commit_files_context.go
+++ b/pkg/gui/context/commit_files_context.go
@@ -18,6 +18,8 @@ type CommitFilesContext struct {
 	*ListContextTrait
 	*DynamicTitleBuilder
 	*SearchTrait
+
+	c *ContextCommon
 }
 
 var (
@@ -49,6 +51,7 @@ func NewCommitFilesContext(c *ContextCommon) *CommitFilesContext {
 		CommitFileTreeViewModel: viewModel,
 		DynamicTitleBuilder:     NewDynamicTitleBuilder(c.Tr.CommitFilesDynamicTitle),
 		SearchTrait:             NewSearchTrait(c),
+		c:                       c,
 		ListContextTrait: &ListContextTrait{
 			Context: NewSimpleContext(
 				NewBaseContext(NewBaseContextOpts{

--- a/pkg/gui/controllers/helpers/window_arrangement_helper.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper.go
@@ -435,6 +435,19 @@ func sidePanelChildren(args WindowArrangementArgs) func(width int, height int) [
 				}
 			}
 
+			// In half-screen mode, when commits is focused, show both commits
+			// and commitFiles in a split layout
+			if args.ScreenMode == types.SCREEN_HALF && args.CurrentSideWindow == "commits" {
+				return []*boxlayout.Box{
+					{Window: "status", Size: 0},
+					{Window: "files", Size: 0},
+					{Window: "branches", Size: 0},
+					{Window: "commits", Weight: 1},
+					{Window: "commitFiles", Weight: 1},
+					{Window: "stash", Size: 0},
+				}
+			}
+
 			return []*boxlayout.Box{
 				fullHeightBox("status"),
 				fullHeightBox("files"),

--- a/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
@@ -347,6 +347,40 @@ func TestGetWindowDimensions(t *testing.T) {
 			`,
 		},
 		{
+			name: "half screen mode, commits focused with commitFiles split",
+			mutateArgs: func(args *WindowArrangementArgs) {
+				args.Height = 20
+				args.ScreenMode = types.SCREEN_HALF
+				args.CurrentWindow = "commits"
+				args.CurrentSideWindow = "commits"
+				args.UserConfig.Gui.EnlargedSideViewLocation = "left"
+			},
+			expected: `
+			╭commits─────────────────────────────╮╭main───────────────────────────────╮
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			╰────────────────────────────────────╯│                                   │
+			╭commitFiles─────────────────────────╮│                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			│                                    ││                                   │
+			╰────────────────────────────────────╯╰───────────────────────────────────╯
+			<stashns──────────────────────────────────────────────────────>A<B────────>
+			A: statusSpacer1
+			B: information
+			`,
+		},
+		{
 			name: "search mode",
 			mutateArgs: func(args *WindowArrangementArgs) {
 				args.InSearchPrompt = true

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -617,6 +617,9 @@ func initialWindowViewNameMap(contextTree *context.ContextTree) *utils.ThreadSaf
 		result.Set(context.GetWindowName(), context.GetViewName())
 	}
 
+	// Add direct mapping for commitFiles window used in half-screen split layout
+	result.Set("commitFiles", "commitFiles")
+
 	return result
 }
 


### PR DESCRIPTION
Fixes #2151

## Changes
- Add split layout in half-screen mode when commits panel is focused
- Show commits list in upper half and commit files in lower half
- Add window mapping for commitFiles to enable the split view
- Add test case for the new layout behavior