### PR TITLE
feat: When creating a fixup commit on an existing fixup commit, offer to use the base commit

### DIFF
--- a/pkg/gui/controllers/helpers/fixup_helper.go
+++ b/pkg/gui/controllers/helpers/fixup_helper.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/jesseduffield/generics/set"
@@ -407,6 +408,25 @@ func IsFixupCommit(subject string) (string, bool) {
 		}
 		return subject, true
 	}
-
 	return subject, false
+}
+
+// FindFixupBaseCommit will search commits (oldest first) to find a matching
+// commit for the given subject. It expects the subject to be already trimmed,
+// as if it were returned from [IsFixupCommit].
+//
+// It also returns whether the commit message has an exact match to the target base commit.
+// If no matches are found, it returns nil.
+func FindFixupBaseCommit(subject string, commits []*models.Commit) (model *models.Commit) {
+	for _, commit := range slices.Backward(commits) {
+		candidateSubject, _, _ := strings.Cut(commit.Name, "\n")
+
+		if strings.HasPrefix(commit.Hash(), subject) {
+			return commit
+		}
+		if strings.HasPrefix(candidateSubject, subject) {
+			return commit
+		}
+	}
+	return nil
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -479,6 +479,10 @@ type TranslationSet struct {
 	FixupMenu_AmendWithChangesTooltip     string
 	FixupMenu_AmendWithoutChanges         string
 	FixupMenu_AmendWithoutChangesTooltip  string
+	FixupMenu_SelectCommit                string
+	FixupMenu_SelectBase                  string
+	FixupMenu_SelectGlobalBase            string
+	FixUpMenu_SelectSelected              string
 	SquashAboveCommitsTooltip             string
 	SquashCommitsAboveSelectedTooltip     string
 	SquashCommitsInCurrentBranchTooltip   string
@@ -1592,6 +1596,10 @@ func EnglishTranslationSet() *TranslationSet {
 		FixupMenu_AmendWithChangesTooltip:    "Lets you fixup another commit and also change its commit message.",
 		FixupMenu_AmendWithoutChanges:        "amend! commit without changes (pure reword)",
 		FixupMenu_AmendWithoutChangesTooltip: "Lets you change the commit message of another commit without changing its content.",
+		FixupMenu_SelectCommit:               "Select base commit",
+		FixupMenu_SelectBase:                 "base commit",
+		FixupMenu_SelectGlobalBase:           "base commit (searching all commits)",
+		FixUpMenu_SelectSelected:             "selected commit",
 		SquashAboveCommits:                   "Apply fixup commits",
 		SquashAboveCommitsTooltip:            `Squash all 'fixup!' commits, either above the selected commit, or all in current branch (autosquash).`,
 		SquashCommitsAboveSelectedTooltip:    `Squash all 'fixup!' commits above the selected commit (autosquash).`,

--- a/pkg/integration/tests/commit/create_fixup_commit_on_fixup_commit.go
+++ b/pkg/integration/tests/commit/create_fixup_commit_on_fixup_commit.go
@@ -1,0 +1,59 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CreateFixupCommitOnFixupCommit = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Create a fixup commit on an existing fixup commit, verify that it prompts you to create it on the base commit",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	GitVersion:   AtLeast("2.38.0"),
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.NewBranch("branch1")
+		shell.EmptyCommit("branch1 commit 1")
+		shell.EmptyCommit("branch1 commit 2")
+		shell.EmptyCommit("branch1 commit 3")
+		shell.NewBranch("branch2")
+		shell.EmptyCommit("branch2 commit 1")
+		shell.EmptyCommit("fixup! branch2 commit 1")
+		shell.CreateFileAndAdd("fixup-file", "fixup content")
+
+		shell.SetConfig("rebase.updateRefs", "true")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("CI ◯ fixup! branch2 commit 1"),
+				Contains("CI ◯ branch2 commit 1"),
+				Contains("CI ◯ * branch1 commit 3"),
+				Contains("CI ◯ branch1 commit 2"),
+				Contains("CI ◯ branch1 commit 1"),
+			).
+			NavigateToLine(Contains("fixup! branch2 commit 1")).
+			Press(keys.Commits.CreateFixupCommit).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Create fixup commit")).
+					Select(Contains("fixup! commit")).
+					Confirm()
+			}).
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("Select base commit")).
+					Select(Equals("b base commit")).
+					Confirm()
+			}).
+			Lines(
+				Contains("CI ◯ fixup! branch2 commit 1"),
+				Contains("CI ◯ fixup! branch2 commit 1"),
+				Contains("CI ◯ branch2 commit 1"),
+				Contains("CI ◯ * branch1 commit 3"),
+				Contains("CI ◯ branch1 commit 2"),
+				Contains("CI ◯ branch1 commit 1"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -123,6 +123,7 @@ var tests = []*components.IntegrationTest{
 	commit.CopyTagToClipboard,
 	commit.CreateAmendCommit,
 	commit.CreateFixupCommitInBranchStack,
+	commit.CreateFixupCommitOnFixupCommit,
 	commit.CreateTag,
 	commit.DisableCopyCommitMessageBody,
 	commit.DiscardOldFileChanges,


### PR DESCRIPTION
When in a workflow where you are applying fixups and using the `findBaseCommitForFixup` action, a fixup commit (to the intended base commit) instead of the base commit may be selected. In those situations, this PR prompts to target the original commit instead in a modal. This primarily helps in improving commit messages from becoming "fixup! fixup! <base commit message>".

Three commits are prompted, if a matching base commit is found.
1. The selected commit, if that is the intended behaviour.
2. A base commit in the current todo list of commits (that are pending rebase) using Git's logic for determining the base commits when autosquashing.
3. A base commit using slightly stricter yet more expected rules which is incredibly useful in a workflow when maintaining your own fork.
