### PR TITLE
Show commit hashes in command log when deleting branches

### DIFF
--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -133,13 +133,14 @@ func (self *BranchCommands) PreviousRef() (string, error) {
 }
 
 // LocalDelete delete branch locally
-func (self *BranchCommands) LocalDelete(branches []string, force bool) error {
+func (self *BranchCommands) LocalDelete(branches []string, force bool) (string, error) {
 	cmdArgs := NewGitCmd("branch").
 		ArgIfElse(force, "-D", "-d").
 		Arg(branches...).
 		ToArgv()
 
-	return self.cmd.New(cmdArgs).Run()
+	output, err := self.cmd.New(cmdArgs).DontLog().RunWithOutput()
+	return output, err
 }
 
 // Checkout checks out a branch (or commit), with --force if you set the force arg to true

--- a/pkg/commands/git_commands/branch_test.go
+++ b/pkg/commands/git_commands/branch_test.go
@@ -66,7 +66,7 @@ func TestBranchDeleteBranch(t *testing.T) {
 		branchNames []string
 		force       bool
 		runner      *oscommands.FakeCmdObjRunner
-		test        func(error)
+		test        func(string, error)
 	}
 
 	scenarios := []scenario{
@@ -75,7 +75,7 @@ func TestBranchDeleteBranch(t *testing.T) {
 			[]string{"test"},
 			false,
 			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"branch", "-d", "test"}, "", nil),
-			func(err error) {
+			func(_ string, err error) {
 				assert.NoError(t, err)
 			},
 		},
@@ -84,7 +84,7 @@ func TestBranchDeleteBranch(t *testing.T) {
 			[]string{"test1", "test2", "test3"},
 			false,
 			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"branch", "-d", "test1", "test2", "test3"}, "", nil),
-			func(err error) {
+			func(_ string, err error) {
 				assert.NoError(t, err)
 			},
 		},
@@ -93,7 +93,7 @@ func TestBranchDeleteBranch(t *testing.T) {
 			[]string{"test"},
 			true,
 			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"branch", "-D", "test"}, "", nil),
-			func(err error) {
+			func(_ string, err error) {
 				assert.NoError(t, err)
 			},
 		},
@@ -102,7 +102,7 @@ func TestBranchDeleteBranch(t *testing.T) {
 			[]string{"test1", "test2", "test3"},
 			true,
 			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"branch", "-D", "test1", "test2", "test3"}, "", nil),
-			func(err error) {
+			func(_ string, err error) {
 				assert.NoError(t, err)
 			},
 		},


### PR DESCRIPTION
### PR Description
When you delete a branch, git tells you the hash it pointed to ("Deleted branch foo (was abc1234)") but lazygit was throwing that away. Now LocalDelete captures the output and we parse the hashes out, appending them to the logged command so you can rescue a mistakenly deleted branch without spelunking through reflog.

### Please check if the PR fulfills these requirements

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [n/a] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [n/a] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [n/a] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
