### PR TITLE
Fix copying a file's absolute path when running in a linked worktree

### DIFF
--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -248,7 +248,11 @@ func (self *CommitFilesController) openCopyMenu() error {
 	copyAbsolutePathItem := &types.MenuItem{
 		Label: self.c.Tr.CopyAbsoluteFilePath,
 		OnPress: func() error {
-			if err := self.c.OS().CopyToClipboard(filepath.Join(self.c.Git().RepoPaths.RepoPath(), node.GetPath())); err != nil {
+			absPath, err := filepath.Abs(node.GetPath())
+			if err != nil {
+				return err
+			}
+			if err := self.c.OS().CopyToClipboard(absPath); err != nil {
 				return err
 			}
 			self.c.Toast(self.c.Tr.FilePathCopiedToast)

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -1199,7 +1199,11 @@ func (self *FilesController) openCopyMenu() error {
 	copyAbsolutePathItem := &types.MenuItem{
 		Label: self.c.Tr.CopyAbsoluteFilePath,
 		OnPress: func() error {
-			if err := self.c.OS().CopyToClipboard(filepath.Join(self.c.Git().RepoPaths.RepoPath(), node.GetPath())); err != nil {
+			absPath, err := filepath.Abs(node.GetPath())
+			if err != nil {
+				return err
+			}
+			if err := self.c.OS().CopyToClipboard(absPath); err != nil {
 				return err
 			}
 			self.c.Toast(self.c.Tr.FilePathCopiedToast)

--- a/pkg/integration/tests/diff/copy_to_clipboard.go
+++ b/pkg/integration/tests/diff/copy_to_clipboard.go
@@ -2,7 +2,6 @@ package diff
 
 import (
 	"os"
-	"path/filepath"
 
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
@@ -90,10 +89,7 @@ var CopyToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 						t.ExpectToast(Equals("File path copied to clipboard"))
 						worktreeDir, _ := os.Getwd()
 						// On windows the following path would have backslashes, but we don't run integration tests on windows yet.
-						/* EXPECTED:
 						expectClipboard(t, Equals(worktreeDir+"/dir/file1"))
-						ACTUAL: */
-						expectClipboard(t, Equals(filepath.Dir(worktreeDir)+"/repo/dir/file1"))
 					})
 			}).
 			Press(keys.Files.CopyFileInfoToClipboard).

--- a/pkg/integration/tests/diff/copy_to_clipboard.go
+++ b/pkg/integration/tests/diff/copy_to_clipboard.go
@@ -2,6 +2,7 @@ package diff
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
@@ -22,6 +23,12 @@ var CopyToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 		config.GetUserConfig().OS.CopyToClipboardCmd = "printf '%s' {{text}} > clipboard"
 	},
 	SetupRepo: func(shell *Shell) {
+		// Run the test in a linked worktree so that we catch bugs where we
+		// use the main repo's path instead of the current worktree's path.
+		shell.EmptyCommit("initial commit")
+		shell.AddWorktree("HEAD", "../linked-worktree", "mybranch")
+		shell.Chdir("../linked-worktree")
+
 		shell.CreateDir("dir")
 		shell.CreateFileAndAdd("dir/file1", "1st line\n")
 		shell.Commit("1")
@@ -38,6 +45,7 @@ var CopyToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("3").IsSelected(),
 				Contains("2"),
 				Contains("1"),
+				Contains("initial commit"),
 			).
 			SelectNextItem().
 			PressEnter()
@@ -80,9 +88,12 @@ var CopyToClipboard = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm().
 					Tap(func() {
 						t.ExpectToast(Equals("File path copied to clipboard"))
-						repoDir, _ := os.Getwd()
+						worktreeDir, _ := os.Getwd()
 						// On windows the following path would have backslashes, but we don't run integration tests on windows yet.
-						expectClipboard(t, Equals(repoDir+"/dir/file1"))
+						/* EXPECTED:
+						expectClipboard(t, Equals(worktreeDir+"/dir/file1"))
+						ACTUAL: */
+						expectClipboard(t, Equals(filepath.Dir(worktreeDir)+"/repo/dir/file1"))
 					})
 			}).
 			Press(keys.Files.CopyFileInfoToClipboard).

--- a/pkg/integration/tests/file/copy_menu.go
+++ b/pkg/integration/tests/file/copy_menu.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"os"
-	"path/filepath"
 
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
@@ -139,10 +138,7 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 
 				worktreeDir, _ := os.Getwd()
 				// On windows the following path would have backslashes, but we don't run integration tests on windows yet.
-				/* EXPECTED:
 				expectClipboard(t, Equals(worktreeDir+"/dir/1-unstaged_file"))
-				ACTUAL: */
-				expectClipboard(t, Equals(filepath.Dir(worktreeDir)+"/repo/dir/1-unstaged_file"))
 			})
 
 		// Selected path diff on a single (unstaged) file

--- a/pkg/integration/tests/file/copy_menu.go
+++ b/pkg/integration/tests/file/copy_menu.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/jesseduffield/lazygit/pkg/config"
 	. "github.com/jesseduffield/lazygit/pkg/integration/components"
@@ -21,7 +22,13 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupConfig: func(config *config.AppConfig) {
 		config.GetUserConfig().OS.CopyToClipboardCmd = "printf '%s' {{text}} > clipboard"
 	},
-	SetupRepo: func(shell *Shell) {},
+	SetupRepo: func(shell *Shell) {
+		// Run the test in a linked worktree so that we catch bugs where we
+		// use the main repo's path instead of the current worktree's path.
+		shell.EmptyCommit("initial commit")
+		shell.AddWorktree("HEAD", "../linked-worktree", "mybranch")
+		shell.Chdir("../linked-worktree")
+	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		// Disabled item
 		t.Views().Files().
@@ -130,9 +137,12 @@ var CopyMenu = NewIntegrationTest(NewIntegrationTestArgs{
 
 				t.ExpectToast(Equals("File path copied to clipboard"))
 
-				repoDir, _ := os.Getwd()
+				worktreeDir, _ := os.Getwd()
 				// On windows the following path would have backslashes, but we don't run integration tests on windows yet.
-				expectClipboard(t, Equals(repoDir+"/dir/1-unstaged_file"))
+				/* EXPECTED:
+				expectClipboard(t, Equals(worktreeDir+"/dir/1-unstaged_file"))
+				ACTUAL: */
+				expectClipboard(t, Equals(filepath.Dir(worktreeDir)+"/repo/dir/1-unstaged_file"))
 			})
 
 		// Selected path diff on a single (unstaged) file


### PR DESCRIPTION
When copying a file's absolute path in a worktree, the result would be relative to the main repo rather than the worktree you're in.

Fixes #5522.