### PR TITLE
fix: fix off-by-one error when calculating popup panel dimensions (fi…

### DIFF
--- a/pkg/gui/controllers/helpers/confirmation_helper.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper.go
@@ -117,7 +117,7 @@ func (self *ConfirmationHelper) getPopupPanelDimensionsAux(panelWidth int, panel
 		x0, y0, _, _ := parentPopupContext.GetView().Dimensions()
 		x0 += 2
 		y0 += 1
-		return x0, y0, x0 + panelWidth, y0 + panelHeight + 1
+		return x0, y0, x0 + panelWidth, y0 + panelHeight
 	}
 	return width/2 - panelWidth/2,
 		height/2 - panelHeight/2 - panelHeight%2 - 1,


### PR DESCRIPTION
Fixes an off-by-one error in popup panel dimension calculations when nested popups are displayed. The panel height calculation was adding an extra pixel, causing improper spacing and positioning. This one-line fix corrects the calculation to ensure popups display at the correct dimensions.

Fixes #5312

