### PR TITLE
Don't log the "git ls-remote" call when opening a PR

### DIFF
--- a/pkg/commands/git_commands/remote.go
+++ b/pkg/commands/git_commands/remote.go
@@ -85,6 +85,6 @@ func (self *RemoteCommands) GetRemoteURL(remoteName string) (string, error) {
 		Arg("--get-url", remoteName).
 		ToArgv()
 
-	url, err := self.cmd.New(cmdArgs).RunWithOutput()
+	url, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
 	return strings.TrimSpace(url), err
 }


### PR DESCRIPTION
When opening a PR, a "git ls-remote" call would appear in the Command log. This is confusing, it's an internal detail that is not interesting for the user to see.
