### PR TITLE
fix: guard against nil remote branch pointers in GetRemoteBranchListDisplayStrings

### DIFF
--- a/pkg/gui/presentation/remote_branches.go
+++ b/pkg/gui/presentation/remote_branches.go
@@ -8,9 +8,12 @@ import (
 )
 
 func GetRemoteBranchListDisplayStrings(branches []*models.RemoteBranch, diffName string) [][]string {
-	return lo.Map(branches, func(branch *models.RemoteBranch, _ int) []string {
+	return lo.FilterMap(branches, func(branch *models.RemoteBranch, _ int) ([]string, bool) {
+		if branch == nil {
+			return nil, false
+		}
 		diffed := branch.FullName() == diffName
-		return getRemoteBranchDisplayStrings(branch, diffed)
+		return getRemoteBranchDisplayStrings(branch, diffed), true
 	})
 }
 

--- a/pkg/gui/presentation/remote_branches_test.go
+++ b/pkg/gui/presentation/remote_branches_test.go
@@ -1,0 +1,18 @@
+package presentation
+
+import (
+	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRemoteBranchListDisplayStrings_NilBranch(t *testing.T) {
+	branch := &models.RemoteBranch{Name: "main", RemoteName: "origin"}
+	branches := []*models.RemoteBranch{nil, branch, nil}
+
+	result := GetRemoteBranchListDisplayStrings(branches, "")
+
+	// nil entries must be skipped; only the valid branch produces a row
+	assert.Len(t, result, 1)
+}


### PR DESCRIPTION
## Summary

Fixes #5370.

During concurrent remote refresh, stale nil pointers can appear in the `branches` slice. `GetRemoteBranchListDisplayStrings` calls `branch.FullName()` unconditionally, causing a nil pointer panic.

**Fix:** switch from `lo.Map` to `lo.FilterMap` and skip nil entries.

## Changes

- `pkg/gui/presentation/remote_branches.go`: use `lo.FilterMap` to skip nil branch pointers
- `pkg/gui/presentation/remote_branches_test.go`: new test that passes a slice containing nil entries and asserts only non-nil branches produce display rows

## Test plan

- [x] `go test ./pkg/gui/presentation/...` passes
- [x] New test `TestGetRemoteBranchListDisplayStrings_NilBranch` confirms nil entries are skipped without panic