### PR TITLE
Fix the check_for_fixups.sh script again

### DIFF
--- a/scripts/check_for_fixups.sh
+++ b/scripts/check_for_fixups.sh
@@ -2,7 +2,7 @@
 
 # We will have only done a shallow clone, so the git log will consist only of
 # commits on the current PR
-commits=$(git log --format="%h %s" | egrep '(^fixup!|^squash!|^amend!|WIP|DROPME)')
+commits=$(git log --format="%s" | egrep '(^fixup!|^squash!|^amend!|WIP|DROPME)')
 
 if [ -z "$commits" ]; then
     echo "No fixup commits found."


### PR DESCRIPTION
Our most recent change to the script (58309b02a900) broke it because the anchored regex's no longer match the beginning of the subject. Fix this by omitting the hash, which is a bit unfortunate but probably acceptable (I rarely look at the output of the script anyway).
