### PR TITLE
Normalize repository owner casing to fix GitHub PR integration

### DIFF
--- a/pkg/commands/git_commands/github.go
+++ b/pkg/commands/git_commands/github.go
@@ -283,7 +283,7 @@ func GenerateGithubPullRequestMap(
 	prByKey := map[prKey]models.GithubPullRequest{}
 
 	for _, pr := range prs {
-		key := prKey{owner: pr.UserName(), branchName: pr.BranchName()}
+		key := prKey{owner: strings.ToLower(pr.UserName()), branchName: pr.BranchName()}
 		// PRs are returned newest-first from the API, so the first one we
 		// see for each key is the most recent and therefore the most relevant.
 		if _, exists := prByKey[key]; !exists {
@@ -307,7 +307,7 @@ func GenerateGithubPullRequestMap(
 			owner = repoInfo.Owner
 		}
 
-		pr, hasPr := prByKey[prKey{owner: owner, branchName: branch.UpstreamBranch}]
+		pr, hasPr := prByKey[prKey{owner: strings.ToLower(owner), branchName: branch.UpstreamBranch}]
 
 		if !hasPr {
 			continue
@@ -348,7 +348,7 @@ func (self *GitHubCommands) InGithubRepo(remotes []*models.Remote) bool {
 	}
 
 	url := remote.Urls[0]
-	return strings.Contains(url, "github.com")
+	return strings.Contains(strings.ToLower(url), "github.com")
 }
 
 func getMainRemote(remotes []*models.Remote) *models.Remote {

--- a/pkg/commands/git_commands/github_test.go
+++ b/pkg/commands/git_commands/github_test.go
@@ -318,6 +318,40 @@ func TestGenerateGithubPullRequestMap(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "matches when owner casing differs",
+			prs: []*models.GithubPullRequest{
+				{
+					HeadRefName:         "fix-case-insensitive",
+					Number:              42,
+					Title:               "Fix case insensitive",
+					State:               "OPEN",
+					HeadRepositoryOwner: models.GithubRepositoryOwner{Login: "Jesseduffield"}, // Uppercase J
+				},
+			},
+			branches: []*models.Branch{
+				{
+					Name:           "fix-case-insensitive",
+					UpstreamRemote: "origin",
+					UpstreamBranch: "fix-case-insensitive",
+				},
+			},
+			remotes: []*models.Remote{
+				{
+					Name: "origin",
+					Urls: []string{"git@github.com:jesseduffield/lazygit.git"}, // Lowercase j
+				},
+			},
+			expected: map[string]*models.GithubPullRequest{
+				"fix-case-insensitive": {
+					HeadRefName:         "fix-case-insensitive",
+					Number:              42,
+					Title:               "Fix case insensitive",
+					State:               "OPEN",
+					HeadRepositoryOwner: models.GithubRepositoryOwner{Login: "Jesseduffield"},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
### PR Description

Close #5494 

Normalizes the repository owner to lowercase during the PR mapping.
This ensures that PR icons and integration features work correctly even when the local git remote URL casing differs from the official repository casing on GitHub.

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
