### PR TITLE
fix: create .git/info directory when adding to exclude file

### DIFF
--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -247,6 +247,9 @@ func (self *WorkingTreeCommands) Ignore(filename string) error {
 // Exclude adds a file to the .git/info/exclude for the repo
 func (self *WorkingTreeCommands) Exclude(filename string) error {
 	excludeFile := filepath.Join(self.repoPaths.repoGitDirPath, "info", "exclude")
+	if err := os.MkdirAll(filepath.Dir(excludeFile), 0o755); err != nil {
+		return err
+	}
 	return self.os.AppendLineToFile(excludeFile, escapeFilename(filename))
 }
 

--- a/pkg/integration/tests/file/exclude_without_info_dir.go
+++ b/pkg/integration/tests/file/exclude_without_info_dir.go
@@ -1,0 +1,31 @@
+package file
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ExcludeWithoutInfoDir = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Exclude a file when .git/info directory does not exist",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFile("toExclude", "")
+		shell.DeleteFile(".git/info")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			IsFocused().
+			Lines(
+				Contains("toExclude").IsSelected(),
+			).
+			Press(keys.Files.IgnoreFile).
+			Tap(func() {
+				t.ExpectPopup().Menu().Title(Equals("Ignore or exclude file")).Select(Contains("Add to .git/info/exclude")).Confirm()
+			}).
+			IsEmpty()
+
+		t.FileSystem().FileContent(".git/info/exclude", Contains("/toExclude"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -221,6 +221,7 @@ var tests = []*components.IntegrationTest{
 	file.DiscardUnstagedRangeSelect,
 	file.DiscardVariousChanges,
 	file.DiscardVariousChangesRangeSelect,
+	file.ExcludeWithoutInfoDir,
 	file.Gitignore,
 	file.GitignoreSpecialCharacters,
 	file.RememberCommitMessageAfterFail,


### PR DESCRIPTION
Lazygit fails to add files to `.git/info/exclude` if the `.git/info` directory doesn't already exist. This PR adds a call to create the parent directory before trying to append to the exclude file.

I've also added an integration test that reproduces the error by deleting the directory before triggering the exclude action.

Closes #5302

- [x] I have read [`CONTRIBUTING.md`](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md).