### PR TITLE
fix: auto-close rebase continue popup when rebase completes externally

### DIFF
--- a/pkg/gui/controllers/helpers/merge_and_rebase_helper.go
+++ b/pkg/gui/controllers/helpers/merge_and_rebase_helper.go
@@ -222,8 +222,9 @@ func (self *MergeAndRebaseHelper) AbortMergeOrRebaseWithConfirm() error {
 // PromptToContinueRebase asks the user if they want to continue the rebase/merge that's in progress
 func (self *MergeAndRebaseHelper) PromptToContinueRebase() error {
 	self.c.Confirm(types.ConfirmOpts{
-		Title:  self.c.Tr.Continue,
-		Prompt: fmt.Sprintf(self.c.Tr.ConflictsResolved, self.c.Git().Status.WorkingTreeState().CommandName()),
+		Title:              self.c.Tr.Continue,
+		Prompt:             fmt.Sprintf(self.c.Tr.ConflictsResolved, self.c.Git().Status.WorkingTreeState().CommandName()),
+		AutoCloseCondition: types.PopupAutoCloseWorkingTreeStateNone,
 		HandleConfirm: func() error {
 			// By the time we get here, we might have unstaged changes again,
 			// e.g. if the user had to fix build errors after resolving the
@@ -240,8 +241,9 @@ func (self *MergeAndRebaseHelper) PromptToContinueRebase() error {
 			root := self.c.Contexts().Files.FileTreeViewModel.GetRoot()
 			if root.GetHasUnstagedChanges() {
 				self.c.Confirm(types.ConfirmOpts{
-					Title:  self.c.Tr.Continue,
-					Prompt: self.c.Tr.UnstagedFilesAfterConflictsResolved,
+					Title:              self.c.Tr.Continue,
+					Prompt:             self.c.Tr.UnstagedFilesAfterConflictsResolved,
+					AutoCloseCondition: types.PopupAutoCloseWorkingTreeStateNone,
 					HandleConfirm: func() error {
 						self.c.LogAction(self.c.Tr.Actions.StageAllFiles)
 						if err := self.c.Git().WorkingTree.StageAll(true); err != nil {

--- a/pkg/gui/popup/popup_handler.go
+++ b/pkg/gui/popup/popup_handler.go
@@ -108,21 +108,17 @@ func (self *PopupHandler) Alert(title string, message string) {
 
 func (self *PopupHandler) Confirm(opts types.ConfirmOpts) {
 	self.createPopupPanelFn(context.Background(), types.CreatePopupPanelOpts{
-		Title:         opts.Title,
-		Prompt:        opts.Prompt,
-		HandleConfirm: opts.HandleConfirm,
-		HandleClose:   opts.HandleClose,
+		Title:              opts.Title,
+		Prompt:             opts.Prompt,
+		HandleConfirm:      opts.HandleConfirm,
+		HandleClose:        opts.HandleClose,
+		AutoCloseCondition: opts.AutoCloseCondition,
 	})
 }
 
 func (self *PopupHandler) ConfirmIf(condition bool, opts types.ConfirmOpts) error {
 	if condition {
-		self.createPopupPanelFn(context.Background(), types.CreatePopupPanelOpts{
-			Title:         opts.Title,
-			Prompt:        opts.Prompt,
-			HandleConfirm: opts.HandleConfirm,
-			HandleClose:   opts.HandleClose,
-		})
+		self.Confirm(opts)
 		return nil
 	}
 

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -149,6 +149,13 @@ const (
 	ToastKindError
 )
 
+type PopupAutoCloseCondition int
+
+const (
+	PopupAutoCloseNone PopupAutoCloseCondition = iota
+	PopupAutoCloseWorkingTreeStateNone
+)
+
 type CreateMenuOptions struct {
 	Title                      string
 	Prompt                     string // a message that will be displayed above the menu options
@@ -168,6 +175,7 @@ type CreatePopupPanelOpts struct {
 	HandleConfirmPrompt    func(string) error
 	HandleClose            func() error
 	HandleDeleteSuggestion func(int) error
+	AutoCloseCondition     PopupAutoCloseCondition
 
 	FindSuggestionsFunc func(string) []*Suggestion
 	Mask                bool
@@ -184,6 +192,7 @@ type ConfirmOpts struct {
 	FindSuggestionsFunc func(string) []*Suggestion
 	Editable            bool
 	Mask                bool
+	AutoCloseCondition  PopupAutoCloseCondition
 }
 
 type PromptOpts struct {

--- a/pkg/integration/tests/branch/rebase_conflicts_resolved_externally.go
+++ b/pkg/integration/tests/branch/rebase_conflicts_resolved_externally.go
@@ -1,0 +1,63 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+	"github.com/jesseduffield/lazygit/pkg/integration/tests/shared"
+)
+
+var RebaseConflictsResolvedExternally = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Resolve conflicts and continue rebase externally, verify popup auto-dismisses.",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Git.LocalBranchSortOrder = "recency"
+	},
+	SetupRepo: func(shell *Shell) {
+		shared.MergeConflictsSetup(shell)
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("first-change-branch"),
+				Contains("second-change-branch"),
+				Contains("original-branch"),
+			).
+			SelectNextItem().
+			Press(keys.Branches.RebaseBranch)
+
+		t.ExpectPopup().Menu().
+			Title(Equals("Rebase 'first-change-branch'")).
+			Select(Contains("Simple rebase")).
+			Confirm()
+
+		t.Common().AcknowledgeConflicts()
+
+		t.Views().Files().
+			IsFocused().
+			Tap(func() {
+				t.Shell().UpdateFile("file", shared.FirstChangeFileContent)
+				t.Shell().GitAdd("file")
+			}).
+			Press(keys.Universal.Refresh)
+
+		t.ExpectPopup().Confirmation().
+			Title(Equals("Continue")).
+			Content(Contains("All merge conflicts resolved. Continue the rebase?"))
+
+		t.Shell().RunCommandWithEnv([]string{"git", "rebase", "--continue"}, []string{
+			"GIT_EDITOR=true",
+			"GIT_SEQUENCE_EDITOR=true",
+			"EDITOR=true",
+			"VISUAL=true",
+			"GIT_TERMINAL_PROMPT=0",
+		})
+
+		t.GlobalPress(keys.Universal.Refresh)
+		t.Wait(500) // Allow time for the refresh to complete and the popup to auto-close
+
+		t.Views().Files().IsFocused()
+		t.Views().Information().Content(DoesNotContain("Rebasing"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -69,6 +69,7 @@ var tests = []*components.IntegrationTest{
 	branch.RebaseAndDrop,
 	branch.RebaseCancelOnConflict,
 	branch.RebaseConflictsFixBuildErrors,
+	branch.RebaseConflictsResolvedExternally,
 	branch.RebaseCopiedBranch,
 	branch.RebaseDoesNotAutosquash,
 	branch.RebaseFromMarkedBase,


### PR DESCRIPTION
### PR Description

When a rebase has conflicts and the user resolves them and runs `git rebase --continue` in an external terminal, the "Continue rebase?" confirmation popup now automatically dismisses instead of staying visible.

The implementation introduces `PopupAutoCloseCondition` to tag popups that should auto-close under specific conditions. During status refresh, if the working tree state becomes none (no rebase/merge in progress) and the current popup has matching auto-close condition, the popup is closed.

To allow refresh while the auto-closable popup is showing, the refresh keybinding now uses `refreshAllowPopupAutoClose` which permits refresh only for popups with an auto-close condition set.

Fixes #5197

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->

---

### Manual Test

#### Steps

```bash
# 1. Create test repo with rebase conflict
mkdir test-repo && cd test-repo
git init
echo "original" > file.txt && git add . && git commit -m "initial"
git checkout -b feature
echo "feature" > file.txt && git add . && git commit -m "feature"
git checkout master
echo "master" > file.txt && git add . && git commit -m "master"
git checkout feature
git rebase master  # This will conflict

# 2. Open lazygit in another terminal
lazygit

# 3. Resolve conflict externally (in original terminal)
echo "resolved" > file.txt
git add file.txt
# Wait for "Continue rebase?" popup to appear in lazygit

# 4. Complete rebase externally
git rebase --continue

# 5. Verify: popup should auto-close in lazygit
```

#### Expected

The "Continue rebase?" popup automatically dismisses after step 4.

#### Cleanup

```bash
cd .. && rm -rf test-repo
```