### PR TITLE
fix: open commit URL against selected remote

### DIFF
--- a/pkg/gui/controllers/helpers/host_helper.go
+++ b/pkg/gui/controllers/helpers/host_helper.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"github.com/jesseduffield/lazygit/pkg/commands/hosting_service"
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
 )
 
 // this helper just wraps our hosting_service package
@@ -37,10 +38,31 @@ func (self *HostHelper) GetCommitURL(commitHash string) (string, error) {
 // getting this on every request rather than storing it in state in case our remoteURL changes
 // from one invocation to the next.
 func (self *HostHelper) getHostingServiceMgr() (*hosting_service.HostingServiceMgr, error) {
-	remoteUrl, err := self.c.Git().Remote.GetRemoteURL("origin")
+	remoteName := getPreferredRemoteName(
+		self.c.Contexts().RemoteBranches.GetSelected(),
+		self.c.Contexts().Remotes.GetSelected(),
+	)
+
+	remoteUrl, err := self.c.Git().Remote.GetRemoteURL(remoteName)
+	if err != nil && remoteName != "origin" {
+		remoteUrl, err = self.c.Git().Remote.GetRemoteURL("origin")
+	}
 	if err != nil {
 		return nil, err
 	}
+
 	configServices := self.c.UserConfig().Services
 	return hosting_service.NewHostingServiceMgr(self.c.Log, self.c.Tr, remoteUrl, configServices), nil
+}
+
+func getPreferredRemoteName(selectedRemoteBranch *models.RemoteBranch, selectedRemote *models.Remote) string {
+	if selectedRemoteBranch != nil && selectedRemoteBranch.RemoteName != "" {
+		return selectedRemoteBranch.RemoteName
+	}
+
+	if selectedRemote != nil && selectedRemote.Name != "" {
+		return selectedRemote.Name
+	}
+
+	return "origin"
 }

--- a/pkg/gui/controllers/helpers/host_helper_test.go
+++ b/pkg/gui/controllers/helpers/host_helper_test.go
@@ -1,0 +1,42 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPreferredRemoteName(t *testing.T) {
+	tests := []struct {
+		name                 string
+		selectedRemoteBranch *models.RemoteBranch
+		selectedRemote       *models.Remote
+		expected             string
+	}{
+		{
+			name:                 "uses selected remote branch when available",
+			selectedRemoteBranch: &models.RemoteBranch{RemoteName: "upstream"},
+			selectedRemote:       &models.Remote{Name: "origin"},
+			expected:             "upstream",
+		},
+		{
+			name:                 "falls back to selected remote",
+			selectedRemoteBranch: nil,
+			selectedRemote:       &models.Remote{Name: "mirror"},
+			expected:             "mirror",
+		},
+		{
+			name:                 "defaults to origin",
+			selectedRemoteBranch: nil,
+			selectedRemote:       nil,
+			expected:             "origin",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, getPreferredRemoteName(test.selectedRemoteBranch, test.selectedRemote))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- stop hardcoding `origin` when building hosting-service URLs for commit links
- prefer the selected remote branch's remote name, then selected remote name, then fallback to `origin`
- keep a fallback to `origin` URL resolution if the selected remote lookup fails
- add focused unit tests for remote selection precedence

## Why
When browsing commits from a non-`origin` remote in the Remotes/Remote Branches flow, pressing `o` should open the selected remote host, not always the first remote.

Fixes #5260

## Testing
- `go test ./pkg/gui/controllers/helpers -run TestGetPreferredRemoteName`
