### PR TITLE
Fix stale continue-rebase confirmation after external completion

### DIFF
--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -576,8 +576,11 @@ func (self *RefreshHelper) refreshStateFiles() error {
 		}
 	}
 
-	if self.c.Git().Status.WorkingTreeState().Any() && conflictFileCount == 0 && prevConflictFileCount > 0 {
+	workingTreeState := self.c.Git().Status.WorkingTreeState()
+	if workingTreeState.Any() && conflictFileCount == 0 && prevConflictFileCount > 0 {
 		self.c.OnUIThread(func() error { return self.mergeAndRebaseHelper.PromptToContinueRebase() })
+	} else if !workingTreeState.Any() {
+		self.dismissStaleConflictsResolvedPrompt()
 	}
 
 	fileTreeViewModel.RWMutex.Lock()
@@ -598,6 +601,69 @@ func (self *RefreshHelper) refreshStateFiles() error {
 	fileTreeViewModel.RWMutex.Unlock()
 
 	return nil
+}
+
+func (self *RefreshHelper) dismissStaleConflictsResolvedPrompt() {
+	self.c.Mutexes().PopupMutex.Lock()
+	currentPopupOpts := self.c.State().GetRepoState().GetCurrentPopupOpts()
+	self.c.Mutexes().PopupMutex.Unlock()
+
+	if currentPopupOpts == nil || currentPopupOpts.Editable {
+		return
+	}
+
+	if !matchesPromptTemplate(currentPopupOpts.Prompt, self.c.Tr.ConflictsResolved) {
+		return
+	}
+
+	self.c.OnUIThread(func() error {
+		if self.c.Context().Current().GetKey() == context.CONFIRMATION_CONTEXT_KEY {
+			self.c.Context().Pop()
+		}
+		return nil
+	})
+}
+
+func matchesPromptTemplate(prompt string, template string) bool {
+	if template == "" {
+		return false
+	}
+
+	parts := strings.Split(template, "%s")
+	if len(parts) == 1 {
+		return prompt == template
+	}
+
+	firstPart := parts[0]
+	if firstPart != "" && !strings.HasPrefix(prompt, firstPart) {
+		return false
+	}
+
+	lastPart := parts[len(parts)-1]
+	if lastPart != "" && !strings.HasSuffix(prompt, lastPart) {
+		return false
+	}
+
+	start := len(firstPart)
+	end := len(prompt) - len(lastPart)
+	if end < start {
+		return false
+	}
+
+	for _, part := range parts[1 : len(parts)-1] {
+		if part == "" {
+			continue
+		}
+
+		idx := strings.Index(prompt[start:end], part)
+		if idx < 0 {
+			return false
+		}
+
+		start += idx + len(part)
+	}
+
+	return true
 }
 
 // the reflogs panel is the only panel where we cache data, in that we only

--- a/pkg/gui/controllers/helpers/refresh_helper_test.go
+++ b/pkg/gui/controllers/helpers/refresh_helper_test.go
@@ -1,0 +1,55 @@
+package helpers
+
+import "testing"
+
+func TestMatchesPromptTemplate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		prompt   string
+		template string
+		want     bool
+	}{
+		{
+			name:     "matches template with placeholder",
+			prompt:   "All merge conflicts resolved. Continue the rebase?",
+			template: "All merge conflicts resolved. Continue the %s?",
+			want:     true,
+		},
+		{
+			name:     "matches translated-like template with placeholder",
+			prompt:   "Tous les conflits sont resolus. Continuer le rebase ?",
+			template: "Tous les conflits sont resolus. Continuer le %s ?",
+			want:     true,
+		},
+		{
+			name:     "rejects unrelated prompt",
+			prompt:   "Do you really want to quit?",
+			template: "All merge conflicts resolved. Continue the %s?",
+			want:     false,
+		},
+		{
+			name:     "rejects empty template",
+			prompt:   "All merge conflicts resolved. Continue the rebase?",
+			template: "",
+			want:     false,
+		},
+		{
+			name:     "exact match when no placeholder",
+			prompt:   "Continue",
+			template: "Continue",
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := matchesPromptTemplate(tt.prompt, tt.template); got != tt.want {
+				t.Fatalf("matchesPromptTemplate(%q, %q) = %v, want %v", tt.prompt, tt.template, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- dismiss the "All merge conflicts resolved. Continue the rebase?" confirmation when the rebase/merge has already finished externally
- only auto-close confirmations that match the localized `ConflictsResolved` prompt template
- add a helper test that verifies localized template matching behavior

## Repro
Fixes #5197.

1. Start a rebase that produces conflicts
2. Resolve conflicts outside lazygit and trigger the continue prompt
3. Run `git rebase --continue` in another terminal before confirming in lazygit
4. Refresh lazygit

Before: the continue prompt could remain visible after rebase completion.
After: stale continue prompt is dismissed once no merge/rebase is in progress.

## Validation
- `go test ./pkg/gui/controllers/helpers -run TestMatchesPromptTemplate`
- `git diff --check`
