### PR TITLE
fix: limit popup panel width on large screens

### DIFF
--- a/pkg/gui/controllers/helpers/confirmation_helper.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper.go
@@ -127,12 +127,10 @@ func (self *ConfirmationHelper) getPopupPanelDimensionsAux(panelWidth int, panel
 
 func (self *ConfirmationHelper) getPopupPanelWidth() int {
 	width, _ := self.c.GocuiGui().Size()
-	// we want a minimum width up to a point, then we do it based on ratio.
-	panelWidth := 4 * width / 7
-	minWidth := 80
-	if panelWidth < minWidth {
-		panelWidth = min(width-2, minWidth)
-	}
+	// we want a width based on commit auto-wrap plus some padding, then we cap it to terminal size when it's smaller than the desired width.
+	commitAutoWrapWidth := self.c.UserConfig().Git.Commit.AutoWrapWidth
+	desiredPanelWidth := commitAutoWrapWidth + 25
+	panelWidth := min(width-2, desiredPanelWidth)
 
 	return panelWidth
 }


### PR DESCRIPTION
### PR Description
Fix visual annoyance on large monitors (e.g. 2K, ultrawide) where popup panels become unnecessarily wide, leaving excessive empty space on the right side.

Problem: popup panels (commit description, confirmations, menus) used 57% of terminal width, which made them very wide on larger screens.

Solution: Popup panel width now derives from git.commit.autoWrapWidth + 25 (padding)

Before: Panel width = 57% of terminal (regardless of auto-wrap setting)
After: Panel width = commitAutoWrapWidth + 25 (capped to terminal width - 2)

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

### Screenshots
#### Wide Terminal
*before:*
<img width="2536" height="1390" alt="lazygit_fullscreen" src="https://github.com/user-attachments/assets/c601f9d8-4be7-42ca-889e-f0cd57684b48" />

*after fix:*
<img width="2528" height="1533" alt="fix_fullscreen" src="https://github.com/user-attachments/assets/774c84e8-8bee-4c7d-93ef-f8e080852091" />

#### Narrow/Small Terminal
*before:*
<img width="771" height="1390" alt="lazygit_smallscreen" src="https://github.com/user-attachments/assets/e8c445e5-0faa-4b33-9684-e0f1a9982ce4" />

*after fix:*
<img width="1018" height="1533" alt="fix_smallscreen" src="https://github.com/user-attachments/assets/a25e4672-cce9-4cc6-af3b-ca2914a9353b" />