### PR TITLE
Disable the automatic, scheduled release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,11 @@
 name: Release
 
 on:
-  schedule:
-    # Runs at 8:00 AM UTC on every Saturday
-    # We'll check below if it's the first Saturday of the month, and fail if not
-    - cron: '0 8 * * 6'
+  # schedule:
+  #   # Runs at 8:00 AM UTC on every Saturday
+  #   # We'll check below if it's the first Saturday of the month, and fail if not
+  #   - cron: '0 8 * * 6'
+
   # Allow manual triggering of the workflow
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
There's too much manual work involved in releasing now (updating translations, copying docs-master) to make automatic releases infeasible. I'm not worried that I forget to release on the first Saturday of every month.

Keeping the code commented out in case we want to re-enable it at some point.
