### PR TITLE
Fix dependabot label for github-actions-related updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,4 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
-      - "github-actions"
+      - "github_actions"


### PR DESCRIPTION
I misspelled this when I added the labels section in ca941ffb1825; seems it was using github_actions before.
