### PR TITLE
fix: Co-authored-by and Signed-off-by auto-wrapping

### DIFF
--- a/pkg/integration/tests/commit/auto_wrap_message_footnotes_and_trailers.go
+++ b/pkg/integration/tests/commit/auto_wrap_message_footnotes_and_trailers.go
@@ -1,0 +1,38 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var AutoWrapMessageFootnotesAndTrailers = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Commit, and test how auto-wrap preserves footnotes and trailers",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		// Use a ridiculously small width so that we don't have to use so much test data
+		config.GetUserConfig().Git.Commit.AutoWrapWidth = 20
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFile("file", "file content")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			IsEmpty()
+
+		t.Views().Files().
+			IsFocused().
+			PressPrimaryAction(). // stage file
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			Type("subject").
+			SwitchToDescription().
+			Type("[1]: https://github.com/jesseduffield/lazygit").
+			AddNewline().
+			Type("Co-authored-by: John Smith <jsmith@gmail.com>").
+			Content(Equals("[1]: https://github.com/jesseduffield/lazygit\nCo-authored-by: John Smith <jsmith@gmail.com>")).
+			SwitchToSummary().
+			Confirm()
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -104,6 +104,7 @@ var tests = []*components.IntegrationTest{
 	commit.AmendWhenThereAreConflictsAndCancel,
 	commit.AmendWhenThereAreConflictsAndContinue,
 	commit.AutoWrapMessage,
+	commit.AutoWrapMessageFootnotesAndTrailers,
 	commit.Checkout,
 	commit.CheckoutFileFromCommit,
 	commit.CheckoutFileFromRangeSelectionOfCommits,


### PR DESCRIPTION
### PR Description
In addition to ignoring footnote, also ignore Co-authored-by and Signed-off-by

This no-wrap detection only needs to check for leading ASCII, so we can use a fixed bytebuffer.  This avoids repeated heap allocs when building strings

- Closes https://github.com/jesseduffield/lazygit/issues/5216

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->

