### PR TITLE
Refresh diff output on window resize

### DIFF
--- a/pkg/gui/pty_windows.go
+++ b/pkg/gui/pty_windows.go
@@ -8,6 +8,7 @@ import (
 )
 
 func (gui *Gui) onResize() error {
+	gui.refreshMainContentOnResize()
 	return nil
 }
 

--- a/pkg/gui/resize_refresh.go
+++ b/pkg/gui/resize_refresh.go
@@ -1,0 +1,32 @@
+package gui
+
+import (
+	gui_context "github.com/jesseduffield/lazygit/pkg/gui/context"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+)
+
+// refreshMainContentOnResize recalculates the main diff-like content when a
+// resize changes formatting-sensitive output (e.g. external diff pagers).
+func (gui *Gui) refreshMainContentOnResize() {
+	current := gui.c.Context().CurrentStatic()
+
+	switch current.GetKind() {
+	case types.SIDE_CONTEXT:
+		current.HandleRenderToMain()
+
+	case types.MAIN_CONTEXT:
+		switch current.GetKey() {
+		case gui_context.NORMAL_MAIN_CONTEXT_KEY, gui_context.NORMAL_SECONDARY_CONTEXT_KEY:
+			// If focus is in a normal main context, rerender via the side context
+			// because that's where the diff-render task is defined.
+			gui.c.Context().CurrentSide().HandleRenderToMain()
+
+		case gui_context.STAGING_MAIN_CONTEXT_KEY,
+			gui_context.STAGING_SECONDARY_CONTEXT_KEY,
+			gui_context.PATCH_BUILDING_MAIN_CONTEXT_KEY,
+			gui_context.MERGE_CONFLICTS_CONTEXT_KEY:
+			// These contexts refresh their own content from GetOnFocus handlers.
+			current.HandleFocus(types.OnFocusOpts{})
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- recalculate main diff content on window resize so formatting-sensitive pager output is regenerated
- keep PTY resize behavior and then trigger content refresh for side/main contexts as needed
- apply the same refresh behavior on Windows resize path

## Testing
- Tested only on macOS