### PR TITLE
Change 'Keep file' shortcut from 'k' to 'r' in merge conflict menu

### DIFF
--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -647,7 +647,7 @@ func (self *FilesController) handleNonInlineConflict(file *models.File) error {
 		OnPress: func() error {
 			return handle(self.c.Git().WorkingTree.StageFile, self.c.Tr.Actions.ResolveConflictByKeepingFile)
 		},
-		Key: 'k',
+		Key: 'r', // 'r' for retain; avoid 'k' which conflicts with navigation
 	}
 	deleteItem := &types.MenuItem{
 		Label: self.c.Tr.MergeConflictDeleteFile,


### PR DESCRIPTION
When resolving non-textual merge conflicts (e.g. file modified on one side, deleted on the other), the "Keep file" option has shortcut key 'k'. This conflicts with vim-style navigation where 'k' moves up in the menu, leading to accidental selection when users just want to navigate.

<img width="1898" height="528" alt="screenshot-20260313-124124" src="https://github.com/user-attachments/assets/1136098d-1142-41bf-a236-df5ad2bddb5e" />
Changed the shortcut to 'r' (for "retain") to avoid this conflict.