### PR TITLE
fix: guard against nil current worktree in porcelain parser

### DIFF
--- a/pkg/commands/git_commands/worktree_loader.go
+++ b/pkg/commands/git_commands/worktree_loader.go
@@ -68,10 +68,14 @@ func (self *WorktreeLoader) GetWorktrees() ([]*models.Worktree, error) {
 				GitDir: "",
 			}
 		} else if strings.HasPrefix(splitLine, "HEAD ") {
-			current.Head = strings.SplitN(splitLine, " ", 2)[1]
+			if current != nil {
+				current.Head = strings.SplitN(splitLine, " ", 2)[1]
+			}
 		} else if strings.HasPrefix(splitLine, "branch ") {
-			branch := strings.SplitN(splitLine, " ", 2)[1]
-			current.Branch = strings.TrimPrefix(branch, "refs/heads/")
+			if current != nil {
+				branch := strings.SplitN(splitLine, " ", 2)[1]
+				current.Branch = strings.TrimPrefix(branch, "refs/heads/")
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds nil checks for `current` before accessing `current.Head` and `current.Branch` in the worktree porcelain output parser. This prevents a nil pointer panic when git produces unexpected output without a preceding "worktree" line.

Related: #5266
Closes #5372