### PR TITLE
fix: auto-switch to main worktree when linked worktree is deleted externally

### DIFF
--- a/pkg/commands/git_commands/repo_paths.go
+++ b/pkg/commands/git_commands/repo_paths.go
@@ -57,6 +57,13 @@ func (self *RepoPaths) IsBareRepo() bool {
 	return self.isBareRepo
 }
 
+// InLinkedWorktree returns true if the current working directory is a linked
+// worktree (as opposed to the main worktree). When true, RepoPath() points to
+// the main worktree that can be used as a fallback.
+func (self *RepoPaths) InLinkedWorktree() bool {
+	return self.worktreePath != self.repoPath
+}
+
 // Returns the repo paths for a typical repo
 func MockRepoPaths(currentPath string) *RepoPaths {
 	return &RepoPaths{

--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -66,6 +66,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 		mergeConflictsHelper,
 		worktreeHelper,
 		searchHelper,
+		reposHelper,
 	)
 	diffHelper := helpers.NewDiffHelper(helperCommon)
 	cherryPickHelper := helpers.NewCherryPickHelper(

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -30,6 +31,8 @@ type RefreshHelper struct {
 	mergeConflictsHelper *MergeConflictsHelper
 	worktreeHelper       *WorktreeHelper
 	searchHelper         *SearchHelper
+	reposHelper          *ReposHelper
+	switchingToMainOnce  sync.Once
 
 	// Tracks repos for which the user has dismissed the "select base GitHub remote"
 	// prompt, to avoid re-prompting on every subsequent refresh within the same session.
@@ -47,6 +50,7 @@ func NewRefreshHelper(
 	mergeConflictsHelper *MergeConflictsHelper,
 	worktreeHelper *WorktreeHelper,
 	searchHelper *SearchHelper,
+	reposHelper *ReposHelper,
 ) *RefreshHelper {
 	return &RefreshHelper{
 		c:                    c,
@@ -57,12 +61,44 @@ func NewRefreshHelper(
 		mergeConflictsHelper: mergeConflictsHelper,
 		worktreeHelper:       worktreeHelper,
 		searchHelper:         searchHelper,
+		reposHelper:          reposHelper,
 	}
 }
 
 func (self *RefreshHelper) Refresh(options types.RefreshOptions) {
 	if options.Mode == types.ASYNC && options.Then != nil {
 		panic("RefreshOptions.Then doesn't work with mode ASYNC")
+	}
+
+	// If the working directory has been deleted (e.g. a worktree removed
+	// externally), every git command will fail. Detect this early.
+	// Two platform-specific behaviors:
+	//   Linux:  os.Getwd() fails (returns ENOENT)
+	//   macOS:  os.Getwd() succeeds (inode kept alive) but os.Stat(cwd) fails
+	cwdDeleted := false
+	if cwd, err := os.Getwd(); err != nil {
+		cwdDeleted = true
+	} else if _, statErr := os.Stat(cwd); os.IsNotExist(statErr) {
+		cwdDeleted = true
+	}
+	if cwdDeleted {
+		repoPaths := self.c.Git().RepoPaths
+		if repoPaths.InLinkedWorktree() {
+			self.switchingToMainOnce.Do(func() {
+				mainPath := repoPaths.RepoPath()
+				self.c.Log.Warnf("Working directory removed, switching to main worktree at %s", mainPath)
+				// Restore the CWD first so DispatchSwitchToRepo can
+				// call os.Getwd() without failing.
+				if err := os.Chdir(mainPath); err != nil {
+					panic("fatal: working directory removed and cannot switch to main worktree: " + err.Error())
+				}
+				self.c.OnUIThread(func() error {
+					return self.reposHelper.DispatchSwitchToRepo(mainPath, context.WORKTREES_CONTEXT_KEY)
+				})
+			})
+			return
+		}
+		panic("fatal: working directory has been removed")
 	}
 
 	t := time.Now()

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -93,7 +93,11 @@ func (self *RefreshHelper) Refresh(options types.RefreshOptions) {
 					panic("fatal: working directory removed and cannot switch to main worktree: " + err.Error())
 				}
 				self.c.OnUIThread(func() error {
-					return self.reposHelper.DispatchSwitchToRepo(mainPath, context.WORKTREES_CONTEXT_KEY)
+					if err := self.reposHelper.DispatchSwitchToRepo(mainPath, context.WORKTREES_CONTEXT_KEY); err != nil {
+						return err
+					}
+					self.c.Toast(self.c.Tr.WorktreeDeletedSwitchingToMain)
+					return nil
 				})
 			})
 			return

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -761,6 +761,7 @@ type TranslationSet struct {
 	ErrStageDirWithInlineMergeConflicts      string
 	ErrRepositoryMovedOrDeleted              string
 	ErrWorktreeMovedOrRemoved                string
+	WorktreeDeletedSwitchingToMain           string
 	CommandLog                               string
 	ToggleShowCommandLog                     string
 	FocusCommandLog                          string
@@ -1886,6 +1887,7 @@ func EnglishTranslationSet() *TranslationSet {
 		ErrRepositoryMovedOrDeleted:              "Cannot find repo. It might have been moved or deleted ¯\\_(ツ)_/¯",
 		CommandLog:                               "Command log",
 		ErrWorktreeMovedOrRemoved:                "Cannot find worktree. It might have been moved or removed ¯\\_(ツ)_/¯",
+		WorktreeDeletedSwitchingToMain:           "Worktree deleted externally. Switched to main worktree.",
 		ToggleShowCommandLog:                     "Toggle show/hide command log",
 		FocusCommandLog:                          "Focus command log",
 		CommandLogHeader:                         "You can hide/focus this panel by pressing '%s'\n",

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -487,6 +487,7 @@ var tests = []*components.IntegrationTest{
 	worktree.DotfileBareRepo,
 	worktree.DoubleNestedLinkedSubmodule,
 	worktree.ExcludeFileInWorktree,
+	worktree.ExternalRemoveCurrentWorktree,
 	worktree.FastForwardWorktreeBranch,
 	worktree.FastForwardWorktreeBranchShouldNotPolluteCurrentWorktree,
 	worktree.ForceRemoveWorktree,

--- a/pkg/integration/tests/worktree/external_remove_current_worktree.go
+++ b/pkg/integration/tests/worktree/external_remove_current_worktree.go
@@ -30,6 +30,8 @@ var ExternalRemoveCurrentWorktree = NewIntegrationTest(NewIntegrationTestArgs{
 		// Trigger a refresh so lazygit detects the deleted CWD
 		t.GlobalPress(keys.Universal.Refresh)
 
+		t.ExpectToast(Contains("Worktree deleted externally"))
+
 		// Lazygit should auto-switch to the main worktree
 		t.Views().Status().
 			Lines(

--- a/pkg/integration/tests/worktree/external_remove_current_worktree.go
+++ b/pkg/integration/tests/worktree/external_remove_current_worktree.go
@@ -1,0 +1,39 @@
+package worktree
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var ExternalRemoveCurrentWorktree = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Recover when the current linked worktree is deleted externally",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.NewBranch("mybranch")
+		shell.CreateFileAndAdd("README.md", "hello world")
+		shell.Commit("initial commit")
+		shell.AddWorktree("mybranch", "../linked-worktree", "newbranch")
+		shell.Chdir("../linked-worktree")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		// Confirm we're in the linked worktree
+		t.Views().Status().
+			Lines(
+				Contains("repo(linked-worktree) → newbranch"),
+			)
+
+		// Simulate external deletion (e.g. another terminal runs rm -rf)
+		t.Shell().RunShellCommand("rm -rf ../linked-worktree")
+
+		// Trigger a refresh so lazygit detects the deleted CWD
+		t.GlobalPress(keys.Universal.Refresh)
+
+		// Lazygit should auto-switch to the main worktree
+		t.Views().Status().
+			Lines(
+				Contains("repo → mybranch"),
+			)
+	},
+})


### PR DESCRIPTION
### PR Description

Relates to #5266. Alternative approach to #5355.

When lazygit is running inside a linked worktree and that directory gets deleted externally (e.g. a Claude Code session cleaning up its worktree, or `rm -rf` from another terminal), every git command fails and lazygit panics in `obtainBranches`.

Instead of exiting with an error (#5355's approach), this detects the missing CWD at the top of `Refresh` and switches back to the main worktree automatically. The user keeps their lazygit session. A toast notification informs the user that the switch happened. If the main worktree itself is gone, it panics since there's nowhere to recover to.

One platform subtlety: on macOS, `os.Stat(".")` succeeds on a deleted directory because the kernel holds the inode alive. The detection has to stat the absolute path from `os.Getwd()` instead. On Linux, `os.Getwd()` itself fails with `ENOENT`. Both cases are handled.

Changes:
- `RepoPaths.InLinkedWorktree()`: returns whether we're in a linked worktree
- `RefreshHelper.Refresh()`: checks if CWD is gone before running git commands, uses `sync.Once` to avoid duplicate recovery from concurrent refresh goroutines
- Shows a toast notification ("Worktree deleted externally. Switched to main worktree.") so the user knows what happened (addresses feedback from #5355)
- Integration test that creates a worktree, starts lazygit in it, deletes it, and verifies lazygit lands on the main worktree with the expected toast

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig)) - no new config entries
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc