### PR TITLE
Add support for collapsible panes

### DIFF
--- a/docs-master/keybindings/Keybindings_en.md
+++ b/docs-master/keybindings/Keybindings_en.md
@@ -14,6 +14,14 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` @ `` | View command log options | View options for the command log e.g. show/hide the command log and focus the command log. |
 | `` P `` | Push | Push the current branch to its upstream branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
 | `` p `` | Pull | Pull changes from the remote for the current branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Increase diff context size | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs-master/keybindings/Keybindings_ja.md
+++ b/docs-master/keybindings/Keybindings_ja.md
@@ -14,6 +14,14 @@ _凡例：`＜c-b＞` はctrl+b、`＜a-b＞` はalt+b、`B` はshift+bを意味
 | `` @ `` | コマンドログオプションを表示 | コマンドログのオプションを表示します（例：コマンドログの表示/非表示、コマンドログへのフォーカスなど）。 |
 | `` P `` | プッシュ | 現在のブランチを対応するアップストリームブランチにプッシュします。アップストリームが設定されていない場合、アップストリームブランチの設定を求められます。 |
 | `` p `` | プル | 現在のブランチのリモートから変更をプルします。アップストリームが設定されていない場合、アップストリームブランチの設定を求められます。 |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | リネーム検出の類似度しきい値を上げる | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | リネーム検出の類似度しきい値を下げる | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | 差分コンテキストサイズを増やす | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs-master/keybindings/Keybindings_ko.md
+++ b/docs-master/keybindings/Keybindings_ko.md
@@ -14,6 +14,14 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` @ `` | 명령어 로그 메뉴 열기 | View options for the command log e.g. show/hide the command log and focus the command log. |
 | `` P `` | 푸시 | Push the current branch to its upstream branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
 | `` p `` | 업데이트 | Pull changes from the remote for the current branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Diff 보기의 변경 사항 주위에 표시되는 컨텍스트의 크기를 늘리기 | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs-master/keybindings/Keybindings_nl.md
+++ b/docs-master/keybindings/Keybindings_nl.md
@@ -14,6 +14,14 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` @ `` | View command log options | View options for the command log e.g. show/hide the command log and focus the command log. |
 | `` P `` | Push | Push the current branch to its upstream branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
 | `` p `` | Pull | Pull changes from the remote for the current branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Increase diff context size | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs-master/keybindings/Keybindings_pl.md
+++ b/docs-master/keybindings/Keybindings_pl.md
@@ -14,6 +14,14 @@ _Legenda: `<c-b>` oznacza ctrl+b, `<a-b>` oznacza alt+b, `B` oznacza shift+b_
 | `` @ `` | Pokaż opcje dziennika poleceń | Pokaż opcje dla dziennika poleceń, np. pokazywanie/ukrywanie dziennika poleceń i skupienie na dzienniku poleceń. |
 | `` P `` | Wypchnij | Wypchnij bieżącą gałąź do jej gałęzi nadrzędnej. Jeśli nie skonfigurowano gałęzi nadrzędnej, zostaniesz poproszony o skonfigurowanie gałęzi nadrzędnej. |
 | `` p `` | Pociągnij | Pociągnij zmiany z zdalnego dla bieżącej gałęzi. Jeśli nie skonfigurowano gałęzi nadrzędnej, zostaniesz poproszony o skonfigurowanie gałęzi nadrzędnej. |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Zwiększ rozmiar kontekstu w widoku różnic | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs-master/keybindings/Keybindings_pt.md
+++ b/docs-master/keybindings/Keybindings_pt.md
@@ -14,6 +14,14 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` @ `` | View command log options | View options for the command log e.g. show/hide the command log and focus the command log. |
 | `` P `` | Empurre (Push) | Faça push do branch atual para o seu branch upstream. Se nenhum upstream estiver configurado, você será solicitado a configurar um branch a montante. |
 | `` p `` | Puxar (Pull) | Puxe alterações do controle remoto para o ramo atual. Se nenhum upstream estiver configurado, será solicitado configurar um ramo a montante. |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Increase diff context size | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs-master/keybindings/Keybindings_ru.md
+++ b/docs-master/keybindings/Keybindings_ru.md
@@ -14,6 +14,14 @@ _Связки клавиш_
 | `` @ `` | Открыть меню журнала команд | View options for the command log e.g. show/hide the command log and focus the command log. |
 | `` P `` | Отправить изменения | Push the current branch to its upstream branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
 | `` p `` | Получить и слить изменения | Pull changes from the remote for the current branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Увеличить размер контекста, отображаемого вокруг изменений в просмотрщике сравнении | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs-master/keybindings/Keybindings_zh-CN.md
+++ b/docs-master/keybindings/Keybindings_zh-CN.md
@@ -14,6 +14,14 @@ _图例：`<c-b>` 意味着ctrl+b, `<a-b>意味着Alt+b, `B` 意味着shift+b_
 | `` @ `` | 打开命令日志菜单 | 查看命令日志的选项，例如显示/隐藏命令日志以及聚焦命令日志 |
 | `` P `` | 推送 | 推送当前分支到它的上游。如果上游未配置，您可以在弹窗中配置上游分支。 |
 | `` p `` | 拉取 | 从当前分支的远程分支获取改动。如果上游未配置，您可以在弹窗中配置上游分支。 |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | 提高重命名相似度阈值 | 提高将删除和添加对视为重命名所需的相似度阈值。<br><br>默认值可在配置文件中通过键 'git.renameSimilarityThreshold' 更改。 |
 | `` ( `` | 降低重命名相似度阈值 | 降低将删除和添加对视为重命名所需的相似度阈值。<br><br>默认值可在配置文件中通过键 'git.renameSimilarityThreshold' 更改。 |
 | `` } `` | 扩大差异视图中显示的上下文范围 | 增加差异视图中变更周围显示的上下文量。<br><br>默认值可在配置文件中通过键 'git.diffContextSize' 更改。 |

--- a/docs-master/keybindings/Keybindings_zh-TW.md
+++ b/docs-master/keybindings/Keybindings_zh-TW.md
@@ -14,6 +14,14 @@ _說明：`<c-b>` 表示 Ctrl＋B、`<a-b>` 表示 Alt＋B，`B`表示 Shift＋B
 | `` @ `` | 開啟命令記錄選單 | View options for the command log e.g. show/hide the command log and focus the command log. |
 | `` P `` | 推送 | 推送到遠端。如果沒有設定遠端，會開啟設定視窗。 |
 | `` p `` | 拉取 | 從遠端同步當前分支。如果沒有設定遠端，會開啟設定視窗。 |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | 增加差異檢視中顯示變更周圍上下文的大小 | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -14,6 +14,14 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` @ `` | View command log options | View options for the command log e.g. show/hide the command log and focus the command log. |
 | `` P `` | Push | Push the current branch to its upstream branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
 | `` p `` | Pull | Pull changes from the remote for the current branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Increase diff context size | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs/keybindings/Keybindings_ja.md
+++ b/docs/keybindings/Keybindings_ja.md
@@ -14,6 +14,14 @@ _凡例：`＜c-b＞` はctrl+b、`＜a-b＞` はalt+b、`B` はshift+bを意味
 | `` @ `` | コマンドログオプションを表示 | コマンドログのオプションを表示します（例：コマンドログの表示/非表示、コマンドログへのフォーカスなど）。 |
 | `` P `` | プッシュ | 現在のブランチを対応するアップストリームブランチにプッシュします。アップストリームが設定されていない場合、アップストリームブランチの設定を求められます。 |
 | `` p `` | プル | 現在のブランチのリモートから変更をプルします。アップストリームが設定されていない場合、アップストリームブランチの設定を求められます。 |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | リネーム検出の類似度しきい値を上げる | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | リネーム検出の類似度しきい値を下げる | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | 差分コンテキストサイズを増やす | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs/keybindings/Keybindings_ko.md
+++ b/docs/keybindings/Keybindings_ko.md
@@ -14,6 +14,14 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` @ `` | 명령어 로그 메뉴 열기 | View options for the command log e.g. show/hide the command log and focus the command log. |
 | `` P `` | 푸시 | Push the current branch to its upstream branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
 | `` p `` | 업데이트 | Pull changes from the remote for the current branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Diff 보기의 변경 사항 주위에 표시되는 컨텍스트의 크기를 늘리기 | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -14,6 +14,14 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` @ `` | View command log options | View options for the command log e.g. show/hide the command log and focus the command log. |
 | `` P `` | Push | Push the current branch to its upstream branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
 | `` p `` | Pull | Pull changes from the remote for the current branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Increase diff context size | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -14,6 +14,14 @@ _Legenda: `<c-b>` oznacza ctrl+b, `<a-b>` oznacza alt+b, `B` oznacza shift+b_
 | `` @ `` | Pokaż opcje dziennika poleceń | Pokaż opcje dla dziennika poleceń, np. pokazywanie/ukrywanie dziennika poleceń i skupienie na dzienniku poleceń. |
 | `` P `` | Wypchnij | Wypchnij bieżącą gałąź do jej gałęzi nadrzędnej. Jeśli nie skonfigurowano gałęzi nadrzędnej, zostaniesz poproszony o skonfigurowanie gałęzi nadrzędnej. |
 | `` p `` | Pociągnij | Pociągnij zmiany z zdalnego dla bieżącej gałęzi. Jeśli nie skonfigurowano gałęzi nadrzędnej, zostaniesz poproszony o skonfigurowanie gałęzi nadrzędnej. |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Zwiększ rozmiar kontekstu w widoku różnic | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs/keybindings/Keybindings_pt.md
+++ b/docs/keybindings/Keybindings_pt.md
@@ -14,6 +14,14 @@ _Legend: `<c-b>` means ctrl+b, `<a-b>` means alt+b, `B` means shift+b_
 | `` @ `` | View command log options | View options for the command log e.g. show/hide the command log and focus the command log. |
 | `` P `` | Empurre (Push) | Faça push do branch atual para o seu branch upstream. Se nenhum upstream estiver configurado, você será solicitado a configurar um branch a montante. |
 | `` p `` | Puxar (Pull) | Puxe alterações do controle remoto para o ramo atual. Se nenhum upstream estiver configurado, será solicitado configurar um ramo a montante. |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Increase diff context size | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs/keybindings/Keybindings_ru.md
+++ b/docs/keybindings/Keybindings_ru.md
@@ -14,6 +14,14 @@ _Связки клавиш_
 | `` @ `` | Открыть меню журнала команд | View options for the command log e.g. show/hide the command log and focus the command log. |
 | `` P `` | Отправить изменения | Push the current branch to its upstream branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
 | `` p `` | Получить и слить изменения | Pull changes from the remote for the current branch. If no upstream is configured, you will be prompted to configure an upstream branch. |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | Увеличить размер контекста, отображаемого вокруг изменений в просмотрщике сравнении | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/docs/keybindings/Keybindings_zh-CN.md
+++ b/docs/keybindings/Keybindings_zh-CN.md
@@ -14,6 +14,14 @@ _图例：`<c-b>` 意味着ctrl+b, `<a-b>意味着Alt+b, `B` 意味着shift+b_
 | `` @ `` | 打开命令日志菜单 | 查看命令日志的选项，例如显示/隐藏命令日志以及聚焦命令日志 |
 | `` P `` | 推送 | 推送当前分支到它的上游。如果上游未配置，您可以在弹窗中配置上游分支。 |
 | `` p `` | 拉取 | 从当前分支的远程分支获取改动。如果上游未配置，您可以在弹窗中配置上游分支。 |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | 提高重命名相似度阈值 | 提高将删除和添加对视为重命名所需的相似度阈值。<br><br>默认值可在配置文件中通过键 'git.renameSimilarityThreshold' 更改。 |
 | `` ( `` | 降低重命名相似度阈值 | 降低将删除和添加对视为重命名所需的相似度阈值。<br><br>默认值可在配置文件中通过键 'git.renameSimilarityThreshold' 更改。 |
 | `` } `` | 扩大差异视图中显示的上下文范围 | 增加差异视图中变更周围显示的上下文量。<br><br>默认值可在配置文件中通过键 'git.diffContextSize' 更改。 |

--- a/docs/keybindings/Keybindings_zh-TW.md
+++ b/docs/keybindings/Keybindings_zh-TW.md
@@ -14,6 +14,14 @@ _說明：`<c-b>` 表示 Ctrl＋B、`<a-b>` 表示 Alt＋B，`B`表示 Shift＋B
 | `` @ `` | 開啟命令記錄選單 | View options for the command log e.g. show/hide the command log and focus the command log. |
 | `` P `` | 推送 | 推送到遠端。如果沒有設定遠端，會開啟設定視窗。 |
 | `` p `` | 拉取 | 從遠端同步當前分支。如果沒有設定遠端，會開啟設定視窗。 |
+| `` <a-2> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-3> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` <a-4> `` | Collapse/expand side panel | Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts. |
+| `` 1 `` | Jump to side panel |  |
+| `` 2 `` | Jump to side panel |  |
+| `` 3 `` | Jump to side panel |  |
+| `` 4 `` | Jump to side panel |  |
+| `` 5 `` | Jump to side panel |  |
 | `` ) `` | Increase rename similarity threshold | Increase the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` ( `` | Decrease rename similarity threshold | Decrease the similarity threshold for a deletion and addition pair to be treated as a rename.<br><br>The default can be changed in the config file with the key 'git.renameSimilarityThreshold'. |
 | `` } `` | 增加差異檢視中顯示變更周圍上下文的大小 | Increase the amount of the context shown around changes in the diff view.<br><br>The default can be changed in the config file with the key 'git.diffContextSize'. |

--- a/pkg/cheatsheet/generate.go
+++ b/pkg/cheatsheet/generate.go
@@ -157,7 +157,7 @@ func getBindingSections(bindings []*types.Binding, tr *i18n.TranslationSet) []*b
 		bindingsByHeader,
 		func(header header, hBindings []*types.Binding) headerWithBindings {
 			uniqBindings := lo.UniqBy(hBindings, func(binding *types.Binding) string {
-				return binding.Description + keybindings.LabelFromKey(binding.Key)
+				return binding.Description + keybindings.LabelFromKeyAndMod(binding.Key, binding.Modifier)
 			})
 
 			return headerWithBindings{
@@ -217,7 +217,7 @@ func formatTitle(title string) string {
 }
 
 func formatBinding(binding *types.Binding) string {
-	action := keybindings.LabelFromKey(binding.Key)
+	action := keybindings.LabelFromKeyAndMod(binding.Key, binding.Modifier)
 	description := binding.Description
 	if binding.Alternative != "" {
 		action += fmt.Sprintf(" (%s)", binding.Alternative)

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -708,6 +708,9 @@ type AppState struct {
 	// Cache of GitHub pull requests per repo path, so that PR info can be
 	// shown instantly on startup before the async refresh completes.
 	GithubPullRequests map[string][]CachedPullRequest `yaml:"githubPullRequests"`
+
+	// Side windows that the user has manually collapsed (files, branches, commits).
+	CollapsedSideWindows []string
 }
 
 // CachedPullRequest stores the essential fields of a GitHub pull request

--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -196,6 +196,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 	promptController := controllers.NewPromptController(common)
 	suggestionsController := controllers.NewSuggestionsController(common)
 	jumpToSideWindowController := controllers.NewJumpToSideWindowController(common, gui.handleNextTab)
+	collapseSideWindowController := controllers.NewCollapseSideWindowController(common)
 
 	sideWindowControllerFactory := controllers.NewSideWindowControllerFactory(common)
 
@@ -418,6 +419,7 @@ func (gui *Gui) resetHelpersAndControllers() {
 		contextLinesController,
 		renameSimilarityThresholdController,
 		jumpToSideWindowController,
+		collapseSideWindowController,
 		syncController,
 	)
 

--- a/pkg/gui/controllers/collapse_side_window_controller.go
+++ b/pkg/gui/controllers/collapse_side_window_controller.go
@@ -1,0 +1,91 @@
+package controllers
+
+import (
+	"log"
+
+	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/samber/lo"
+	"golang.org/x/exp/slices"
+)
+
+// CollapsibleSideWindows are the side windows that can be collapsed.
+// Status (1) and stash (5) are excluded.
+var CollapsibleSideWindows = []string{"files", "branches", "commits"}
+
+type CollapseSideWindowController struct {
+	baseController
+	c *ControllerCommon
+}
+
+func NewCollapseSideWindowController(
+	c *ControllerCommon,
+) *CollapseSideWindowController {
+	return &CollapseSideWindowController{
+		baseController: baseController{},
+		c:              c,
+	}
+}
+
+func (self *CollapseSideWindowController) Context() types.Context {
+	return nil
+}
+
+func (self *CollapseSideWindowController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
+	windows := self.c.Helpers().Window.SideWindows()
+
+	if len(opts.Config.Universal.JumpToBlock) != len(windows) {
+		log.Fatal("Jump to block keybindings cannot be set. Exactly 5 keybindings must be supplied.")
+	}
+
+	bindings := make([]*types.Binding, 0, len(CollapsibleSideWindows))
+	for index, window := range windows {
+		if !slices.Contains(CollapsibleSideWindows, window) {
+			continue
+		}
+		bindings = append(bindings, &types.Binding{
+			ViewName:    "",
+			Description: self.c.Tr.CollapseSidePanel,
+			Tooltip:     "Toggle collapsing the side panel to a minimal size. The collapsed state is persisted across restarts.",
+			Key:         opts.GetKey(opts.Config.Universal.JumpToBlock[index]),
+			Modifier:    gocui.ModAlt,
+			Handler:     opts.Guards.NoPopupPanel(self.toggleCollapse(window)),
+		})
+	}
+	return bindings
+}
+
+func (self *CollapseSideWindowController) toggleCollapse(window string) func() error {
+	return func() error {
+		appState := self.c.GetAppState()
+		isCollapsed := slices.Contains(appState.CollapsedSideWindows, window)
+
+		if isCollapsed {
+			// Uncollapse the window and focus it
+			appState.CollapsedSideWindows = lo.Filter(appState.CollapsedSideWindows, func(w string, _ int) bool {
+				return w != window
+			})
+			self.c.SaveAppStateAndLogError()
+
+			context := self.c.Helpers().Window.GetContextForWindow(window)
+			self.c.Context().Push(context, types.OnFocusOpts{})
+		} else {
+			// Collapse the window
+			appState.CollapsedSideWindows = append(appState.CollapsedSideWindows, window)
+			self.c.SaveAppStateAndLogError()
+
+			// If the collapsed window was focused, move focus to the nearest non-collapsed side window
+			if self.c.Helpers().Window.CurrentWindow() == window {
+				allSideWindows := self.c.Helpers().Window.SideWindows()
+				for _, candidate := range allSideWindows {
+					if candidate != window && !slices.Contains(appState.CollapsedSideWindows, candidate) {
+						context := self.c.Helpers().Window.GetContextForWindow(candidate)
+						self.c.Context().Push(context, types.OnFocusOpts{})
+						break
+					}
+				}
+			}
+		}
+		return nil
+	}
+}

--- a/pkg/gui/controllers/helpers/window_arrangement_helper.go
+++ b/pkg/gui/controllers/helpers/window_arrangement_helper.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
+	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
 )
 
@@ -72,6 +73,8 @@ type WindowArrangementArgs struct {
 	InSearchPrompt bool
 	// One of '' (not searching), 'Search: ', and 'Filter: '
 	SearchPrefix string
+	// Side windows that the user has manually collapsed
+	CollapsedSideWindows []string
 }
 
 func (self *WindowArrangementHelper) GetWindowDimensions(informationStr string, appStatus string) map[string]boxlayout.Dimensions {
@@ -86,20 +89,21 @@ func (self *WindowArrangementHelper) GetWindowDimensions(informationStr string, 
 	}
 
 	args := WindowArrangementArgs{
-		Width:             width,
-		Height:            height,
-		UserConfig:        self.c.UserConfig(),
-		CurrentWindow:     self.c.Context().CurrentStatic().GetWindowName(),
-		CurrentSideWindow: self.c.Context().CurrentSide().GetWindowName(),
-		SplitMainPanel:    repoState.GetSplitMainPanel(),
-		ScreenMode:        repoState.GetScreenMode(),
-		AppStatus:         appStatus,
-		InformationStr:    informationStr,
-		ShowExtrasWindow:  self.c.State().GetShowExtrasWindow(),
-		InDemo:            self.c.InDemo(),
-		IsAnyModeActive:   self.modeHelper.IsAnyModeActive(),
-		InSearchPrompt:    repoState.InSearchPrompt(),
-		SearchPrefix:      searchPrefix,
+		Width:                width,
+		Height:               height,
+		UserConfig:           self.c.UserConfig(),
+		CurrentWindow:        self.c.Context().CurrentStatic().GetWindowName(),
+		CurrentSideWindow:    self.c.Context().CurrentSide().GetWindowName(),
+		SplitMainPanel:       repoState.GetSplitMainPanel(),
+		ScreenMode:           repoState.GetScreenMode(),
+		AppStatus:            appStatus,
+		InformationStr:       informationStr,
+		ShowExtrasWindow:     self.c.State().GetShowExtrasWindow(),
+		InDemo:               self.c.InDemo(),
+		IsAnyModeActive:      self.modeHelper.IsAnyModeActive(),
+		InSearchPrompt:       repoState.InSearchPrompt(),
+		SearchPrefix:         searchPrefix,
+		CollapsedSideWindows: self.c.GetAppState().CollapsedSideWindows,
 	}
 
 	return GetWindowDimensions(args)
@@ -420,6 +424,10 @@ func getDefaultStashWindowBox(args WindowArrangementArgs) *boxlayout.Box {
 }
 
 func sidePanelChildren(args WindowArrangementArgs) func(width int, height int) []*boxlayout.Box {
+	isCollapsed := func(window string) bool {
+		return slices.Contains(args.CollapsedSideWindows, window)
+	}
+
 	return func(width int, height int) []*boxlayout.Box {
 		if args.ScreenMode == types.SCREEN_FULL || args.ScreenMode == types.SCREEN_HALF {
 			fullHeightBox := func(window string) *boxlayout.Box {
@@ -446,6 +454,9 @@ func sidePanelChildren(args WindowArrangementArgs) func(width int, height int) [
 		} else if height >= 28 {
 			accordionMode := args.UserConfig.Gui.ExpandFocusedSidePanel
 			accordionBox := func(defaultBox *boxlayout.Box) *boxlayout.Box {
+				if isCollapsed(defaultBox.Window) {
+					return &boxlayout.Box{Window: defaultBox.Window, Size: 3}
+				}
 				if accordionMode && defaultBox.Window == args.CurrentSideWindow {
 					return &boxlayout.Box{
 						Window: defaultBox.Window,
@@ -456,7 +467,7 @@ func sidePanelChildren(args WindowArrangementArgs) func(width int, height int) [
 				return defaultBox
 			}
 
-			return []*boxlayout.Box{
+			boxes := []*boxlayout.Box{
 				{
 					Window: "status",
 					Size:   3,
@@ -466,6 +477,13 @@ func sidePanelChildren(args WindowArrangementArgs) func(width int, height int) [
 				accordionBox(&boxlayout.Box{Window: "commits", Weight: 1}),
 				accordionBox(getDefaultStashWindowBox(args)),
 			}
+			// If all panels ended up with a fixed size (e.g. all collapsible
+			// panels are collapsed), give stash a weight so the remaining
+			// space is allocated and boxlayout doesn't panic.
+			if !lo.SomeBy(boxes, func(b *boxlayout.Box) bool { return b.Weight > 0 }) {
+				boxes[4] = &boxlayout.Box{Window: "stash", Weight: 1}
+			}
+			return boxes
 		}
 
 		squashedHeight := 1
@@ -474,6 +492,9 @@ func sidePanelChildren(args WindowArrangementArgs) func(width int, height int) [
 		}
 
 		squashedSidePanelBox := func(window string) *boxlayout.Box {
+			if isCollapsed(window) {
+				return &boxlayout.Box{Window: window, Size: 3}
+			}
 			if window == args.CurrentSideWindow {
 				return &boxlayout.Box{
 					Window: window,
@@ -487,12 +508,16 @@ func sidePanelChildren(args WindowArrangementArgs) func(width int, height int) [
 			}
 		}
 
-		return []*boxlayout.Box{
+		boxes := []*boxlayout.Box{
 			squashedSidePanelBox("status"),
 			squashedSidePanelBox("files"),
 			squashedSidePanelBox("branches"),
 			squashedSidePanelBox("commits"),
 			squashedSidePanelBox("stash"),
 		}
+		if !lo.SomeBy(boxes, func(b *boxlayout.Box) bool { return b.Weight > 0 }) {
+			boxes[4] = &boxlayout.Box{Window: "stash", Weight: 1}
+		}
+		return boxes
 	}
 }

--- a/pkg/gui/controllers/jump_to_side_window_controller.go
+++ b/pkg/gui/controllers/jump_to_side_window_controller.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/samber/lo"
+	"golang.org/x/exp/slices"
 )
 
 type JumpToSideWindowController struct {
@@ -38,7 +39,8 @@ func (self *JumpToSideWindowController) GetKeybindings(opts types.KeybindingsOpt
 
 	return lo.Map(windows, func(window string, index int) *types.Binding {
 		return &types.Binding{
-			ViewName: "",
+			ViewName:    "",
+			Description: self.c.Tr.JumpToSidePanel,
 			// by default the keys are 1, 2, 3, etc
 			Key:      opts.GetKey(opts.Config.Universal.JumpToBlock[index]),
 			Modifier: gocui.ModNone,
@@ -49,13 +51,23 @@ func (self *JumpToSideWindowController) GetKeybindings(opts types.KeybindingsOpt
 
 func (self *JumpToSideWindowController) goToSideWindow(window string) func() error {
 	return func() error {
+		appState := self.c.GetAppState()
+		isCollapsed := slices.Contains(appState.CollapsedSideWindows, window)
+
+		if isCollapsed {
+			// Uncollapse and navigate to the window
+			appState.CollapsedSideWindows = lo.Filter(appState.CollapsedSideWindows, func(w string, _ int) bool {
+				return w != window
+			})
+			self.c.SaveAppStateAndLogError()
+		}
+
 		sideWindowAlreadyActive := self.c.Helpers().Window.CurrentWindow() == window
 		if sideWindowAlreadyActive && self.c.UserConfig().Gui.SwitchTabsWithPanelJumpKeys {
 			return self.nextTabFunc()
 		}
 
 		context := self.c.Helpers().Window.GetContextForWindow(window)
-
 		self.c.Context().Push(context, types.OnFocusOpts{})
 		return nil
 	}

--- a/pkg/gui/gui_driver.go
+++ b/pkg/gui/gui_driver.go
@@ -29,6 +29,13 @@ var _ integrationTypes.GuiDriver = &GuiDriver{}
 func (self *GuiDriver) PressKey(keyStr string) {
 	self.CheckAllToastsAcknowledged()
 
+	mod := tcell.ModNone
+	// Support alt-modified keys like "<a-1>", "<a-2>", etc.
+	if strings.HasPrefix(keyStr, "<a-") && strings.HasSuffix(keyStr, ">") {
+		mod = tcell.ModAlt
+		keyStr = keyStr[3 : len(keyStr)-1]
+	}
+
 	key := keybindings.GetKey(keyStr)
 
 	var r rune
@@ -42,7 +49,7 @@ func (self *GuiDriver) PressKey(keyStr string) {
 	}
 
 	self.gui.g.ReplayedEvents.Keys <- gocui.NewTcellKeyEventWrapper(
-		tcell.NewEventKey(tcellKey, r, tcell.ModNone),
+		tcell.NewEventKey(tcellKey, r, mod),
 		0,
 	)
 

--- a/pkg/gui/keybindings/keybindings.go
+++ b/pkg/gui/keybindings/keybindings.go
@@ -17,6 +17,10 @@ func Label(name string) string {
 }
 
 func LabelFromKey(key types.Key) string {
+	return LabelFromKeyAndMod(key, gocui.ModNone)
+}
+
+func LabelFromKeyAndMod(key types.Key, mod gocui.Modifier) string {
 	if key == nil {
 		return ""
 	}
@@ -29,12 +33,19 @@ func LabelFromKey(key types.Key) string {
 	case gocui.Key:
 		value, ok := config.LabelByKey[key]
 		if ok {
+			if mod == gocui.ModAlt {
+				return fmt.Sprintf("<a-%s>", strings.TrimSuffix(strings.TrimPrefix(value, "<"), ">"))
+			}
 			return value
 		}
 		keyInt = int(key)
 	}
 
-	return fmt.Sprintf("%c", keyInt)
+	label := fmt.Sprintf("%c", keyInt)
+	if mod == gocui.ModAlt {
+		return fmt.Sprintf("<a-%s>", label)
+	}
+	return label
 }
 
 func GetKey(key string) types.Key {

--- a/pkg/gui/options_map.go
+++ b/pkg/gui/options_map.go
@@ -59,7 +59,7 @@ func (self *OptionsMapMgr) renderContextOptionsMap() {
 		}
 
 		return bindingInfo{
-			key:         keybindings.LabelFromKey(binding.Key),
+			key:         keybindings.LabelFromKeyAndMod(binding.Key, binding.Modifier),
 			description: binding.GetShortDescription(),
 			style:       displayStyle,
 		}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -265,6 +265,8 @@ type TranslationSet struct {
 	ExcludeFile                           string
 	RefreshFiles                          string
 	FocusMainView                         string
+	JumpToSidePanel                       string
+	CollapseSidePanel                     string
 	Merge                                 string
 	MergeBranchTooltip                    string
 	RegularMergeFastForward               string
@@ -1384,6 +1386,8 @@ func EnglishTranslationSet() *TranslationSet {
 		ExcludeFile:                          `Add to .git/info/exclude`,
 		RefreshFiles:                         `Refresh files`,
 		FocusMainView:                        "Focus main view",
+		JumpToSidePanel:                      "Jump to side panel",
+		CollapseSidePanel:                    "Collapse/expand side panel",
 		Merge:                                `Merge`,
 		MergeBranchTooltip:                   "View options for merging the selected item into the current branch (regular merge, squash merge)",
 		RegularMergeFastForward:              "Regular merge (fast-forward)",

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -462,6 +462,8 @@ var tests = []*components.IntegrationTest{
 	tag.Reset,
 	tag.ResetToDuplicateNamedBranch,
 	ui.Accordion,
+	ui.CollapseSidePanel,
+	ui.CollapseSidePanelSticky,
 	ui.DisableSwitchTabWithPanelJumpKeys,
 	ui.EmptyMenu,
 	ui.KeybindingSuggestionsWhenSwitchingRepos,

--- a/pkg/integration/tests/ui/collapse_side_panel.go
+++ b/pkg/integration/tests/ui/collapse_side_panel.go
@@ -1,0 +1,48 @@
+package ui
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CollapseSidePanel = NewIntegrationTest(NewIntegrationTestArgs{
+	Description: "Alt+number collapses a side panel; pressing again uncollapses it",
+	SetupConfig: func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateNCommits(3)
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		// Start with files focused (default)
+		t.Views().Files().IsFocused()
+
+		// Alt+2 to collapse the files panel; focus should move away
+		t.GlobalPress("<a-2>")
+		t.Views().Status().IsFocused()
+
+		// Alt+2 again to uncollapse files and focus it
+		t.GlobalPress("<a-2>")
+		t.Views().Files().IsFocused()
+
+		// Navigate to branches panel
+		t.Views().Branches().Focus()
+
+		// Alt+3 to collapse branches; focus should move away
+		t.GlobalPress("<a-3>")
+		t.Views().Status().IsFocused()
+
+		// Alt+3 again to uncollapse branches and focus it
+		t.GlobalPress("<a-3>")
+		t.Views().Branches().IsFocused()
+
+		// Navigate to commits panel
+		t.Views().Commits().Focus()
+
+		// Alt+4 to collapse commits; focus should move away
+		t.GlobalPress("<a-4>")
+		t.Views().Status().IsFocused()
+
+		// When files is collapsed and we jump to it via number key, it uncollapses
+		t.Views().Files().Focus()
+		t.Views().Files().IsFocused()
+	},
+})

--- a/pkg/integration/tests/ui/collapse_side_panel_sticky.go
+++ b/pkg/integration/tests/ui/collapse_side_panel_sticky.go
@@ -1,0 +1,43 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CollapseSidePanelSticky = NewIntegrationTest(NewIntegrationTestArgs{
+	Description: "Collapsing a side panel is persisted to state.yml so it survives restarts",
+	SetupConfig: func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateNCommits(3)
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		stateFile := filepath.Join(os.Getenv("CONFIG_DIR"), "state.yml")
+
+		// Collapse files (pane 2) via alt+2
+		t.Views().Files().IsFocused()
+		t.GlobalPress("<a-2>")
+		t.Views().Status().IsFocused()
+
+		// State file should now record "files" as collapsed
+		t.FileSystem().FileContent(stateFile, Contains("collapsedsidewindows"))
+		t.FileSystem().FileContent(stateFile, Contains("- files"))
+
+		// Collapse branches (pane 3) too via alt+3
+		t.Views().Branches().Focus()
+		t.GlobalPress("<a-3>")
+		t.Views().Status().IsFocused()
+
+		t.FileSystem().FileContent(stateFile, Contains("- branches"))
+
+		// Uncollapsing should remove the entry from state.yml
+		t.GlobalPress("<a-2>")
+		t.Views().Files().IsFocused()
+
+		t.FileSystem().FileContent(stateFile, DoesNotContain("- files"))
+		t.FileSystem().FileContent(stateFile, Contains("- branches"))
+	},
+})


### PR DESCRIPTION
### PR Description

Use alt+number keys (e.g. alt+2, alt+3, alt+4) to collapse/expand
side panels. Retains last setting between runs of lazygit.

Relates to https://github.com/jesseduffield/lazygit/issues/4600

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
