### PR TITLE
Define PR colors as hex colors to make them the same as GitHub's

### DIFF
--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -253,42 +253,12 @@ func stateText(state string) string {
 func coloredStateText(state string) string {
 	if icons.IsIconEnabled() {
 		return fmt.Sprintf("%s%s%s",
-			withPrFgColor(state, ""),
-			withPrBgColor(state, style.FgWhite.Sprint(stateText(state))),
-			withPrFgColor(state, ""))
+			presentation.WithPrColor(state, "", false),
+			presentation.WithPrColor(state, color.RGB(0xFF, 0xFF, 0xFF, false).Sprint(stateText(state)), true),
+			presentation.WithPrColor(state, "", false))
 	}
 
-	return withPrFgColor(state, stateText(state))
-}
-
-func withPrFgColor(state string, text string) string {
-	switch state {
-	case "OPEN":
-		return style.FgGreen.Sprint(text)
-	case "CLOSED":
-		return style.FgRed.Sprint(text)
-	case "MERGED":
-		return style.FgMagenta.Sprint(text)
-	case "DRAFT":
-		return color.RGB(0x66, 0x66, 0x66, false).Sprint(text)
-	default:
-		return style.FgDefault.Sprint(text)
-	}
-}
-
-func withPrBgColor(state string, text string) string {
-	switch state {
-	case "OPEN":
-		return style.BgGreen.Sprint(text)
-	case "CLOSED":
-		return style.BgRed.Sprint(text)
-	case "MERGED":
-		return style.BgMagenta.Sprint(text)
-	case "DRAFT":
-		return color.RGB(0x66, 0x66, 0x66, true).Sprint(text)
-	default:
-		return style.BgDefault.Sprint(text)
-	}
+	return presentation.WithPrColor(state, stateText(state), false)
 }
 
 func (self *BranchesController) viewUpstreamOptions(selectedBranch *models.Branch) error {

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gookit/color"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/config"
@@ -148,7 +149,7 @@ func getBranchDisplayStrings(
 		} else {
 			prIcon = "●"
 		}
-		coloredPrIcon = prColor(pr.State).Sprint(prIcon)
+		coloredPrIcon = WithPrColor(pr.State, prIcon, false)
 	}
 	res = append(res, coloredPrIcon)
 
@@ -271,18 +272,18 @@ func SetCustomBranches(customBranchColors map[string]string, isRegex bool) {
 	}
 }
 
-func prColor(state string) style.TextStyle {
+func WithPrColor(state string, text string, isBg bool) string {
 	switch state {
 	case "OPEN":
-		return style.FgGreen
+		return color.RGB(0x43, 0x84, 0x40, isBg).Sprint(text)
 	case "CLOSED":
-		return style.FgRed
+		return color.RGB(0xC9, 0x45, 0x3C, isBg).Sprint(text)
 	case "MERGED":
-		return style.FgMagenta
+		return color.RGB(0x82, 0x59, 0xDD, isBg).Sprint(text)
 	case "DRAFT":
-		return style.FgBlackLighter
+		return color.RGB(0x67, 0x6C, 0x75, isBg).Sprint(text)
 	default:
-		return style.FgDefault
+		return lo.Ternary(isBg, style.BgDefault, style.FgDefault).Sprint(text)
 	}
 }
 


### PR DESCRIPTION
This is so that they look the same no matter what color palette the terminal is using. (One user complained that the text for the Open state is barely readable, because they are using a palette that has a very pale green.)

GitHub uses slightly different colors depending on light vs. dark mode; fortunately they are very close, so hopefully we can ignore this. I picked the ones for dark mode here, on the assumption that this is more common.

Also, not all terminals support true hex colors; for example, Terminal.app on macOS doesn't, so it maps the colors to the closest ones in the Xterm-256 palette. This shouldn't be a huge problem, but for some reason it displays draft PRs as something closer to Cyan than grey, and I don't understand why.
