### PR TITLE
Fix commit graph order when using --all with date-order

### DIFF
--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -587,9 +587,9 @@ func (self *CommitLoader) getLogCmd(opts GetCommitsOptions) *oscommands.CmdObj {
 	}
 
 	cmdArgs := NewGitCmd("log").
+		ArgIf(opts.All, "--all").
 		Arg(refSpec).
 		ArgIf(gitLogOrder != "default", "--"+gitLogOrder).
-		ArgIf(opts.All, "--all").
 		Arg("--oneline").
 		Arg(prettyFormat).
 		Arg("--abbrev=40").


### PR DESCRIPTION
Fixes #5162

## Problem
When toggling "show whole git graph" before changing to "date order", the commit graph was displaying in the wrong order compared to the output of `git log --graph --all --oneline`.

## Root Cause
The git log command was constructed with arguments in the wrong order:
```
git log HEAD --date-order --all
```

This caused git to apply date-order to HEAD first, then try to apply `--all`, resulting in incorrect graph ordering.

## Solution
Moved the `--all` flag to appear before the refSpec:
```
git log --all HEAD --date-order
```

This ensures git applies the date-order sorting to the entire graph from all refs.

## Testing
- Existing unit tests all pass
- The fix addresses the exact scenario described in the issue: toggling "show whole git graph" and then changing to "date order" now produces the correct commit order matching `git log --graph --all --oneline`