### PR TITLE
docs: Include cat in custom pagers examples

### DIFF
--- a/docs/Custom_Pagers.md
+++ b/docs/Custom_Pagers.md
@@ -14,6 +14,7 @@ git:
     - pager: delta --dark --paging=never
     - pager: ydiff -p cat -s --wrap --width={{columnWidth}}
       colorArg: never
+    - pager: cat
     - externalDiffCommand: difft --color=always
 ```
 


### PR DESCRIPTION
cat is the default git pager, and although not as sophisticated, it redraws faster than other pagers who suffer from the bug in #5327. Adding it to the docs will help new devs know that this is an option.

### PR Description

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
