### PR TITLE
Add "Remove worktree and delete local branch" option to branch delete menu

### DIFF
--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -560,6 +560,24 @@ func (self *BranchesController) delete(branches []*models.Branch) error {
 		return branch.IsTrackingRemote() && !branch.UpstreamGone
 	})
 
+	menuItems := []*types.MenuItem{}
+
+	// If a single branch is checked out by another worktree, offer to remove
+	// the worktree as the first (default) option in the delete menu.
+	if len(branches) == 1 {
+		worktree, ok := git_commands.WorktreeForBranch(branches[0], self.c.Model().Worktrees)
+		if ok && !worktree.IsCurrent {
+			branch := branches[0]
+			menuItems = append(menuItems, &types.MenuItem{
+				Label: self.c.Tr.RemoveWorktreeAndBranch,
+				Key:   'w',
+				OnPress: func() error {
+					return self.c.Helpers().Worktree.RemoveAndDeleteBranch(worktree, branch, false)
+				},
+			})
+		}
+	}
+
 	localDeleteItem := &types.MenuItem{
 		Label: lo.Ternary(len(branches) > 1, self.c.Tr.DeleteLocalBranches, self.c.Tr.DeleteLocalBranch),
 		Key:   'c',
@@ -599,6 +617,8 @@ func (self *BranchesController) delete(branches []*models.Branch) error {
 		}
 	}
 
+	menuItems = append(menuItems, localDeleteItem, remoteDeleteItem, deleteBothItem)
+
 	var menuTitle string
 	if len(branches) == 1 {
 		menuTitle = utils.ResolvePlaceholderString(
@@ -613,7 +633,7 @@ func (self *BranchesController) delete(branches []*models.Branch) error {
 
 	return self.c.Menu(types.CreateMenuOptions{
 		Title: menuTitle,
-		Items: []*types.MenuItem{localDeleteItem, remoteDeleteItem, deleteBothItem},
+		Items: menuItems,
 	})
 }
 

--- a/pkg/gui/controllers/helpers/worktree_helper.go
+++ b/pkg/gui/controllers/helpers/worktree_helper.go
@@ -165,6 +165,21 @@ func (self *WorktreeHelper) Switch(worktree *models.Worktree, contextKey types.C
 }
 
 func (self *WorktreeHelper) Remove(worktree *models.Worktree, force bool) error {
+	return self.removeWorktree(worktree, force, nil)
+}
+
+func (self *WorktreeHelper) RemoveAndDeleteBranch(worktree *models.Worktree, branch *models.Branch, force bool) error {
+	return self.removeWorktree(worktree, force, func() error {
+		self.c.LogAction(self.c.Tr.Actions.DeleteLocalBranch)
+		if err := self.c.Git().Branch.LocalDelete([]string{branch.Name}, true); err != nil {
+			return err
+		}
+		self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.BRANCHES}})
+		return nil
+	})
+}
+
+func (self *WorktreeHelper) removeWorktree(worktree *models.Worktree, force bool, afterRemove func() error) error {
 	title := self.c.Tr.RemoveWorktreeTitle
 	var templateStr string
 	if force {
@@ -193,9 +208,14 @@ func (self *WorktreeHelper) Remove(worktree *models.Worktree, force bool) error 
 					}
 
 					if !force {
-						return self.Remove(worktree, true)
+						return self.removeWorktree(worktree, true, afterRemove)
 					}
 					return err
+				}
+				if afterRemove != nil {
+					if err := afterRemove(); err != nil {
+						return err
+					}
 				}
 				self.c.Refresh(types.RefreshOptions{Mode: types.ASYNC, Scope: []types.RefreshableView{types.WORKTREES, types.BRANCHES, types.FILES}})
 				return nil

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -862,6 +862,7 @@ type TranslationSet struct {
 	DetachWorktreeTooltip                    string
 	Switching                                string
 	RemoveWorktree                           string
+	RemoveWorktreeAndBranch                  string
 	RemoveWorktreeTitle                      string
 	DetachWorktree                           string
 	DetachingWorktree                        string
@@ -1978,6 +1979,7 @@ func EnglishTranslationSet() *TranslationSet {
 		DetachWorktreeTooltip:                    "This will run `git checkout --detach` on the worktree so that it stops hogging the branch, but the worktree's working tree will be left alone.",
 		Switching:                                "Switching",
 		RemoveWorktree:                           "Remove worktree",
+		RemoveWorktreeAndBranch:                  "Remove worktree and delete local branch",
 		RemoveWorktreeTitle:                      "Remove worktree",
 		RemoveWorktreePrompt:                     "Are you sure you want to remove worktree '{{.worktreeName}}'?",
 		ForceRemoveWorktreePrompt:                "'{{.worktreeName}}' contains modified or untracked files, or submodules (or all of these). Are you sure you want to remove it?",

--- a/pkg/integration/tests/worktree/detach_worktree_from_branch.go
+++ b/pkg/integration/tests/worktree/detach_worktree_from_branch.go
@@ -28,8 +28,7 @@ var DetachWorktreeFromBranch = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("newbranch")).
 			Press(keys.Universal.Remove).
 			Tap(func() {
-				t.ExpectPopup().
-					Menu().
+				t.ExpectPopup().Menu().
 					Title(Equals("Delete branch 'newbranch'?")).
 					Select(Contains("Delete local branch")).
 					Confirm()

--- a/pkg/integration/tests/worktree/remove_worktree_from_branch.go
+++ b/pkg/integration/tests/worktree/remove_worktree_from_branch.go
@@ -6,7 +6,7 @@ import (
 )
 
 var RemoveWorktreeFromBranch = NewIntegrationTest(NewIntegrationTestArgs{
-	Description:  "Remove a worktree from the branches view",
+	Description:  "Remove a worktree and delete its branch from the branches view",
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig:  func(config *config.AppConfig) {},
@@ -29,16 +29,9 @@ var RemoveWorktreeFromBranch = NewIntegrationTest(NewIntegrationTestArgs{
 			NavigateToLine(Contains("newbranch")).
 			Press(keys.Universal.Remove).
 			Tap(func() {
-				t.ExpectPopup().
-					Menu().
-					Title(Equals("Delete branch 'newbranch'?")).
-					Select(Contains("Delete local branch")).
-					Confirm()
-			}).
-			Tap(func() {
 				t.ExpectPopup().Menu().
-					Title(Equals("Branch newbranch is checked out by worktree linked-worktree")).
-					Select(Equals("Remove worktree")).
+					Title(Equals("Delete branch 'newbranch'?")).
+					Select(Contains("Remove worktree")).
 					Confirm()
 
 				t.ExpectPopup().Confirmation().
@@ -52,8 +45,7 @@ var RemoveWorktreeFromBranch = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			Lines(
-				Contains("mybranch"),
-				Contains("newbranch").DoesNotContain("(worktree)").IsSelected(),
+				Contains("mybranch").IsSelected(),
 			)
 
 		t.Views().Worktrees().


### PR DESCRIPTION
### PR Description

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

When pressing 'd' on a branch that is checked out by another worktree, the delete menu now shows "Remove worktree and delete local branch" as the first (default) option, making it easy to clean up both in one step.

<img width="1414" height="432" alt="Screenshot 2026-03-12 at 07 52 11@2x" src="https://github.com/user-attachments/assets/80e9a76b-2c78-40b3-b180-cc09756c1c65" />

