### PR TITLE
Add hotkeys to the worktree-conflict menu shown when deleting a branch

### DIFF
--- a/pkg/gui/controllers/helpers/branches_helper.go
+++ b/pkg/gui/controllers/helpers/branches_helper.go
@@ -223,6 +223,7 @@ func (self *BranchesHelper) promptWorktreeBranchDelete(selectedBranch *models.Br
 		Items: []*types.MenuItem{
 			{
 				Label: self.c.Tr.SwitchToWorktree,
+				Key:   gocui.NewKeyRune('s'),
 				OnPress: func() error {
 					return self.worktreeHelper.Switch(worktree, context.LOCAL_BRANCHES_CONTEXT_KEY)
 				},
@@ -230,12 +231,14 @@ func (self *BranchesHelper) promptWorktreeBranchDelete(selectedBranch *models.Br
 			{
 				Label:   self.c.Tr.DetachWorktree,
 				Tooltip: self.c.Tr.DetachWorktreeTooltip,
+				Key:     gocui.NewKeyRune('d'),
 				OnPress: func() error {
 					return self.worktreeHelper.Detach(worktree)
 				},
 			},
 			{
 				Label: self.c.Tr.RemoveWorktree,
+				Key:   gocui.NewKeyRune('r'),
 				OnPress: func() error {
 					return self.worktreeHelper.Remove(worktree, false)
 				},

--- a/pkg/integration/tests/worktree/detach_worktree_from_branch.go
+++ b/pkg/integration/tests/worktree/detach_worktree_from_branch.go
@@ -37,7 +37,7 @@ var DetachWorktreeFromBranch = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Branch newbranch is checked out by worktree linked-worktree")).
-					Select(Equals("Detach worktree")).
+					Select(Contains("Detach worktree")).
 					Confirm()
 			}).
 			Lines(

--- a/pkg/integration/tests/worktree/remove_worktree_from_branch.go
+++ b/pkg/integration/tests/worktree/remove_worktree_from_branch.go
@@ -38,7 +38,7 @@ var RemoveWorktreeFromBranch = NewIntegrationTest(NewIntegrationTestArgs{
 			Tap(func() {
 				t.ExpectPopup().Menu().
 					Title(Equals("Branch newbranch is checked out by worktree linked-worktree")).
-					Select(Equals("Remove worktree")).
+					Select(Contains("Remove worktree")).
 					Confirm()
 
 				t.ExpectPopup().Confirmation().


### PR DESCRIPTION
### PR Description

The menu that appears when deleting a branch that's checked out in another worktree had no keybindings, forcing users to navigate with arrow keys. Add 's', 'd', and 'r' for switch / detach / remove.

<img width="713" height="98" alt="image" src="https://github.com/user-attachments/assets/2318b628-4869-4ea7-bcea-d2758efc8c40" />

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->