### PR TITLE
Expand ~ in the worktree creation prompt path

### DIFF
--- a/pkg/gui/controllers/helpers/worktree_helper.go
+++ b/pkg/gui/controllers/helpers/worktree_helper.go
@@ -114,7 +114,11 @@ func (self *WorktreeHelper) NewWorktreeCheckout(base string, canCheckoutBase boo
 	self.c.Prompt(types.PromptOpts{
 		Title: self.c.Tr.NewWorktreePath,
 		HandleConfirm: func(path string) error {
-			opts.Path = path
+			expanded, err := utils.ExpandHomeDir(path)
+			if err != nil {
+				return err
+			}
+			opts.Path = expanded
 
 			if detached {
 				return f()

--- a/pkg/utils/path.go
+++ b/pkg/utils/path.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExpandHomeDir expands a leading "~" or "~/" in path to the user's
+// home directory. Paths that do not begin with "~" are returned
+// unchanged, including the empty string.
+//
+// We deliberately only support "~" for the current user (no
+// "~user" syntax) because that is what the shells lazygit users
+// expect to see lazygit honour, and the cross-platform story for
+// other-user expansion is messy.
+//
+// If path begins with "~" but the home directory cannot be
+// determined, the unexpanded path is returned along with the error.
+func ExpandHomeDir(path string) (string, error) {
+	if path == "" || path[0] != '~' {
+		return path, nil
+	}
+	// Only "~" alone or "~/..." — not "~user/...".
+	if path != "~" && !strings.HasPrefix(path, "~"+string(filepath.Separator)) && !strings.HasPrefix(path, "~/") {
+		return path, errors.New("only the current user's home directory can be expanded with ~")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path, err
+	}
+	if path == "~" {
+		return home, nil
+	}
+	return filepath.Join(home, path[2:]), nil
+}

--- a/pkg/utils/path_test.go
+++ b/pkg/utils/path_test.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandHomeDir(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir failed: %v", err)
+	}
+
+	scenarios := []struct {
+		name     string
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "empty stays empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "no tilde left untouched",
+			input:    filepath.Join("path", "to", "thing"),
+			expected: filepath.Join("path", "to", "thing"),
+		},
+		{
+			name:     "absolute path left untouched",
+			input:    "/absolute/path",
+			expected: "/absolute/path",
+		},
+		{
+			name:     "tilde alone expands to home",
+			input:    "~",
+			expected: home,
+		},
+		{
+			name:     "tilde slash expands to home/rest",
+			input:    "~/foo/bar",
+			expected: filepath.Join(home, "foo", "bar"),
+		},
+		{
+			name:     "tilde without separator (~user style) is rejected",
+			input:    "~bob/foo",
+			expected: "~bob/foo",
+			wantErr:  true,
+		},
+		{
+			name:     "tilde mid-path is not expanded",
+			input:    filepath.Join("foo", "~", "bar"),
+			expected: filepath.Join("foo", "~", "bar"),
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			got, err := ExpandHomeDir(s.input)
+			if s.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, s.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4708.

## The bug

When creating a new worktree from the worktree prompt and entering a path that begins with `~` (e.g. `~/code/feature-x`), lazygit creates a directory literally called `~` inside the repo, e.g. `<repo>/~/code/feature-x`. The `~` is meant to expand to the user's home directory the way it does in shells.

## Root cause

The user-entered path flows from the `New worktree path` prompt (`pkg/gui/controllers/helpers/worktree_helper.go`) into `WorktreeCommands.New`, which builds `git worktree add <path> <base>` and runs it via `os/exec`. `os/exec` does not invoke a shell, so `~` is taken literally. This was confirmed in the issue thread (cc @ChrisMcD1, @stefanhaller).

## The fix

Adds a small helper `utils.ExpandHomeDir` (per @stefanhaller's suggestion to put the logic in `pkg/utils/`) that expands a leading `~` or `~/` to `os.UserHomeDir()`. Other paths — absolute paths, `../foo` (which already worked because git resolves relative paths against cwd), or paths with a non-leading `~` — are returned unchanged. The `~user` form is rejected explicitly so we don't silently do the wrong thing.

The helper is applied at the prompt's `HandleConfirm` callback so the expanded path is what flows through the rest of the worktree creation pipeline.

## Tests

- New table-driven unit test in `pkg/utils/path_test.go` covering: empty input, untouched relative path, untouched absolute path, `~` alone, `~/foo/bar`, `~user/foo` rejection, and a mid-path `~` segment.
- All existing tests still pass (`pkg/utils/...`, `pkg/gui/controllers/helpers/...`, `pkg/commands/...`).
- `go build ./...` succeeds.

I deliberately scoped this to home-directory expansion — env var expansion (`$HOME/...`) is a larger surface area and the issue thread converged on `~` specifically.