### PR TITLE
Add config option to exclude branches from GitHub PR integration

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -498,9 +498,11 @@ git:
   # to 40 to disable truncation.
   truncateCopiedCommitHashesTo: 12
 
-  # List of branches for which GitHub pull request integration is disabled.
-  # PRs will not be shown for these branches in the branches view.
-  pullRequestExcludeBranches: []
+  # Config for GitHub integration
+  github:
+    # List of branches for which GitHub pull request integration is disabled.
+    # PRs will not be shown for these branches in the branches view.
+    pullRequestExcludeBranches: []
 
 # Periodic update checks
 update:

--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -498,6 +498,10 @@ git:
   # to 40 to disable truncation.
   truncateCopiedCommitHashesTo: 12
 
+  # List of branches for which GitHub pull request integration is disabled.
+  # PRs will not be shown for these branches in the branches view.
+  pullRequestExcludeBranches: []
+
 # Periodic update checks
 update:
   # One of: 'prompt' (default) | 'background' | 'never'

--- a/pkg/commands/git_commands/github_test.go
+++ b/pkg/commands/git_commands/github_test.go
@@ -361,3 +361,57 @@ func TestGenerateGithubPullRequestMap(t *testing.T) {
 		})
 	}
 }
+
+func TestExcludeBranchesFromPullRequestMap(t *testing.T) {
+	pr1 := &models.GithubPullRequest{
+		HeadRefName:         "feature",
+		Number:              1,
+		HeadRepositoryOwner: models.GithubRepositoryOwner{Login: "jesseduffield"},
+	}
+	pr2 := &models.GithubPullRequest{
+		HeadRefName:         "main",
+		Number:              2,
+		HeadRepositoryOwner: models.GithubRepositoryOwner{Login: "jesseduffield"},
+	}
+
+	cases := []struct {
+		name     string
+		prMap    map[string]*models.GithubPullRequest
+		exclude  []string
+		expected map[string]*models.GithubPullRequest
+	}{
+		{
+			name:     "no exclusions",
+			prMap:    map[string]*models.GithubPullRequest{"feature": pr1, "main": pr2},
+			exclude:  []string{},
+			expected: map[string]*models.GithubPullRequest{"feature": pr1, "main": pr2},
+		},
+		{
+			name:     "exclude one branch",
+			prMap:    map[string]*models.GithubPullRequest{"feature": pr1, "main": pr2},
+			exclude:  []string{"main"},
+			expected: map[string]*models.GithubPullRequest{"feature": pr1},
+		},
+		{
+			name:     "exclude all branches",
+			prMap:    map[string]*models.GithubPullRequest{"feature": pr1, "main": pr2},
+			exclude:  []string{"feature", "main"},
+			expected: map[string]*models.GithubPullRequest{},
+		},
+		{
+			name:     "exclude non-existent branch is no-op",
+			prMap:    map[string]*models.GithubPullRequest{"feature": pr1},
+			exclude:  []string{"no-such-branch"},
+			expected: map[string]*models.GithubPullRequest{"feature": pr1},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			for _, branchName := range c.exclude {
+				delete(c.prMap, branchName)
+			}
+			assert.Equal(t, c.expected, c.prMap)
+		})
+	}
+}

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -330,6 +330,11 @@ type GitConfig struct {
 	RemoteBranchSortOrder string `yaml:"remoteBranchSortOrder" jsonschema:"enum=date,enum=alphabetical"`
 	// When copying commit hashes to the clipboard, truncate them to this length. Set to 40 to disable truncation.
 	TruncateCopiedCommitHashesTo int `yaml:"truncateCopiedCommitHashesTo"`
+	// Config for GitHub integration
+	GitHub GitHubConfig `yaml:"github"`
+}
+
+type GitHubConfig struct {
 	// List of branches for which GitHub pull request integration is disabled.
 	// PRs will not be shown for these branches in the branches view.
 	PullRequestExcludeBranches []string `yaml:"pullRequestExcludeBranches" jsonschema:"uniqueItems=true"`

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -330,6 +330,9 @@ type GitConfig struct {
 	RemoteBranchSortOrder string `yaml:"remoteBranchSortOrder" jsonschema:"enum=date,enum=alphabetical"`
 	// When copying commit hashes to the clipboard, truncate them to this length. Set to 40 to disable truncation.
 	TruncateCopiedCommitHashesTo int `yaml:"truncateCopiedCommitHashesTo"`
+	// List of branches for which GitHub pull request integration is disabled.
+	// PRs will not be shown for these branches in the branches view.
+	PullRequestExcludeBranches []string `yaml:"pullRequestExcludeBranches" jsonschema:"uniqueItems=true"`
 }
 
 type PagerType string

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -903,6 +903,9 @@ func (self *RefreshHelper) rebuildPullRequestsMap() {
 		self.c.Model().Branches,
 		self.c.Model().Remotes,
 	)
+	for _, branchName := range self.c.UserConfig().Git.PullRequestExcludeBranches {
+		delete(self.c.Model().PullRequestsMap, branchName)
+	}
 }
 
 func (self *RefreshHelper) setGithubPullRequests(authToken string, baseRemote *models.Remote) error {
@@ -910,8 +913,9 @@ func (self *RefreshHelper) setGithubPullRequests(authToken string, baseRemote *m
 		return nil
 	}
 
+	excludedBranches := self.c.UserConfig().Git.PullRequestExcludeBranches
 	branches := lo.Filter(self.c.Model().Branches, func(branch *models.Branch, _ int) bool {
-		return branch.IsTrackingRemote()
+		return branch.IsTrackingRemote() && !lo.Contains(excludedBranches, branch.Name)
 	})
 	branchNames := lo.Map(branches, func(branch *models.Branch, _ int) string {
 		return branch.UpstreamBranch

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -903,7 +903,7 @@ func (self *RefreshHelper) rebuildPullRequestsMap() {
 		self.c.Model().Branches,
 		self.c.Model().Remotes,
 	)
-	for _, branchName := range self.c.UserConfig().Git.PullRequestExcludeBranches {
+	for _, branchName := range self.c.UserConfig().Git.GitHub.PullRequestExcludeBranches {
 		delete(self.c.Model().PullRequestsMap, branchName)
 	}
 }
@@ -913,7 +913,7 @@ func (self *RefreshHelper) setGithubPullRequests(authToken string, baseRemote *m
 		return nil
 	}
 
-	excludedBranches := self.c.UserConfig().Git.PullRequestExcludeBranches
+	excludedBranches := self.c.UserConfig().Git.GitHub.PullRequestExcludeBranches
 	branches := lo.Filter(self.c.Model().Branches, func(branch *models.Branch, _ int) bool {
 		return branch.IsTrackingRemote() && !lo.Contains(excludedBranches, branch.Name)
 	})

--- a/pkg/gui/presentation/branches_test.go
+++ b/pkg/gui/presentation/branches_test.go
@@ -31,6 +31,7 @@ func Test_getBranchDisplayStrings(t *testing.T) {
 		useIcons             bool
 		checkedOutByWorktree bool
 		showDivergenceCfg    string
+		prs                  map[string]*models.GithubPullRequest
 		expected             []string
 	}{
 		// First some tests for when the view is wide enough so that everything fits:
@@ -333,6 +334,45 @@ func Test_getBranchDisplayStrings(t *testing.T) {
 			showDivergenceCfg:    "none",
 			expected:             []string{"1m", "", "12345678", "bran… ✓", "origin branch_name", "commit title"},
 		},
+		// PR integration tests:
+		{
+			branch:               &models.Branch{Name: "feature-branch", Recency: "1m"},
+			itemOperation:        types.ItemOperationNone,
+			fullDescription:      false,
+			viewWidth:            100,
+			useIcons:             false,
+			checkedOutByWorktree: false,
+			showDivergenceCfg:    "none",
+			prs: map[string]*models.GithubPullRequest{
+				"feature-branch": {
+					HeadRefName: "feature-branch",
+					Number:      42,
+					Title:       "Add feature",
+					State:       "OPEN",
+					Url:         "https://github.com/jesseduffield/lazygit/pull/42",
+				},
+			},
+			expected: []string{"1m", "●", "feature-branch"},
+		},
+		{
+			branch:               &models.Branch{Name: "main", Recency: "1m"},
+			itemOperation:        types.ItemOperationNone,
+			fullDescription:      false,
+			viewWidth:            100,
+			useIcons:             false,
+			checkedOutByWorktree: false,
+			showDivergenceCfg:    "none",
+			prs: map[string]*models.GithubPullRequest{
+				"feature-branch": {
+					HeadRefName: "feature-branch",
+					Number:      42,
+					Title:       "Add feature",
+					State:       "OPEN",
+					Url:         "https://github.com/jesseduffield/lazygit/pull/42",
+				},
+			},
+			expected: []string{"1m", "", "main"},
+		},
 	}
 
 	oldColorLevel := color.ForceSetColorLevel(terminfo.ColorLevelNone)
@@ -350,8 +390,13 @@ func Test_getBranchDisplayStrings(t *testing.T) {
 			worktrees = append(worktrees, &models.Worktree{Branch: s.branch.Name, Name: "other-worktree"})
 		}
 
+		prs := s.prs
+		if prs == nil {
+			prs = map[string]*models.GithubPullRequest{}
+		}
+
 		t.Run(fmt.Sprintf("getBranchDisplayStrings_%d", i), func(t *testing.T) {
-			strings := getBranchDisplayStrings(s.branch, s.itemOperation, s.fullDescription, false, s.viewWidth, c.Tr, c.UserConfig(), worktrees, time.Time{}, map[string]*models.GithubPullRequest{})
+			strings := getBranchDisplayStrings(s.branch, s.itemOperation, s.fullDescription, false, s.viewWidth, c.Tr, c.UserConfig(), worktrees, time.Time{}, prs)
 			assert.Equal(t, s.expected, strings)
 		})
 	}

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -453,6 +453,14 @@
           "type": "integer",
           "description": "When copying commit hashes to the clipboard, truncate them to this length. Set to 40 to disable truncation.",
           "default": 12
+        },
+        "pullRequestExcludeBranches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true,
+          "description": "List of branches for which GitHub pull request integration is disabled.\nPRs will not be shown for these branches in the branches view."
         }
       },
       "additionalProperties": false,

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -454,6 +454,17 @@
           "description": "When copying commit hashes to the clipboard, truncate them to this length. Set to 40 to disable truncation.",
           "default": 12
         },
+        "github": {
+          "$ref": "#/$defs/GitHubConfig",
+          "description": "Config for GitHub integration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Config relating to git"
+    },
+    "GitHubConfig": {
+      "properties": {
         "pullRequestExcludeBranches": {
           "items": {
             "type": "string"
@@ -465,7 +476,7 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "description": "Config relating to git"
+      "description": "Config for GitHub integration"
     },
     "GuiConfig": {
       "properties": {


### PR DESCRIPTION
### PR Description

First off, thanks for the GitHub PR integration. It's been great! However, in my repository, someone opened a PR from `develop` into their branch, which left a permanent closed PR indicator next to `develop` that I couldn't dismiss. So this PR adds a config option to hide PR status for specific branches:

```yaml
git:
  github:
    pullRequestExcludeBranches:
      - develop
```

Open questions:
- Should this just be `git.pullRequestExcludeBranches` instead of nesting under `git.github`? Happy to flatten it.
- Let me know if I missed updating something. First contribution here :)

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
