### PR TITLE
Add "Detach worktree" option when checking out a branch occupied by another worktree

### DIFF
--- a/pkg/commands/git_commands/worktree.go
+++ b/pkg/commands/git_commands/worktree.go
@@ -48,6 +48,13 @@ func (self *WorktreeCommands) Delete(worktreePath string, force bool) error {
 	return self.cmd.New(cmdArgs).Run()
 }
 
+func (self *WorktreeCommands) IsWorktreeClean(worktreePath string) bool {
+	cmdArgs := NewGitCmd("status").Arg("--porcelain").Dir(worktreePath).ToArgv()
+
+	output, err := self.cmd.New(cmdArgs).RunWithOutput()
+	return err == nil && output == ""
+}
+
 func (self *WorktreeCommands) Detach(worktreePath string) error {
 	cmdArgs := NewGitCmd("checkout").Arg("--detach").GitDir(filepath.Join(worktreePath, ".git")).ToArgv()
 

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -475,7 +475,7 @@ func (self *BranchesController) press(selectedBranch *models.Branch) error {
 
 	worktreeForRef, ok := self.worktreeForBranch(selectedBranch)
 	if ok && !worktreeForRef.IsCurrent {
-		return self.promptToCheckoutWorktree(worktreeForRef)
+		return self.promptToCheckoutWorktree(worktreeForRef, selectedBranch.Name)
 	}
 
 	self.c.LogAction(self.c.Tr.Actions.CheckoutBranch)
@@ -498,16 +498,39 @@ func (self *BranchesController) worktreeForBranch(branch *models.Branch) (*model
 	return git_commands.WorktreeForBranch(branch, self.c.Model().Worktrees)
 }
 
-func (self *BranchesController) promptToCheckoutWorktree(worktree *models.Worktree) error {
-	prompt := utils.ResolvePlaceholderString(self.c.Tr.AlreadyCheckedOutByWorktree, map[string]string{
+func (self *BranchesController) promptToCheckoutWorktree(worktree *models.Worktree, branchName string) error {
+	title := utils.ResolvePlaceholderString(self.c.Tr.BranchCheckedOutByWorktree, map[string]string{
 		"worktreeName": worktree.Name,
+		"branchName":   branchName,
 	})
 
-	return self.c.ConfirmIf(!self.c.UserConfig().Gui.SkipSwitchWorktreeOnCheckoutWarning, types.ConfirmOpts{
-		Title:  self.c.Tr.SwitchToWorktree,
-		Prompt: prompt,
-		HandleConfirm: func() error {
-			return self.c.Helpers().Worktree.Switch(worktree, context.LOCAL_BRANCHES_CONTEXT_KEY)
+	var detachDisabledReason *types.DisabledReason
+	if !worktree.IsPathMissing && !self.c.Git().Worktree.IsWorktreeClean(worktree.Path) {
+		detachDisabledReason = &types.DisabledReason{Text: self.c.Tr.DetachWorktreeHasUncommittedChanges}
+	}
+
+	return self.c.Menu(types.CreateMenuOptions{
+		Title: title,
+		Items: []*types.MenuItem{
+			{
+				Label: self.c.Tr.SwitchToWorktree,
+				OnPress: func() error {
+					return self.c.Helpers().Worktree.Switch(worktree, context.LOCAL_BRANCHES_CONTEXT_KEY)
+				},
+			},
+			{
+				Label:          self.c.Tr.DetachWorktree,
+				Tooltip:        self.c.Tr.DetachWorktreeTooltip,
+				DisabledReason: detachDisabledReason,
+				OnPress: func() error {
+					return self.c.Helpers().Refs.CheckoutRef(branchName, types.CheckoutRefOptions{
+						PreCheckoutCommand: func() error {
+							self.c.LogAction(self.c.Tr.DetachingWorktree)
+							return self.c.Git().Worktree.Detach(worktree.Path)
+						},
+					})
+				},
+			},
 		},
 	})
 }

--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -86,6 +86,11 @@ func (self *RefsHelper) CheckoutRef(ref string, options types.CheckoutRefOptions
 	self.c.Context().Push(self.c.Contexts().Branches, types.OnFocusOpts{})
 
 	return withCheckoutStatus(func(gocui.Task) error {
+		if options.PreCheckoutCommand != nil {
+			if err := options.PreCheckoutCommand(); err != nil {
+				return err
+			}
+		}
 		if err := self.c.Git().Branch.Checkout(ref, cmdOptions); err != nil {
 			// note, this will only work for english-language git commands. If we force git to use english, and the error isn't this one, then the user will receive an english command they may not understand. I'm not sure what the best solution to this is. Running the command once in english and a second time in the native language is one option
 

--- a/pkg/gui/types/common_commands.go
+++ b/pkg/gui/types/common_commands.go
@@ -9,4 +9,8 @@ type CheckoutRefOptions struct {
 	// (e.g. checking out a remote branch), but it not needed when checking out an existing local
 	// branch or a detached head (e.g. a tag).
 	RefreshPullRequests bool
+
+	// If set, this function is called right before the checkout command.
+	// Used e.g. to detach a worktree before checking out the branch.
+	PreCheckoutCommand func() error
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -864,6 +864,7 @@ type TranslationSet struct {
 	BranchCheckedOutByWorktree               string
 	SomeBranchesCheckedOutByWorktreeError    string
 	DetachWorktreeTooltip                    string
+	DetachWorktreeHasUncommittedChanges      string
 	Switching                                string
 	RemoveWorktree                           string
 	RemoveWorktreeTitle                      string
@@ -1985,6 +1986,7 @@ func EnglishTranslationSet() *TranslationSet {
 		BranchCheckedOutByWorktree:               "Branch {{.branchName}} is checked out by worktree {{.worktreeName}}",
 		SomeBranchesCheckedOutByWorktreeError:    "Some of the selected branches are checked out by other worktrees. Select them one by one to delete them.",
 		DetachWorktreeTooltip:                    "This will run `git checkout --detach` on the worktree so that it stops hogging the branch, but the worktree's working tree will be left alone.",
+		DetachWorktreeHasUncommittedChanges:      "Worktree has uncommitted changes that would be lost",
 		Switching:                                "Switching",
 		RemoveWorktree:                           "Remove worktree",
 		RemoveWorktreeTitle:                      "Remove worktree",

--- a/pkg/integration/tests/worktree/add_from_branch.go
+++ b/pkg/integration/tests/worktree/add_from_branch.go
@@ -47,9 +47,9 @@ var AddFromBranch = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("mybranch")).
 			Press(keys.Universal.Select).
 			Tap(func() {
-				t.ExpectPopup().Confirmation().
-					Title(Equals("Switch to worktree")).
-					Content(Equals("This branch is checked out by worktree repo. Do you want to switch to that worktree?")).
+				t.ExpectPopup().Menu().
+					Title(Equals("Branch mybranch is checked out by worktree repo")).
+					Select(Equals("Switch to worktree")).
 					Confirm()
 			}).
 			Lines(

--- a/pkg/integration/tests/worktree/associate_branch_bisect.go
+++ b/pkg/integration/tests/worktree/associate_branch_bisect.go
@@ -61,9 +61,9 @@ var AssociateBranchBisect = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("newbranch")).
 			Press(keys.Universal.Select).
 			Tap(func() {
-				t.ExpectPopup().Confirmation().
-					Title(Equals("Switch to worktree")).
-					Content(Equals("This branch is checked out by worktree linked-worktree. Do you want to switch to that worktree?")).
+				t.ExpectPopup().Menu().
+					Title(Equals("Branch newbranch is checked out by worktree linked-worktree")).
+					Select(Equals("Switch to worktree")).
 					Confirm()
 
 				t.Views().Information().Content(DoesNotContain("Bisecting"))
@@ -79,9 +79,9 @@ var AssociateBranchBisect = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("mybranch")).
 			Press(keys.Universal.Select).
 			Tap(func() {
-				t.ExpectPopup().Confirmation().
-					Title(Equals("Switch to worktree")).
-					Content(Equals("This branch is checked out by worktree repo. Do you want to switch to that worktree?")).
+				t.ExpectPopup().Menu().
+					Title(Equals("Branch mybranch is checked out by worktree repo")).
+					Select(Equals("Switch to worktree")).
 					Confirm()
 			})
 	},

--- a/pkg/integration/tests/worktree/associate_branch_rebase.go
+++ b/pkg/integration/tests/worktree/associate_branch_rebase.go
@@ -48,9 +48,9 @@ var AssociateBranchRebase = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("newbranch")).
 			Press(keys.Universal.Select).
 			Tap(func() {
-				t.ExpectPopup().Confirmation().
-					Title(Equals("Switch to worktree")).
-					Content(Equals("This branch is checked out by worktree linked-worktree. Do you want to switch to that worktree?")).
+				t.ExpectPopup().Menu().
+					Title(Equals("Branch newbranch is checked out by worktree linked-worktree")).
+					Select(Equals("Switch to worktree")).
 					Confirm()
 
 				t.Views().Information().Content(DoesNotContain("Rebasing"))
@@ -74,9 +74,9 @@ var AssociateBranchRebase = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("mybranch")).
 			Press(keys.Universal.Select).
 			Tap(func() {
-				t.ExpectPopup().Confirmation().
-					Title(Equals("Switch to worktree")).
-					Content(Equals("This branch is checked out by worktree repo. Do you want to switch to that worktree?")).
+				t.ExpectPopup().Menu().
+					Title(Equals("Branch mybranch is checked out by worktree repo")).
+					Select(Equals("Switch to worktree")).
 					Confirm()
 			}).
 			Lines(


### PR DESCRIPTION

### PR Description

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

When working with worktrees it's common to have a main project installation (e.g. running your database and services) alongside several worktrees for feature work. Previously, checking out a branch occupied by another worktree only offered "Switch to worktree", forcing you to switch to that worktree, detach it, then navigate back and check out the branch: a tedious round-trip.

This is the current behavior:
<img width="1956" height="280" alt="Screenshot 2026-03-05 at 12 57 33@2x" src="https://github.com/user-attachments/assets/f41805dd-f2b2-43a7-ad8d-d4a5a8721260" />


Now the prompt shows a menu with two options: "Switch to worktree" and "Detach worktree". The detach option runs `git checkout --detach` on the other worktree and then checks out the branch in one step.
<img width="1974" height="642" alt="Screenshot 2026-03-05 at 12 57 43@2x" src="https://github.com/user-attachments/assets/31f41ba2-a84b-4546-b10f-bae20d132778" />
<img width="1336" height="1118" alt="Screenshot 2026-03-05 at 12 57 47@2x" src="https://github.com/user-attachments/assets/e6bd1dac-9b44-4670-9e83-e65ff3a3dbe2" />



The detach option is disabled when the other worktree has uncommitted changes, to prevent accidental loss of work.
<img width="1950" height="672" alt="Screenshot 2026-03-05 at 12 57 06@2x" src="https://github.com/user-attachments/assets/af4e33e1-0c3c-4435-8c56-9bddfc5b14a1" />


