### PR TITLE
Enable { and } to change diff context size in branches and tags panels in diffing mode

### DIFF
--- a/pkg/gui/controllers/context_lines_controller.go
+++ b/pkg/gui/controllers/context_lines_controller.go
@@ -7,24 +7,9 @@ import (
 
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
-	"github.com/samber/lo"
 )
 
 // This controller lets you change the context size for diffs. The 'context' in 'context size' refers to the conventional meaning of the word 'context' in a diff, as opposed to lazygit's own idea of a 'context'.
-
-var CONTEXT_KEYS_SHOWING_DIFFS = []types.ContextKey{
-	context.FILES_CONTEXT_KEY,
-	context.COMMIT_FILES_CONTEXT_KEY,
-	context.STASH_CONTEXT_KEY,
-	context.LOCAL_COMMITS_CONTEXT_KEY,
-	context.SUB_COMMITS_CONTEXT_KEY,
-	context.STAGING_MAIN_CONTEXT_KEY,
-	context.STAGING_SECONDARY_CONTEXT_KEY,
-	context.PATCH_BUILDING_MAIN_CONTEXT_KEY,
-	context.PATCH_BUILDING_SECONDARY_CONTEXT_KEY,
-	context.NORMAL_MAIN_CONTEXT_KEY,
-	context.NORMAL_SECONDARY_CONTEXT_KEY,
-}
 
 type ContextLinesController struct {
 	baseController
@@ -66,33 +51,25 @@ func (self *ContextLinesController) Context() types.Context {
 }
 
 func (self *ContextLinesController) Increase() error {
-	if self.isShowingDiff() {
-		if err := self.checkCanChangeContext(); err != nil {
-			return err
-		}
-
-		if self.c.UserConfig().Git.DiffContextSize < math.MaxUint64 {
-			self.c.UserConfig().Git.DiffContextSize++
-		}
-		return self.applyChange()
+	if err := self.checkCanChangeContext(); err != nil {
+		return err
 	}
 
-	return nil
+	if self.c.UserConfig().Git.DiffContextSize < math.MaxUint64 {
+		self.c.UserConfig().Git.DiffContextSize++
+	}
+	return self.applyChange()
 }
 
 func (self *ContextLinesController) Decrease() error {
-	if self.isShowingDiff() {
-		if err := self.checkCanChangeContext(); err != nil {
-			return err
-		}
-
-		if self.c.UserConfig().Git.DiffContextSize > 0 {
-			self.c.UserConfig().Git.DiffContextSize--
-		}
-		return self.applyChange()
+	if err := self.checkCanChangeContext(); err != nil {
+		return err
 	}
 
-	return nil
+	if self.c.UserConfig().Git.DiffContextSize > 0 {
+		self.c.UserConfig().Git.DiffContextSize--
+	}
+	return self.applyChange()
 }
 
 func (self *ContextLinesController) applyChange() error {
@@ -117,13 +94,6 @@ func (self *ContextLinesController) checkCanChangeContext() error {
 	}
 
 	return nil
-}
-
-func (self *ContextLinesController) isShowingDiff() bool {
-	return lo.Contains(
-		CONTEXT_KEYS_SHOWING_DIFFS,
-		self.currentSidePanel().GetKey(),
-	)
 }
 
 func (self *ContextLinesController) currentSidePanel() types.Context {

--- a/pkg/gui/controllers/rename_similarity_threshold_controller.go
+++ b/pkg/gui/controllers/rename_similarity_threshold_controller.go
@@ -5,19 +5,9 @@ import (
 
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
-	"github.com/samber/lo"
 )
 
 // This controller lets you change the similarity threshold for detecting renames.
-
-var CONTEXT_KEYS_SHOWING_RENAMES = []types.ContextKey{
-	context.FILES_CONTEXT_KEY,
-	context.SUB_COMMITS_CONTEXT_KEY,
-	context.LOCAL_COMMITS_CONTEXT_KEY,
-	context.STASH_CONTEXT_KEY,
-	context.NORMAL_MAIN_CONTEXT_KEY,
-	context.NORMAL_SECONDARY_CONTEXT_KEY,
-}
 
 type RenameSimilarityThresholdController struct {
 	baseController
@@ -61,23 +51,21 @@ func (self *RenameSimilarityThresholdController) Context() types.Context {
 func (self *RenameSimilarityThresholdController) Increase() error {
 	old_size := self.c.UserConfig().Git.RenameSimilarityThreshold
 
-	if self.isShowingRenames() && old_size < 100 {
+	if old_size < 100 {
 		self.c.UserConfig().Git.RenameSimilarityThreshold = min(100, old_size+5)
-		return self.applyChange()
 	}
 
-	return nil
+	return self.applyChange()
 }
 
 func (self *RenameSimilarityThresholdController) Decrease() error {
 	old_size := self.c.UserConfig().Git.RenameSimilarityThreshold
 
-	if self.isShowingRenames() && old_size > 5 {
+	if old_size > 5 {
 		self.c.UserConfig().Git.RenameSimilarityThreshold = max(5, old_size-5)
-		return self.applyChange()
 	}
 
-	return nil
+	return self.applyChange()
 }
 
 func (self *RenameSimilarityThresholdController) applyChange() error {
@@ -92,13 +80,6 @@ func (self *RenameSimilarityThresholdController) applyChange() error {
 		currentContext.HandleRenderToMain()
 	}
 	return nil
-}
-
-func (self *RenameSimilarityThresholdController) isShowingRenames() bool {
-	return lo.Contains(
-		CONTEXT_KEYS_SHOWING_RENAMES,
-		self.currentSidePanel().GetKey(),
-	)
 }
 
 func (self *RenameSimilarityThresholdController) currentSidePanel() types.Context {


### PR DESCRIPTION
When looking at a diff in diffing mode in the branches or tags panels (e.g. after pressing `W` on a branch and then selecting a different branch to diff it against the first one) it wasn't possible to change the diff context size using `{` and `}`, or the rename threshold using `(` and `)`.

Fixes #5254.