### PR TITLE
fix: add nil checks in worktree porcelain parser (closes #5372)

### DIFF
--- a/pkg/commands/git_commands/worktree_loader.go
+++ b/pkg/commands/git_commands/worktree_loader.go
@@ -68,10 +68,14 @@ func (self *WorktreeLoader) GetWorktrees() ([]*models.Worktree, error) {
 				GitDir: "",
 			}
 		} else if strings.HasPrefix(splitLine, "HEAD ") {
-			current.Head = strings.SplitN(splitLine, " ", 2)[1]
+			if current != nil {
+				current.Head = strings.SplitN(splitLine, " ", 2)[1]
+			}
 		} else if strings.HasPrefix(splitLine, "branch ") {
-			branch := strings.SplitN(splitLine, " ", 2)[1]
-			current.Branch = strings.TrimPrefix(branch, "refs/heads/")
+			if current != nil {
+				branch := strings.SplitN(splitLine, " ", 2)[1]
+				current.Branch = strings.TrimPrefix(branch, "refs/heads/")
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
This PR adds defensive nil checks in the worktree porcelain parser to prevent nil pointer dereference.

## Problem
In `pkg/commands/git_commands/worktree_loader.go`, the porcelain output parser accesses `current.Head` and `current.Branch` without checking if `current` is nil.

`current` starts as nil and is also set to nil after encountering a "bare" line. If `git worktree list --porcelain` produces unexpected output (e.g., a "HEAD" or "branch" line without a preceding "worktree" line), this causes a panic.

## Solution
Added nil checks before accessing `current.Head` and `current.Branch`.

## Changes
- Lines 71 and 75: Added `if current != nil` guards
- Prevents panic when parsing malformed/corrupted worktree output

## Testing
- Code compiles successfully
- Defensive check matches the pattern used elsewhere in the codebase

Closes #5372