### PR TITLE
feat: Add dynamic side panel width

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -110,6 +110,24 @@ gui:
   # is true.
   expandedSidePanelWeight: 2
 
+  # If true, automatically resize the left and right sections based on which panel
+  # has focus.
+  # When a side panel (files, branches, commits, etc.) has focus, the left section
+  # becomes larger.
+  # When the main panel has focus, the right section becomes larger. Only applies
+  # in normal screen mode.
+  # Use sidePanelFocusedRatio and mainPanelFocusedRatio to configure the exact
+  # ratios.
+  dynamicSidePanelWidth: false
+
+  # Ratio for the side panel width when a side panel has focus (only applies when
+  # dynamicSidePanelWidth is true). Number from 0 to 1.0. Default is 0.618.
+  sidePanelFocusedRatio: 0.618
+
+  # Ratio for the main panel width when the main panel has focus (only applies
+  # when dynamicSidePanelWidth is true). Number from 0 to 1.0. Default is 0.85.
+  mainPanelFocusedRatio: 0.85
+
   # Sometimes the main window is split in two (e.g. when the selected file has
   # both staged and unstaged changes). This setting controls how the two sections
   # are split.

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -101,6 +101,15 @@ type GuiConfig struct {
 	ExpandFocusedSidePanel bool `yaml:"expandFocusedSidePanel"`
 	// The weight of the expanded side panel, relative to the other panels. 2 means twice as tall as the other panels. Only relevant if `expandFocusedSidePanel` is true.
 	ExpandedSidePanelWeight int `yaml:"expandedSidePanelWeight"`
+	// If true, automatically resize the left and right sections based on which panel has focus.
+	// When a side panel (files, branches, commits, etc.) has focus, the left section becomes larger.
+	// When the main panel has focus, the right section becomes larger. Only applies in normal screen mode.
+	// Use sidePanelFocusedRatio and mainPanelFocusedRatio to configure the exact ratios.
+	DynamicSidePanelWidth bool `yaml:"dynamicSidePanelWidth"`
+	// Ratio for the side panel width when a side panel has focus (only applies when dynamicSidePanelWidth is true). Number from 0 to 1.0. Default is 0.618.
+	SidePanelFocusedRatio float64 `yaml:"sidePanelFocusedRatio" jsonschema:"maximum=1,minimum=0"`
+	// Ratio for the main panel width when the main panel has focus (only applies when dynamicSidePanelWidth is true). Number from 0 to 1.0. Default is 0.85.
+	MainPanelFocusedRatio float64 `yaml:"mainPanelFocusedRatio" jsonschema:"maximum=1,minimum=0"`
 	// Sometimes the main window is split in two (e.g. when the selected file has both staged and unstaged changes). This setting controls how the two sections are split.
 	// Options are:
 	// - 'horizontal': split the window horizontally
@@ -764,6 +773,9 @@ func GetDefaultConfig() *UserConfig {
 			SidePanelWidth:           0.3333,
 			ExpandFocusedSidePanel:   false,
 			ExpandedSidePanelWeight:  2,
+			DynamicSidePanelWidth:    false,
+			SidePanelFocusedRatio:    0.618,
+			MainPanelFocusedRatio:    0.85,
 			MainPanelSplitMode:       "flexible",
 			EnlargedSideViewLocation: "left",
 			WrapLinesInStagingView:   true,

--- a/pkg/config/user_config_validation.go
+++ b/pkg/config/user_config_validation.go
@@ -45,6 +45,12 @@ func (config *UserConfig) Validate() error {
 	if err := validateCustomCommands(config.CustomCommands); err != nil {
 		return err
 	}
+	if err := validateFloatRange("gui.sidePanelFocusedRatio", config.Gui.SidePanelFocusedRatio, 0, 1); err != nil {
+		return err
+	}
+	if err := validateFloatRange("gui.mainPanelFocusedRatio", config.Gui.MainPanelFocusedRatio, 0, 1); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -54,6 +60,13 @@ func validateEnum(name string, value string, allowedValues []string) error {
 	}
 	allowedValuesStr := strings.Join(allowedValues, ", ")
 	return fmt.Errorf("Unexpected value '%s' for '%s'. Allowed values: %s", value, name, allowedValuesStr)
+}
+
+func validateFloatRange(name string, value float64, min float64, max float64) error {
+	if value < min || value > max {
+		return fmt.Errorf("Value for '%s' must be between %g and %g (got %g)", name, min, max, value)
+	}
+	return nil
 }
 
 func validateKeybindingsRecurse(path string, node any) error {

--- a/pkg/config/user_config_validation_test.go
+++ b/pkg/config/user_config_validation_test.go
@@ -289,3 +289,64 @@ func TestUserConfigValidate_enums(t *testing.T) {
 		})
 	}
 }
+
+func TestUserConfigValidate_floatRanges(t *testing.T) {
+	type testCase struct {
+		value float64
+		valid bool
+	}
+
+	scenarios := []struct {
+		name      string
+		setup     func(config *UserConfig, value float64)
+		testCases []testCase
+	}{
+		{
+			name: "Gui.SidePanelFocusedRatio",
+			setup: func(config *UserConfig, value float64) {
+				config.Gui.SidePanelFocusedRatio = value
+			},
+			testCases: []testCase{
+				{value: 0.0, valid: true},
+				{value: 0.5, valid: true},
+				{value: 0.618, valid: true},
+				{value: 1.0, valid: true},
+				{value: -0.1, valid: false},
+				{value: 1.1, valid: false},
+				{value: 1.5, valid: false},
+			},
+		},
+		{
+			name: "Gui.MainPanelFocusedRatio",
+			setup: func(config *UserConfig, value float64) {
+				config.Gui.MainPanelFocusedRatio = value
+			},
+			testCases: []testCase{
+				{value: 0.0, valid: true},
+				{value: 0.5, valid: true},
+				{value: 0.75, valid: true},
+				{value: 0.85, valid: true},
+				{value: 1.0, valid: true},
+				{value: -0.1, valid: false},
+				{value: 1.1, valid: false},
+				{value: 2.0, valid: false},
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			for _, testCase := range s.testCases {
+				config := GetDefaultConfig()
+				s.setup(config, testCase.value)
+				err := config.Validate()
+
+				if testCase.valid {
+					assert.NoError(t, err)
+				} else {
+					assert.Error(t, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/gui/controllers/helpers/window_arrangement_helper.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper.go
@@ -238,8 +238,23 @@ func getMidSectionWeights(args WindowArrangementArgs) (int, int) {
 	sidePanelWidthRatio := args.UserConfig.Gui.SidePanelWidth
 	// Using 120 so that the default of 0.3333 will remain consistent with previous behavior
 	const maxColumnCount = 120
-	mainSectionWeight := int(math.Round(maxColumnCount * (1 - sidePanelWidthRatio)))
-	sideSectionWeight := int(math.Round(maxColumnCount * sidePanelWidthRatio))
+
+	var mainSectionWeight, sideSectionWeight int
+
+	if args.UserConfig.Gui.DynamicSidePanelWidth && args.ScreenMode == types.SCREEN_NORMAL {
+		if args.CurrentWindow != "main" && args.CurrentWindow != "secondary" {
+			// Side panel focused: make left section larger
+			sideSectionWeight = int(math.Round(maxColumnCount * args.UserConfig.Gui.SidePanelFocusedRatio))
+			mainSectionWeight = int(math.Round(maxColumnCount * (1 - args.UserConfig.Gui.SidePanelFocusedRatio)))
+		} else {
+			// Main panel focused: make right section larger
+			sideSectionWeight = int(math.Round(maxColumnCount * (1 - args.UserConfig.Gui.MainPanelFocusedRatio)))
+			mainSectionWeight = int(math.Round(maxColumnCount * args.UserConfig.Gui.MainPanelFocusedRatio))
+		}
+	} else {
+		mainSectionWeight = int(math.Round(maxColumnCount * (1 - sidePanelWidthRatio)))
+		sideSectionWeight = int(math.Round(maxColumnCount * sidePanelWidthRatio))
+	}
 
 	if splitMainPanelSideBySide(args) {
 		mainSectionWeight = sideSectionWeight * 5 // need to shrink side panel to make way for main panels if side-by-side

--- a/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper_test.go
@@ -283,6 +283,174 @@ func TestGetWindowDimensions(t *testing.T) {
 			`,
 		},
 		{
+			name: "dynamic side panel width, side panel focused",
+			mutateArgs: func(args *WindowArrangementArgs) {
+				args.UserConfig.Gui.DynamicSidePanelWidth = true
+				args.CurrentWindow = "files"
+			},
+			expected: `
+			╭status─────────────────────────────────────╮╭main────────────────────────╮
+			│                                           ││                            │
+			╰───────────────────────────────────────────╯│                            │
+			╭files──────────────────────────────────────╮│                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			╰───────────────────────────────────────────╯│                            │
+			╭branches───────────────────────────────────╮│                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			╰───────────────────────────────────────────╯│                            │
+			╭commits────────────────────────────────────╮│                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			│                                           ││                            │
+			╰───────────────────────────────────────────╯│                            │
+			╭stash──────────────────────────────────────╮│                            │
+			│                                           ││                            │
+			╰───────────────────────────────────────────╯╰────────────────────────────╯
+			<options──────────────────────────────────────────────────────>A<B────────>
+			A: statusSpacer1
+			B: information
+			`,
+		},
+		{
+			name: "dynamic side panel width, main panel focused",
+			mutateArgs: func(args *WindowArrangementArgs) {
+				args.UserConfig.Gui.DynamicSidePanelWidth = true
+				args.CurrentWindow = "main"
+			},
+			expected: `
+			╭status────╮╭main─────────────────────────────────────────────────────────╮
+			│          ││                                                             │
+			╰──────────╯│                                                             │
+			╭files─────╮│                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			╰──────────╯│                                                             │
+			╭branches──╮│                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			╰──────────╯│                                                             │
+			╭commits───╮│                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			│          ││                                                             │
+			╰──────────╯│                                                             │
+			╭stash─────╮│                                                             │
+			│          ││                                                             │
+			╰──────────╯╰─────────────────────────────────────────────────────────────╯
+			<options──────────────────────────────────────────────────────>A<B────────>
+			A: statusSpacer1
+			B: information
+			`,
+		},
+		{
+			name: "dynamic side panel width, custom main panel ratio 0.9",
+			mutateArgs: func(args *WindowArrangementArgs) {
+				args.UserConfig.Gui.DynamicSidePanelWidth = true
+				args.UserConfig.Gui.MainPanelFocusedRatio = 0.9
+				args.CurrentWindow = "main"
+			},
+			expected: `
+			╭status╮╭main─────────────────────────────────────────────────────────────╮
+			│      ││                                                                 │
+			╰──────╯│                                                                 │
+			╭files─╮│                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			╰──────╯│                                                                 │
+			╭A─────╮│                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			╰──────╯│                                                                 │
+			╭B─────╮│                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			│      ││                                                                 │
+			╰──────╯│                                                                 │
+			╭stash─╮│                                                                 │
+			│      ││                                                                 │
+			╰──────╯╰─────────────────────────────────────────────────────────────────╯
+			<options──────────────────────────────────────────────────────>C<D────────>
+			A: branches
+			B: commits
+			C: statusSpacer1
+			D: information
+			`,
+		},
+		{
+			name: "dynamic side panel width, custom side panel ratio 0.7",
+			mutateArgs: func(args *WindowArrangementArgs) {
+				args.UserConfig.Gui.DynamicSidePanelWidth = true
+				args.UserConfig.Gui.SidePanelFocusedRatio = 0.7
+				args.CurrentWindow = "files"
+			},
+			expected: `
+			╭status────────────────────────────────────────────╮╭main─────────────────╮
+			│                                                  ││                     │
+			╰──────────────────────────────────────────────────╯│                     │
+			╭files─────────────────────────────────────────────╮│                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			╰──────────────────────────────────────────────────╯│                     │
+			╭branches──────────────────────────────────────────╮│                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			╰──────────────────────────────────────────────────╯│                     │
+			╭commits───────────────────────────────────────────╮│                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			│                                                  ││                     │
+			╰──────────────────────────────────────────────────╯│                     │
+			╭stash─────────────────────────────────────────────╮│                     │
+			│                                                  ││                     │
+			╰──────────────────────────────────────────────────╯╰─────────────────────╯
+			<options──────────────────────────────────────────────────────>A<B────────>
+			A: statusSpacer1
+			B: information
+			`,
+		},
+		{
 			name: "half screen mode, enlargedSideViewLocation left",
 			mutateArgs: func(args *WindowArrangementArgs) {
 				args.Height = 20 // smaller height because we don't more here

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -441,6 +441,7 @@ var tests = []*components.IntegrationTest{
 	tag.ResetToDuplicateNamedBranch,
 	ui.Accordion,
 	ui.DisableSwitchTabWithPanelJumpKeys,
+	ui.DynamicSidePanelWidth,
 	ui.EmptyMenu,
 	ui.KeybindingSuggestionsWhenSwitchingRepos,
 	ui.ModeSpecificKeybindingSuggestions,

--- a/pkg/integration/tests/ui/dynamic_side_panel_width.go
+++ b/pkg/integration/tests/ui/dynamic_side_panel_width.go
@@ -1,0 +1,48 @@
+package ui
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var DynamicSidePanelWidth = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Verify dynamic side panel width resizes panels when switching focus",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.GetUserConfig().Gui.DynamicSidePanelWidth = true
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateNCommits(5)
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().IsFocused()
+
+		t.Views().Commits().
+			Focus().
+			IsFocused().
+			Lines(
+				Contains("commit 05").IsSelected(),
+				Contains("commit 04"),
+				Contains("commit 03"),
+				Contains("commit 02"),
+				Contains("commit 01"),
+			)
+
+		t.Views().Branches().
+			Focus().
+			IsFocused()
+
+		t.Views().Commits().
+			Focus().
+			IsFocused().
+			PressEnter()
+
+		t.Views().CommitFiles().
+			IsFocused()
+
+		t.Views().Commits().
+			Focus().
+			IsFocused()
+	},
+})

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -558,6 +558,25 @@
           "description": "The weight of the expanded side panel, relative to the other panels. 2 means twice as tall as the other panels. Only relevant if `expandFocusedSidePanel` is true.",
           "default": 2
         },
+        "dynamicSidePanelWidth": {
+          "type": "boolean",
+          "description": "If true, automatically resize the left and right sections based on which panel has focus.\nWhen a side panel (files, branches, commits, etc.) has focus, the left section becomes larger.\nWhen the main panel has focus, the right section becomes larger. Only applies in normal screen mode.\nUse sidePanelFocusedRatio and mainPanelFocusedRatio to configure the exact ratios.",
+          "default": false
+        },
+        "sidePanelFocusedRatio": {
+          "type": "number",
+          "maximum": 1,
+          "minimum": 0,
+          "description": "Ratio for the side panel width when a side panel has focus (only applies when dynamicSidePanelWidth is true). Number from 0 to 1.0. Default is 0.618.",
+          "default": 0.618
+        },
+        "mainPanelFocusedRatio": {
+          "type": "number",
+          "maximum": 1,
+          "minimum": 0,
+          "description": "Ratio for the main panel width when the main panel has focus (only applies when dynamicSidePanelWidth is true). Number from 0 to 1.0. Default is 0.85.",
+          "default": 0.85
+        },
         "mainPanelSplitMode": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
### PR Description
Introduced a new configuration option `dynamicSidePanelWidth` that allows the GUI to automatically adjust the width of side panels based on which panel has focus. When a side panel is focused, the left section expands, and when the main panel is focused, the right section expands. This feature is only applicable in normal screen mode.

The feature includes two new configuration options:
- `sidePanelFocusedRatio`: Defines the ratio of the side panel's width when a side panel has focus.
- `mainPanelFocusedRatio`: Defines the ratio of the main panel's width when the main panel has focus.

The idea comes from emacs's golden-ratio.el 

https://github.com/roman/golden-ratio.el

#### Demo

https://github.com/user-attachments/assets/015efeb2-31b5-4894-ad82-2b34dfaa6276

### Please check if the PR fulfills these requirements

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
