### PR TITLE
fix: Shift+Numpad minus no longer matches plain '-'

### DIFF
--- a/pkg/gui/tcell_neweventkey_test.go
+++ b/pkg/gui/tcell_neweventkey_test.go
@@ -1,0 +1,16 @@
+package gui_test
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// Regression (issue #5253): Shift+NumpadSubtract must not normalize to the same
+// event as plain '-', or it wrongly triggers plain '-' keybindings.
+func TestTcellNewEventKey_preservesShiftForHyphenRune(t *testing.T) {
+	ev := tcell.NewEventKey(tcell.KeyRune, '-', tcell.ModShift)
+	if ev.Modifiers() != tcell.ModShift {
+		t.Fatalf("want ModShift, got %v", ev.Modifiers())
+	}
+}

--- a/vendor/github.com/gdamore/tcell/v2/key.go
+++ b/vendor/github.com/gdamore/tcell/v2/key.go
@@ -281,7 +281,11 @@ func NewEventKey(k Key, ch rune, mod ModMask) *EventKey {
 	// Windows reports ModShift for shifted keys.  This is inconsistent
 	// with UNIX, lets harmonize this.
 	if k == KeyRune && mod == ModShift && ch != 0 {
-		mod = ModNone
+		// Shift+NumpadSubtract still produces '-'; clearing ModShift made it
+		// indistinguishable from the main-keyboard minus key (lazygit#5253).
+		if ch != '-' {
+			mod = ModNone
+		}
 	}
 
 	if k >= KeyCtrlA && k <= KeyCtrlZ {

--- a/vendor/github.com/jesseduffield/gocui/tcell_driver.go
+++ b/vendor/github.com/jesseduffield/gocui/tcell_driver.go
@@ -311,11 +311,14 @@ func (g *Gui) pollEvent() GocuiEvent {
 			mod = 0
 			ch = rune(0)
 			k = tcell.KeyF63
-		} else if mod == tcell.ModCtrl || mod == tcell.ModShift {
-			// remove Ctrl or Shift if specified
-			// - shift - will be translated to the final code of rune
-			// - ctrl  - is translated in the key
+		} else if mod == tcell.ModCtrl {
 			mod = 0
+		} else if mod == tcell.ModShift {
+			// Shift+NumpadSubtract is '-' with ModShift; keep it so it does not
+			// match plain '-' bindings (lazygit#5253).
+			if !(k == 0 && ch == '-') {
+				mod = 0
+			}
 		} else if mod == tcell.ModAlt && k == tcell.KeyEnter {
 			// for the sake of convenience I'm having a KeyAltEnter key. I will likely
 			// regret this laziness in the future. We're arbitrarily mapping that to tcell's


### PR DESCRIPTION
## Summary
Fixes #5253.
**Root cause:** tcell cleared `ModShift` for every `KeyRune` on Windows, so Shift+Numpad subtract looked like plain `-` and hit checkout-previous-branch. gocui stripped `ModShift` on rune keys too.
**Fix:** Keep `ModShift` when the rune is `-` in tcell `NewEventKey`, and preserve it in gocui when building `GocuiEvent`.

## Changes
- `vendor/github.com/gdamore/tcell/v2/key.go`: skip shift harmonization for `-`
- `vendor/github.com/jesseduffield/gocui/tcell_driver.go`: do not strip `ModShift` for `-` rune
- `pkg/gui/tcell_neweventkey_test.go`: regression test

## Testing
- `go test -run TestTcellNewEventKey ./pkg/gui/`
