### PR TITLE
feat: Allow the fixup helper to return commits on the main branch with a warning.

### DIFF
--- a/pkg/gui/controllers/helpers/fixup_helper.go
+++ b/pkg/gui/controllers/helpers/fixup_helper.go
@@ -104,12 +104,33 @@ func (self *FixupHelper) HandleFindBaseCommitForFixupPress() error {
 	}
 
 	if len(hashGroups[NOT_MERGED]) == 0 {
-		// If all the commits are merged, show the "already on main branch"
-		// error. It isn't worth doing a detailed report of which commits we
-		// found.
-		return errors.New(self.c.Tr.BaseCommitIsAlreadyOnMainBranch)
-	}
+		// The commit is already merged, but we attempt to show it anyway.
+		if len(hashGroups[MERGED]) > 1 {
+			// We found multiple merged commits. List them in error message
+			subjects := self.getHashesAndSubjects(commits, hashGroups[NOT_MERGED])
+			message := self.c.Tr.MultipleBaseCommitsFoundMerged
+			return fmt.Errorf("%s\n\n%s", message, subjects)
+		} else if len(hashGroups[MERGED]) == 0 {
+			// This can not happen, as the commit has to be either in
+			// CANNOT_TELL, NOT_MERGED or MERGED state and we already established,
+			// that it is not in CANNOT_TELL or NOT_MERGED
+			return errors.New(self.c.Tr.BaseCommitIsNotInCurrentView)
+		}
 
+		// At this point we know that the MERGED bucket has exactly one commit,
+		// and that's the one we want to select.
+		_, index, found := self.findCommit(commits, hashGroups[MERGED][0])
+		if !found {
+			// However the commit is not in view, so we cannot select it.
+			return errors.New(self.c.Tr.BaseCommitIsNotInCurrentView)
+		}
+		// We found the commit, so we show it with a warning message, that it is already merged.
+		return self.c.ConfirmIf(true, types.ConfirmOpts{
+			Title:         self.c.Tr.FindBaseCommitForFixup,
+			Prompt:        self.c.Tr.BaseCommitIsAlreadyOnMainBranch,
+			HandleConfirm: self.getHandlerToStageAndSelectIndex(hasStagedChanges, index),
+		})
+	}
 	if len(hashGroups[NOT_MERGED]) > 1 {
 		// If there are multiple commits that could be the base commit, list
 		// them in the error message. But only the candidates from the current

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -45,6 +45,7 @@ type TranslationSet struct {
 	NoBaseCommitsFound                    string
 	MultipleBaseCommitsFoundStaged        string
 	MultipleBaseCommitsFoundUnstaged      string
+	MultipleBaseCommitsFoundMerged        string
 	BaseCommitIsAlreadyOnMainBranch       string
 	BaseCommitIsNotInCurrentView          string
 	HunksWithOnlyAddedLinesWarning        string
@@ -1140,6 +1141,7 @@ func EnglishTranslationSet() *TranslationSet {
 		NoBaseCommitsFound:                   "No base commits found",
 		MultipleBaseCommitsFoundStaged:       "Multiple base commits found. (Try staging fewer changes at once)",
 		MultipleBaseCommitsFoundUnstaged:     "Multiple base commits found. (Try staging some of the changes)",
+		MultipleBaseCommitsFoundMerged:       "Multiple base commits found, that are already on the main branch. (Try staging some of the changes)",
 		BaseCommitIsAlreadyOnMainBranch:      "The base commit for this change is already on the main branch",
 		BaseCommitIsNotInCurrentView:         "Base commit is not in current view",
 		HunksWithOnlyAddedLinesWarning:       "There are ranges of only added lines in the diff; be careful to check that these belong in the found base commit.\n\nProceed?",

--- a/pkg/integration/tests/commit/find_base_commit_for_fixup_in_main_branch.go
+++ b/pkg/integration/tests/commit/find_base_commit_for_fixup_in_main_branch.go
@@ -1,0 +1,51 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var FindBaseCommitForFixupInMainBranch = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Finds the base commit to create a fixup for when the commit is already merged into master",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			EmptyCommit("1st commit").
+			CreateFileAndAdd("file1", "file1 content\n").
+			Commit("2nd commit").
+			NewBranch("mybranch").
+			CreateFileAndAdd("file2", "file2 content\n").
+			Commit("3rd commit").
+			EmptyCommit("4th commit").
+			UpdateFile("file1", "file1 changed content")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Lines(
+				Contains("4th commit").IsSelected(),
+				Contains("3rd commit"),
+				Contains("2nd commit"),
+				Contains("1st commit"),
+			)
+
+		t.Views().Files().
+			Focus().
+			Press(keys.Files.FindBaseCommitForFixup)
+		t.ExpectPopup().
+			Confirmation().
+			Title(Equals("Find base commit for fixup")).
+			Content(Contains("already on the main branch")).
+			Confirm()
+
+		t.Views().Commits().
+			IsFocused().
+			Lines(
+				Contains("4th commit"),
+				Contains("3rd commit"),
+				Contains("2nd commit").IsSelected(),
+				Contains("1st commit"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -131,6 +131,7 @@ var tests = []*components.IntegrationTest{
 	commit.FailHooksThenCommitNoHooks,
 	commit.FindBaseCommitForFixup,
 	commit.FindBaseCommitForFixupDisregardMainBranch,
+	commit.FindBaseCommitForFixupInMainBranch,
 	commit.FindBaseCommitForFixupOnlyAddedLines,
 	commit.FindBaseCommitForFixupWarningForAddedLines,
 	commit.Highlight,


### PR DESCRIPTION

### PR Description

Sometimes it is permissible/required to fixup a commit, even though it is already on the `main` branch. Even if it is not permissible it might be useful information which commit would have to be changed.

This PR changes the ctrl-f function to instead of showing an error when the commit is already merged to only show a confirmation warning.

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
