### PR TITLE
Clear LC_* env vars when running LANG tests

### DIFF
--- a/pkg/i18n/i18n_test.go
+++ b/pkg/i18n/i18n_test.go
@@ -104,6 +104,8 @@ func TestNewTranslationSetFromConfig(t *testing.T) {
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
 			log := newDummyLog()
+			t.Setenv("LC_ALL", "")
+			t.Setenv("LC_MESSAGES", "")
 			t.Setenv("LANG", s.envLanguage)
 			actualTranslationSet, err := NewTranslationSetFromConfig(log, s.configLanguage)
 			if s.expectedErr {


### PR DESCRIPTION
In the event that LC_ALL was set, for example, the tests would fail as it takes precedence over LANG.

Tiny change that prevents language tests from failing if LC_ALL is set (I also added LC_MESSAGES but I am not sure if that's also needed, from what I read it also takes precedence) so I did not open an issue prior, hopefully that's ok!