### PR TITLE
diff: add color-words toggle with ctrl-x keybinding

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -256,6 +256,7 @@ func (self *CommitCommands) ShowCmdObj(hash string, filterPaths []string) *oscom
 		Arg("-p").
 		Arg(hash).
 		ArgIf(self.UserConfig().Git.IgnoreWhitespaceInDiffView, "--ignore-all-space").
+		ArgIf(self.UserConfig().Git.ColorWordsInDiffView, "--color-words").
 		Arg(fmt.Sprintf("--find-renames=%d%%", self.UserConfig().Git.RenameSimilarityThreshold)).
 		Arg("--").
 		Arg(filterPaths...).

--- a/pkg/commands/git_commands/diff.go
+++ b/pkg/commands/git_commands/diff.go
@@ -23,6 +23,7 @@ func (self *DiffCommands) DiffCmdObj(diffArgs []string) *oscommands.CmdObj {
 	useExtDiff := extDiffCmd != ""
 	useExtDiffGitConfig := self.pagerConfig.GetUseExternalDiffGitConfig()
 	ignoreWhitespace := self.UserConfig().Git.IgnoreWhitespaceInDiffView
+	colorWords := self.UserConfig().Git.ColorWordsInDiffView
 
 	return self.cmd.New(
 		NewGitCmd("diff").
@@ -32,6 +33,7 @@ func (self *DiffCommands) DiffCmdObj(diffArgs []string) *oscommands.CmdObj {
 			Arg("--submodule").
 			Arg(fmt.Sprintf("--color=%s", self.pagerConfig.GetColorArg())).
 			ArgIf(ignoreWhitespace, "--ignore-all-space").
+			ArgIf(colorWords, "--color-words").
 			Arg(fmt.Sprintf("--unified=%d", self.UserConfig().Git.DiffContextSize)).
 			Arg(diffArgs...).
 			Dir(self.repoPaths.worktreePath).

--- a/pkg/commands/git_commands/stash.go
+++ b/pkg/commands/git_commands/stash.go
@@ -94,6 +94,7 @@ func (self *StashCommands) ShowStashEntryCmdObj(index int) *oscommands.CmdObj {
 		Arg(fmt.Sprintf("--color=%s", self.pagerConfig.GetColorArg())).
 		Arg(fmt.Sprintf("--unified=%d", self.UserConfig().Git.DiffContextSize)).
 		ArgIf(self.UserConfig().Git.IgnoreWhitespaceInDiffView, "--ignore-all-space").
+		ArgIf(self.UserConfig().Git.ColorWordsInDiffView, "--color-words").
 		Arg(fmt.Sprintf("--find-renames=%d%%", self.UserConfig().Git.RenameSimilarityThreshold)).
 		Arg(fmt.Sprintf("refs/stash@{%d}", index)).
 		Dir(self.repoPaths.worktreePath).

--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -277,6 +277,7 @@ func (self *WorkingTreeCommands) WorktreeFileDiffCmdObj(node models.IFile, plain
 		Arg(fmt.Sprintf("--unified=%d", contextSize)).
 		Arg(fmt.Sprintf("--color=%s", colorArg)).
 		ArgIf(!plain && self.UserConfig().Git.IgnoreWhitespaceInDiffView, "--ignore-all-space").
+		ArgIf(!plain && self.UserConfig().Git.ColorWordsInDiffView, "--color-words").
 		Arg(fmt.Sprintf("--find-renames=%d%%", self.UserConfig().Git.RenameSimilarityThreshold)).
 		ArgIf(cached, "--cached").
 		ArgIf(noIndex, "--no-index").
@@ -320,6 +321,7 @@ func (self *WorkingTreeCommands) ShowFileDiffCmdObj(from string, to string, reve
 		Arg(to).
 		ArgIf(reverse, "-R").
 		ArgIf(!plain && self.UserConfig().Git.IgnoreWhitespaceInDiffView, "--ignore-all-space").
+		ArgIf(!plain && self.UserConfig().Git.ColorWordsInDiffView, "--color-words").
 		Arg("--").
 		Arg(fileName).
 		Dir(self.repoPaths.worktreePath).

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -292,6 +292,8 @@ type GitConfig struct {
 	AllBranchesLogCmds []string `yaml:"allBranchesLogCmds"`
 	// If true, git diffs are rendered with the `--ignore-all-space` flag, which ignores whitespace changes. Can be toggled from within Lazygit with `<c-w>`.
 	IgnoreWhitespaceInDiffView bool `yaml:"ignoreWhitespaceInDiffView"`
+	// If true, git diffs are rendered with the `--color-words` flag, which shows word-level diffs. Can be toggled from within Lazygit with `<c-x>`.
+	ColorWordsInDiffView bool `yaml:"colorWordsInDiffView"`
 	// The number of lines of context to show around each diff hunk. Can be changed from within Lazygit with the `{` and `}` keys.
 	DiffContextSize uint64 `yaml:"diffContextSize"`
 	// The threshold for considering a file to be renamed, in percent. Can be changed from within Lazygit with the `(` and `)` keys.
@@ -485,6 +487,7 @@ type KeybindingUniversalConfig struct {
 	SubmitEditorText                  string   `yaml:"submitEditorText"`
 	ExtrasMenu                        string   `yaml:"extrasMenu"`
 	ToggleWhitespaceInDiffView        string   `yaml:"toggleWhitespaceInDiffView"`
+	ToggleColorWordsInDiffView        string   `yaml:"toggleColorWordsInDiffView"`
 	IncreaseContextInDiffView         string   `yaml:"increaseContextInDiffView"`
 	DecreaseContextInDiffView         string   `yaml:"decreaseContextInDiffView"`
 	IncreaseRenameSimilarityThreshold string   `yaml:"increaseRenameSimilarityThreshold"`
@@ -849,6 +852,7 @@ func GetDefaultConfig() *UserConfig {
 			BranchLogCmd:                 "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",
 			AllBranchesLogCmds:           []string{"git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium"},
 			IgnoreWhitespaceInDiffView:   false,
+			ColorWordsInDiffView:         false,
 			DiffContextSize:              3,
 			RenameSimilarityThreshold:    50,
 			DisableForcePushing:          false,
@@ -947,6 +951,7 @@ func GetDefaultConfig() *UserConfig {
 				SubmitEditorText:                  "<enter>",
 				ExtrasMenu:                        "@",
 				ToggleWhitespaceInDiffView:        "<c-w>",
+				ToggleColorWordsInDiffView:        "<c-x>",
 				IncreaseContextInDiffView:         "}",
 				DecreaseContextInDiffView:         "{",
 				IncreaseRenameSimilarityThreshold: ")",

--- a/pkg/gui/controllers/global_controller.go
+++ b/pkg/gui/controllers/global_controller.go
@@ -152,6 +152,12 @@ func (self *GlobalController) GetKeybindings(opts types.KeybindingsOpts) []*type
 			Description: self.c.Tr.ToggleWhitespaceInDiffView,
 			Tooltip:     self.c.Tr.ToggleWhitespaceInDiffViewTooltip,
 		},
+		{
+			Key:         opts.GetKey(opts.Config.Universal.ToggleColorWordsInDiffView),
+			Handler:     self.toggleColorWords,
+			Description: self.c.Tr.ToggleColorWordsInDiffView,
+			Tooltip:     self.c.Tr.ToggleColorWordsInDiffViewTooltip,
+		},
 	}
 }
 
@@ -252,6 +258,10 @@ func (self *GlobalController) escapeEnabled() *types.DisabledReason {
 
 func (self *GlobalController) toggleWhitespace() error {
 	return (&ToggleWhitespaceAction{c: self.c}).Call()
+}
+
+func (self *GlobalController) toggleColorWords() error {
+	return (&ToggleColorWordsAction{c: self.c}).Call()
 }
 
 func (self *GlobalController) canShowRebaseOptions() *types.DisabledReason {

--- a/pkg/gui/controllers/helpers/diff_helper.go
+++ b/pkg/gui/controllers/helpers/diff_helper.go
@@ -167,11 +167,21 @@ func (self *DiffHelper) WithDiffModeCheck(f func()) {
 }
 
 func (self *DiffHelper) IgnoringWhitespaceSubTitle() string {
-	if self.c.UserConfig().Git.IgnoreWhitespaceInDiffView {
-		return self.c.Tr.IgnoreWhitespaceDiffViewSubTitle
+	ignoreWhitespace := self.c.UserConfig().Git.IgnoreWhitespaceInDiffView
+	colorWords := self.c.UserConfig().Git.ColorWordsInDiffView
+
+	var subtitle string
+	if ignoreWhitespace {
+		subtitle = self.c.Tr.IgnoreWhitespaceDiffViewSubTitle
+	}
+	if colorWords {
+		if subtitle != "" {
+			subtitle += " | "
+		}
+		subtitle += self.c.Tr.ColorWordsDiffViewSubTitle
 	}
 
-	return ""
+	return subtitle
 }
 
 func (self *DiffHelper) OpenDiffToolForRef(selectedRef models.Ref) error {

--- a/pkg/gui/controllers/toggle_color_words_action.go
+++ b/pkg/gui/controllers/toggle_color_words_action.go
@@ -1,0 +1,30 @@
+package controllers
+
+import (
+	"errors"
+
+	"github.com/jesseduffield/lazygit/pkg/gui/context"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/samber/lo"
+)
+
+type ToggleColorWordsAction struct {
+	c *ControllerCommon
+}
+
+func (self *ToggleColorWordsAction) Call() error {
+	contextsThatDontSupportColorWords := []types.ContextKey{
+		context.STAGING_MAIN_CONTEXT_KEY,
+		context.STAGING_SECONDARY_CONTEXT_KEY,
+		context.PATCH_BUILDING_MAIN_CONTEXT_KEY,
+	}
+
+	if lo.Contains(contextsThatDontSupportColorWords, self.c.Context().Current().GetKey()) {
+		return errors.New(self.c.Tr.ColorWordsNotSupportedHere)
+	}
+
+	self.c.UserConfig().Git.ColorWordsInDiffView = !self.c.UserConfig().Git.ColorWordsInDiffView
+
+	self.c.Context().CurrentSide().HandleFocus(types.OnFocusOpts{})
+	return nil
+}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -751,6 +751,10 @@ type TranslationSet struct {
 	ToggleWhitespaceInDiffViewTooltip        string
 	IgnoreWhitespaceDiffViewSubTitle         string
 	IgnoreWhitespaceNotSupportedHere         string
+	ToggleColorWordsInDiffView               string
+	ToggleColorWordsInDiffViewTooltip        string
+	ColorWordsDiffViewSubTitle               string
+	ColorWordsNotSupportedHere               string
 	IncreaseContextInDiffView                string
 	IncreaseContextInDiffViewTooltip         string
 	DecreaseContextInDiffView                string
@@ -1851,6 +1855,10 @@ func EnglishTranslationSet() *TranslationSet {
 		ToggleWhitespaceInDiffViewTooltip:        "Toggle whether or not whitespace changes are shown in the diff view.\n\nThe default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'.",
 		IgnoreWhitespaceDiffViewSubTitle:         "(ignoring whitespace)",
 		IgnoreWhitespaceNotSupportedHere:         "Ignoring whitespace is not supported in this view",
+		ToggleColorWordsInDiffView:               "Toggle color words",
+		ToggleColorWordsInDiffViewTooltip:        "Toggle whether or not word-level diffs are shown in the diff view.\n\nThe default can be changed in the config file with the key 'git.colorWordsInDiffView'.",
+		ColorWordsDiffViewSubTitle:               "(color words)",
+		ColorWordsNotSupportedHere:               "Color words is not supported in this view",
 		IncreaseContextInDiffView:                "Increase diff context size",
 		IncreaseContextInDiffViewTooltip:         "Increase the amount of the context shown around changes in the diff view.\n\nThe default can be changed in the config file with the key 'git.diffContextSize'.",
 		DecreaseContextInDiffView:                "Decrease diff context size",


### PR DESCRIPTION
## Description

Adds runtime toggle for word-level diffs using git's `--color-words` flag. Complements existing whitespace toggle by providing finer-grained diff visualization.

### Example

The code in this example is out of context, but it shows how word-level diffing can be used to see what actually changed. This is a sample of what it looks like in lazy git when you apply the word level change and enable it:

<img width="723" height="74" alt="image" src="https://github.com/user-attachments/assets/6e9e1c03-eef0-4b90-b586-c006393d2b30" />

## Type of Change

- [x] Feature (non-breaking change that adds functionality)

## Implementation Details

Mirrors whitespace toggle architecture:
- Config field `git.colorWordsInDiffView` (default: false)
- Controller `toggle_color_words_action.go` with context exclusions for staging/patch-building
- Keybinding `<c-x>` registered in `global_controller.go`
- Git commands: added `--color-words` flag conditionally to `diff`, `show`, and `stash show` commands
- UI: subtitle displays active modes: "(ignoring whitespace) | (color words)"

Both flags can be enabled simultaneously in git commands without conflict.

## Testing

- [x] Tests pass locally (all 72 unit test packages)
- [x] Build successful