### PR TITLE
fix: preserve commit message when canceling reword mode

### DIFF
--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -353,7 +353,7 @@ func (self *LocalCommitsController) reword(commit *models.Commit) error {
 			InitialMessage:   commitMessage,
 			SummaryTitle:     self.c.Tr.Actions.RewordCommit,
 			DescriptionTitle: self.c.Tr.CommitDescriptionTitle,
-			PreserveMessage:  false,
+			PreserveMessage:  true,
 			OnConfirm:        self.handleReword,
 			OnSwitchToEditor: self.switchFromCommitMessagePanelToEditor,
 		},


### PR DESCRIPTION
## Summary
- When using `r` to reword a commit message and pressing ESC, the message is now preserved
- This makes reword mode consistent with normal commit behavior
- Simple one-line change: `PreserveMessage: false` → `PreserveMessage: true`

## Changes
- Modified `reword()` method in `pkg/gui/controllers/local_commits_controller.go`
- Changed `PreserveMessage` flag from `false` to `true`

## Motivation
Fixes #5183 - users often need to press ESC to look at changes while editing a commit message, and the message was lost when returning to reword mode

## Test manual
1. Select any commit
2. Press `r` (reword)
3. Change message to "Test message 123"
4. Press `ESC`
5. Select the same commit again
6. Press `r`

Expected: Message "Test message 123" is present ✅

## Behavior note
- The preserved message is stored in `.git/LAZYGIT_PENDING_COMMIT` (same file as normal commit)
- If you reword multiple commits, only the last message is preserved
- This is consistent with how normal commit mode works

## Checklist
- [x] Code compiles (`go build`)
- [x] Code formatted with `gofumpt`
- [x] Commit message follows conventional commits