### PR TITLE
Add git.allBranchesLogExcludeRefs config option

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -413,6 +413,10 @@ git:
   allBranchesLogCmds:
     - git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium
 
+  # Ref globs to exclude when displaying git log of all branches in the main
+  # window, e.g. refs/jj/*
+  allBranchesLogExcludeRefs: []
+
   # If true, git diffs are rendered with the `--ignore-all-space` flag, which
   # ignores whitespace changes. Can be toggled from within Lazygit with `<c-w>`.
   ignoreWhitespaceInDiffView: false

--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -308,7 +308,36 @@ func (self *BranchCommands) AllBranchesLogCmdObj() *oscommands.CmdObj {
 	}
 
 	i := self.allBranchesLogCmdIndex
-	return self.cmd.New(str.ToArgv(candidates[i])).DontLog()
+	cmdArgs := applyAllBranchesLogExcludeRefs(str.ToArgv(candidates[i]), self.UserConfig().Git.AllBranchesLogExcludeRefs)
+	return self.cmd.New(cmdArgs).DontLog()
+}
+
+func applyAllBranchesLogExcludeRefs(cmdArgs []string, excludeRefs []string) []string {
+	cleanExcludeRefs := lo.Uniq(lo.WithoutEmpty(excludeRefs))
+	if len(cleanExcludeRefs) == 0 {
+		return cmdArgs
+	}
+
+	rewritten := make([]string, 0, len(cmdArgs)+len(cleanExcludeRefs))
+	for _, arg := range cmdArgs {
+		if isAllBranchesLogRefSelector(arg) {
+			for _, excludeRef := range cleanExcludeRefs {
+				rewritten = append(rewritten, "--exclude="+excludeRef)
+			}
+		}
+
+		rewritten = append(rewritten, arg)
+	}
+
+	return rewritten
+}
+
+func isAllBranchesLogRefSelector(arg string) bool {
+	return arg == "--all" ||
+		arg == "--branches" || strings.HasPrefix(arg, "--branches=") ||
+		arg == "--tags" || strings.HasPrefix(arg, "--tags=") ||
+		arg == "--remotes" || strings.HasPrefix(arg, "--remotes=") ||
+		arg == "--glob" || strings.HasPrefix(arg, "--glob=")
 }
 
 func (self *BranchCommands) RotateAllBranchesLogIdx() {

--- a/pkg/commands/git_commands/branch_test.go
+++ b/pkg/commands/git_commands/branch_test.go
@@ -248,6 +248,69 @@ func TestBranchGetAllBranchGraph(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestBranchGetAllBranchGraphWithExcludeRefs(t *testing.T) {
+	runner := oscommands.NewFakeRunner(t).ExpectGitArgs([]string{
+		"log", "--graph", "--exclude=refs/jj/*", "--all", "--color=always", "--abbrev-commit", "--decorate", "--date=relative", "--pretty=medium",
+	}, "", nil)
+	instance := buildBranchCommands(commonDeps{
+		runner: runner,
+		userConfig: &config.UserConfig{
+			Git: config.GitConfig{
+				AllBranchesLogCmds:        []string{"git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium"},
+				AllBranchesLogExcludeRefs: []string{"refs/jj/*"},
+			},
+		},
+	})
+	err := instance.AllBranchesLogCmdObj().Run()
+	assert.NoError(t, err)
+}
+
+func TestApplyAllBranchesLogExcludeRefs(t *testing.T) {
+	tests := []struct {
+		name        string
+		cmdArgs     []string
+		excludeRefs []string
+		expected    []string
+	}{
+		{
+			name:        "no exclude refs",
+			cmdArgs:     []string{"git", "log", "--all", "--oneline"},
+			excludeRefs: nil,
+			expected:    []string{"git", "log", "--all", "--oneline"},
+		},
+		{
+			name:        "inject before all",
+			cmdArgs:     []string{"git", "log", "--graph", "--all", "--oneline"},
+			excludeRefs: []string{"refs/jj/*"},
+			expected:    []string{"git", "log", "--graph", "--exclude=refs/jj/*", "--all", "--oneline"},
+		},
+		{
+			name:        "inject before multiple ref selectors",
+			cmdArgs:     []string{"git", "log", "--branches", "--tags=v*", "--oneline"},
+			excludeRefs: []string{"refs/jj/*", "refs/cache/*"},
+			expected:    []string{"git", "log", "--exclude=refs/jj/*", "--exclude=refs/cache/*", "--branches", "--exclude=refs/jj/*", "--exclude=refs/cache/*", "--tags=v*", "--oneline"},
+		},
+		{
+			name:        "leave commands without selectors unchanged",
+			cmdArgs:     []string{"echo", "view1"},
+			excludeRefs: []string{"refs/jj/*"},
+			expected:    []string{"echo", "view1"},
+		},
+		{
+			name:        "dedupe and ignore empty exclude refs",
+			cmdArgs:     []string{"git", "log", "--all"},
+			excludeRefs: []string{"refs/jj/*", "", "refs/jj/*"},
+			expected:    []string{"git", "log", "--exclude=refs/jj/*", "--all"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, applyAllBranchesLogExcludeRefs(test.cmdArgs, test.excludeRefs))
+		})
+	}
+}
+
 func TestBranchCurrentBranchInfo(t *testing.T) {
 	type scenario struct {
 		testName string

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -290,6 +290,8 @@ type GitConfig struct {
 	BranchLogCmd string `yaml:"branchLogCmd"`
 	// Commands used to display git log of all branches in the main window, they will be cycled in order of appearance (array of strings)
 	AllBranchesLogCmds []string `yaml:"allBranchesLogCmds"`
+	// Ref globs to exclude when displaying git log of all branches in the main window, e.g. refs/jj/*
+	AllBranchesLogExcludeRefs []string `yaml:"allBranchesLogExcludeRefs" jsonschema:"uniqueItems=true"`
 	// If true, git diffs are rendered with the `--ignore-all-space` flag, which ignores whitespace changes. Can be toggled from within Lazygit with `<c-w>`.
 	IgnoreWhitespaceInDiffView bool `yaml:"ignoreWhitespaceInDiffView"`
 	// The number of lines of context to show around each diff hunk. Can be changed from within Lazygit with the `{` and `}` keys.
@@ -850,6 +852,7 @@ func GetDefaultConfig() *UserConfig {
 			AutoStageResolvedConflicts:   true,
 			BranchLogCmd:                 "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",
 			AllBranchesLogCmds:           []string{"git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium"},
+			AllBranchesLogExcludeRefs:    []string{},
 			IgnoreWhitespaceInDiffView:   false,
 			DiffContextSize:              3,
 			RenameSimilarityThreshold:    50,

--- a/pkg/integration/tests/status/log_cmd_exclude_refs.go
+++ b/pkg/integration/tests/status/log_cmd_exclude_refs.go
@@ -1,0 +1,34 @@
+package status
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var LogCmdExcludeRefs = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Exclude configured refs from the all-branches log command",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Git.AllBranchesLogCmds = []string{"git log --all --pretty=%s"}
+		config.GetUserConfig().Git.AllBranchesLogExcludeRefs = []string{"refs/jj/*"}
+		config.GetUserConfig().Gui.StatusPanelView = "allBranchesLog"
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			EmptyCommit("base commit").
+			NewBranch("hidden").
+			EmptyCommit("hidden jj commit").
+			RunCommand([]string{"git", "update-ref", "refs/jj/test", "HEAD"}).
+			Checkout("master").
+			RunCommand([]string{"git", "branch", "-D", "hidden"}).
+			EmptyCommit("visible main commit")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Status().
+			Focus()
+
+		t.Views().Main().
+			Content(Contains("visible main commit").DoesNotContain("hidden jj commit"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -402,6 +402,7 @@ var tests = []*components.IntegrationTest{
 	status.ClickToFocus,
 	status.ClickWorkingTreeStateToOpenRebaseOptionsMenu,
 	status.LogCmd,
+	status.LogCmdExcludeRefs,
 	status.LogCmdStatusPanelAllBranchesLog,
 	submodule.Add,
 	submodule.Enter,

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -366,6 +366,14 @@
             "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium"
           ]
         },
+        "allBranchesLogExcludeRefs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Ref globs to exclude when displaying git log of all branches in the main window, e.g. refs/jj/*"
+        },
         "ignoreWhitespaceInDiffView": {
           "type": "boolean",
           "description": "If true, git diffs are rendered with the `--ignore-all-space` flag, which ignores whitespace changes. Can be toggled from within Lazygit with `\u003cc-w\u003e`.",


### PR DESCRIPTION
Adds a config option to exclude refs from the all-branches log view.

Changes:
- Injects `--exclude` flag before supported ref selectors in git log command
- Adds test coverage for exclude refs behavior
- Resolves #5332

This PR is ready for CI validation. Full local testing completed (unit tests, integration tests, manual git log behavior verification).