### PR TITLE
Fix opening a menu when a previous menu was scrolled down

### DIFF
--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -61,6 +61,8 @@ func (gui *Gui) createMenu(opts types.CreateMenuOptions) error {
 	gui.State.Contexts.Menu.SetKeybindingsTakePrecedence(!opts.KeepConflictingKeybindings)
 	gui.State.Contexts.Menu.SetSelection(0)
 
+	gui.Views.Menu.SetOriginY(0)
+
 	gui.Views.Menu.Title = opts.Title
 	gui.Views.Menu.FgColor = theme.GocuiDefaultTextColor
 


### PR DESCRIPTION
To reproduce: open the keybindings menu ('?'), press '>' to select the last line, esc to close it, open it again. The view would appear still scrolled down, so the selected first line was out of view. Even worse, if you open a different, shorter menu (e.g. the "View upstream reset options..." menu in the Files panel), you'd only see the Cancel item, the other ones were scrolled out of view.

This is a regression introduced with efd4298b5e91 (#5134).
