### PR TITLE
Request info about terminal in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,6 +27,9 @@ If applicable, add screenshots to help explain your problem.
 
 * _Run `lazygit --version` and paste the result here_
 
+### Terminal info:
+What terminal are you using, and which version? For some types of bugs this information can be relevant.
+
 ### Additional context
 Add any other context about the problem here.
 


### PR DESCRIPTION
For some types of bugs it can be relevant what terminal is being used, so ask users to provide this information when they file an issue.