### PR TITLE
Disable gh telemetry when running integration tests

### DIFF
--- a/pkg/integration/components/env.go
+++ b/pkg/integration/components/env.go
@@ -61,5 +61,10 @@ func NewTestEnvironment(rootDir string) []string {
 	// versions >= 2.32.0
 	env = append(env, fmt.Sprintf("%s=%s", GIT_CONFIG_GLOBAL_ENV_VAR, globalGitConfigPath(rootDir)))
 
+	// Disable gh telemetry. It was enabled by default in gh 2.91.0, and
+	// this would cause gh config files to be left in the working tree
+	// (e.g. `test/.local/state/gh/device-id`).
+	env = append(env, "GH_TELEMETRY=disabled")
+
 	return env
 }


### PR DESCRIPTION
This prevents a file `test/.local/state/gh/device-id` from appearing in the working copy after running integration tests locally.