### PR TITLE
fix: preserve user-selected half screen mode when clearing filters

### DIFF
--- a/pkg/gui/controllers/filtering_menu_action.go
+++ b/pkg/gui/controllers/filtering_menu_action.go
@@ -101,23 +101,29 @@ func (self *FilteringMenuAction) Call() error {
 }
 
 func (self *FilteringMenuAction) setFilteringPath(path string) error {
-	self.c.Modes().Filtering.Reset()
+	wasFiltering := self.c.Modes().Filtering.Active()
+	self.c.Modes().Filtering.SetAuthor("")
 	self.c.Modes().Filtering.SetPath(path)
-	return self.setFiltering()
+	return self.setFiltering(wasFiltering)
 }
 
 func (self *FilteringMenuAction) setFilteringAuthor(author string) error {
-	self.c.Modes().Filtering.Reset()
+	wasFiltering := self.c.Modes().Filtering.Active()
+	self.c.Modes().Filtering.SetPath("")
 	self.c.Modes().Filtering.SetAuthor(author)
-	return self.setFiltering()
+	return self.setFiltering(wasFiltering)
 }
 
-func (self *FilteringMenuAction) setFiltering() error {
+func (self *FilteringMenuAction) setFiltering(wasFiltering bool) error {
 	self.c.Modes().Filtering.SetSelectedCommitHash(self.c.Contexts().LocalCommits.GetSelectedCommitHash())
 
 	repoState := self.c.State().GetRepoState()
-	if repoState.GetScreenMode() == types.SCREEN_NORMAL {
-		repoState.SetScreenMode(types.SCREEN_HALF)
+	if !wasFiltering {
+		screenModeChanged := repoState.GetScreenMode() == types.SCREEN_NORMAL
+		self.c.Modes().Filtering.SetScreenModeChanged(screenModeChanged)
+		if screenModeChanged {
+			repoState.SetScreenMode(types.SCREEN_HALF)
+		}
 	}
 
 	self.c.Context().Push(self.c.Contexts().LocalCommits, types.OnFocusOpts{})

--- a/pkg/gui/controllers/helpers/mode_helper.go
+++ b/pkg/gui/controllers/helpers/mode_helper.go
@@ -184,10 +184,10 @@ func (self *ModeHelper) ExitFilterMode() error {
 
 func (self *ModeHelper) ClearFiltering() error {
 	selectedCommitHash := self.c.Contexts().LocalCommits.GetSelectedCommitHash()
-	self.c.Modes().Filtering.Reset()
-	if self.c.State().GetRepoState().GetScreenMode() == types.SCREEN_HALF {
+	if self.c.Modes().Filtering.ScreenModeChanged() && self.c.State().GetRepoState().GetScreenMode() == types.SCREEN_HALF {
 		self.c.State().GetRepoState().SetScreenMode(types.SCREEN_NORMAL)
 	}
+	self.c.Modes().Filtering.Reset()
 
 	self.c.Refresh(types.RefreshOptions{
 		Scope: ScopesToRefreshWhenFilteringModeChanges(),

--- a/pkg/gui/modes/filtering/filtering.go
+++ b/pkg/gui/modes/filtering/filtering.go
@@ -4,6 +4,7 @@ type Filtering struct {
 	path               string // the filename that gets passed to git log
 	author             string // the author that gets passed to git log
 	selectedCommitHash string // the commit that was selected before we entered filtering mode
+	screenModeChanged  bool   // whether entering filtering mode changed screen mode from normal -> half
 }
 
 func New(path string, author string) Filtering {
@@ -17,6 +18,7 @@ func (m *Filtering) Active() bool {
 func (m *Filtering) Reset() {
 	m.path = ""
 	m.author = ""
+	m.screenModeChanged = false
 }
 
 func (m *Filtering) SetPath(path string) {
@@ -41,4 +43,12 @@ func (m *Filtering) SetSelectedCommitHash(hash string) {
 
 func (m *Filtering) GetSelectedCommitHash() string {
 	return m.selectedCommitHash
+}
+
+func (m *Filtering) SetScreenModeChanged(changed bool) {
+	m.screenModeChanged = changed
+}
+
+func (m *Filtering) ScreenModeChanged() bool {
+	return m.screenModeChanged
 }

--- a/pkg/gui/modes/filtering/filtering_test.go
+++ b/pkg/gui/modes/filtering/filtering_test.go
@@ -1,0 +1,19 @@
+package filtering
+
+import "testing"
+
+func TestFilteringScreenModeChangedReset(t *testing.T) {
+	mode := New("", "")
+	mode.SetPath("foo")
+	mode.SetScreenModeChanged(true)
+
+	if !mode.ScreenModeChanged() {
+		t.Fatalf("expected screenModeChanged to be true")
+	}
+
+	mode.Reset()
+
+	if mode.ScreenModeChanged() {
+		t.Fatalf("expected screenModeChanged to be false after Reset")
+	}
+}


### PR DESCRIPTION
## Summary
Fixes a screen-mode regression when exiting commit filtering.

Closes #5179.

When users start filtering from `screenMode: half`, clearing the filter should keep the UI in half mode. Instead, Lazygit switched back to normal mode.

## Root cause
`ModeHelper.ClearFiltering()` always converted `SCREEN_HALF -> SCREEN_NORMAL` on exit, without distinguishing:
- half mode that was entered automatically for filtering, vs
- half mode explicitly configured by the user.

## What changed
- Track whether entering filtering actually changed screen mode (`normal -> half`) using a new `screenModeChanged` flag in filtering mode state.
- Only restore `half -> normal` on filter clear when that flag is true.
- Preserve this flag while changing filter type/path during an active filtering session.
- Added a unit test for filtering-mode state reset behavior.

## Validation
- `go test ./pkg/gui/modes/filtering ./pkg/gui/controllers/...`

All tests passed.