### PR TITLE
fix: guard against nil remote branch in presentation layer

### DIFF
--- a/pkg/gui/presentation/remote_branches.go
+++ b/pkg/gui/presentation/remote_branches.go
@@ -9,6 +9,12 @@ import (
 
 func GetRemoteBranchListDisplayStrings(branches []*models.RemoteBranch, diffName string) [][]string {
 	return lo.Map(branches, func(branch *models.RemoteBranch, _ int) []string {
+		if branch == nil {
+			if icons.IsIconEnabled() {
+				return []string{"", ""}
+			}
+			return []string{""}
+		}
 		diffed := branch.FullName() == diffName
 		return getRemoteBranchDisplayStrings(branch, diffed)
 	})


### PR DESCRIPTION
Adds a nil guard in `GetRemoteBranchListDisplayStrings` before accessing `branch.FullName()`. Prevents a nil pointer panic that can occur when the remote branch list contains stale nil entries during concurrent refresh operations.

Related: #5240
Closes #5370