### PR TITLE
Re-run pager-rendered diff output after resize

### DIFF
--- a/pkg/gui/pty.go
+++ b/pkg/gui/pty.go
@@ -22,16 +22,23 @@ func (gui *Gui) desiredPtySize(view *gocui.View) *pty.Winsize {
 
 func (gui *Gui) onResize() error {
 	gui.Mutexes.PtyMutex.Lock()
-	defer gui.Mutexes.PtyMutex.Unlock()
+	hasPtyViews := len(gui.viewPtmxMap) > 0
 
 	for viewName, ptmx := range gui.viewPtmxMap {
-		// TODO: handle resizing properly: we need to actually clear the main view
-		// and re-read the output from our pty. Or we could just re-run the original
-		// command from scratch
+		// Resize any active ptys first so they match the new view dimensions.
 		view, _ := gui.g.View(viewName)
 		if err := pty.Setsize(ptmx, gui.desiredPtySize(view)); err != nil {
+			gui.Mutexes.PtyMutex.Unlock()
 			return utils.WrapError(err)
 		}
+	}
+
+	gui.Mutexes.PtyMutex.Unlock()
+
+	if hasPtyViews {
+		// Custom pagers can render based on width. Re-running the current side's main
+		// render after a resize ensures the diff output is regenerated for the new size.
+		gui.c.Context().CurrentSide().HandleRenderToMain()
 	}
 
 	return nil


### PR DESCRIPTION
### PR Description

Fixes #4415.

When a terminal resize happens while a diff is rendered through a PTY-backed pager (for example `delta`), lazygit previously only resized the PTY and kept the already-rendered pager output.

This change re-runs `HandleRenderToMain()` after resize whenever there are active PTY-backed views, so the current diff is regenerated using the new width.

### Please check if the PR fulfills these requirements

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

### Validation

- `go test ./pkg/gui ./pkg/gui/controllers -run "TestScreenModeActions" -count=1`
- `go test ./pkg/gui/...` (partially ran; unrelated pre-existing failures in `pkg/gui/presentation` and `pkg/gui/style` on this environment)
