### PR TITLE
Preserve commit message when quitting while the commit message panel is open

### DIFF
--- a/pkg/gui/context/base_context.go
+++ b/pkg/gui/context/base_context.go
@@ -21,6 +21,7 @@ type BaseContext struct {
 	onRenderToMainFn         func()
 	onFocusFns               []onFocusFn
 	onFocusLostFns           []onFocusLostFn
+	onQuitFns                []func()
 
 	focusable                   bool
 	transient                   bool
@@ -141,6 +142,7 @@ func (self *BaseContext) ClearAllAttachedControllerFunctions() {
 	self.mouseKeybindingsFns = nil
 	self.onFocusFns = nil
 	self.onFocusLostFns = nil
+	self.onQuitFns = nil
 	self.onDoubleClickFn = nil
 	self.onClickFn = nil
 	self.onClickFocusedMainViewFn = nil
@@ -204,6 +206,12 @@ func (self *BaseContext) AddOnFocusFn(fn onFocusFn) {
 func (self *BaseContext) AddOnFocusLostFn(fn onFocusLostFn) {
 	if fn != nil {
 		self.onFocusLostFns = append(self.onFocusLostFns, fn)
+	}
+}
+
+func (self *BaseContext) AddOnQuitFn(fn func()) {
+	if fn != nil {
+		self.onQuitFns = append(self.onQuitFns, fn)
 	}
 }
 

--- a/pkg/gui/context/simple_context.go
+++ b/pkg/gui/context/simple_context.go
@@ -54,6 +54,12 @@ func (self *SimpleContext) HandleFocusLost(opts types.OnFocusLostOpts) {
 	}
 }
 
+func (self *SimpleContext) HandleQuit() {
+	for _, fn := range self.onQuitFns {
+		fn()
+	}
+}
+
 func (self *SimpleContext) FocusLine(scrollIntoView bool) {
 }
 

--- a/pkg/gui/controllers/attach.go
+++ b/pkg/gui/controllers/attach.go
@@ -12,5 +12,6 @@ func AttachControllers(context types.Context, controllers ...types.IController) 
 		context.AddOnRenderToMainFn(controller.GetOnRenderToMain())
 		context.AddOnFocusFn(controller.GetOnFocus())
 		context.AddOnFocusLostFn(controller.GetOnFocusLost())
+		context.AddOnQuitFn(controller.GetOnQuit())
 	}
 }

--- a/pkg/gui/controllers/base_controller.go
+++ b/pkg/gui/controllers/base_controller.go
@@ -38,3 +38,7 @@ func (self *baseController) GetOnFocus() func(types.OnFocusOpts) {
 func (self *baseController) GetOnFocusLost() func(types.OnFocusLostOpts) {
 	return nil
 }
+
+func (self *baseController) GetOnQuit() func() {
+	return nil
+}

--- a/pkg/gui/controllers/commit_description_controller.go
+++ b/pkg/gui/controllers/commit_description_controller.go
@@ -91,6 +91,12 @@ func (self *CommitDescriptionController) GetOnFocus() func(types.OnFocusOpts) {
 	}
 }
 
+func (self *CommitDescriptionController) GetOnQuit() func() {
+	return func() {
+		self.c.Helpers().Commits.PreserveCommitMessage()
+	}
+}
+
 func (self *CommitDescriptionController) switchToCommitMessage() error {
 	self.c.Context().Replace(self.c.Contexts().CommitMessage)
 	return nil

--- a/pkg/gui/controllers/commit_message_controller.go
+++ b/pkg/gui/controllers/commit_message_controller.go
@@ -82,6 +82,12 @@ func (self *CommitMessageController) GetOnFocusLost() func(types.OnFocusLostOpts
 	}
 }
 
+func (self *CommitMessageController) GetOnQuit() func() {
+	return func() {
+		self.c.Helpers().Commits.PreserveCommitMessage()
+	}
+}
+
 func (self *CommitMessageController) Context() types.Context {
 	return self.context()
 }

--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -179,8 +179,6 @@ func (self *CommitsHelper) CloseCommitMessagePanel() {
 		if message != self.c.Contexts().CommitMessage.GetInitialMessage() {
 			self.c.Contexts().CommitMessage.SetPreservedMessageAndLogError(message)
 		}
-	} else {
-		self.SetMessageAndDescriptionInView("")
 	}
 
 	self.c.Contexts().CommitMessage.SetHistoryMessage("")

--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -173,13 +173,17 @@ func (self *CommitsHelper) HandleCommitConfirm() error {
 	return nil
 }
 
-func (self *CommitsHelper) CloseCommitMessagePanel() {
+func (self *CommitsHelper) PreserveCommitMessage() {
 	if self.c.Contexts().CommitMessage.GetPreserveMessage() {
 		message := self.JoinCommitMessageAndUnwrappedDescription()
 		if message != self.c.Contexts().CommitMessage.GetInitialMessage() {
 			self.c.Contexts().CommitMessage.SetPreservedMessageAndLogError(message)
 		}
 	}
+}
+
+func (self *CommitsHelper) CloseCommitMessagePanel() {
+	self.PreserveCommitMessage()
 
 	self.c.Contexts().CommitMessage.SetHistoryMessage("")
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -935,7 +935,12 @@ func (gui *Gui) Run(startArgs appTypes.StartArgs) error {
 	// setting here so we can use it in layout.go
 	gui.integrationTest = startArgs.IntegrationTest
 
-	return gui.g.MainLoop()
+	err = gui.g.MainLoop()
+	if errors.Is(err, gocui.ErrQuit) {
+		// Give the focused context a chance to clean up before we tear down the app.
+		gui.c.Context().Current().HandleQuit()
+	}
+	return err
 }
 
 func (gui *Gui) RunAndHandleError(startArgs appTypes.StartArgs) error {

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -105,6 +105,7 @@ type IBaseContext interface {
 	AddOnRenderToMainFn(func())
 	AddOnFocusFn(func(OnFocusOpts))
 	AddOnFocusLostFn(func(OnFocusLostOpts))
+	AddOnQuitFn(func())
 }
 
 type Context interface {
@@ -112,6 +113,7 @@ type Context interface {
 
 	HandleFocus(opts OnFocusOpts)
 	HandleFocusLost(opts OnFocusLostOpts)
+	HandleQuit()
 	FocusLine(scrollIntoView bool)
 	HandleRender()
 	HandleRenderToMain()
@@ -273,6 +275,10 @@ type IController interface {
 	GetOnRenderToMain() func()
 	GetOnFocus() func(OnFocusOpts)
 	GetOnFocusLost() func(OnFocusLostOpts)
+
+	// Implement this to get called when the app quits, and the controller's context has the focus.
+	// Useful for saving state on quit.
+	GetOnQuit() func()
 }
 
 type IList interface {


### PR DESCRIPTION
This isn't possible with the default quit binding ('q'), but there's an alternative binding (ctrl-c) that does work while the panel is open; also, users can rebind quit to something like ctrl-q.

Fixes #5513.