### PR TITLE
Add RepoName, RepoPath, and WorktreePath to custom command placeholders

### DIFF
--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -339,6 +339,14 @@ SelectedWorktree
 CheckedOutBranch
 ```
 
+The following string values are also available:
+
+| Placeholder | Description |
+|-------------|-------------|
+| `RepoName` | Name of the repository (basename of the repo folder) |
+| `RepoPath` | Full path to the repository root |
+| `WorktreePath` | Full path to the current worktree (same as `RepoPath` in the main worktree) |
+
 (For legacy reasons, `SelectedLocalCommit`, `SelectedReflogCommit`, and `SelectedSubCommit` are also available, but they are deprecated.)
 
 

--- a/pkg/gui/services/custom_commands/session_state_loader.go
+++ b/pkg/gui/services/custom_commands/session_state_loader.go
@@ -209,6 +209,9 @@ type SessionState struct {
 	SelectedCommitFilePath string
 	SelectedWorktree       *Worktree
 	CheckedOutBranch       *Branch
+	RepoName               string
+	RepoPath               string
+	WorktreePath           string
 }
 
 func (self *SessionStateLoader) call() *SessionState {
@@ -254,5 +257,8 @@ func (self *SessionStateLoader) call() *SessionState {
 		SelectedCommitFilePath: selectedCommitFilePath,
 		SelectedWorktree:       worktreeShimFromModelRemote(self.c.Contexts().Worktrees.GetSelected()),
 		CheckedOutBranch:       branchShimFromModelBranch(self.refsHelper.GetCheckedOutRef()),
+		RepoName:               self.c.Git().RepoPaths.RepoName(),
+		RepoPath:               self.c.Git().RepoPaths.RepoPath(),
+		WorktreePath:           self.c.Git().RepoPaths.WorktreePath(),
 	}
 }


### PR DESCRIPTION
### PR Description

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->

### Summary

Adds three new placeholders for custom commands:
- `RepoName` - basename of the repo folder
- `RepoPath` - full path to the repository root
- `WorktreePath` - full path to current worktree (differs from `RepoPath` in linked worktrees)

### Example usage

```yaml
customCommands:
  - key: "w"
    description: "WIP commit"
    context: files
    prompts:
      - type: "menu"
        title: "commit message"
        options:
          - value: "WIP [ci skip]"
          - value: "WIP"
    command: "git -C {{.RepoPath}} commit -m '{{index .PromptResponses 0}}'"
```