### PR TITLE
Add configurable whitespace replacement for branch names

### DIFF
--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -306,6 +306,8 @@ type GitConfig struct {
 	CommitPrefixes map[string][]CommitPrefixConfig `yaml:"commitPrefixes"`
 	// See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#predefined-branch-name-prefix
 	BranchPrefix string `yaml:"branchPrefix"`
+	// Character(s) used to replace whitespace when sanitizing branch names.
+	BranchWhitespaceChar string `yaml:"branchWhitespaceChar"`
 	// If true, parse emoji strings in commit messages e.g. render :rocket: as 🚀
 	// (This should really be under 'gui', not 'git')
 	ParseEmoji bool `yaml:"parseEmoji"`
@@ -856,6 +858,7 @@ func GetDefaultConfig() *UserConfig {
 			DisableForcePushing:          false,
 			CommitPrefixes:               map[string][]CommitPrefixConfig(nil),
 			BranchPrefix:                 "",
+			BranchWhitespaceChar:         "-",
 			ParseEmoji:                   false,
 			TruncateCopiedCommitHashesTo: 12,
 		},

--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -707,7 +707,7 @@ func (self *BranchesController) rename(branch *models.Branch) error {
 			InitialContent: branch.Name,
 			HandleConfirm: func(newBranchName string) error {
 				self.c.LogAction(self.c.Tr.Actions.RenameBranch)
-				if err := self.c.Git().Branch.Rename(branch.Name, helpers.SanitizedBranchName(newBranchName)); err != nil {
+				if err := self.c.Git().Branch.Rename(branch.Name, helpers.SanitizedBranchName(newBranchName, self.c.UserConfig().Git.BranchWhitespaceChar)); err != nil {
 					return err
 				}
 

--- a/pkg/gui/controllers/helpers/refs_helper.go
+++ b/pkg/gui/controllers/helpers/refs_helper.go
@@ -366,7 +366,7 @@ func (self *RefsHelper) NewBranch(from string, fromFormattedName string, suggest
 		InitialContent: suggestedBranchName,
 		HandleConfirm: func(response string) error {
 			self.c.LogAction(self.c.Tr.Actions.CreateBranch)
-			newBranchName := SanitizedBranchName(response)
+			newBranchName := SanitizedBranchName(response, self.c.UserConfig().Git.BranchWhitespaceChar)
 			newBranchFunc := self.c.Git().Branch.New
 			if newBranchName != suggestedBranchName {
 				newBranchFunc = self.c.Git().Branch.NewWithoutTracking
@@ -429,7 +429,7 @@ func (self *RefsHelper) MoveCommitsToNewBranch() error {
 			InitialContent: suggestedBranchName,
 			HandleConfirm: func(response string) error {
 				self.c.LogAction(self.c.Tr.MoveCommitsToNewBranch)
-				newBranchName := SanitizedBranchName(response)
+				newBranchName := SanitizedBranchName(response, self.c.UserConfig().Git.BranchWhitespaceChar)
 				return self.c.WithWaitingStatus(self.c.Tr.MovingCommitsToNewBranchStatus, func(gocui.Task) error {
 					return f(newBranchName)
 				})
@@ -576,10 +576,13 @@ func (self *RefsHelper) CanMoveCommitsToNewBranch() *types.DisabledReason {
 	return nil
 }
 
-// SanitizedBranchName will remove all spaces in favor of a dash "-" to meet
-// git's branch naming requirement.
-func SanitizedBranchName(input string) string {
-	return strings.ReplaceAll(input, " ", "-")
+// SanitizedBranchName will replace all spaces with the configured replacement
+// string to meet git's branch naming requirement.
+func SanitizedBranchName(input, whitespaceReplacement string) string {
+	if whitespaceReplacement == "" {
+		whitespaceReplacement = "-"
+	}
+	return strings.ReplaceAll(input, " ", whitespaceReplacement)
 }
 
 // Checks if the given branch name is a remote branch, and returns the name of

--- a/pkg/gui/controllers/helpers/refs_helper_test.go
+++ b/pkg/gui/controllers/helpers/refs_helper_test.go
@@ -1,0 +1,25 @@
+package helpers
+
+import "testing"
+
+func TestSanitizedBranchName(t *testing.T) {
+	tests := []struct {
+		name                 string
+		input                string
+		whitespaceReplacement string
+		expected             string
+	}{
+		{name: "default fallback", input: "feature new branch", whitespaceReplacement: "", expected: "feature-new-branch"},
+		{name: "custom replacement", input: "feature new branch", whitespaceReplacement: "_", expected: "feature_new_branch"},
+		{name: "multiple characters", input: "feature new branch", whitespaceReplacement: "--", expected: "feature--new--branch"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizedBranchName(tt.input, tt.whitespaceReplacement)
+			if got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `git.branchWhitespaceChar` config with default `-`
- use configured replacement when sanitizing branch names for create/move/rename flows
- keep backward compatibility by falling back to `-` when config is empty
- add unit tests for branch-name sanitization

## Testing
- `go test ./pkg/gui/controllers/helpers ./pkg/gui/controllers ./pkg/config`

Fixes jesseduffield/lazygit#2663