### PR TITLE
Default bottom keybindings line text to white for dark terminals

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -168,7 +168,7 @@ gui:
 
     # Color of keybindings help text in the bottom line
     optionsTextColor:
-      - blue
+      - white
 
     # Background color of selected line.
     # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#highlighting-the-selected-line

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -168,7 +168,7 @@ gui:
 
     # Color of keybindings help text in the bottom line
     optionsTextColor:
-      - blue
+      - white
 
     # Background color of selected line.
     # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#highlighting-the-selected-line

--- a/pkg/config/app_config_test.go
+++ b/pkg/config/app_config_test.go
@@ -458,7 +458,7 @@ gui:
 
     # Color of keybindings help text in the bottom line
     optionsTextColor:
-      - blue
+      - white
 
     # Background color of selected line.
     # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#highlighting-the-selected-line

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -801,7 +801,7 @@ func GetDefaultConfigForPlatform(platform string) *UserConfig {
 				ActiveBorderColor:               []string{"green", "bold"},
 				SearchingActiveBorderColor:      []string{"cyan", "bold"},
 				InactiveBorderColor:             []string{"default"},
-				OptionsTextColor:                []string{"blue"},
+				OptionsTextColor:                []string{"white"},
 				SelectedLineBgColor:             []string{"blue"},
 				InactiveViewSelectedLineBgColor: []string{"bold"},
 				CherryPickedCommitBgColor:       []string{"cyan"},

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -1873,7 +1873,7 @@
           "uniqueItems": true,
           "description": "Color of keybindings help text in the bottom line",
           "default": [
-            "blue"
+            "white"
           ]
         },
         "selectedLineBgColor": {

--- a/schema/config.json
+++ b/schema/config.json
@@ -1852,7 +1852,7 @@
           "uniqueItems": true,
           "description": "Color of keybindings help text in the bottom line",
           "default": [
-            "blue"
+            "white"
           ]
         },
         "selectedLineBgColor": {


### PR DESCRIPTION
Change the default gui.theme.optionsTextColor from blue to white.

The bottom bar shows keybinding hints; previously it defaulted to ANSI blue (optionsTextColor: ["blue"]). On the most common setup—palette-based dark/black terminal background plus no special tweaking—this is effectively dark/low-luminance saturated blue glyphs on black, which performs very poorly for legibility compared to lighter neutrals like white.

From a perceptual/contrast standpoint: readable text relies on sufficient luminance contrast between foreground and background, not hue alone. On a nearly black background, blue has intrinsically low luminance relative to colours like yellow, cyan, or white: the perceived brightness stays low unless the palette uses a consciously “bright/high-luminance blue”. Many default 16‑colour palettes do not strongly boost blue’s luminance, so the foreground sits close to the background in lightness. That sharply reduces discriminability—especially at a glance, in peripheral vision, on smaller fonts, or for users whose colour vision skews differentiation between saturated blues (not rare), where hue difference does not reliably rescue readability when lightness contrast is marginal.

ANSI “blue-on-black” is a well‑known readability pain point in TUIs compared to pale grey/white; defaulting keybinding help to white matches the expectation that ancillary UI chrome should remain legible across stock terminals without forcing every user into custom theme overrides.

Behaviour when users explicitly set optionsTextColor in config is unchanged; only defaults and docs/schema are updated accordingly.

<img width="609" height="214" alt="image" src="https://github.com/user-attachments/assets/c5856b77-9e53-49ab-80ff-b03b87529c4a" />
