### PR TITLE
fix: add missing return in loadWorktrees and bounds check in status parser

### DIFF
--- a/pkg/commands/git_commands/file_loader.go
+++ b/pkg/commands/git_commands/file_loader.go
@@ -203,9 +203,11 @@ func (self *FileLoader) gitStatus(opts GitStatusOptions) ([]FileStatus, error) {
 
 		if strings.HasPrefix(status.Change, "R") || strings.HasPrefix(status.Change, "C") {
 			// if a line starts with 'R' (rename) or 'C' (copy) then the next line is the original file.
-			status.PreviousPath = splitLines[i+1]
-			status.StatusString = fmt.Sprintf("%s %s -> %s", status.Change, status.PreviousPath, status.Path)
-			i++
+			if i+1 < len(splitLines) {
+				status.PreviousPath = splitLines[i+1]
+				status.StatusString = fmt.Sprintf("%s %s -> %s", status.Change, status.PreviousPath, status.Path)
+				i++
+			}
 		}
 
 		response = append(response, status)

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -679,6 +679,7 @@ func (self *RefreshHelper) loadWorktrees() {
 	if err != nil {
 		self.c.Log.Error(err)
 		self.c.Model().Worktrees = []*models.Worktree{}
+		return
 	}
 
 	self.c.Model().Worktrees = worktrees


### PR DESCRIPTION
Two small defensive fixes:

1. **refresh_helper.go**: Added missing `return` in `loadWorktrees` error path. Without it, the empty-slice fallback was immediately overwritten by the nil worktrees value.

2. **file_loader.go**: Added bounds check before accessing `splitLines[i+1]` in the rename/copy status parser to prevent panic on truncated git output.

Closes #5368