### PR TITLE
fix: case-insensitive owner matching in PR integration

### DIFF
--- a/pkg/commands/git_commands/github.go
+++ b/pkg/commands/git_commands/github.go
@@ -283,7 +283,7 @@ func GenerateGithubPullRequestMap(
 	prByKey := map[prKey]models.GithubPullRequest{}
 
 	for _, pr := range prs {
-		key := prKey{owner: pr.UserName(), branchName: pr.BranchName()}
+		key := prKey{owner: strings.ToLower(pr.UserName()), branchName: pr.BranchName()}
 		// PRs are returned newest-first from the API, so the first one we
 		// see for each key is the most recent and therefore the most relevant.
 		if _, exists := prByKey[key]; !exists {
@@ -307,7 +307,7 @@ func GenerateGithubPullRequestMap(
 			owner = repoInfo.Owner
 		}
 
-		pr, hasPr := prByKey[prKey{owner: owner, branchName: branch.UpstreamBranch}]
+		pr, hasPr := prByKey[prKey{owner: strings.ToLower(owner), branchName: branch.UpstreamBranch}]
 
 		if !hasPr {
 			continue

--- a/pkg/commands/git_commands/github_test.go
+++ b/pkg/commands/git_commands/github_test.go
@@ -318,6 +318,42 @@ func TestGenerateGithubPullRequestMap(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "matches when remote URL owner casing differs from API",
+			prs: []*models.GithubPullRequest{
+				{
+					HeadRefName:         "feature/feature-flags",
+					Number:              42,
+					Title:               "Add feature flags",
+					State:               "OPEN",
+					Url:                 "https://github.com/NTUT-NPC/tattoo/pull/42",
+					HeadRepositoryOwner: models.GithubRepositoryOwner{Login: "NTUT-NPC"},
+				},
+			},
+			branches: []*models.Branch{
+				{
+					Name:           "feature/feature-flags",
+					UpstreamRemote: "origin",
+					UpstreamBranch: "feature/feature-flags",
+				},
+			},
+			remotes: []*models.Remote{
+				{
+					Name: "origin",
+					Urls: []string{"https://github.com/ntut-npc/tattoo.git"},
+				},
+			},
+			expected: map[string]*models.GithubPullRequest{
+				"feature/feature-flags": {
+					HeadRefName:         "feature/feature-flags",
+					Number:              42,
+					Title:               "Add feature flags",
+					State:               "OPEN",
+					Url:                 "https://github.com/NTUT-NPC/tattoo/pull/42",
+					HeadRepositoryOwner: models.GithubRepositoryOwner{Login: "NTUT-NPC"},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Fixes #5494.

`GenerateGithubPullRequestMap` compares the owner parsed from the local remote URL against `HeadRepositoryOwner.Login` from the GitHub API using an exact-match map key. When the casing differs — e.g. remote URL has `ntut-npc` but the API returns `NTUT-NPC` — the lookup fails and the PR is never linked to its branch.

GitHub treats usernames and org names as case-insensitive, so a local remote pointing to `github.com/ntut-npc/tattoo` is the same repo as `NTUT-NPC/tattoo` in the API response.

The fix normalizes both sides of the map key to lowercase via `strings.ToLower()`. A regression test using the exact scenario from the issue is included.

**Before:** PR icon missing, `Shift+G` shows "no pull req found on this branch"
**After:** PR correctly matched regardless of remote URL casing

All existing tests pass (`go test ./pkg/commands/git_commands/ -run TestGenerateGithubPullRequestMap`).