### PR TITLE
fix: Typo Correction - Update text to account for 4 items, not 3

### DIFF
--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -1070,7 +1070,7 @@ type Actions struct {
 }
 
 const englishIntroPopupMessage = `
-Thanks for using lazygit! Seriously you rock. Three things to share with you:
+Thanks for using lazygit! Seriously you rock. Four things to share with you:
 
  1) If you want to learn about lazygit's features, watch this vid:
       https://youtu.be/CPLdltN7wgE


### PR DESCRIPTION
### PR Description

Recently installed `lazygit` on a new machine, and noticed the intro message has 4 bullet points, but the text says "Three things to share with you".

This just changes `Three` to `Four` to account for this extra bullet point.

Sidenote - this text may need updating in the translations too?