### PR TITLE
When doing ctrl-f, and the resulting commit is not visible, scroll it into view

### DIFF
--- a/pkg/gui/controllers/helpers/fixup_helper.go
+++ b/pkg/gui/controllers/helpers/fixup_helper.go
@@ -137,6 +137,7 @@ func (self *FixupHelper) HandleFindBaseCommitForFixupPress() error {
 			}
 
 			self.c.Contexts().LocalCommits.SetSelection(index)
+			self.c.Contexts().LocalCommits.FocusLine(true)
 			self.c.Context().Push(self.c.Contexts().LocalCommits, types.OnFocusOpts{})
 			return nil
 		},


### PR DESCRIPTION
This used to work in the last version, but broke with efd4298b5e91 (#5134).
