### PR TITLE
Platform-specific edit bindings for move-by-word and backspace-word

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -630,6 +630,15 @@ keybinding:
     nextMatch: "n"
     prevMatch: "N"
     startSearch: /
+
+    # <a-left> on Mac
+    moveWordLeft: <c-left>
+
+    # <a-right> on Mac
+    moveWordRight: <c-right>
+
+    # <a-backspace> on Mac
+    backspaceWord: <c-backspace>
     optionMenu: <disabled>
     optionMenu-alt1: '?'
     select: <space>

--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -639,6 +639,9 @@ keybinding:
 
     # <a-backspace> on Mac
     backspaceWord: <c-backspace>
+
+    # <a-delete> on Mac
+    forwardDeleteWord: <c-delete>
     optionMenu: <disabled>
     optionMenu-alt1: '?'
     select: <space>

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -454,6 +454,9 @@ type KeybindingUniversalConfig struct {
 	NextMatch                         string   `yaml:"nextMatch"`
 	PrevMatch                         string   `yaml:"prevMatch"`
 	StartSearch                       string   `yaml:"startSearch"`
+	MoveWordLeft                      string   `yaml:"moveWordLeft"`  // <a-left> on Mac
+	MoveWordRight                     string   `yaml:"moveWordRight"` // <a-right> on Mac
+	BackspaceWord                     string   `yaml:"backspaceWord"` // <a-backspace> on Mac
 	OptionMenu                        string   `yaml:"optionMenu"`
 	OptionMenuAlt1                    string   `yaml:"optionMenu-alt1"`
 	Select                            string   `yaml:"select"`
@@ -933,6 +936,9 @@ func GetDefaultConfigForPlatform(platform string) *UserConfig {
 				NextMatch:                         "n",
 				PrevMatch:                         "N",
 				StartSearch:                       "/",
+				MoveWordLeft:                      platformKeyBinding(platform, map[string]string{"darwin": "<a-left>"}, "<c-left>"),
+				MoveWordRight:                     platformKeyBinding(platform, map[string]string{"darwin": "<a-right>"}, "<c-right>"),
+				BackspaceWord:                     platformKeyBinding(platform, map[string]string{"darwin": "<a-backspace>"}, "<c-backspace>"),
 				OptionMenu:                        "<disabled>",
 				OptionMenuAlt1:                    "?",
 				Select:                            "<space>",

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -454,9 +454,10 @@ type KeybindingUniversalConfig struct {
 	NextMatch                         string   `yaml:"nextMatch"`
 	PrevMatch                         string   `yaml:"prevMatch"`
 	StartSearch                       string   `yaml:"startSearch"`
-	MoveWordLeft                      string   `yaml:"moveWordLeft"`  // <a-left> on Mac
-	MoveWordRight                     string   `yaml:"moveWordRight"` // <a-right> on Mac
-	BackspaceWord                     string   `yaml:"backspaceWord"` // <a-backspace> on Mac
+	MoveWordLeft                      string   `yaml:"moveWordLeft"`      // <a-left> on Mac
+	MoveWordRight                     string   `yaml:"moveWordRight"`     // <a-right> on Mac
+	BackspaceWord                     string   `yaml:"backspaceWord"`     // <a-backspace> on Mac
+	ForwardDeleteWord                 string   `yaml:"forwardDeleteWord"` // <a-delete> on Mac
 	OptionMenu                        string   `yaml:"optionMenu"`
 	OptionMenuAlt1                    string   `yaml:"optionMenu-alt1"`
 	Select                            string   `yaml:"select"`
@@ -939,6 +940,7 @@ func GetDefaultConfigForPlatform(platform string) *UserConfig {
 				MoveWordLeft:                      platformKeyBinding(platform, map[string]string{"darwin": "<a-left>"}, "<c-left>"),
 				MoveWordRight:                     platformKeyBinding(platform, map[string]string{"darwin": "<a-right>"}, "<c-right>"),
 				BackspaceWord:                     platformKeyBinding(platform, map[string]string{"darwin": "<a-backspace>"}, "<c-backspace>"),
+				ForwardDeleteWord:                 platformKeyBinding(platform, map[string]string{"darwin": "<a-delete>"}, "<c-delete>"),
 				OptionMenu:                        "<disabled>",
 				OptionMenuAlt1:                    "?",
 				Select:                            "<space>",

--- a/pkg/gocui/edit.go
+++ b/pkg/gocui/edit.go
@@ -22,10 +22,16 @@ func (f EditorFunc) Edit(v *View, key Key) bool {
 // DefaultEditor is the default editor.
 var DefaultEditor Editor = EditorFunc(SimpleEditor)
 
+var (
+	moveWordLeftKeybinding  = NewKey(KeyArrowLeft, "", ModCtrl)
+	moveWordRightKeybinding = NewKey(KeyArrowRight, "", ModCtrl)
+	backspaceWordKeybinding = NewKey(KeyBackspace, "", ModCtrl)
+)
+
 // SimpleEditor is used as the default gocui editor.
 func SimpleEditor(v *View, key Key) bool {
 	switch {
-	case key.Equals(NewKey(KeyBackspace, "", ModAlt)),
+	case key.Equals(backspaceWordKeybinding),
 		key.Equals(NewKeyStrMod("w", ModCtrl)):
 		v.TextArea.BackSpaceWord()
 	case key.Equals(NewKeyName(KeyBackspace)):
@@ -38,13 +44,13 @@ func SimpleEditor(v *View, key Key) bool {
 	case key.Equals(NewKeyName(KeyArrowUp)):
 		v.TextArea.MoveCursorUp()
 	case key.Equals(NewKeyStrMod("b", ModAlt)),
-		key.Equals(NewKey(KeyArrowLeft, "", ModAlt)):
+		key.Equals(moveWordLeftKeybinding):
 		v.TextArea.MoveLeftWord()
 	case key.Equals(NewKeyName(KeyArrowLeft)),
 		key.Equals(NewKeyStrMod("b", ModCtrl)):
 		v.TextArea.MoveCursorLeft()
 	case key.Equals(NewKeyStrMod("f", ModAlt)),
-		key.Equals(NewKey(KeyArrowRight, "", ModAlt)):
+		key.Equals(moveWordRightKeybinding):
 		v.TextArea.MoveRightWord()
 	case key.Equals(NewKeyName(KeyArrowRight)),
 		key.Equals(NewKeyStrMod("b", ModCtrl)):

--- a/pkg/gocui/edit.go
+++ b/pkg/gocui/edit.go
@@ -23,9 +23,10 @@ func (f EditorFunc) Edit(v *View, key Key) bool {
 var DefaultEditor Editor = EditorFunc(SimpleEditor)
 
 var (
-	moveWordLeftKeybinding  = NewKey(KeyArrowLeft, "", ModCtrl)
-	moveWordRightKeybinding = NewKey(KeyArrowRight, "", ModCtrl)
-	backspaceWordKeybinding = NewKey(KeyBackspace, "", ModCtrl)
+	moveWordLeftKeybinding      = NewKey(KeyArrowLeft, "", ModCtrl)
+	moveWordRightKeybinding     = NewKey(KeyArrowRight, "", ModCtrl)
+	backspaceWordKeybinding     = NewKey(KeyBackspace, "", ModCtrl)
+	forwardDeleteWordKeybinding = NewKey(KeyDelete, "", ModCtrl)
 )
 
 // SimpleEditor is used as the default gocui editor.
@@ -34,6 +35,9 @@ func SimpleEditor(v *View, key Key) bool {
 	case key.Equals(backspaceWordKeybinding),
 		key.Equals(NewKeyStrMod("w", ModCtrl)):
 		v.TextArea.BackSpaceWord()
+	case key.Equals(forwardDeleteWordKeybinding),
+		key.Equals(NewKeyStrMod("d", ModAlt)):
+		v.TextArea.ForwardDeleteWord()
 	case key.Equals(NewKeyName(KeyBackspace)):
 		v.TextArea.BackSpaceChar()
 	case key.Equals(NewKeyStrMod("d", ModCtrl)),

--- a/pkg/gocui/gui.go
+++ b/pkg/gocui/gui.go
@@ -1629,3 +1629,9 @@ func (g *Gui) Snapshot() string {
 
 	return builder.String()
 }
+
+func (g *Gui) SetEditKeybindings(moveWordLeft, moveWordRight, backspaceWord Key) {
+	moveWordLeftKeybinding = moveWordLeft
+	moveWordRightKeybinding = moveWordRight
+	backspaceWordKeybinding = backspaceWord
+}

--- a/pkg/gocui/gui.go
+++ b/pkg/gocui/gui.go
@@ -1630,8 +1630,9 @@ func (g *Gui) Snapshot() string {
 	return builder.String()
 }
 
-func (g *Gui) SetEditKeybindings(moveWordLeft, moveWordRight, backspaceWord Key) {
+func (g *Gui) SetEditKeybindings(moveWordLeft, moveWordRight, backspaceWord, forwardDeleteWord Key) {
 	moveWordLeftKeybinding = moveWordLeft
 	moveWordRightKeybinding = moveWordRight
 	backspaceWordKeybinding = backspaceWord
+	forwardDeleteWordKeybinding = forwardDeleteWord
 }

--- a/pkg/gocui/text_area.go
+++ b/pkg/gocui/text_area.go
@@ -340,13 +340,12 @@ func (self *TextArea) MoveLeftWord() {
 	self.cursor = self.newCursorForMoveLeftWord()
 }
 
-func (self *TextArea) MoveRightWord() {
+func (self *TextArea) newCursorForMoveRightWord() int {
 	if self.atEnd() {
-		return
+		return self.cursor
 	}
 	if self.atLineEnd() {
-		self.cursor++
-		return
+		return self.cursor + 1
 	}
 
 	cellCursor := self.contentCursorToCellCursor(self.cursor)
@@ -364,7 +363,11 @@ func (self *TextArea) MoveRightWord() {
 		}
 	}
 
-	self.cursor = self.cellCursorToContentCursor(cellCursor)
+	return self.cellCursorToContentCursor(cellCursor)
+}
+
+func (self *TextArea) MoveRightWord() {
+	self.cursor = self.newCursorForMoveRightWord()
 }
 
 func (self *TextArea) MoveCursorUp() {
@@ -556,6 +559,20 @@ func (self *TextArea) BackSpaceWord() {
 	}
 	self.content = self.content[:newCursor] + self.content[self.cursor:]
 	self.cursor = newCursor
+	self.updateCells()
+}
+
+func (self *TextArea) ForwardDeleteWord() {
+	newCursor := self.newCursorForMoveRightWord()
+	if newCursor == self.cursor {
+		return
+	}
+
+	clipboard := self.content[self.cursor:newCursor]
+	if clipboard != "\n" {
+		self.clipboard = clipboard
+	}
+	self.content = self.content[:self.cursor] + self.content[newCursor:]
 	self.updateCells()
 }
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -474,6 +474,12 @@ func (gui *Gui) onUserConfigLoaded() error {
 	gui.g.NextSearchMatchKey = config.GetValidatedKeyBindingKey(userConfig.Keybinding.Universal.NextMatch)
 	gui.g.PrevSearchMatchKey = config.GetValidatedKeyBindingKey(userConfig.Keybinding.Universal.PrevMatch)
 
+	gui.g.SetEditKeybindings(
+		config.GetValidatedKeyBindingKey(userConfig.Keybinding.Universal.MoveWordLeft),
+		config.GetValidatedKeyBindingKey(userConfig.Keybinding.Universal.MoveWordRight),
+		config.GetValidatedKeyBindingKey(userConfig.Keybinding.Universal.BackspaceWord),
+	)
+
 	gui.g.ShowListFooter = userConfig.Gui.ShowListFooter
 
 	gui.g.Mouse = userConfig.Gui.MouseEvents

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -478,6 +478,7 @@ func (gui *Gui) onUserConfigLoaded() error {
 		config.GetValidatedKeyBindingKey(userConfig.Keybinding.Universal.MoveWordLeft),
 		config.GetValidatedKeyBindingKey(userConfig.Keybinding.Universal.MoveWordRight),
 		config.GetValidatedKeyBindingKey(userConfig.Keybinding.Universal.BackspaceWord),
+		config.GetValidatedKeyBindingKey(userConfig.Keybinding.Universal.ForwardDeleteWord),
 	)
 
 	gui.g.ShowListFooter = userConfig.Gui.ShowListFooter

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -1410,6 +1410,21 @@
           "type": "string",
           "default": "/"
         },
+        "moveWordLeft": {
+          "type": "string",
+          "description": "\u003ca-left\u003e on Mac",
+          "default": "\u003cc-left\u003e"
+        },
+        "moveWordRight": {
+          "type": "string",
+          "description": "\u003ca-right\u003e on Mac",
+          "default": "\u003cc-right\u003e"
+        },
+        "backspaceWord": {
+          "type": "string",
+          "description": "\u003ca-backspace\u003e on Mac",
+          "default": "\u003cc-backspace\u003e"
+        },
         "optionMenu": {
           "type": "string",
           "default": "\u003cdisabled\u003e"

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -1425,6 +1425,11 @@
           "description": "\u003ca-backspace\u003e on Mac",
           "default": "\u003cc-backspace\u003e"
         },
+        "forwardDeleteWord": {
+          "type": "string",
+          "description": "\u003ca-delete\u003e on Mac",
+          "default": "\u003cc-delete\u003e"
+        },
         "optionMenu": {
           "type": "string",
           "default": "\u003cdisabled\u003e"


### PR DESCRIPTION
Make the edit keybindings for "move-by-word" and "backspace-word" platform-dependent so that they are with ctrl on Windows and Linux, but alt on Mac. These are the common conventions on these platforms. Also, make them configurable so that user who can't get used to the change can map it back to what they were.

Add a "forward-delete-word" keybinding, bound to alt-delete on Mac, and ctrl-delete on Windows and Linux.