### PR TITLE
fix: resolve empty tree OID for SHA-256 repos

### DIFF
--- a/pkg/commands/git_commands/commit_loader.go
+++ b/pkg/commands/git_commands/commit_loader.go
@@ -74,6 +74,12 @@ type GetCommitsOptions struct {
 func (self *CommitLoader) GetCommits(opts GetCommitsOptions) ([]*models.Commit, error) {
 	commits := []*models.Commit{}
 
+	emptyTreeHash, err := GetEmptyTreeOID(self.cmd)
+	if err != nil {
+		return nil, err
+	}
+	emptyTreePtr := opts.HashPool.Add(emptyTreeHash)
+
 	if opts.IncludeRebaseCommits && opts.FilterPath == "" {
 		var err error
 		commits, err = self.MergeRebasingCommits(opts.HashPool, commits)
@@ -92,7 +98,7 @@ func (self *CommitLoader) GetCommits(opts GetCommitsOptions) ([]*models.Commit, 
 
 		var realCommits []*models.Commit
 		realCommits, logErr = loadCommits(self.getLogCmd(opts), opts.FilterPath, func(line string) (*models.Commit, bool) {
-			return self.extractCommitFromLine(opts.HashPool, line, opts.RefToShowDivergenceFrom != ""), false
+			return self.extractCommitFromLine(opts.HashPool, line, opts.RefToShowDivergenceFrom != "", emptyTreePtr), false
 		})
 		if logErr == nil {
 			commits = append(commits, realCommits...)
@@ -189,7 +195,7 @@ func (self *CommitLoader) MergeRebasingCommits(hashPool *utils.StringPool, commi
 // then puts them into a commit object
 // example input:
 // 8ad01fe32fcc20f07bc6693f87aa4977c327f1e1|10 hours ago|Jesse Duffield| (HEAD -> master, tag: v0.15.2)|refresh commits when adding a tag
-func (self *CommitLoader) extractCommitFromLine(hashPool *utils.StringPool, line string, showDivergence bool) *models.Commit {
+func (self *CommitLoader) extractCommitFromLine(hashPool *utils.StringPool, line string, showDivergence bool, emptyTreeParent *string) *models.Commit {
 	split := strings.SplitN(line, "\x00", 8)
 
 	// Ensure we have the minimum required fields (at least 7 for basic functionality)
@@ -238,7 +244,7 @@ func (self *CommitLoader) extractCommitFromLine(hashPool *utils.StringPool, line
 		parents = strings.Split(parentHashes, " ")
 	}
 
-	return models.NewCommit(hashPool, models.NewCommitOpts{
+	commitOpts := models.NewCommitOpts{
 		Hash:          hash,
 		Name:          message,
 		Tags:          tags,
@@ -248,7 +254,11 @@ func (self *CommitLoader) extractCommitFromLine(hashPool *utils.StringPool, line
 		AuthorEmail:   authorEmail,
 		Parents:       parents,
 		Divergence:    divergence,
-	})
+	}
+	if len(parents) == 0 {
+		commitOpts.EmptyTreeParent = emptyTreeParent
+	}
+	return models.NewCommit(hashPool, commitOpts)
 }
 
 func (self *CommitLoader) getHydratedRebasingCommits(hashPool *utils.StringPool, addConflictingCommit bool) ([]*models.Commit, error) {
@@ -279,6 +289,12 @@ func (self *CommitLoader) getHydratedTodoCommits(hashPool *utils.StringPool, tod
 		return nil, nil
 	}
 
+	emptyTreeHash, err := GetEmptyTreeOID(self.cmd)
+	if err != nil {
+		return nil, err
+	}
+	emptyTreePtr := hashPool.Add(emptyTreeHash)
+
 	commitHashes := lo.FilterMap(todoCommits, func(commit *models.Commit, _ int) (string, bool) {
 		return commit.Hash(), commit.Hash() != ""
 	})
@@ -294,11 +310,11 @@ func (self *CommitLoader) getHydratedTodoCommits(hashPool *utils.StringPool, tod
 	).DontLog()
 
 	fullCommits := map[string]*models.Commit{}
-	err := cmdObj.RunAndProcessLines(func(line string) (bool, error) {
+	err = cmdObj.RunAndProcessLines(func(line string) (bool, error) {
 		if line == "" || line[0] != '+' {
 			return false, nil
 		}
-		commit := self.extractCommitFromLine(hashPool, line[1:], false)
+		commit := self.extractCommitFromLine(hashPool, line[1:], false, emptyTreePtr)
 		fullCommits[commit.Hash()] = commit
 		return false, nil
 	})

--- a/pkg/commands/git_commands/commit_loader_test.go
+++ b/pkg/commands/git_commands/commit_loader_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func commitLoaderFakeRunner(t *testing.T) *oscommands.FakeCmdObjRunner {
+	return oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"hash-object", "-t", "tree", "--stdin"}, models.EmptyTreeCommitHash, nil)
+}
+
 var commitsOutput = strings.ReplaceAll(`+0eea75e8c631fba6b58135697835d58ba4c18dbc|1640826609|Jesse Duffield|jessedduffield@gmail.com|b21997d6b4cbdf84b149|>|HEAD -> better-tests|better typing for rebase mode
 +b21997d6b4cbdf84b149d8e6a2c4d06a8e9ec164|1640824515|Jesse Duffield|jessedduffield@gmail.com|e94e8fc5b6fab4cb755f|>|origin/better-tests|fix logging
 +e94e8fc5b6fab4cb755f29f1bdb3ee5e001df35c|1640823749|Jesse Duffield|jessedduffield@gmail.com|d8084cd558925eb7c9c3|>|tag: 123, tag: 456|refactor
@@ -43,7 +47,7 @@ func TestGetCommits(t *testing.T) {
 			testName: "should return no commits if there are none",
 			logOrder: "topo-order",
 			opts:     GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: &models.Branch{Name: "mybranch"}, IncludeRebaseCommits: false},
-			runner: oscommands.NewFakeRunner(t).
+			runner: commitLoaderFakeRunner(t).
 				ExpectGitArgs([]string{"rev-list", "refs/heads/mybranch", "^mybranch@{u}"}, "", nil).
 				ExpectGitArgs([]string{"log", "HEAD", "--topo-order", "--oneline", "--pretty=format:+%H%x00%at%x00%aN%x00%ae%x00%P%x00%m%x00%D%x00%s", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
 
@@ -54,7 +58,7 @@ func TestGetCommits(t *testing.T) {
 			testName: "should use proper upstream name for branch",
 			logOrder: "topo-order",
 			opts:     GetCommitsOptions{RefName: "refs/heads/mybranch", RefForPushedStatus: &models.Branch{Name: "mybranch"}, IncludeRebaseCommits: false},
-			runner: oscommands.NewFakeRunner(t).
+			runner: commitLoaderFakeRunner(t).
 				ExpectGitArgs([]string{"rev-list", "refs/heads/mybranch", "^mybranch@{u}"}, "", nil).
 				ExpectGitArgs([]string{"log", "refs/heads/mybranch", "--topo-order", "--oneline", "--pretty=format:+%H%x00%at%x00%aN%x00%ae%x00%P%x00%m%x00%D%x00%s", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
 
@@ -66,7 +70,7 @@ func TestGetCommits(t *testing.T) {
 			logOrder:     "topo-order",
 			opts:         GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: &models.Branch{Name: "mybranch"}, IncludeRebaseCommits: false},
 			mainBranches: []string{"master", "main", "develop"},
-			runner: oscommands.NewFakeRunner(t).
+			runner: commitLoaderFakeRunner(t).
 				// here it's seeing which commits are yet to be pushed
 				ExpectGitArgs([]string{"rev-list", "refs/heads/mybranch", "^mybranch@{u}", "^refs/remotes/origin/master", "^refs/remotes/origin/main"}, "0eea75e8c631fba6b58135697835d58ba4c18dbc\n", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
@@ -203,7 +207,7 @@ func TestGetCommits(t *testing.T) {
 			logOrder:     "topo-order",
 			opts:         GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: &models.Branch{Name: "mybranch"}, IncludeRebaseCommits: false},
 			mainBranches: []string{"master", "main"},
-			runner: oscommands.NewFakeRunner(t).
+			runner: commitLoaderFakeRunner(t).
 				// here it's seeing which commits are yet to be pushed
 				ExpectGitArgs([]string{"rev-list", "refs/heads/mybranch", "^mybranch@{u}"}, "0eea75e8c631fba6b58135697835d58ba4c18dbc\n", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
@@ -239,7 +243,7 @@ func TestGetCommits(t *testing.T) {
 			logOrder:     "topo-order",
 			opts:         GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: &models.Branch{Name: "mybranch"}, IncludeRebaseCommits: false},
 			mainBranches: []string{"master", "main", "develop", "1.0-hotfixes"},
-			runner: oscommands.NewFakeRunner(t).
+			runner: commitLoaderFakeRunner(t).
 				// here it's seeing which commits are yet to be pushed
 				ExpectGitArgs([]string{"rev-list", "refs/heads/mybranch", "^mybranch@{u}", "^refs/remotes/origin/master", "^refs/remotes/origin/develop", "^refs/remotes/origin/1.0-hotfixes"}, "0eea75e8c631fba6b58135697835d58ba4c18dbc\n", nil).
 				// here it's actually getting all the commits in a formatted form, one per line
@@ -276,7 +280,7 @@ func TestGetCommits(t *testing.T) {
 			testName: "should not specify order if `log.order` is `default`",
 			logOrder: "default",
 			opts:     GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: &models.Branch{Name: "mybranch"}, IncludeRebaseCommits: false},
-			runner: oscommands.NewFakeRunner(t).
+			runner: commitLoaderFakeRunner(t).
 				ExpectGitArgs([]string{"rev-list", "refs/heads/mybranch", "^mybranch@{u}"}, "", nil).
 				ExpectGitArgs([]string{"log", "HEAD", "--oneline", "--pretty=format:+%H%x00%at%x00%aN%x00%ae%x00%P%x00%m%x00%D%x00%s", "--abbrev=40", "--no-show-signature", "--"}, "", nil),
 
@@ -287,7 +291,7 @@ func TestGetCommits(t *testing.T) {
 			testName: "should set filter path",
 			logOrder: "default",
 			opts:     GetCommitsOptions{RefName: "HEAD", RefForPushedStatus: &models.Branch{Name: "mybranch"}, FilterPath: "src"},
-			runner: oscommands.NewFakeRunner(t).
+			runner: commitLoaderFakeRunner(t).
 				ExpectGitArgs([]string{"rev-list", "refs/heads/mybranch", "^mybranch@{u}"}, "", nil).
 				ExpectGitArgs([]string{"log", "HEAD", "--oneline", "--pretty=format:+%H%x00%at%x00%aN%x00%ae%x00%P%x00%m%x00%D%x00%s", "--abbrev=40", "--follow", "--name-status", "--no-show-signature", "--", "src"}, "", nil),
 
@@ -596,6 +600,7 @@ func TestCommitLoader_setCommitStatuses(t *testing.T) {
 func TestCommitLoader_extractCommitFromLine(t *testing.T) {
 	common := common.NewDummyCommon()
 	hashPool := &utils.StringPool{}
+	emptyTreePtr := hashPool.Add(models.EmptyTreeCommitHash)
 
 	loader := &CommitLoader{
 		Common: common,
@@ -676,15 +681,16 @@ func TestCommitLoader_extractCommitFromLine(t *testing.T) {
 			line:           "root123\x001640000000\x00Alice Cooper\x00alice@example.com\x00\x00>\x00\x00initial commit",
 			showDivergence: true,
 			expectedCommit: models.NewCommit(hashPool, models.NewCommitOpts{
-				Hash:          "root123",
-				Name:          "initial commit",
-				Tags:          nil,
-				ExtraInfo:     "",
-				UnixTimestamp: 1640000000,
-				AuthorName:    "Alice Cooper",
-				AuthorEmail:   "alice@example.com",
-				Parents:       nil,
-				Divergence:    models.DivergenceRight,
+				Hash:            "root123",
+				Name:            "initial commit",
+				Tags:            nil,
+				ExtraInfo:       "",
+				UnixTimestamp:   1640000000,
+				AuthorName:      "Alice Cooper",
+				AuthorEmail:     "alice@example.com",
+				Parents:         nil,
+				Divergence:      models.DivergenceRight,
+				EmptyTreeParent: emptyTreePtr,
 			}),
 		},
 		{
@@ -785,7 +791,7 @@ func TestCommitLoader_extractCommitFromLine(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.testName, func(t *testing.T) {
-			result := loader.extractCommitFromLine(hashPool, scenario.line, scenario.showDivergence)
+			result := loader.extractCommitFromLine(hashPool, scenario.line, scenario.showDivergence, emptyTreePtr)
 			if scenario.expectedCommit == nil {
 				assert.Nil(t, result)
 			} else {

--- a/pkg/commands/git_commands/empty_tree_oid.go
+++ b/pkg/commands/git_commands/empty_tree_oid.go
@@ -1,0 +1,19 @@
+package git_commands
+
+import (
+	"strings"
+
+	"github.com/jesseduffield/lazygit/pkg/commands/oscommands"
+)
+
+// GetEmptyTreeOID returns the empty tree object ID for the repository's object format
+// (SHA-1 vs SHA-256). The SHA-1 empty tree constant is wrong for sha256 repositories.
+func GetEmptyTreeOID(cmd oscommands.ICmdObjBuilder) (string, error) {
+	stdout, _, err := cmd.New(
+		NewGitCmd("hash-object").Arg("-t", "tree", "--stdin").ToArgv(),
+	).SetStdin("").DontLog().RunWithOutputs()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(stdout), nil
+}

--- a/pkg/commands/git_commands/reflog_commit_loader.go
+++ b/pkg/commands/git_commands/reflog_commit_loader.go
@@ -25,6 +25,12 @@ func NewReflogCommitLoader(common *common.Common, cmd oscommands.ICmdObjBuilder)
 // GetReflogCommits only returns the new reflog commits since the given lastReflogCommit
 // if none is passed (i.e. it's value is nil) then we get all the reflog commits
 func (self *ReflogCommitLoader) GetReflogCommits(hashPool *utils.StringPool, lastReflogCommit *models.Commit, filterPath string, filterAuthor string) ([]*models.Commit, bool, error) {
+	emptyTreeHash, err := GetEmptyTreeOID(self.cmd)
+	if err != nil {
+		return nil, false, err
+	}
+	emptyTreePtr := hashPool.Add(emptyTreeHash)
+
 	cmdArgs := NewGitCmd("log").
 		Config("log.showSignature=false").
 		Arg("-g").
@@ -38,7 +44,7 @@ func (self *ReflogCommitLoader) GetReflogCommits(hashPool *utils.StringPool, las
 	onlyObtainedNewReflogCommits := false
 
 	commits, err := loadCommits(cmdObj, filterPath, func(line string) (*models.Commit, bool) {
-		commit, ok := self.parseLine(hashPool, line)
+		commit, ok := self.parseLine(hashPool, line, emptyTreePtr)
 		if !ok {
 			return nil, false
 		}
@@ -66,7 +72,7 @@ func (self *ReflogCommitLoader) sameReflogCommit(a *models.Commit, b *models.Com
 	return a.Hash() == b.Hash() && a.UnixTimestamp == b.UnixTimestamp && a.Name == b.Name
 }
 
-func (self *ReflogCommitLoader) parseLine(hashPool *utils.StringPool, line string) (*models.Commit, bool) {
+func (self *ReflogCommitLoader) parseLine(hashPool *utils.StringPool, line string, emptyTreeParent *string) (*models.Commit, bool) {
 	fields := strings.SplitN(line, "\x00", 4)
 	if len(fields) <= 3 {
 		return nil, false
@@ -80,11 +86,15 @@ func (self *ReflogCommitLoader) parseLine(hashPool *utils.StringPool, line strin
 		parents = strings.Split(parentHashes, " ")
 	}
 
-	return models.NewCommit(hashPool, models.NewCommitOpts{
+	opts := models.NewCommitOpts{
 		Hash:          fields[0],
 		Name:          fields[2],
 		UnixTimestamp: int64(unixTimestamp),
 		Status:        models.StatusReflog,
 		Parents:       parents,
-	}), true
+	}
+	if len(parents) == 0 {
+		opts.EmptyTreeParent = emptyTreeParent
+	}
+	return models.NewCommit(hashPool, opts), true
 }

--- a/pkg/commands/git_commands/reflog_commit_loader_test.go
+++ b/pkg/commands/git_commands/reflog_commit_loader_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func reflogFakeRunner(t *testing.T) *oscommands.FakeCmdObjRunner {
+	return oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"hash-object", "-t", "tree", "--stdin"}, models.EmptyTreeCommitHash, nil)
+}
+
 var reflogOutput = strings.ReplaceAll(`+c3c4b66b64c97ffeecde|1643150483|checkout: moving from A to B|51baa8c1
 +c3c4b66b64c97ffeecde|1643150483|checkout: moving from B to A|51baa8c1
 +c3c4b66b64c97ffeecde|1643150483|checkout: moving from A to B|51baa8c1
@@ -38,7 +42,7 @@ func TestGetReflogCommits(t *testing.T) {
 	scenarios := []scenario{
 		{
 			testName: "no reflog entries",
-			runner: oscommands.NewFakeRunner(t).
+			runner: reflogFakeRunner(t).
 				ExpectGitArgs([]string{"-c", "log.showSignature=false", "log", "-g", "--format=+%H%x00%ct%x00%gs%x00%P"}, "", nil),
 
 			lastReflogCommit:        nil,
@@ -48,7 +52,7 @@ func TestGetReflogCommits(t *testing.T) {
 		},
 		{
 			testName: "some reflog entries",
-			runner: oscommands.NewFakeRunner(t).
+			runner: reflogFakeRunner(t).
 				ExpectGitArgs([]string{"-c", "log.showSignature=false", "log", "-g", "--format=+%H%x00%ct%x00%gs%x00%P"}, reflogOutput, nil),
 
 			lastReflogCommit: nil,
@@ -94,7 +98,7 @@ func TestGetReflogCommits(t *testing.T) {
 		},
 		{
 			testName: "some reflog entries where last commit is given",
-			runner: oscommands.NewFakeRunner(t).
+			runner: reflogFakeRunner(t).
 				ExpectGitArgs([]string{"-c", "log.showSignature=false", "log", "-g", "--format=+%H%x00%ct%x00%gs%x00%P"}, reflogOutput, nil),
 
 			lastReflogCommit: models.NewCommit(hashPool, models.NewCommitOpts{
@@ -118,7 +122,7 @@ func TestGetReflogCommits(t *testing.T) {
 		},
 		{
 			testName: "when passing filterPath",
-			runner: oscommands.NewFakeRunner(t).
+			runner: reflogFakeRunner(t).
 				ExpectGitArgs([]string{"-c", "log.showSignature=false", "log", "-g", "--format=+%H%x00%ct%x00%gs%x00%P", "--follow", "--name-status", "--", "path"}, reflogOutput, nil),
 
 			lastReflogCommit: models.NewCommit(hashPool, models.NewCommitOpts{
@@ -143,7 +147,7 @@ func TestGetReflogCommits(t *testing.T) {
 		},
 		{
 			testName: "when passing filterAuthor",
-			runner: oscommands.NewFakeRunner(t).
+			runner: reflogFakeRunner(t).
 				ExpectGitArgs([]string{"-c", "log.showSignature=false", "log", "-g", "--format=+%H%x00%ct%x00%gs%x00%P", "--author=John Doe <john@doe.com>"}, reflogOutput, nil),
 
 			lastReflogCommit: models.NewCommit(hashPool, models.NewCommitOpts{
@@ -168,7 +172,7 @@ func TestGetReflogCommits(t *testing.T) {
 		},
 		{
 			testName: "when command returns error",
-			runner: oscommands.NewFakeRunner(t).
+			runner: reflogFakeRunner(t).
 				ExpectGitArgs([]string{"-c", "log.showSignature=false", "log", "-g", "--format=+%H%x00%ct%x00%gs%x00%P"}, "", errors.New("haha")),
 
 			lastReflogCommit:        nil,

--- a/pkg/commands/models/commit.go
+++ b/pkg/commands/models/commit.go
@@ -8,7 +8,8 @@ import (
 	"github.com/stefanhaller/git-todo-parser/todo"
 )
 
-// Special commit hash for empty tree object
+// EmptyTreeCommitHash is the SHA-1 empty tree OID, used when a root commit has no
+// repo-specific empty tree (e.g. tests or synthetic commits).
 const EmptyTreeCommitHash = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 type CommitStatus uint8
@@ -44,6 +45,7 @@ const (
 // Commit : A git commit
 type Commit struct {
 	hash          *string
+	emptyParent   *string
 	Name          string
 	Tags          []string
 	ExtraInfo     string // something like 'HEAD -> master, tag: v0.15.2'
@@ -77,11 +79,18 @@ type NewCommitOpts struct {
 	UnixTimestamp int64
 	Divergence    Divergence
 	Parents       []string
+	// EmptyTreeParent is the repo empty tree OID for root commits (from the string pool).
+	EmptyTreeParent *string
 }
 
 func NewCommit(hashPool *utils.StringPool, opts NewCommitOpts) *Commit {
+	var emptyParent *string
+	if len(opts.Parents) == 0 && opts.EmptyTreeParent != nil {
+		emptyParent = opts.EmptyTreeParent
+	}
 	return &Commit{
 		hash:          hashPool.Add(opts.Hash),
+		emptyParent:   emptyParent,
 		Name:          opts.Name,
 		Status:        opts.Status,
 		Action:        opts.Action,
@@ -122,9 +131,17 @@ func (c *Commit) ShortRefName() string {
 
 func (c *Commit) ParentRefName() string {
 	if c.IsFirstCommit() {
+		if c.emptyParent != nil {
+			return *c.emptyParent
+		}
 		return EmptyTreeCommitHash
 	}
 	return c.RefName() + "^"
+}
+
+// EmptyTreeParentPtr returns the synthetic parent hash pointer for graph rendering of root commits.
+func (c *Commit) EmptyTreeParentPtr() *string {
+	return c.emptyParent
 }
 
 func (c *Commit) Parents() []string {

--- a/pkg/commands/models/commit_test.go
+++ b/pkg/commands/models/commit_test.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitParentRefNameRootUsesEmptyTreeParent(t *testing.T) {
+	pool := &utils.StringPool{}
+	oid := pool.Add("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	c := NewCommit(pool, NewCommitOpts{Hash: "abc", Parents: nil, EmptyTreeParent: oid})
+	assert.Equal(t, *oid, c.ParentRefName())
+}
+
+func TestCommitParentRefNameRootFallsBackToSHA1EmptyTree(t *testing.T) {
+	pool := &utils.StringPool{}
+	c := NewCommit(pool, NewCommitOpts{Hash: "abc", Parents: nil})
+	assert.Equal(t, EmptyTreeCommitHash, c.ParentRefName())
+}

--- a/pkg/gui/presentation/graph/graph.go
+++ b/pkg/gui/presentation/graph/graph.go
@@ -142,7 +142,11 @@ func getNextPipes(prevPipes []Pipe, commit *models.Commit, getStyle func(c *mode
 
 	var toHash *string
 	if commit.IsFirstCommit() {
-		toHash = &EmptyTreeCommitHash
+		if ptr := commit.EmptyTreeParentPtr(); ptr != nil {
+			toHash = ptr
+		} else {
+			toHash = &EmptyTreeCommitHash
+		}
 	} else {
 		toHash = commit.ParentPtrs()[0]
 	}


### PR DESCRIPTION
## Summary
Fixes #5385.
**Root cause:** The initial commit has no parent; lazygit used the SHA-1 empty tree OID as the synthetic parent, which is not a valid object in SHA-256 repos.
**Fix:** Call `git hash-object -t tree --stdin` with empty stdin to get this repo's empty tree OID, store it on root commits from log/reflog, and use it for diffs and the commit graph.
## Changes
- `pkg/commands/git_commands/empty_tree_oid.go`: helper wrapping that git invocation
- `pkg/commands/models/commit.go`: optional empty-tree parent on root commits; `ParentRefName` / graph use it when set
- `commit_loader.go`, `reflog_commit_loader.go`, `graph.go`: wire it through
## Testing
- Adjusted fake git runners for the extra command
- `pkg/commands/models/commit_test.go`: `ParentRefName` with and without `EmptyTreeParent`