### PR TITLE
feat(config): add skip push hooks

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -431,6 +431,9 @@ git:
   # If true, do not allow force pushes
   disableForcePushing: false
 
+  # If true, pass --no-verify to git push, skipping pre-push hooks
+  skipHookOnPush: false
+
   # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix
   commitPrefix: []
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -383,6 +383,9 @@ git:
   # will be skipped when the commit message starts with 'WIP'
   skipHookPrefix: WIP
 
+  # If true, pass --no-verify when pushing, skipping pre-push hooks
+  skipHookOnPush: false
+
   # If true, periodically fetch from remote
   autoFetch: true
 

--- a/pkg/commands/git_commands/sync.go
+++ b/pkg/commands/git_commands/sync.go
@@ -22,6 +22,7 @@ func NewSyncCommands(gitCommon *GitCommon) *SyncCommands {
 type PushOpts struct {
 	Force          bool
 	ForceWithLease bool
+	NoVerify       bool
 	CurrentBranch  string
 	UpstreamRemote string
 	UpstreamBranch string
@@ -36,6 +37,7 @@ func (self *SyncCommands) PushCmdObj(task gocui.Task, opts PushOpts) (*oscommand
 	cmdArgs := NewGitCmd("push").
 		ArgIf(opts.Force, "--force").
 		ArgIf(opts.ForceWithLease, "--force-with-lease").
+		ArgIf(opts.NoVerify, "--no-verify").
 		ArgIf(opts.SetUpstream, "--set-upstream").
 		ArgIf(opts.UpstreamRemote != "", opts.UpstreamRemote).
 		ArgIf(opts.UpstreamBranch != "", fmt.Sprintf("refs/heads/%s:%s", opts.CurrentBranch, opts.UpstreamBranch)).

--- a/pkg/commands/git_commands/sync_test.go
+++ b/pkg/commands/git_commands/sync_test.go
@@ -82,6 +82,14 @@ func TestSyncPush(t *testing.T) {
 			},
 		},
 		{
+			testName: "Push with no-verify",
+			opts:     PushOpts{NoVerify: true},
+			test: func(cmdObj *oscommands.CmdObj, err error) {
+				assert.Equal(t, cmdObj.Args(), []string{"git", "push", "--no-verify"})
+				assert.NoError(t, err)
+			},
+		},
+		{
 			testName: "Push with remote branch but no origin",
 			opts: PushOpts{
 				ForceWithLease: true,

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -300,6 +300,8 @@ type GitConfig struct {
 	OverrideGpg bool `yaml:"overrideGpg"`
 	// If true, do not allow force pushes
 	DisableForcePushing bool `yaml:"disableForcePushing"`
+	// If true, pass --no-verify to git push, skipping pre-push hooks
+	SkipHookOnPush bool `yaml:"skipHookOnPush"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix
 	CommitPrefix []CommitPrefixConfig `yaml:"commitPrefix"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-commit-message-prefix

--- a/pkg/gui/controllers/sync_controller.go
+++ b/pkg/gui/controllers/sync_controller.go
@@ -200,6 +200,7 @@ func (self *SyncController) pushAux(currentBranch *models.Branch, opts pushOpts)
 			git_commands.PushOpts{
 				Force:          opts.force,
 				ForceWithLease: opts.forceWithLease,
+				NoVerify:       self.c.UserConfig().Git.SkipHookOnPush,
 				CurrentBranch:  currentBranch.Name,
 				UpstreamRemote: opts.upstreamRemote,
 				UpstreamBranch: opts.upstreamBranch,

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -393,6 +393,11 @@
           "description": "If true, do not allow force pushes",
           "default": false
         },
+        "skipHookOnPush": {
+          "type": "boolean",
+          "description": "If true, pass --no-verify to git push, skipping pre-push hooks",
+          "default": false
+        },
         "commitPrefix": {
           "items": {
             "$ref": "#/$defs/CommitPrefixConfig"


### PR DESCRIPTION
### PR Description
Adds a skipHookOnPush config option that, when set to true in config, passes --no-verify to every git push.

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
