### PR TITLE
Fix typo: MacOS to macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   </div>
   <b>Warp, the intelligent terminal</b>
   <br>
-  <b>Available for MacOS and Linux</b>
+  <b>Available for macOS and Linux</b>
   <br>
   <div>
     <sup>Visit warp.dev to learn more.</sup>
@@ -503,7 +503,7 @@ go install github.com/jesseduffield/lazygit@latest
 
 Please note:
 If you get an error claiming that lazygit cannot be found or is not defined, you
-may need to add `~/go/bin` to your $PATH (MacOS/Linux), or `%HOME%\go\bin`
+may need to add `~/go/bin` to your $PATH (macOS/Linux), or `%HOME%\go\bin`
 (Windows). Not to be mistaken for `C:\Go\bin` (which is for Go's own binaries,
 not apps like lazygit).
 


### PR DESCRIPTION
Corrects macOS capitalization to follow Apple's official branding guidelines (2 occurrences in README).