### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
       GOFLAGS: -mod=vendor
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.x
       - name: Test code
@@ -39,7 +39,7 @@ jobs:
           mkdir -p /tmp/code_coverage
           go test ./... -short -cover -args "-test.gocoverdir=/tmp/code_coverage"
       - name: Upload code coverage artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-unit-${{ matrix.os }}-${{ github.run_id }}
           path: /tmp/code_coverage
@@ -59,7 +59,7 @@ jobs:
       GOFLAGS: -mod=vendor
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Restore Git cache
         if: matrix.git-version != 'latest'
         id: cache-git-restore
@@ -85,7 +85,7 @@ jobs:
           path: ~/git-${{matrix.git-version}}
           key: ${{runner.os}}-git-${{matrix.git-version}}
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.x
       - name: Print git version
@@ -98,7 +98,7 @@ jobs:
           mkdir -p /tmp/code_coverage
           ./scripts/run_integration_tests.sh
       - name: Upload code coverage artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-integration-${{ matrix.git-version }}-${{ github.run_id }}
           path: /tmp/code_coverage
@@ -109,9 +109,9 @@ jobs:
       GOARCH: amd64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.x
       - name: Build linux binary
@@ -136,9 +136,9 @@ jobs:
       GOARCH: amd64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.x
       - name: Check Vendor Directory
@@ -162,13 +162,13 @@ jobs:
       GOFLAGS: -mod=vendor
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.x
       - name: Lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           # If you change this, make sure to also update scripts/golangci-lint-shim.sh
           version: v2.4.0
@@ -182,15 +182,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.x
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: /tmp/code_coverage
 
@@ -219,7 +219,7 @@ jobs:
         run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} ))" >> "${GITHUB_ENV}"
 
       - name: "Checkout PR branch and all PR commits"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.pull_request == null && startsWith(github.event.comment.body, '/close') }}
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           script: |
             const trustedUsers = ['ChrisMcD1', 'jesseduffield', 'stefanhaller']

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Annotate locations with typos
         uses: codespell-project/codespell-problem-matcher@v1
       - name: Codespell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           fi
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: jesseduffield/lazygit
           token: ${{ secrets.LAZYGIT_RELEASE_PAT }}
@@ -146,7 +146,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.LAZYGIT_RELEASE_PAT }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.25.x
 

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.repository == 'jesseduffield/lazygit' }}
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate Sponsors 💖
         uses: JamesIves/github-sponsors-readme-action@v1.2.2
@@ -19,7 +19,7 @@ jobs:
           file: "README.md"
 
       - name: Create Pull Request 🚀
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "README.md: Update Sponsors"
           title: "README.md: Update Sponsors"


### PR DESCRIPTION
### PR Description

- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/close-issues.yml`
- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/release.yml`
- Updated `golangci/golangci-lint-action` from `v8` to `v9` in `.github/workflows/ci.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/codespell.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `peter-evans/create-pull-request` from `v7` to `v8` in `.github/workflows/sponsors.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/ci.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/ci.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/sponsors.yml`
- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/ci.yml`

The changes ensure that the GitHub Action workflows are using the latest versions of the actions, which include improved functionality and compatibility. These updates will be tested in the CI pipeline of the pull request.