### PR TITLE
Fix regressions with alternate edit bindings for backspace and move-cursor-right

### DIFF
--- a/pkg/gocui/edit.go
+++ b/pkg/gocui/edit.go
@@ -38,7 +38,8 @@ func SimpleEditor(v *View, key Key) bool {
 	case key.Equals(forwardDeleteWordKeybinding),
 		key.Equals(NewKeyStrMod("d", ModAlt)):
 		v.TextArea.ForwardDeleteWord()
-	case key.Equals(NewKeyName(KeyBackspace)):
+	case key.Equals(NewKeyName(KeyBackspace)),
+		key.Equals(NewKeyStrMod("h", ModCtrl)):
 		v.TextArea.BackSpaceChar()
 	case key.Equals(NewKeyStrMod("d", ModCtrl)),
 		key.Equals(NewKeyName(KeyDelete)):
@@ -57,7 +58,7 @@ func SimpleEditor(v *View, key Key) bool {
 		key.Equals(moveWordRightKeybinding):
 		v.TextArea.MoveRightWord()
 	case key.Equals(NewKeyName(KeyArrowRight)),
-		key.Equals(NewKeyStrMod("b", ModCtrl)):
+		key.Equals(NewKeyStrMod("f", ModCtrl)):
 		v.TextArea.MoveCursorRight()
 	case key.Equals(NewKeyName(KeyEnter)):
 		v.TextArea.TypeCharacter("\n")


### PR DESCRIPTION
These have alternate keys (`<ctrl+h>` for backspace, and `<ctrl+f>` for move-cursor-right). Both of these broke with commit 22169e22ffc46c5; the first because it was accidentally omitted, the second because of a stupid copy/paste mistake.
