### PR TITLE
feat: add copy branch URL keybinding to branches panel

### DIFF
--- a/pkg/commands/hosting_service/definitions.go
+++ b/pkg/commands/hosting_service/definitions.go
@@ -15,6 +15,7 @@ var githubServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/compare/{{.From}}?expand=1",
 	pullRequestURLIntoTargetBranch:  "/compare/{{.To}}...{{.From}}?expand=1",
 	commitURL:                       "/commit/{{.CommitHash}}",
+	branchURL:                       "/tree/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }
@@ -24,6 +25,7 @@ var bitbucketServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pull-requests/new?source={{.From}}&t=1",
 	pullRequestURLIntoTargetBranch:  "/pull-requests/new?source={{.From}}&dest={{.To}}&t=1",
 	commitURL:                       "/commits/{{.CommitHash}}",
+	branchURL:                       "/src/{{.BranchName}}",
 	regexStrings: []string{
 		`^(?:https?|ssh)://.*/(?P<owner>.*)/(?P<repo>.*?)(?:\.git)?$`,
 		`^.*@.*:/*(?P<owner>.*)/(?P<repo>.*?)(?:\.git)?$`,
@@ -36,6 +38,7 @@ var gitLabServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/-/merge_requests/new?merge_request%5Bsource_branch%5D={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/-/merge_requests/new?merge_request%5Bsource_branch%5D={{.From}}&merge_request%5Btarget_branch%5D={{.To}}",
 	commitURL:                       "/-/commit/{{.CommitHash}}",
+	branchURL:                       "/-/tree/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }
@@ -45,6 +48,7 @@ var azdoServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pullrequestcreate?sourceRef={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/pullrequestcreate?sourceRef={{.From}}&targetRef={{.To}}",
 	commitURL:                       "/commit/{{.CommitHash}}",
+	branchURL:                       "?version=GB{{.BranchName}}",
 	regexStrings: []string{
 		`^.+@vs-ssh\.visualstudio\.com[:/](?:v3/)?(?P<org>[^/]+)/(?P<project>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$`,
 		`^git@ssh.dev.azure.com.*/(?P<org>.*)/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
@@ -59,6 +63,7 @@ var bitbucketServerServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/pull-requests?create&sourceBranch={{.From}}",
 	pullRequestURLIntoTargetBranch:  "/pull-requests?create&targetBranch={{.To}}&sourceBranch={{.From}}",
 	commitURL:                       "/commits/{{.CommitHash}}",
+	branchURL:                       "/browse?at={{.BranchName}}",
 	regexStrings: []string{
 		`^ssh://git@.*/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
 		`^https://.*/scm/(?P<project>.*)/(?P<repo>.*?)(?:\.git)?$`,
@@ -71,6 +76,7 @@ var giteaServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/compare/{{.From}}",
 	pullRequestURLIntoTargetBranch:  "/compare/{{.To}}...{{.From}}",
 	commitURL:                       "/commit/{{.CommitHash}}",
+	branchURL:                       "/src/branch/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }
@@ -80,6 +86,7 @@ var codebergServiceDef = ServiceDefinition{
 	pullRequestURLIntoDefaultBranch: "/compare/{{.From}}",
 	pullRequestURLIntoTargetBranch:  "/compare/{{.To}}...{{.From}}",
 	commitURL:                       "/commit/{{.CommitHash}}",
+	branchURL:                       "/src/branch/{{.BranchName}}",
 	regexStrings:                    defaultUrlRegexStrings,
 	repoURLTemplate:                 defaultRepoURLTemplate,
 }

--- a/pkg/commands/hosting_service/hosting_service.go
+++ b/pkg/commands/hosting_service/hosting_service.go
@@ -61,6 +61,17 @@ func (self *HostingServiceMgr) GetCommitURL(commitHash string) (string, error) {
 	return pullRequestURL, nil
 }
 
+func (self *HostingServiceMgr) GetBranchURL(branchName string) (string, error) {
+	gitService, err := self.getService()
+	if err != nil {
+		return "", err
+	}
+
+	branchURL := gitService.getBranchURL(branchName)
+
+	return branchURL, nil
+}
+
 func (self *HostingServiceMgr) getService() (*Service, error) {
 	serviceDomain, err := self.getServiceDomain(self.remoteURL)
 	if err != nil {
@@ -141,6 +152,7 @@ type ServiceDefinition struct {
 	pullRequestURLIntoDefaultBranch string
 	pullRequestURLIntoTargetBranch  string
 	commitURL                       string
+	branchURL                       string
 	regexStrings                    []string
 
 	// can expect 'webdomain' to be passed in. Otherwise, you get to pick what we match in the regex
@@ -175,6 +187,10 @@ func (self *Service) getPullRequestURLIntoTargetBranch(from string, to string) s
 
 func (self *Service) getCommitURL(commitHash string) string {
 	return self.resolveUrl(self.commitURL, map[string]string{"CommitHash": commitHash})
+}
+
+func (self *Service) getBranchURL(branchName string) string {
+	return self.resolveUrl(self.branchURL, map[string]string{"BranchName": branchName})
 }
 
 func (self *Service) resolveUrl(templateString string, args map[string]string) string {

--- a/pkg/commands/hosting_service/hosting_service_test.go
+++ b/pkg/commands/hosting_service/hosting_service_test.go
@@ -577,3 +577,147 @@ func TestGetPullRequestURL(t *testing.T) {
 		})
 	}
 }
+
+func TestGetBranchURL(t *testing.T) {
+	type scenario struct {
+		testName             string
+		branchName           string
+		remoteUrl            string
+		configServiceDomains map[string]string
+		test                 func(url string, err error)
+	}
+
+	scenarios := []scenario{
+		{
+			testName:   "GitHub SSH",
+			branchName: "feature/my-branch",
+			remoteUrl:  "git@github.com:peter/calculator.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://github.com/peter/calculator/tree/feature/my-branch", url)
+			},
+		},
+		{
+			testName:   "GitHub HTTPS",
+			branchName: "feature/my-branch",
+			remoteUrl:  "https://github.com/peter/calculator.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://github.com/peter/calculator/tree/feature/my-branch", url)
+			},
+		},
+		{
+			testName:   "GitLab SSH",
+			branchName: "feature/my-branch",
+			remoteUrl:  "git@gitlab.com:peter/calculator.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://gitlab.com/peter/calculator/-/tree/feature/my-branch", url)
+			},
+		},
+		{
+			testName:   "GitLab HTTPS",
+			branchName: "feature/my-branch",
+			remoteUrl:  "https://gitlab.com/peter/calculator.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://gitlab.com/peter/calculator/-/tree/feature/my-branch", url)
+			},
+		},
+		{
+			testName:   "Bitbucket SSH",
+			branchName: "feature/my-branch",
+			remoteUrl:  "git@bitbucket.org:johndoe/social_network.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://bitbucket.org/johndoe/social_network/src/feature/my-branch", url)
+			},
+		},
+		{
+			testName:   "Bitbucket HTTPS",
+			branchName: "feature/my-branch",
+			remoteUrl:  "https://my_username@bitbucket.org/johndoe/social_network.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://bitbucket.org/johndoe/social_network/src/feature/my-branch", url)
+			},
+		},
+		{
+			testName:   "Azure DevOps SSH",
+			branchName: "feature/my-branch",
+			remoteUrl:  "git@ssh.dev.azure.com:v3/myorg/myproject/myrepo",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://dev.azure.com/myorg/myproject/_git/myrepo?version=GBfeature/my-branch", url)
+			},
+		},
+		{
+			testName:   "Azure DevOps HTTPS",
+			branchName: "feature/my-branch",
+			remoteUrl:  "https://myorg@dev.azure.com/myorg/myproject/_git/myrepo",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://dev.azure.com/myorg/myproject/_git/myrepo?version=GBfeature/my-branch", url)
+			},
+		},
+		{
+			testName:   "Bitbucket Server SSH",
+			branchName: "feature/my-branch",
+			remoteUrl:  "ssh://git@mycompany.bitbucket.com/myproject/myrepo.git",
+			configServiceDomains: map[string]string{
+				"mycompany.bitbucket.com": "bitbucketServer:mycompany.bitbucket.com",
+			},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://mycompany.bitbucket.com/projects/myproject/repos/myrepo/browse?at=feature/my-branch", url)
+			},
+		},
+		{
+			testName:   "Gitea SSH",
+			branchName: "feature/my-branch",
+			remoteUrl:  "ssh://git@mycompany.gitea.io/myproject/myrepo.git",
+			configServiceDomains: map[string]string{
+				"mycompany.gitea.io": "gitea:mycompany.gitea.io",
+			},
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://mycompany.gitea.io/myproject/myrepo/src/branch/feature/my-branch", url)
+			},
+		},
+		{
+			testName:   "Codeberg SSH",
+			branchName: "feature/my-branch",
+			remoteUrl:  "git@codeberg.org:johndoe/myrepo.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://codeberg.org/johndoe/myrepo/src/branch/feature/my-branch", url)
+			},
+		},
+		{
+			testName:   "Codeberg HTTPS",
+			branchName: "feature/my-branch",
+			remoteUrl:  "https://codeberg.org/johndoe/myrepo.git",
+			test: func(url string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "https://codeberg.org/johndoe/myrepo/src/branch/feature/my-branch", url)
+			},
+		},
+		{
+			testName:   "Unsupported service",
+			branchName: "feature/my-branch",
+			remoteUrl:  "git@something.com:peter/calculator.git",
+			test: func(url string, err error) {
+				assert.EqualError(t, err, "Unsupported git service")
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.testName, func(t *testing.T) {
+			tr := i18n.EnglishTranslationSet()
+			log := &fakes.FakeFieldLogger{}
+			hostingServiceMgr := NewHostingServiceMgr(log, tr, s.remoteUrl, s.configServiceDomains)
+			s.test(hostingServiceMgr.GetBranchURL(s.branchName))
+		})
+	}
+}

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -524,6 +524,7 @@ type KeybindingBranchesConfig struct {
 	CreatePullRequest      string `yaml:"createPullRequest"`
 	ViewPullRequestOptions string `yaml:"viewPullRequestOptions"`
 	CopyPullRequestURL     string `yaml:"copyPullRequestURL"`
+	CopyBranchURL          string `yaml:"copyBranchURL"`
 	CheckoutBranchByName   string `yaml:"checkoutBranchByName"`
 	ForceCheckoutBranch    string `yaml:"forceCheckoutBranch"`
 	CheckoutPreviousBranch string `yaml:"checkoutPreviousBranch"`
@@ -982,6 +983,7 @@ func GetDefaultConfig() *UserConfig {
 			},
 			Branches: KeybindingBranchesConfig{
 				CopyPullRequestURL:     "<c-y>",
+				CopyBranchURL:          "<c-u>",
 				CreatePullRequest:      "o",
 				ViewPullRequestOptions: "O",
 				CheckoutBranchByName:   "c",

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -84,6 +84,12 @@ func (self *BranchesController) GetKeybindings(opts types.KeybindingsOpts) []*ty
 			Description:       self.c.Tr.CopyPullRequestURL,
 		},
 		{
+			Key:               opts.GetKey(opts.Config.Branches.CopyBranchURL),
+			Handler:           self.copyBranchURL,
+			GetDisabledReason: self.require(self.singleItemSelected()),
+			Description:       self.c.Tr.CopyBranchURL,
+		},
+		{
 			Key:         opts.GetKey(opts.Config.Branches.CheckoutBranchByName),
 			Handler:     self.checkoutByName,
 			Description: self.c.Tr.CheckoutByName,
@@ -461,6 +467,29 @@ func (self *BranchesController) copyPullRequestURL() error {
 	}
 
 	self.c.Toast(self.c.Tr.PullRequestURLCopiedToClipboard)
+
+	return nil
+}
+
+func (self *BranchesController) copyBranchURL() error {
+	branch := self.context().GetSelected()
+
+	branchExistsOnRemote := self.c.Git().Remote.CheckRemoteBranchExists(branch.Name)
+
+	if !branchExistsOnRemote {
+		return errors.New(self.c.Tr.NoBranchOnRemote)
+	}
+
+	url, err := self.c.Helpers().Host.GetBranchURL(branch.Name)
+	if err != nil {
+		return err
+	}
+	self.c.LogAction(self.c.Tr.Actions.CopyBranchURL)
+	if err := self.c.OS().CopyToClipboard(url); err != nil {
+		return err
+	}
+
+	self.c.Toast(self.c.Tr.BranchURLCopiedToClipboard)
 
 	return nil
 }

--- a/pkg/gui/controllers/helpers/host_helper.go
+++ b/pkg/gui/controllers/helpers/host_helper.go
@@ -34,6 +34,14 @@ func (self *HostHelper) GetCommitURL(commitHash string) (string, error) {
 	return mgr.GetCommitURL(commitHash)
 }
 
+func (self *HostHelper) GetBranchURL(branchName string) (string, error) {
+	mgr, err := self.getHostingServiceMgr()
+	if err != nil {
+		return "", err
+	}
+	return mgr.GetBranchURL(branchName)
+}
+
 // getting this on every request rather than storing it in state in case our remoteURL changes
 // from one invocation to the next.
 func (self *HostHelper) getHostingServiceMgr() (*hosting_service.HostingServiceMgr, error) {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -281,6 +281,7 @@ type TranslationSet struct {
 	AllBranchesLogGraph                   string
 	UnsupportedGitService                 string
 	CopyPullRequestURL                    string
+	CopyBranchURL                         string
 	NoBranchOnRemote                      string
 	Fetch                                 string
 	FetchTooltip                          string
@@ -732,6 +733,7 @@ type TranslationSet struct {
 	SuggestionsSubtitle                      string
 	ExtrasTitle                              string
 	PullRequestURLCopiedToClipboard          string
+	BranchURLCopiedToClipboard               string
 	CommitDiffCopiedToClipboard              string
 	CommitURLCopiedToClipboard               string
 	CommitMessageCopiedToClipboard           string
@@ -1066,6 +1068,7 @@ type Actions struct {
 	Undo                             string
 	Redo                             string
 	CopyPullRequestURL               string
+	CopyBranchURL                    string
 	OpenMergeTool                    string
 	OpenCommitInBrowser              string
 	OpenPullRequest                  string
@@ -1384,6 +1387,7 @@ func EnglishTranslationSet() *TranslationSet {
 		UnsupportedGitService:                `Unsupported git service`,
 		CreatePullRequest:                    `Create pull request`,
 		CopyPullRequestURL:                   `Copy pull request URL to clipboard`,
+		CopyBranchURL:                        `Copy branch URL to clipboard`,
 		NoBranchOnRemote:                     `This branch doesn't exist on remote. You need to push it to remote first.`,
 		Fetch:                                `Fetch`,
 		FetchTooltip:                         "Fetch changes from remote.",
@@ -1839,6 +1843,7 @@ func EnglishTranslationSet() *TranslationSet {
 		SuggestionsSubtitle:                      "(press %s to delete, %s to edit)",
 		ExtrasTitle:                              "Command log",
 		PullRequestURLCopiedToClipboard:          "Pull request URL copied to clipboard",
+		BranchURLCopiedToClipboard:               "Branch URL copied to clipboard",
 		CommitDiffCopiedToClipboard:              "Commit diff copied to clipboard",
 		CommitURLCopiedToClipboard:               "Commit URL copied to clipboard",
 		CommitMessageCopiedToClipboard:           "Commit message copied to clipboard",
@@ -2134,6 +2139,7 @@ func EnglishTranslationSet() *TranslationSet {
 			Undo:                             "Undo",
 			Redo:                             "Redo",
 			CopyPullRequestURL:               "Copy pull request URL",
+			CopyBranchURL:                    "Copy branch URL",
 			OpenMergeTool:                    "Open merge tool",
 			OpenCommitInBrowser:              "Open commit in browser",
 			OpenPullRequest:                  "Open pull request in browser",


### PR DESCRIPTION
## Summary
- Adds a new keybinding (`<c-u>`) in the branches panel to copy the selected branch's web URL to the clipboard
- Supports all hosting services: GitHub (`/tree/`), GitLab (`/-/tree/`), Bitbucket (`/src/`), Azure DevOps (`?version=GB`), Bitbucket Server (`/browse?at=`), Gitea (`/src/branch/`), and Codeberg (`/src/branch/`)
- Follows the exact same pattern as the existing "copy pull request URL" (`<c-y>`) feature

Closes #1959

## Changes
- `definitions.go` — added `branchURL` template to all 7 service definitions
- `hosting_service.go` — added `branchURL` field, `getBranchURL` on `Service`, `GetBranchURL` on `HostingServiceMgr`
- `host_helper.go` — added `GetBranchURL` helper
- `user_config.go` — added `CopyBranchURL` config with default `<c-u>`
- `english.go` — added translation strings (description, toast, action, keybinding label)
- `branches_controller.go` — registered keybinding and `copyBranchURL()` handler
- `hosting_service_test.go` — added `TestGetBranchURL` with 13 scenarios covering all services

## Test plan
- [x] `go test ./pkg/commands/hosting_service/...` passes
- [x] `go build ./...` succeeds
- [ ] Manual: run lazygit in a repo with a remote, go to branches panel, press `<c-u>` — branch URL should be copied and a toast shown