### PR TITLE
Fix matching of lazygit-edit URLs without line numbers

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -377,7 +377,7 @@ func (gui *Gui) onNewRepo(startArgs appTypes.StartArgs, contextKey types.Context
 
 	gui.g.SetOpenHyperlinkFunc(func(url string, viewname string) error {
 		if strings.HasPrefix(url, "lazygit-edit:") {
-			re := regexp.MustCompile(`^lazygit-edit://(.+?)(?::(\d+))?$`)
+			re := regexp.MustCompile(`^lazygit-edit://(.+?)(?::(\d*))?$`)
 			matches := re.FindStringSubmatch(url)
 			if matches == nil {
 				return fmt.Errorf(gui.Tr.InvalidLazygitEditURL, url)


### PR DESCRIPTION
### PR Description

Tweak regexp such that a trailing ":" is not included in the file path extracted from a lazygit-edit URL.

Previously, when matching a URL containing the ":" separator but no line number, such as `lazygit-edit:///path/to/file.ext:`, the trailing separator would be included in the matched file path, so lazygit would open the non-existent file `/path/to/file.ext:`. Notably, such urls are created when using delta with the hyperlink feature, as suggested in https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Pagers.md#delta, and clicking a file path rather than a line number.

Fixes #5308
### Please check if the PR fulfills these requirements

* [ ] (NA) Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] (NA) Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] (NA) Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] (NA) If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] (NA) Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc