### PR TITLE
feat: add 'Remove worktree and branch' option when deleting a branch checked out by a worktree

### DIFF
--- a/pkg/gui/controllers/helpers/branches_helper.go
+++ b/pkg/gui/controllers/helpers/branches_helper.go
@@ -240,6 +240,16 @@ func (self *BranchesHelper) promptWorktreeBranchDelete(selectedBranch *models.Br
 					return self.worktreeHelper.Remove(worktree, false)
 				},
 			},
+			{
+				Label:   self.c.Tr.RemoveWorktreeAndBranch,
+				Tooltip: self.c.Tr.RemoveWorktreeTooltip,
+				OnPress: func() error {
+					if err := self.worktreeHelper.Remove(worktree, false); err != nil {
+						return err
+					}
+					return self.c.Git().Branch.LocalDelete([]string{selectedBranch.Name}, true)
+				},
+			},
 		},
 	})
 }

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -866,6 +866,7 @@ type TranslationSet struct {
 	DetachWorktreeTooltip                    string
 	Switching                                string
 	RemoveWorktree                           string
+	RemoveWorktreeAndBranch                  string
 	RemoveWorktreeTitle                      string
 	DetachWorktree                           string
 	DetachingWorktree                        string
@@ -1990,6 +1991,7 @@ func EnglishTranslationSet() *TranslationSet {
 		DetachWorktreeTooltip:                    "This will run `git checkout --detach` on the worktree so that it stops hogging the branch, but the worktree's working tree will be left alone.",
 		Switching:                                "Switching",
 		RemoveWorktree:                           "Remove worktree",
+		RemoveWorktreeAndBranch:                  "Remove worktree and branch",
 		RemoveWorktreeTitle:                      "Remove worktree",
 		RemoveWorktreePrompt:                     "Are you sure you want to remove worktree '{{.worktreeName}}'?",
 		ForceRemoveWorktreePrompt:                "'{{.worktreeName}}' contains modified or untracked files, or submodules (or all of these). Are you sure you want to remove it?",


### PR DESCRIPTION
## Description
When deleting a branch that is currently checked out by a worktree, users currently have three options:
1. Switch to worktree
2. Detach worktree
3. Remove worktree

If the user wants to delete BOTH the worktree and the branch, they must first remove the worktree, then delete the branch in a second step. This adds a fourth option that combines both operations.

Closes #5205

## Changes
- Added `RemoveWorktreeAndBranch` i18n string
- Added fourth menu item in `promptWorktreeBranchDelete()` that calls `worktreeHelper.Remove()` followed by `Branch.LocalDelete()`

## Testing
- `go build ./...` ✅
- `go test ./pkg/i18n/ ./pkg/gui/controllers/helpers/` ✅