### PR TITLE
Fix gitignore path collisions

### DIFF
--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -233,10 +233,10 @@ func (self *WorkingTreeCommands) DiscardUnstagedFileChanges(file *models.File) e
 	return self.cmd.New(cmdArgs).Run()
 }
 
-// Escapes special characters in a filename for gitignore and exclude files
+// Escapes special characters in a filename for gitignore and exclude files, and prepends `/`
 func escapeFilename(filename string) string {
 	re := regexp.MustCompile(`^[!#]|[\[\]*]`)
-	return re.ReplaceAllString(filename, `\${0}`)
+	return "/" + re.ReplaceAllString(filename, `\${0}`)
 }
 
 // Ignore adds a file to the gitignore for the repo

--- a/pkg/integration/tests/file/gitignore.go
+++ b/pkg/integration/tests/file/gitignore.go
@@ -50,7 +50,7 @@ var Gitignore = NewIntegrationTest(NewIntegrationTestArgs{
 				t.ExpectPopup().Menu().Title(Equals("Ignore or exclude file")).Select(Contains("Add to .git/info/exclude")).Confirm()
 
 				t.FileSystem().FileContent(".gitignore", Equals(""))
-				t.FileSystem().FileContent(".git/info/exclude", Contains("toExclude"))
+				t.FileSystem().FileContent(".git/info/exclude", Contains("/toExclude"))
 			}).
 			SelectNextItem().
 			Press(keys.Files.IgnoreFile).
@@ -58,8 +58,8 @@ var Gitignore = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Menu().Title(Equals("Ignore or exclude file")).Select(Contains("Add to .gitignore")).Confirm()
 
-				t.FileSystem().FileContent(".gitignore", Equals("toIgnore\n"))
-				t.FileSystem().FileContent(".git/info/exclude", Contains("toExclude"))
+				t.FileSystem().FileContent(".gitignore", Equals("/toIgnore\n"))
+				t.FileSystem().FileContent(".git/info/exclude", Contains("/toExclude"))
 			})
 	},
 })

--- a/pkg/integration/tests/file/gitignore_special_characters.go
+++ b/pkg/integration/tests/file/gitignore_special_characters.go
@@ -61,6 +61,6 @@ var GitignoreSpecialCharacters = NewIntegrationTest(NewIntegrationTestArgs{
 				Equals("  ?? abc_def"),
 			)
 
-		t.FileSystem().FileContent(".gitignore", Equals("\\#file\nfile#abc\n\\!file\nfile!abc\nabc\\*def\nfile\\[x\\]\n"))
+		t.FileSystem().FileContent(".gitignore", Equals("/\\#file\n/file#abc\n/\\!file\n/file!abc\n/abc\\*def\n/file\\[x\\]\n"))
 	},
 })


### PR DESCRIPTION
### PR Description

Paths added to ignore/exclude files need to be prefixed with a forward slash to point to a specific file in the directory tree.

Without that prefix a file at root called `file` (added to `.gitignore` as `file`) would match with `./file` and `./src/file`.

Example flow:
1. User creates a directory called `tests` in root
2. User sees that it's tracked
3. User ignores the directory in Lazygit
4. Changes in `src/tests` are now missing - because `tests` without `/` matches also directories lower in the tree

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc