### PR TITLE
Exit cleanly when worktree/repository is removed while lazygit is running

### DIFF
--- a/pkg/app/errors.go
+++ b/pkg/app/errors.go
@@ -28,6 +28,10 @@ func knownError(tr *i18n.TranslationSet, err error) (string, bool) {
 			newError:      tr.NotARepository,
 		},
 		{
+			originalError: "fatal: Unable to read current working directory",
+			newError:      tr.WorkingDirectoryDoesNotExist,
+		},
+		{
 			originalError: "getwd: no such file or directory",
 			newError:      tr.WorkingDirectoryDoesNotExist,
 		},

--- a/pkg/commands/git_commands/branch_loader.go
+++ b/pkg/commands/git_commands/branch_loader.go
@@ -72,7 +72,10 @@ func (self *BranchLoader) Load(reflogCommits []*models.Commit,
 	onWorker func(func() error),
 	renderFunc func(),
 ) ([]*models.Branch, error) {
-	branches := self.obtainBranches()
+	branches, err := self.obtainBranches()
+	if err != nil {
+		return nil, err
+	}
 
 	if self.UserConfig().Git.LocalBranchSortOrder == "recency" {
 		reflogBranches := self.obtainReflogBranches(reflogCommits)
@@ -232,10 +235,10 @@ func (self *BranchLoader) GetBaseBranch(branch *models.Branch, mainBranches *Mai
 	return split[0], nil
 }
 
-func (self *BranchLoader) obtainBranches() []*models.Branch {
+func (self *BranchLoader) obtainBranches() ([]*models.Branch, error) {
 	output, err := self.getRawBranches()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	trimmedOutput := strings.TrimSpace(output)
@@ -256,7 +259,7 @@ func (self *BranchLoader) obtainBranches() []*models.Branch {
 
 		storeCommitDateAsRecency := self.UserConfig().Git.LocalBranchSortOrder != "recency"
 		return obtainBranch(split, storeCommitDateAsRecency), true
-	})
+	}), nil
 }
 
 func (self *BranchLoader) getRawBranches() (string, error) {

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -471,7 +471,10 @@ func (self *RefreshHelper) refreshBranches(refreshWorktrees bool, keepBranchSele
 			})
 		})
 	if err != nil {
-		self.c.Log.Error(err)
+		self.c.OnUIThread(func() error {
+			return types.ErrFatal{Err: err}
+		})
+		return
 	}
 
 	prevSelectedBranch := self.c.Contexts().Branches.GetSelected()

--- a/pkg/gui/popup/popup_handler.go
+++ b/pkg/gui/popup/popup_handler.go
@@ -81,6 +81,11 @@ func (self *PopupHandler) WithWaitingStatusSync(message string, f func() error) 
 }
 
 func (self *PopupHandler) ErrorHandler(err error) error {
+	var fatalError types.ErrFatal
+	if errors.As(err, &fatalError) {
+		return err
+	}
+
 	var notHandledError *types.ErrKeybindingNotHandled
 	if errors.As(err, &notHandledError) {
 		if !notHandledError.DisabledReason.ShowErrorInPanel {

--- a/pkg/gui/types/keybindings.go
+++ b/pkg/gui/types/keybindings.go
@@ -92,3 +92,17 @@ func (e ErrKeybindingNotHandled) Error() string {
 func (e ErrKeybindingNotHandled) Unwrap() error {
 	return gocui.ErrKeybindingNotHandled
 }
+
+// ErrFatal is an error that should cause the program to exit immediately,
+// bypassing the popup error handler.
+type ErrFatal struct {
+	Err error
+}
+
+func (e ErrFatal) Error() string {
+	return e.Err.Error()
+}
+
+func (e ErrFatal) Unwrap() error {
+	return e.Err
+}


### PR DESCRIPTION

### PR Description

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->

When a worktree or repository is removed while lazygit is running, git commands fail with "fatal: not a git repository" or "fatal: Unable to read current working directory". Previously this caused a panic in BranchLoader.obtainBranches, crashing lazygit with a stack trace.

Changes:

- BranchLoader.obtainBranches: return error instead of panic(err)
- RefreshHelper.refreshBranches: wrap the error in ErrFatal and send it to the UI thread, causing the program to exit
- PopupHandler.ErrorHandler: let ErrFatal bypass the popup handler so the error propagates to the main loop and triggers a clean exit
- Add ErrFatal type to gui/types for errors that should terminate the program immediately
- Add "fatal: Unable to read current working directory" to the known error mappings so it prints a friendly message on exit

Manual testing:

  Terminal 1: cd "$(mktemp -d)" && mkdir test-repo && cd test-repo git init && git commit --allow-empty -m "init" git worktree add ../test-wt && cd ../test-wt
    go build -o lazygit . && ./lazygit   # (or path to built binary)

  Terminal 2: rm -rf /path/to/test-wt /path/to/test-repo

  Then press R in lazygit to refresh. It should exit with: "Error: the current working directory does not exist"
