### PR TITLE
feat: add copy branch URL to clipboard

### DIFF
--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -15,6 +15,7 @@ var githubServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/compare/{{.From}}?expand=1",
 	pullRequestURLIntoTargetBranch:  "/compare/{{.To}}...{{.From}}?expand=1",
 	commitURL:                       "/commit/{{.CommitHash}}",
+	branchURL:                       "/tree/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }
@@ -24,6 +25,7 @@ var bitbucketServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pull-requests/new?source={{.From}}&t=1",
 	pullRequestURLIntoTargetBranch:  "/pull-requests/new?source={{.From}}&dest={{.To}}&t=1",
 	commitURL:                       "/commits/{{.CommitHash}}",
+	branchURL:                       "/branch/{{.BranchName}}",
 	regexStrings: []string{
 		`^(?:https?|ssh)://.*/(?P<owner>.*)/(?P<repo>.*?)(?:\.git)?$`,
 		`^.*@.*:/*(?P<owner>.*)/(?P<repo>.*?)(?:\.git)?$`,
@@ -36,6 +38,7 @@ var gitLabServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/-/merge_requests/new?merge_request%5Bsource_branch%5D={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/-/merge_requests/new?merge_request%5Bsource_branch%5D={{.From}}&merge_request%5Btarget_branch%5D={{.To}}",
 	commitURL:                       "/-/commit/{{.CommitHash}}",
+	branchURL:                       "/-/tree/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }
@@ -45,6 +48,7 @@ var azdoServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pullrequestcreate?sourceRef={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/pullrequestcreate?sourceRef={{.From}}&targetRef={{.To}}",
 	commitURL:                       "/commit/{{.CommitHash}}",
+	branchURL:                       "?version=GB{{.BranchName}}",
 	regexStrings: []string{
 		`^.+@vs-ssh\.visualstudio\.com[:/](?:v3/)?(?P<org>[^/]+)/(?P<project>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$`,
 		`^git@ssh.dev.azure.com.*/(?P<org>.*)/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
@@ -59,6 +63,7 @@ var bitbucketServerServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pull-requests?create&sourceBranch={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/pull-requests?create&targetBranch={{.To}}&sourceBranch={{.From}}",
 	commitURL:                       "/commits/{{.CommitHash}}",
+	branchURL:                       "/browse?at=refs%2Fheads%2F{{.BranchName}}",
 	regexStrings: []string{
 		`^ssh://git@.*/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
 		`^https://.*/scm/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
@@ -71,6 +76,7 @@ var giteaServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/compare/{{.From}}",
 	pullRequestURLIntoTargetBranch:  "/compare/{{.To}}...{{.From}}",
 	commitURL:                       "/commit/{{.CommitHash}}",
+	branchURL:                       "/src/branch/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }
@@ -80,6 +86,7 @@ var codebergServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/compare/{{.From}}",
 	pullRequestURLIntoTargetBranch:  "/compare/{{.To}}...{{.From}}",
 	commitURL:                       "/commit/{{.CommitHash}}",
+	branchURL:                       "/src/branch/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }

--- a/pkg/commands/hosting_service/hosting_service.go
+++ b/pkg/commands/hosting_service/hosting_service.go
@@ -61,6 +61,15 @@ func (self *HostingServiceMgr) GetCommitURL(commitHash string) (string, error) {
 	return pullRequestURL, nil
 }
 
+func (self *HostingServiceMgr) GetBranchURL(branchName string) (string, error) {
+	gitService, err := self.getService()
+	if err != nil {
+		return "", err
+	}
+
+	return gitService.getBranchURL(branchName), nil
+}
+
 func (self *HostingServiceMgr) getService() (*Service, error) {
 	serviceDomain, err := self.getServiceDomain(self.remoteURL)
 	if err != nil {
@@ -141,6 +150,7 @@ type ServiceDefinition struct {
 	pullRequestURLIntoDefaultBranch string
 	pullRequestURLIntoTargetBranch  string
 	commitURL                       string
+	branchURL                       string
 	regexStrings                    []string
 
 	// can expect 'webdomain' to be passed in. Otherwise, you get to pick what we match in the regex
@@ -175,6 +185,10 @@ func (self *Service) getPullRequestURLIntoTargetBranch(from string, to string) s
 
 func (self *Service) getCommitURL(commitHash string) string {
 	return self.resolveUrl(self.commitURL, map[string]string{"CommitHash": commitHash})
+}
+
+func (self *Service) getBranchURL(branchName string) string {
+	return self.resolveUrl(self.branchURL, map[string]string{"BranchName": url.QueryEscape(branchName)})
 }
 
 func (self *Service) resolveUrl(templateString string, args map[string]string) string {

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -524,6 +524,7 @@ type KeybindingBranchesConfig struct {
 	CreatePullRequest      string `yaml:"createPullRequest"`
 	ViewPullRequestOptions string `yaml:"viewPullRequestOptions"`
 	CopyPullRequestURL     string `yaml:"copyPullRequestURL"`
+	CopyBranchURL          string `yaml:"copyBranchURL"`
 	CheckoutBranchByName   string `yaml:"checkoutBranchByName"`
 	ForceCheckoutBranch    string `yaml:"forceCheckoutBranch"`
 	CheckoutPreviousBranch string `yaml:"checkoutPreviousBranch"`
@@ -981,6 +982,7 @@ func GetDefaultConfig() *UserConfig {
 			},
 			Branches: KeybindingBranchesConfig{
 				CopyPullRequestURL:     "<c-y>",
+				CopyBranchURL:          "<c-u>",
 				CreatePullRequest:      "o",
 				ViewPullRequestOptions: "O",
 				CheckoutBranchByName:   "c",

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -84,6 +84,12 @@ func (self *BranchesController) GetKeybindings(opts types.KeybindingsOpts) []*ty
 			Description:       self.c.Tr.CopyPullRequestURL,
 		},
 		{
+			Key:               opts.GetKey(opts.Config.Branches.CopyBranchURL),
+			Handler:           self.copyBranchURL,
+			GetDisabledReason: self.require(self.singleItemSelected()),
+			Description:       self.c.Tr.CopyBranchURL,
+		},
+		{
 			Key:         opts.GetKey(opts.Config.Branches.CheckoutBranchByName),
 			Handler:     self.checkoutByName,
 			Description: self.c.Tr.CheckoutByName,
@@ -461,6 +467,23 @@ func (self *BranchesController) copyPullRequestURL() error {
 	}
 
 	self.c.Toast(self.c.Tr.PullRequestURLCopiedToClipboard)
+
+	return nil
+}
+
+func (self *BranchesController) copyBranchURL() error {
+	branch := self.context().GetSelected()
+
+	url, err := self.c.Helpers().Host.GetBranchURL(branch.Name)
+	if err != nil {
+		return err
+	}
+	self.c.LogAction(self.c.Tr.Actions.CopyBranchURL)
+	if err := self.c.OS().CopyToClipboard(url); err != nil {
+		return err
+	}
+
+	self.c.Toast(self.c.Tr.BranchURLCopiedToClipboard)
 
 	return nil
 }

--- a/pkg/gui/controllers/helpers/host_helper.go
+++ b/pkg/gui/controllers/helpers/host_helper.go
@@ -34,6 +34,14 @@ func (self *HostHelper) GetCommitURL(commitHash string) (string, error) {
 	return mgr.GetCommitURL(commitHash)
 }
 
+func (self *HostHelper) GetBranchURL(branchName string) (string, error) {
+	mgr, err := self.getHostingServiceMgr()
+	if err != nil {
+		return "", err
+	}
+	return mgr.GetBranchURL(branchName)
+}
+
 // getting this on every request rather than storing it in state in case our remoteURL changes
 // from one invocation to the next.
 func (self *HostHelper) getHostingServiceMgr() (*hosting_service.HostingServiceMgr, error) {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -276,6 +276,8 @@ type TranslationSet struct {
 	AllBranchesLogGraph                   string
 	UnsupportedGitService                 string
 	CopyPullRequestURL                    string
+	CopyBranchURL                         string
+	BranchURLCopiedToClipboard            string
 	NoBranchOnRemote                      string
 	Fetch                                 string
 	FetchTooltip                          string
@@ -1059,6 +1061,7 @@ type Actions struct {
 	Undo                             string
 	Redo                             string
 	CopyPullRequestURL               string
+	CopyBranchURL                    string
 	OpenMergeTool                    string
 	OpenCommitInBrowser              string
 	OpenPullRequest                  string
@@ -1372,6 +1375,8 @@ func EnglishTranslationSet() *TranslationSet {
 		UnsupportedGitService:                `Unsupported git service`,
 		CreatePullRequest:                    `Create pull request`,
 		CopyPullRequestURL:                   `Copy pull request URL to clipboard`,
+		CopyBranchURL:                        `Copy branch URL to clipboard`,
+		BranchURLCopiedToClipboard:           "Branch URL copied to clipboard",
 		NoBranchOnRemote:                     `This branch doesn't exist on remote. You need to push it to remote first.`,
 		Fetch:                                `Fetch`,
 		FetchTooltip:                         "Fetch changes from remote.",
@@ -2120,6 +2125,7 @@ func EnglishTranslationSet() *TranslationSet {
 			Undo:                             "Undo",
 			Redo:                             "Redo",
 			CopyPullRequestURL:               "Copy pull request URL",
+			CopyBranchURL:                    "Copy branch URL",
 			OpenMergeTool:                    "Open merge tool",
 			OpenCommitInBrowser:              "Open commit in browser",
 			OpenPullRequest:                  "Open pull request in browser",


### PR DESCRIPTION
## Summary

Adds a new keybinding (`<c-u>` / Ctrl+U) in the branches panel to copy the branch's URL to the clipboard. This complements the existing "copy pull request URL" feature.

### Use Case

When you want to share a link to a specific branch (not a PR), you can now quickly copy the URL. For example:
- `https://github.com/owner/repo/tree/my-feature-branch`

### Changes

1. Added `branchURL` field to `ServiceDefinition` for all supported hosting services
2. Added `GetBranchURL` method to hosting service manager and helper
3. Added `CopyBranchURL` keybinding and handler to branches controller
4. Added translations for the new feature

### Supported Services

| Service | URL Pattern |
|---------|-------------|
| GitHub | `/tree/{branch}` |
| GitLab | `/-/tree/{branch}` |
| Bitbucket | `/branch/{branch}` |
| Bitbucket Server | `/browse?at=refs/heads/{branch}` |
| Azure DevOps | `?version=GB{branch}` |
| Gitea | `/src/branch/{branch}` |
| Codeberg | `/src/branch/{branch}` |

Closes #1959

## Test plan

1. Open lazygit in a GitHub/GitLab/etc. repo
2. Navigate to branches panel
3. Select a branch
4. Press `<c-u>`
5. Verify the correct URL is copied to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)