### PR TITLE
Fix rendering of nodes with both file status and children in file tree

### DIFF
--- a/pkg/gui/presentation/files_test.go
+++ b/pkg/gui/presentation/files_test.go
@@ -109,6 +109,39 @@ M  file1
 			),
 			collapsedPaths: []string{"dir1"},
 		},
+		{
+			name: "deleted symlink replaced with directory containing files",
+			files: []*models.File{
+				{Path: "dir/link", ShortStatus: "D ", HasStagedChanges: true},
+				{Path: "dir/link/file1", ShortStatus: "A ", HasStagedChanges: true},
+				{Path: "dir/link/file2", ShortStatus: "A ", HasStagedChanges: true},
+			},
+			showRootItem: false,
+			expected: toStringSlice(
+				`
+▼ dir
+  D  ▼ link
+    A  file1
+    A  file2
+`,
+			),
+		},
+		{
+			name: "deleted symlink replaced with directory - collapsed",
+			files: []*models.File{
+				{Path: "dir/link", ShortStatus: "D ", HasStagedChanges: true},
+				{Path: "dir/link/file1", ShortStatus: "A ", HasStagedChanges: true},
+				{Path: "dir/link/file2", ShortStatus: "A ", HasStagedChanges: true},
+			},
+			showRootItem:   false,
+			collapsedPaths: []string{"dir/link"},
+			expected: toStringSlice(
+				`
+▼ dir
+  D  ▶ link
+`,
+			),
+		},
 	}
 
 	oldColorLevel := color.ForceSetColorLevel(terminfo.ColorLevelNone)
@@ -199,6 +232,39 @@ M file1
 `,
 			),
 			collapsedPaths: []string{"dir1"},
+		},
+		{
+			name: "deleted symlink replaced with directory containing files",
+			files: []*models.CommitFile{
+				{Path: "dir/link", ChangeStatus: "D"},
+				{Path: "dir/link/file1", ChangeStatus: "A"},
+				{Path: "dir/link/file2", ChangeStatus: "A"},
+			},
+			showRootItem: false,
+			expected: toStringSlice(
+				`
+▼ dir
+  D ▼ link
+    A file1
+    A file2
+`,
+			),
+		},
+		{
+			name: "deleted symlink replaced with directory - collapsed",
+			files: []*models.CommitFile{
+				{Path: "dir/link", ChangeStatus: "D"},
+				{Path: "dir/link/file1", ChangeStatus: "A"},
+				{Path: "dir/link/file2", ChangeStatus: "A"},
+			},
+			showRootItem:   false,
+			collapsedPaths: []string{"dir/link"},
+			expected: toStringSlice(
+				`
+▼ dir
+  D ▶ link
+`,
+			),
 		},
 	}
 


### PR DESCRIPTION
### PR Description
Fixes #5232

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
