### PR TITLE
Stop showing cached PRs when we no longer have a base remote

### DIFF
--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -819,6 +819,9 @@ func (self *RefreshHelper) refreshGithubPullRequests() {
 
 	baseRemote := self.getGithubBaseRemote()
 	if baseRemote == nil {
+		self.c.Model().PullRequests = nil
+		self.c.Model().PullRequestsMap = nil
+
 		if !self.githubBaseRemotePromptDismissed[self.c.Git().RepoPaths.RepoPath()] {
 			self.promptForBaseGithubRepo(authToken)
 		}


### PR DESCRIPTION
If we used to have a base remote (e.g. because there was only one), but now we don't (e.g. because the user has added a second one, and we don't know yet which one is the base), stop showing the cached PRs. This is especially important in the case that the user cancels the prompt, in which case we don't have a base remote for the rest of the session, but would keep showing the (potentially stale) cached PRs forever.

You might ask why we don't retain the previous base remote in the case that we used to have one but no longer do; this may be possible, but it's error-prone because the user might have shuffled their remotes around and changed their names. I don't think it's worth the risk.