### PR TITLE
fix(gui): tolerate UpdateWindowTitle failure on startup

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -1060,8 +1060,12 @@ func (gui *Gui) loadNewRepo() error {
 
 	gui.c.Refresh(types.RefreshOptions{Mode: types.ASYNC})
 
+	// Updating the window title is purely cosmetic (e.g. setting the terminal
+	// window title via `cmd /c title ...` on Windows). If it fails for any
+	// reason we don't want to take down the whole app on startup, so just log
+	// the error and carry on. See https://github.com/jesseduffield/lazygit/issues/5414
 	if err := gui.os.UpdateWindowTitle(); err != nil {
-		return err
+		gui.c.Log.Warnf("failed to update window title: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
Closes #5414

<!-- Drafted by an agent run; please review carefully before merging. -->

## Repo
jesseduffield/lazygit

## Issue
https://github.com/jesseduffield/lazygit/issues/5414

## Root cause
On Windows, `OSCommand.UpdateWindowTitle` (`pkg/commands/oscommands/os_windows.go:24`) shells out to `cmd /c title <basename> - Lazygit` to set the terminal window title. If that subprocess exits non-zero for any environment-specific reason (e.g. `cmd.exe` being intercepted/wrapped, AV/sandboxing, an exotic working-directory name, or a stricter shell), `cmd_obj_runner.sanitisedCommandOutput` wraps the bare `*exec.ExitError` and `loadNewRepo` (`pkg/gui/gui.go:1063`) propagates it out of the gocui layout loop, killing lazygit before the UI is drawn.

## Fix
The window title is purely cosmetic, so the failure should not be fatal. `loadNewRepo` now logs a warning and continues instead of returning the error from `UpdateWindowTitle`.

## Regression test
None added. Exercising this path requires standing up a full `Gui` with a fake `OSCommand`/runner that returns an error from `UpdateWindowTitle`, and there is no existing harness in `pkg/gui` for that (the `gui` package has no unit tests of its own beyond sub-packages). Verified manually that `pkg/commands/oscommands` tests still pass and that both the default and `GOOS=windows` builds compile.

## Risk
trivial

## Verification
- `go build ./...` — ok
- `GOOS=windows GOARCH=amd64 go build ./...` — ok
- `go test ./pkg/commands/oscommands/...` — ok (0.421s)
