### PR TITLE
Fix new gopls linter warnings

### DIFF
--- a/pkg/commands/git_commands/submodule.go
+++ b/pkg/commands/git_commands/submodule.go
@@ -79,6 +79,10 @@ func (self *SubmoduleCommands) GetConfigs(parentModule *models.SubmoduleConfig) 
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
 	return configs, nil
 }
 

--- a/pkg/commands/oscommands/cmd_obj_runner.go
+++ b/pkg/commands/oscommands/cmd_obj_runner.go
@@ -392,6 +392,10 @@ func (self *cmdObjRunner) processOutput(
 			}
 		}
 	}
+
+	if err := scanner.Err(); err != nil {
+		self.log.Error(err)
+	}
 }
 
 // having a function that returns a function because we need to maintain some state inbetween calls hence the closure

--- a/pkg/gui/mergeconflicts/find_conflicts.go
+++ b/pkg/gui/mergeconflicts/find_conflicts.go
@@ -93,11 +93,11 @@ func FileHasConflictMarkers(path string) (bool, error) {
 
 	defer file.Close()
 
-	return fileHasConflictMarkersAux(file), nil
+	return fileHasConflictMarkersAux(file)
 }
 
 // Efficiently scans through a file looking for merge conflict markers. Returns true if it does
-func fileHasConflictMarkersAux(file io.Reader) bool {
+func fileHasConflictMarkersAux(file io.Reader) (bool, error) {
 	scanner := bufio.NewScanner(file)
 	scanner.Split(utils.ScanLinesAndTruncateWhenLongerThanBuffer(bufio.MaxScanTokenSize))
 	for scanner.Scan() {
@@ -105,13 +105,13 @@ func fileHasConflictMarkersAux(file io.Reader) bool {
 
 		// only searching for start/end markers because the others are more ambiguous
 		if bytes.HasPrefix(line, CONFLICT_START_BYTES) {
-			return true
+			return true, nil
 		}
 
 		if bytes.HasPrefix(line, CONFLICT_END_BYTES) {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, scanner.Err()
 }

--- a/pkg/gui/mergeconflicts/find_conflicts_test.go
+++ b/pkg/gui/mergeconflicts/find_conflicts_test.go
@@ -96,6 +96,8 @@ func TestFindConflictsAux(t *testing.T) {
 
 	for _, s := range scenarios {
 		reader := strings.NewReader(s.content)
-		assert.EqualValues(t, s.expected, fileHasConflictMarkersAux(reader))
+		result, err := fileHasConflictMarkersAux(reader)
+		assert.NoError(t, err)
+		assert.EqualValues(t, s.expected, result)
 	}
 }

--- a/pkg/gui/mergeconflicts/rendering.go
+++ b/pkg/gui/mergeconflicts/rendering.go
@@ -24,7 +24,8 @@ func ColoredConflictFile(state *State) string {
 		if i == conflict.end && len(remainingConflicts) > 0 {
 			conflict, remainingConflicts = shiftConflict(remainingConflicts)
 		}
-		outputBuffer.WriteString(textStyle.Sprint(line) + "\n")
+		outputBuffer.WriteString(textStyle.Sprint(line))
+		outputBuffer.WriteByte('\n')
 	}
 	return outputBuffer.String()
 }

--- a/pkg/logs/tail/logs_windows.go
+++ b/pkg/logs/tail/logs_windows.go
@@ -55,6 +55,9 @@ func tailFrom(lastOffset int64, logFilePath string, opts *humanlog.HandlerOption
 		lines = append(lines, fileScanner.Text())
 	}
 	file.Close()
+	if err := fileScanner.Err(); err != nil {
+		return err
+	}
 	lineCount := len(lines)
 	lastTen := lines
 	if lineCount > 10 {

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -210,6 +210,10 @@ func (self *ViewBufferManager) NewCmdTask(start func() (*exec.Cmd, io.Reader), p
 					<-lineWrittenChan
 				}
 			}
+
+			if err := scanner.Err(); err != nil {
+				self.Log.Error(err)
+			}
 		})
 
 		loaded := false


### PR DESCRIPTION
These have started to pop up in my editor after the last gopls update, and I like my IDE's problems panel to be clean, so fix them.