### PR TITLE
Don't default the base repo for pull requests to "origin"

### DIFF
--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -848,10 +848,10 @@ func (self *RefreshHelper) getGithubBaseRemote() *models.Remote {
 		return remotes[0]
 	}
 
-	for _, remoteName := range []string{"upstream", "origin"} {
-		if remote := findRemoteByName(remoteName); remote != nil {
-			return remote
-		}
+	// Not sure if "upstream" is really a common convention for the name of the remote that PRs are
+	// made against, but if it exists it's pretty likely to be the one we want.
+	if remote := findRemoteByName("upstream"); remote != nil {
+		return remote
 	}
 
 	return nil


### PR DESCRIPTION
When no base repository is configured using gh, we have several heuristics for choosing a likely base repo before prompting the user. One of these was that if the origin remote exists, we'd choose that. This may be the right choice in some cases, but in many others it's not; for example, in the common scenario of a forking setup where the upstream repo's remote is called after its owner, and the fork remote is called origin, we would choose origin as the base repo, which results in not showing any PRs. Don't do that, and instead prompt the user for the base repo in this case.