### PR TITLE
feat(github): support enterprise PR indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ If you press `shift+w` on a commit (or branch/ref) a menu will open that allows 
 
 ### Show GitHub pull requests
 
-In the branches panel, lazygit can show which of your branches have an associated GitHub pull request by showing a GitHub icon next to the branch name; its color shows the state of the PR (open, merged, etc.). For those that have one, you can press `shift-G` to open the PR in the browser. There is no configuration needed to enable this, but it requires the [`gh`](https://cli.github.com/) tool to be installed, and you need to do `gh auth login` once to allow lazygit to access GitHub.
+In the branches panel, lazygit can show which of your branches have an associated GitHub pull request by showing a GitHub icon next to the branch name; its color shows the state of the PR (open, merged, etc.). For those that have one, you can press `shift-G` to open the PR in the browser. There is no configuration needed to enable this for github.com, but it requires the [`gh`](https://cli.github.com/) tool to be installed, and you need to do `gh auth login` once to allow lazygit to access GitHub. For GitHub Enterprise, authenticate with `gh auth login --hostname <hostname>` and configure the host under `services` as a `github` provider.
 
 ## Tutorials
 

--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -1102,6 +1102,8 @@ Where:
 - `provider` is one of `github`, `bitbucket`, `bitbucketServer`, `azuredevops`, `gitlab`, `gitea` or `codeberg`
 - `webDomain` is the URL where your git service exposes a web interface and APIs, e.g. `gitservice.work.com`
 
+For GitHub Enterprise, use `github` as the provider and authenticate the web domain with `gh auth login --hostname <webDomain>`. This also enables GitHub pull request indicators in the branches panel for matching remotes.
+
 ## Predefined commit message prefix
 
 In situations where certain naming pattern is used for branches and commits, pattern can be used to populate commit message with prefix that is parsed from the branch name.

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -1102,6 +1102,8 @@ Where:
 - `provider` is one of `github`, `bitbucket`, `bitbucketServer`, `azuredevops`, `gitlab`, `gitea` or `codeberg`
 - `webDomain` is the URL where your git service exposes a web interface and APIs, e.g. `gitservice.work.com`
 
+For GitHub Enterprise, use `github` as the provider and authenticate the web domain with `gh auth login --hostname <webDomain>`. This also enables GitHub pull request indicators in the branches panel for matching remotes.
+
 ## Predefined commit message prefix
 
 In situations where certain naming pattern is used for branches and commits, pattern can be used to populate commit message with prefix that is parsed from the branch name.

--- a/pkg/commands/git_commands/github.go
+++ b/pkg/commands/git_commands/github.go
@@ -139,21 +139,23 @@ func fetchPullRequestsQuery(branches []string, owner string, repo string) (strin
 }
 
 func (self *GitHubCommands) GetAuthToken() string {
-	defaultHost, _ := auth.DefaultHost()
-	token, _ := auth.TokenForHost(defaultHost)
+	return self.GetAuthTokenForHost("")
+}
+
+func (self *GitHubCommands) GetAuthTokenForHost(host string) string {
+	if host == "" {
+		host, _ = auth.DefaultHost()
+	}
+	token, _ := auth.TokenForHost(host)
 	return token
 }
 
 // FetchRecentPRs fetches recent pull requests using GraphQL.
-func (self *GitHubCommands) FetchRecentPRs(branches []string, baseRemote *models.Remote, token string) ([]*models.GithubPullRequest, error) {
-	repoOwner, repoName, err := self.GetBaseRepoOwnerAndName(baseRemote)
-	if err != nil {
-		return nil, err
-	}
-
+func (self *GitHubCommands) FetchRecentPRs(branches []string, repoInfo *hosting_service.ServiceInfo, token string) ([]*models.GithubPullRequest, error) {
 	t := time.Now()
 
 	var g errgroup.Group
+	apiEndpoint := githubGraphQLEndpoint(repoInfo.WebDomain)
 
 	// We want at most 5 concurrent requests, but no less than 10 branches per request
 	concurrency := 5
@@ -171,7 +173,7 @@ func (self *GitHubCommands) FetchRecentPRs(branches []string, baseRemote *models
 
 		// Launch a goroutine for each chunk of branches
 		g.Go(func() error {
-			prs, err := self.fetchRecentPRsAux(repoOwner, repoName, branchChunk, token)
+			prs, err := self.fetchRecentPRsAux(repoInfo.Owner, repoInfo.Repository, branchChunk, token, apiEndpoint)
 			if err != nil {
 				return err
 			}
@@ -181,7 +183,7 @@ func (self *GitHubCommands) FetchRecentPRs(branches []string, baseRemote *models
 	}
 
 	// Wait for all goroutines, then close the channel so the range loop exits
-	err = g.Wait()
+	err := g.Wait()
 	close(results)
 	if err != nil {
 		return nil, err
@@ -198,14 +200,22 @@ func (self *GitHubCommands) FetchRecentPRs(branches []string, baseRemote *models
 	return allPRs, nil
 }
 
-func (self *GitHubCommands) fetchRecentPRsAux(repoOwner string, repoName string, branches []string, token string) ([]*models.GithubPullRequest, error) {
+func githubGraphQLEndpoint(webDomain string) string {
+	if auth.NormalizeHostname(webDomain) == "github.com" {
+		return "https://api.github.com/graphql"
+	}
+
+	return fmt.Sprintf("https://%s/api/graphql", webDomain)
+}
+
+func (self *GitHubCommands) fetchRecentPRsAux(repoOwner string, repoName string, branches []string, token string, apiEndpoint string) ([]*models.GithubPullRequest, error) {
 	queryString, variables := fetchPullRequestsQuery(branches, repoOwner, repoName)
 
 	bodyBytes, err := json.Marshal(graphQLRequest{Query: queryString, Variables: variables})
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", "https://api.github.com/graphql", bytes.NewBuffer(bodyBytes))
+	req, err := http.NewRequest("POST", apiEndpoint, bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +358,19 @@ func (self *GitHubCommands) InGithubRepo(remotes []*models.Remote) bool {
 	}
 
 	url := remote.Urls[0]
-	return strings.Contains(strings.ToLower(url), "github.com")
+	_, ok := self.GetGithubServiceInfoFromRemoteURL(url)
+	return ok
+}
+
+func (self *GitHubCommands) GetGithubServiceInfoFromRemoteURL(remoteURL string) (*hosting_service.ServiceInfo, bool) {
+	configServices := self.UserConfig().Services
+	mgr := hosting_service.NewHostingServiceMgr(self.Log, self.Tr, remoteURL, configServices)
+	serviceInfo, err := mgr.GetServiceInfo()
+	if err != nil || serviceInfo.Provider != "github" {
+		return nil, false
+	}
+
+	return serviceInfo, true
 }
 
 func getMainRemote(remotes []*models.Remote) *models.Remote {

--- a/pkg/commands/git_commands/github_test.go
+++ b/pkg/commands/git_commands/github_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jesseduffield/lazygit/pkg/commands/hosting_service"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,6 +56,60 @@ func TestGetRepoInfoFromURL(t *testing.T) {
 			assert.Equal(t, c.expected, result)
 		})
 	}
+}
+
+func TestGithubGraphQLEndpoint(t *testing.T) {
+	assert.Equal(t, "https://api.github.com/graphql", githubGraphQLEndpoint("github.com"))
+	assert.Equal(t, "https://api.github.com/graphql", githubGraphQLEndpoint("www.github.com"))
+	assert.Equal(t, "https://ghe.example.com/api/graphql", githubGraphQLEndpoint("ghe.example.com"))
+	assert.Equal(t, "https://ghe.example.com:8443/api/graphql", githubGraphQLEndpoint("ghe.example.com:8443"))
+}
+
+func TestGetAuthTokenForHost(t *testing.T) {
+	t.Setenv("GH_ENTERPRISE_TOKEN", "enterprise-token")
+
+	github := NewGitHubCommands(buildGitCommon(commonDeps{}))
+
+	assert.Equal(t, "enterprise-token", github.GetAuthTokenForHost("ghe.example.com"))
+}
+
+func TestGetGithubServiceInfoFromRemoteURL(t *testing.T) {
+	userConfig := config.GetDefaultConfig()
+	userConfig.Services = map[string]string{
+		"git.example.com":    "github:ghe.example.com",
+		"gitlab.example.com": "gitlab:gitlab.example.com",
+	}
+	github := NewGitHubCommands(buildGitCommon(commonDeps{userConfig: userConfig}))
+
+	serviceInfo, ok := github.GetGithubServiceInfoFromRemoteURL("git@git.example.com:my-org/my-repo.git")
+	assert.True(t, ok)
+	assert.Equal(t, &hosting_service.ServiceInfo{
+		Provider:   "github",
+		GitDomain:  "git.example.com",
+		WebDomain:  "ghe.example.com",
+		Owner:      "my-org",
+		Repository: "my-repo",
+		RepoName:   "my-org/my-repo",
+	}, serviceInfo)
+
+	_, ok = github.GetGithubServiceInfoFromRemoteURL("git@gitlab.example.com:my-org/my-repo.git")
+	assert.False(t, ok)
+}
+
+func TestInGithubRepo(t *testing.T) {
+	userConfig := config.GetDefaultConfig()
+	userConfig.Services = map[string]string{
+		"git.example.com":    "github:ghe.example.com",
+		"gitlab.example.com": "gitlab:gitlab.example.com",
+	}
+	github := NewGitHubCommands(buildGitCommon(commonDeps{userConfig: userConfig}))
+
+	assert.True(t, github.InGithubRepo([]*models.Remote{
+		{Name: "origin", Urls: []string{"git@git.example.com:my-org/my-repo.git"}},
+	}))
+	assert.False(t, github.InGithubRepo([]*models.Remote{
+		{Name: "origin", Urls: []string{"git@gitlab.example.com:my-org/my-repo.git"}},
+	}))
 }
 
 func TestGenerateGithubPullRequestMap(t *testing.T) {

--- a/pkg/commands/git_commands/hosting_service.go
+++ b/pkg/commands/git_commands/hosting_service.go
@@ -25,6 +25,10 @@ func (self *HostingService) GetRepoNameFromRemoteURL(remoteURL string) (string, 
 	return self.getHostingServiceMgr(remoteURL).GetRepoName()
 }
 
+func (self *HostingService) GetServiceInfoFromRemoteURL(remoteURL string) (*hosting_service.ServiceInfo, error) {
+	return self.getHostingServiceMgr(remoteURL).GetServiceInfo()
+}
+
 // getting this on every request rather than storing it in state in case our remoteURL changes
 // from one invocation to the next. Note however that we're currently caching config
 // results so we might want to invalidate the cache here if it becomes a problem.

--- a/pkg/commands/hosting_service/hosting_service.go
+++ b/pkg/commands/hosting_service/hosting_service.go
@@ -73,6 +73,32 @@ func (self *HostingServiceMgr) GetRepoName() (string, error) {
 	return repoName, nil
 }
 
+func (self *HostingServiceMgr) GetServiceInfo() (*ServiceInfo, error) {
+	serviceDomain, err := self.getServiceDomain(self.remoteURL)
+	if err != nil {
+		return nil, err
+	}
+
+	repoInfo, err := serviceDomain.serviceDefinition.getRepoInfoFromRemoteURL(self.remoteURL)
+	if err != nil {
+		return nil, err
+	}
+
+	repoName, err := serviceDomain.serviceDefinition.getRepoNameFromRemoteURL(self.remoteURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ServiceInfo{
+		Provider:   serviceDomain.serviceDefinition.provider,
+		GitDomain:  serviceDomain.gitDomain,
+		WebDomain:  serviceDomain.webDomain,
+		Owner:      repoInfo.Owner,
+		Repository: repoInfo.Repository,
+		RepoName:   repoName,
+	}, nil
+}
+
 func (self *HostingServiceMgr) getService() (*Service, error) {
 	serviceDomain, err := self.getServiceDomain(self.remoteURL)
 	if err != nil {
@@ -185,6 +211,18 @@ func (self ServiceDefinition) getRepoNameFromRemoteURL(url string) (string, erro
 	return utils.ResolvePlaceholderString(self.repoNameTemplate, matches), nil
 }
 
+func (self ServiceDefinition) getRepoInfoFromRemoteURL(url string) (RepoInformation, error) {
+	matches, err := self.parseRemoteUrl(url)
+	if err != nil {
+		return RepoInformation{}, err
+	}
+
+	return RepoInformation{
+		Owner:      matches["owner"],
+		Repository: matches["repo"],
+	}, nil
+}
+
 func (self ServiceDefinition) parseRemoteUrl(url string) (map[string]string, error) {
 	for _, regexStr := range self.regexStrings {
 		re := regexp.MustCompile(regexStr)
@@ -201,6 +239,15 @@ func (self ServiceDefinition) parseRemoteUrl(url string) (map[string]string, err
 type RepoInformation struct {
 	Owner      string
 	Repository string
+}
+
+type ServiceInfo struct {
+	Provider   string
+	GitDomain  string
+	WebDomain  string
+	Owner      string
+	Repository string
+	RepoName   string
 }
 
 // GetRepoInfoFromURL parses a remote URL (SSH or HTTPS) and extracts the

--- a/pkg/commands/hosting_service/hosting_service_test.go
+++ b/pkg/commands/hosting_service/hosting_service_test.go
@@ -577,3 +577,84 @@ func TestGetPullRequestURL(t *testing.T) {
 		})
 	}
 }
+
+func TestGetServiceInfo(t *testing.T) {
+	tr := i18n.EnglishTranslationSet()
+
+	scenarios := []struct {
+		name                 string
+		remoteURL            string
+		configServiceDomains map[string]string
+		expected             *ServiceInfo
+	}{
+		{
+			name:      "github.com",
+			remoteURL: "git@github.com:jesseduffield/lazygit.git",
+			expected: &ServiceInfo{
+				Provider:   "github",
+				GitDomain:  "github.com",
+				WebDomain:  "github.com",
+				Owner:      "jesseduffield",
+				Repository: "lazygit",
+				RepoName:   "jesseduffield/lazygit",
+			},
+		},
+		{
+			name:      "github enterprise with same git and web host",
+			remoteURL: "git@github.example.com:my-org/my-repo.git",
+			configServiceDomains: map[string]string{
+				"github.example.com": "github:github.example.com",
+			},
+			expected: &ServiceInfo{
+				Provider:   "github",
+				GitDomain:  "github.example.com",
+				WebDomain:  "github.example.com",
+				Owner:      "my-org",
+				Repository: "my-repo",
+				RepoName:   "my-org/my-repo",
+			},
+		},
+		{
+			name:      "github enterprise with distinct git and web hosts",
+			remoteURL: "git@git.example.com:my-org/my-repo.git",
+			configServiceDomains: map[string]string{
+				"git.example.com": "github:ghe.example.com",
+			},
+			expected: &ServiceInfo{
+				Provider:   "github",
+				GitDomain:  "git.example.com",
+				WebDomain:  "ghe.example.com",
+				Owner:      "my-org",
+				Repository: "my-repo",
+				RepoName:   "my-org/my-repo",
+			},
+		},
+		{
+			name:      "github enterprise with web host port",
+			remoteURL: "git@git.example.com:my-org/my-repo.git",
+			configServiceDomains: map[string]string{
+				"git.example.com": "github:ghe.example.com:8443",
+			},
+			expected: &ServiceInfo{
+				Provider:   "github",
+				GitDomain:  "git.example.com",
+				WebDomain:  "ghe.example.com:8443",
+				Owner:      "my-org",
+				Repository: "my-repo",
+				RepoName:   "my-org/my-repo",
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			log := &fakes.FakeFieldLogger{}
+			mgr := NewHostingServiceMgr(log, tr, scenario.remoteURL, scenario.configServiceDomains)
+
+			serviceInfo, err := mgr.GetServiceInfo()
+
+			assert.NoError(t, err)
+			assert.Equal(t, scenario.expected, serviceInfo)
+		})
+	}
+}

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jesseduffield/generics/set"
 	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
+	"github.com/jesseduffield/lazygit/pkg/commands/hosting_service"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
@@ -804,39 +805,34 @@ func (self *RefreshHelper) refreshGithubPullRequests() {
 	self.c.Mutexes().RefreshingPullRequestsMutex.Lock()
 	defer self.c.Mutexes().RefreshingPullRequestsMutex.Unlock()
 
-	if !self.c.Git().GitHub.InGithubRepo(self.c.Model().Remotes) {
-		self.c.Model().PullRequests = nil
-		self.c.Model().PullRequestsMap = nil
-		return
-	}
-
-	authToken := self.c.Git().GitHub.GetAuthToken()
-	if authToken == "" {
-		self.c.Model().PullRequests = nil
-		self.c.Model().PullRequestsMap = nil
-		return
-	}
-
 	githubRemotes := self.getGithubRemotes()
+	githubRemotes = getAuthenticatedGithubRemotes(githubRemotes, self.c.Git().GitHub.GetAuthTokenForHost)
+	if len(githubRemotes) == 0 {
+		self.c.Model().PullRequests = nil
+		self.c.Model().PullRequestsMap = nil
+		return
+	}
+
 	baseRemote := getGithubBaseRemote(githubRemotes, self.c.Git().GitHub.ConfiguredBaseRemoteName())
 	if baseRemote == nil {
 		self.c.Model().PullRequests = nil
 		self.c.Model().PullRequestsMap = nil
 
 		if len(githubRemotes) > 0 && !self.githubBaseRemotePromptDismissed[self.c.Git().RepoPaths.RepoPath()] {
-			self.promptForBaseGithubRepo(authToken, githubRemotes)
+			self.promptForBaseGithubRepo(githubRemotes)
 		}
 		return
 	}
 
-	if err := self.setGithubPullRequests(authToken, baseRemote); err != nil {
+	if err := self.setGithubPullRequests(baseRemote.authToken, baseRemote.serviceInfo); err != nil {
 		self.c.LogAction(fmt.Sprintf("Error fetching pull requests from GitHub: %s", err.Error()))
 	}
 }
 
 type githubRemoteInfo struct {
-	remote   *models.Remote
-	repoName string
+	remote      *models.Remote
+	serviceInfo *hosting_service.ServiceInfo
+	authToken   string
 }
 
 func (self *RefreshHelper) getGithubRemotes() []githubRemoteInfo {
@@ -844,23 +840,47 @@ func (self *RefreshHelper) getGithubRemotes() []githubRemoteInfo {
 		if len(remote.Urls) == 0 {
 			return githubRemoteInfo{}, false
 		}
-		repoName, err := self.c.Git().HostingService.GetRepoNameFromRemoteURL(remote.Urls[0])
-		if err != nil {
+		serviceInfo, ok := self.c.Git().GitHub.GetGithubServiceInfoFromRemoteURL(remote.Urls[0])
+		if !ok {
 			return githubRemoteInfo{}, false
 		}
-		return githubRemoteInfo{remote: remote, repoName: repoName}, true
+		return githubRemoteInfo{remote: remote, serviceInfo: serviceInfo}, true
 	})
 }
 
-func getGithubBaseRemote(githubRemotes []githubRemoteInfo, configuredRemoteName string) *models.Remote {
-	findRemoteByName := func(name string) *models.Remote {
+func getAuthenticatedGithubRemotes(githubRemotes []githubRemoteInfo, getAuthTokenForHost func(string) string) []githubRemoteInfo {
+	authTokensByHost := map[string]string{}
+
+	return lo.FilterMap(githubRemotes, func(info githubRemoteInfo, _ int) (githubRemoteInfo, bool) {
+		if info.serviceInfo == nil {
+			return githubRemoteInfo{}, false
+		}
+
+		webDomain := info.serviceInfo.WebDomain
+		authToken, ok := authTokensByHost[webDomain]
+		if !ok {
+			authToken = getAuthTokenForHost(webDomain)
+			authTokensByHost[webDomain] = authToken
+		}
+
+		if authToken == "" {
+			return githubRemoteInfo{}, false
+		}
+
+		info.authToken = authToken
+		return info, true
+	})
+}
+
+func getGithubBaseRemote(githubRemotes []githubRemoteInfo, configuredRemoteName string) *githubRemoteInfo {
+	findRemoteByName := func(name string) *githubRemoteInfo {
 		info, ok := lo.Find(githubRemotes, func(info githubRemoteInfo) bool {
 			return info.remote.Name == name
 		})
 		if !ok {
 			return nil
 		}
-		return info.remote
+		return &info
 	}
 
 	if configuredRemoteName != "" {
@@ -868,7 +888,7 @@ func getGithubBaseRemote(githubRemotes []githubRemoteInfo, configuredRemoteName 
 	}
 
 	if len(githubRemotes) == 1 {
-		return githubRemotes[0].remote
+		return &githubRemotes[0]
 	}
 
 	// Not sure if "upstream" is really a common convention for the name of the remote that PRs are
@@ -880,17 +900,21 @@ func getGithubBaseRemote(githubRemotes []githubRemoteInfo, configuredRemoteName 
 	return nil
 }
 
-func (self *RefreshHelper) promptForBaseGithubRepo(authToken string, githubRemotes []githubRemoteInfo) {
+func (self *RefreshHelper) promptForBaseGithubRepo(githubRemotes []githubRemoteInfo) {
 	menuItems := lo.Map(githubRemotes, func(info githubRemoteInfo, _ int) *types.MenuItem {
 		return &types.MenuItem{
-			LabelColumns: []string{info.remote.Name, style.FgCyan.Sprint(info.repoName)},
+			LabelColumns: []string{info.remote.Name, style.FgCyan.Sprint(info.serviceInfo.RepoName)},
 			OnPress: func() error {
 				return self.c.WithWaitingStatus(self.c.Tr.FetchingPullRequests, func(gocui.Task) error {
+					if info.authToken == "" {
+						return nil
+					}
+
 					if err := self.c.Git().GitHub.SetConfiguredBaseRemoteName(info.remote.Name); err != nil {
 						self.c.Log.Error(err)
 					}
 
-					if err := self.setGithubPullRequests(authToken, info.remote); err != nil {
+					if err := self.setGithubPullRequests(info.authToken, info.serviceInfo); err != nil {
 						self.c.LogAction(fmt.Sprintf("Error fetching pull requests from GitHub: %s", err.Error()))
 					}
 					return nil
@@ -920,7 +944,7 @@ func (self *RefreshHelper) rebuildPullRequestsMap() {
 	)
 }
 
-func (self *RefreshHelper) setGithubPullRequests(authToken string, baseRemote *models.Remote) error {
+func (self *RefreshHelper) setGithubPullRequests(authToken string, serviceInfo *hosting_service.ServiceInfo) error {
 	if len(self.c.Model().Branches) == 0 {
 		return nil
 	}
@@ -932,7 +956,7 @@ func (self *RefreshHelper) setGithubPullRequests(authToken string, baseRemote *m
 		return branch.UpstreamBranch
 	})
 
-	prs, err := self.c.Git().GitHub.FetchRecentPRs(branchNames, baseRemote, authToken)
+	prs, err := self.c.Git().GitHub.FetchRecentPRs(branchNames, serviceInfo, authToken)
 	if err != nil {
 		return err
 	}

--- a/pkg/gui/controllers/helpers/refresh_helper_test.go
+++ b/pkg/gui/controllers/helpers/refresh_helper_test.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"testing"
 
+	"github.com/jesseduffield/lazygit/pkg/commands/hosting_service"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -60,14 +61,65 @@ func TestGetGithubBaseRemote(t *testing.T) {
 				assert.Nil(t, result)
 			} else {
 				assert.NotNil(t, result)
-				assert.Equal(t, c.expected, result.Name)
+				assert.Equal(t, c.expected, result.remote.Name)
 			}
 		})
 	}
 }
 
+func TestGetAuthenticatedGithubRemotes(t *testing.T) {
+	githubRemotes := []githubRemoteInfo{
+		makeGithubRemoteInfo("origin", "github.com"),
+		makeGithubRemoteInfo("fork", "github.com"),
+		makeGithubRemoteInfo("enterprise", "ghe.example.com"),
+		makeGithubRemoteInfo("missing-auth", "missing.example.com"),
+		{remote: &models.Remote{Name: "invalid"}},
+	}
+
+	callsByHost := map[string]int{}
+	result := getAuthenticatedGithubRemotes(githubRemotes, func(host string) string {
+		callsByHost[host]++
+
+		switch host {
+		case "github.com":
+			return "github-token"
+		case "ghe.example.com":
+			return "ghe-token"
+		default:
+			return ""
+		}
+	})
+
+	assert.Equal(t, []githubRemoteInfo{
+		makeAuthenticatedGithubRemoteInfo("origin", "github.com", "github-token"),
+		makeAuthenticatedGithubRemoteInfo("fork", "github.com", "github-token"),
+		makeAuthenticatedGithubRemoteInfo("enterprise", "ghe.example.com", "ghe-token"),
+	}, result)
+	assert.Equal(t, map[string]int{
+		"github.com":          1,
+		"ghe.example.com":     1,
+		"missing.example.com": 1,
+	}, callsByHost)
+}
+
 func makeGithubRemoteInfoList(names ...string) []githubRemoteInfo {
 	return lo.Map(names, func(name string, _ int) githubRemoteInfo {
-		return githubRemoteInfo{remote: &models.Remote{Name: name}, repoName: name}
+		return makeGithubRemoteInfo(name, name)
 	})
+}
+
+func makeGithubRemoteInfo(name string, webDomain string) githubRemoteInfo {
+	return githubRemoteInfo{
+		remote: &models.Remote{Name: name},
+		serviceInfo: &hosting_service.ServiceInfo{
+			RepoName:  name,
+			WebDomain: webDomain,
+		},
+	}
+}
+
+func makeAuthenticatedGithubRemoteInfo(name string, webDomain string, authToken string) githubRemoteInfo {
+	info := makeGithubRemoteInfo(name, webDomain)
+	info.authToken = authToken
+	return info
 }


### PR DESCRIPTION
## Summary

- Enable GitHub pull request indicators for GitHub Enterprise remotes configured through `services` with the `github` provider.
- Resolve GitHub service metadata from hosting-service configuration, including distinct git and web domains.
- Use host-specific `gh` authentication and route Enterprise GraphQL requests to `https://<webDomain>/api/graphql` while preserving github.com behavior.
- Filter GitHub remote candidates by available authentication before prompting for a base remote, avoiding stale `remote.<name>.gh-resolved` writes when PR fetching cannot proceed.
- Document GitHub Enterprise setup in the README and config docs.

## Testing

- `go test ./pkg/gui/controllers/helpers ./pkg/commands/git_commands ./pkg/commands/hosting_service`

I also ran `go test ./...`; it failed in unrelated environment-sensitive style/i18n tests where ANSI colors were disabled and locale auto-detection returned English instead of localized strings.

## :robot: Agent Plan

<details>
<summary>Expand full agent plan</summary>

# Add GitHub Enterprise Support For PR Indicators

## Summary
Extend the existing GitHub PR indicator feature so it works for remotes configured in lazygit's `services:` map as `github:<webDomain>`. Keep the behavior opt-in through existing config, reuse `gh` authentication for the enterprise host, and preserve current GitHub.com behavior.

## Key Changes
- Treat a remote as GitHub-capable when its URL matches either default `github.com` or a configured `services` entry whose provider is `github`.
- Resolve GitHub API metadata from the matched service domain:
  - API endpoint: `https://api.github.com/graphql` for `github.com`
  - Enterprise endpoint: `https://<webDomain>/api/graphql`
  - Auth host: `<webDomain>` passed to `auth.TokenForHost`
- Refactor `GitHubCommands` so PR fetching receives host/API information from the matched remote instead of hardcoding `github.com` and `https://api.github.com/graphql`.
- Keep existing create/open PR URL behavior unchanged; this change only expands the “show existing PRs next to branches” path.
- Update README/docs to say GitHub Enterprise PR indicators require:
  - `gh auth login --hostname <enterprise-host>`
  - `services: { "<git-domain>": "github:<web-domain>" }`

## Public Interfaces
- No new user config keys.
- Existing `services` config becomes meaningful for GitHub PR discovery, not just generated PR/commit URLs.
- Internal interface addition: expose or add a helper in the hosting-service layer that returns matched provider, git domain, web domain, repo owner, and repo name for a remote URL.

## Test Plan
- Add unit tests for custom GitHub Enterprise service matching:
  - `git@github.example.com:org/repo.git` with `services.github.example.com = github:github.example.com`
  - distinct git/web hosts, e.g. `git.example.com = github:ghe.example.com`
  - web domain with one port, e.g. `github:ghe.example.com:8443`
- Add `GitHubCommands` tests verifying GraphQL endpoint construction for GitHub.com and Enterprise.
- Add auth-host tests verifying `TokenForHost` receives the enterprise web host, not the default host.
- Add regression tests that non-GitHub providers configured in `services` do not trigger GitHub PR fetching.
- Run `go test ./pkg/commands/hosting_service ./pkg/commands/git_commands ./pkg/gui/controllers/helpers`.

## Assumptions
- GitHub Enterprise Server exposes GraphQL at `https://<webDomain>/api/graphql`.
- The existing `services:` map is the source of truth for custom GitHub Enterprise hosts.
- Users are expected to authenticate with `gh` for the enterprise hostname before lazygit can fetch PRs.

# Review Feedback Follow-up

- Filter GitHub remote candidates by host-specific auth token before base remote selection or prompting.
- Reuse the resolved token when fetching PRs.
- Ensure the base-remote prompt cannot write `remote.<name>.gh-resolved` for unauthenticated remotes.
- Add helper-level tests covering authenticated filtering and token lookup caching per host.

</details>
