### PR TITLE
Hide closed pull requests on main branches

### DIFF
--- a/pkg/gui/controllers/branches_controller.go
+++ b/pkg/gui/controllers/branches_controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
 	"github.com/jesseduffield/lazygit/pkg/gui/controllers/helpers"
+	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/presentation/icons"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
@@ -205,7 +206,8 @@ func (self *BranchesController) GetOnRenderToMain() func() {
 				ptyTask := types.NewRunPtyTask(cmdObj.GetCmd())
 				task = ptyTask
 
-				if pr, ok := self.c.Model().PullRequestsMap[branch.Name]; ok {
+				pr, ok := self.c.Model().PullRequestsMap[branch.Name]
+				if ok && presentation.ShouldShowPrForBranch(pr, branch.Name, self.c.UserConfig()) {
 					icon := lo.Ternary(icons.IsIconEnabled(), icons.IconForRemoteUrl(pr.Url)+"  ", "")
 					ptyTask.Prefix = style.PrintHyperlink(fmt.Sprintf("%s%s  %s  %s\n",
 						icon,

--- a/pkg/gui/presentation/branches.go
+++ b/pkg/gui/presentation/branches.go
@@ -141,7 +141,7 @@ func getBranchDisplayStrings(
 
 	var coloredPrIcon string
 	pr, hasPr := prs[b.Name]
-	if hasPr {
+	if hasPr && ShouldShowPrForBranch(pr, b.Name, userConfig) {
 		var prIcon string
 		if icons.IsIconEnabled() {
 			prIcon = icons.IconForRemoteUrl(pr.Url)
@@ -284,4 +284,14 @@ func prColor(state string) style.TextStyle {
 	default:
 		return style.FgDefault
 	}
+}
+
+func ShouldShowPrForBranch(pr *models.GithubPullRequest, branchName string, userConfig *config.UserConfig) bool {
+	if !lo.Contains(userConfig.Git.MainBranches, branchName) {
+		return true
+	}
+
+	// For main branches we only want to show the PR if it's open (or draft), on the assumption that a
+	// closed PR for a main branch is always a mistake.
+	return pr.State != "CLOSED" && pr.State != "MERGED"
 }


### PR DESCRIPTION
The assumption is that if a pull request exists on a main branch, it was usually created by mistake and then closed, and showing it serves no purpose and is only distracting.

We keep showing _open_ pull requests for main branches though, because this allows you to notice that there is one that you probably want to close.

This only affects the display (in the branches list and in the main view); opening the PR in the browser using shift-G is still possible, as is copying its URL to the clipboard.
