### PR TITLE
Add Terra as an alternative Fedora install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ If you're a mere mortal like me and you're tired of hearing how powerful git is 
   - [gah (Linux and Mac OS)](#gah-linux-and-mac-os)
   - [Arch Linux](#arch-linux)
   - [Fedora / Amazon Linux 2023 / CentOS Stream](#fedora--amazon-linux-2023--centos-stream)
+    - [Fedora / RHEL Derivatives (Terra)](#fedora--rhel-derivatives-terra)
   - [Solus Linux](#solus-linux)
   - [Debian and Ubuntu](#debian-and-ubuntu)
   - [Funtoo Linux](#funtoo-linux)
@@ -323,6 +324,19 @@ These packages are built using the RPM spec file located here: https://codeberg.
 
 You should be able to build RPMs for Fedora 41 or older, and other Fedora derivatives using the
 SRPM (Source RPM) file that you can grab from the latest COPR build.
+
+#### Fedora / RHEL Derivatives (Terra)
+
+Packages for Fedora and RHEL derivatives are also available from the [Terra Repository](https://terra.fyralabs.com/).
+
+```sh
+sudo dnf install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release
+sudo dnf install lazygit
+```
+
+(Install guide for Atomic/EL can be found on their [README](https://github.com/terrapkg/packages/pull/9747))
+
+Terra also has `lazygit-doc`, which contains the contents of the [docs](https://github.com/jesseduffield/lazygit/tree/master/docs) folder.
 
 ### Solus Linux
 


### PR DESCRIPTION
### PR Description

Adds Terra as an alternative Fedora install method. There are a few advantages to this method over the Copr:
- Auto-updates
- Not a sole repo just for lazygit
- Debug packages

Let me know if there are any formatting changes or anything else needed.

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
