### PR TITLE
Don't log the "git rev-list" call when marking bisect commits

### DIFF
--- a/pkg/commands/git_commands/bisect.go
+++ b/pkg/commands/git_commands/bisect.go
@@ -154,7 +154,7 @@ func (self *BisectCommands) IsDone() (bool, []string, error) {
 	candidates := []string{}
 
 	cmdArgs := NewGitCmd("rev-list").Arg(newHash).ToArgv()
-	err := self.cmd.New(cmdArgs).RunAndProcessLines(func(line string) (bool, error) {
+	err := self.cmd.New(cmdArgs).DontLog().RunAndProcessLines(func(line string) (bool, error) {
 		hash := strings.TrimSpace(line)
 
 		if status, ok := info.statusMap[hash]; ok {


### PR DESCRIPTION
When marking commits as good or bad during a bisect, a "git rev-list" call would appear in the Command log. This is confusing, it's an internal detail that is not interesting for the user to see.
