### PR TITLE
Allow rebinding the confirm key for search and prompt inputs

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -644,6 +644,14 @@ keybinding:
     confirmMenu: <enter>
     confirmSuggestion: <enter>
 
+    # Key for confirming the search/filter prompt (the one opened with
+    # `startSearch`).
+    confirmSearch: <enter>
+
+    # Key for confirming a text input prompt (e.g. when naming a stash or a new
+    # branch).
+    confirmPrompt: <enter>
+
     # <meta+enter> on Mac
     confirmInEditor: [<ctrl+enter>, <ctrl+s>]
     remove: d

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -474,7 +474,11 @@ type KeybindingUniversalConfig struct {
 	Confirm           Keybinding   `yaml:"confirm"`
 	ConfirmMenu       Keybinding   `yaml:"confirmMenu"`
 	ConfirmSuggestion Keybinding   `yaml:"confirmSuggestion"`
-	ConfirmInEditor   Keybinding   `yaml:"confirmInEditor"` // <meta+enter> on Mac
+	// Key for confirming the search/filter prompt (the one opened with `startSearch`).
+	ConfirmSearch Keybinding `yaml:"confirmSearch"`
+	// Key for confirming a text input prompt (e.g. when naming a stash or a new branch).
+	ConfirmPrompt   Keybinding `yaml:"confirmPrompt"`
+	ConfirmInEditor Keybinding `yaml:"confirmInEditor"` // <meta+enter> on Mac
 	// Deprecated: add the key to `confirmInEditor` instead.
 	ConfirmInEditorAlt Keybinding `yaml:"confirmInEditor-alt"`
 	Remove             Keybinding `yaml:"remove"`
@@ -986,6 +990,8 @@ func GetDefaultConfigForPlatform(platform string) *UserConfig {
 				Confirm:                           Keybinding{"<enter>"},
 				ConfirmMenu:                       Keybinding{"<enter>"},
 				ConfirmSuggestion:                 Keybinding{"<enter>"},
+				ConfirmSearch:                     Keybinding{"<enter>"},
+				ConfirmPrompt:                     Keybinding{"<enter>"},
 				ConfirmInEditor:                   Keybinding{platformKeyBinding(platform, map[string]string{"darwin": "<meta+enter>"}, "<ctrl+enter>")},
 				ConfirmInEditorAlt:                Keybinding{"<ctrl+s>"},
 				Remove:                            Keybinding{"d"},

--- a/pkg/gui/controllers/prompt_controller.go
+++ b/pkg/gui/controllers/prompt_controller.go
@@ -27,7 +27,7 @@ func NewPromptController(
 func (self *PromptController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
 	bindings := []*types.Binding{
 		{
-			Keys:            []gocui.Key{gocui.NewKeyName(gocui.KeyEnter)},
+			Keys:            opts.GetKeys(opts.Config.Universal.ConfirmPrompt),
 			Handler:         func() error { return self.context().State.OnConfirm() },
 			Description:     self.c.Tr.Confirm,
 			DisplayOnScreen: true,

--- a/pkg/gui/controllers/search_prompt_controller.go
+++ b/pkg/gui/controllers/search_prompt_controller.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"github.com/jesseduffield/lazygit/pkg/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 )
 
@@ -24,7 +23,7 @@ func NewSearchPromptController(
 func (self *SearchPromptController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
 	return []*types.Binding{
 		{
-			Keys:    []gocui.Key{gocui.NewKeyName(gocui.KeyEnter)},
+			Keys:    opts.GetKeys(opts.Config.Universal.ConfirmSearch),
 			Handler: self.confirm,
 		},
 		{

--- a/pkg/integration/tests/config/rebind_confirm_search_and_prompt.go
+++ b/pkg/integration/tests/config/rebind_confirm_search_and_prompt.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var RebindConfirmSearchAndPrompt = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Confirm a search and a text prompt using a rebound confirm keybinding",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(cfg *config.AppConfig) {
+		// The search and prompt confirm keys used to be hard-coded to <enter>,
+		// so they couldn't be rebound like the other confirm keybindings.
+		cfg.GetUserConfig().Keybinding.Universal.ConfirmSearch = []string{"<c-y>"}
+		cfg.GetUserConfig().Keybinding.Universal.ConfirmPrompt = []string{"<c-y>"}
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.NewBranch("branch")
+		shell.EmptyCommit("one")
+		shell.EmptyCommit("two")
+		shell.EmptyCommit("three")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		// Confirming a search with the rebound key works.
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("three").IsSelected(),
+				Contains("two"),
+				Contains("one"),
+			).
+			Press(keys.Universal.StartSearch).
+			Tap(func() {
+				t.ExpectSearch().
+					Type("two")
+
+				t.GlobalPress(keys.Universal.ConfirmSearch)
+
+				t.Views().Search().IsVisible().Content(Contains("matches for 'two' (1 of 1)"))
+			}).
+			Lines(
+				Contains("three"),
+				Contains("two").IsSelected(),
+				Contains("one"),
+			)
+
+		// Confirming a text input prompt with the rebound key works.
+		t.Views().Branches().
+			Focus().
+			Press(keys.Universal.New)
+
+		t.ExpectPopup().Prompt().
+			Title(Contains("New branch name")).
+			Type("new-branch")
+
+		t.GlobalPress(keys.Universal.ConfirmPrompt)
+
+		t.Git().CurrentBranchName("new-branch")
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -160,6 +160,7 @@ var tests = []*components.IntegrationTest{
 	commit.Unstaged,
 	config.CustomCommandsInPerRepoConfig,
 	config.NegativeRefspec,
+	config.RebindConfirmSearchAndPrompt,
 	config.RemoteNamedStar,
 	conflicts.Filter,
 	conflicts.MergeFileBoth,

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -2786,6 +2786,36 @@
           ],
           "default": "\u003center\u003e"
         },
+        "confirmSearch": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Key for confirming the search/filter prompt (the one opened with `startSearch`).",
+          "default": "\u003center\u003e"
+        },
+        "confirmPrompt": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Key for confirming a text input prompt (e.g. when naming a stash or a new branch).",
+          "default": "\u003center\u003e"
+        },
         "confirmInEditor": {
           "oneOf": [
             {


### PR DESCRIPTION
### PR Description

The confirm action for the search/filter prompt and for text input prompts (e.g. when naming a stash or creating a new branch) was hard-coded to `<enter>` in #4860, on the assumption that nobody would want to remap it. As reported in #5510, that assumption was wrong: users who rebind `keybinding.universal.confirm` to something like `<c-j>` could no longer confirm those two prompts at all.

This adds two new keybindings, `confirmSearch` and `confirmPrompt`, following the existing convention of context-specific confirm keys (`confirmMenu`, `confirmSuggestion`, `confirmInEditor`). Both default to `<enter>`, so the behaviour is completely unchanged for users who don't remap them; users who do can now point them at whatever key they like.

Fixes #5510.

Testing: added an integration test (`config/rebind_confirm_search_and_prompt`) that rebinds both keys to `<c-y>` and verifies that a search and a text prompt can each be confirmed with the rebound key. I confirmed the test fails on `master` (both prompts ignore the rebound key) and passes with this change. The existing search/prompt integration tests still pass.

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (no new user-facing strings; the prompt confirm keeps the existing `Confirm` label)
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (keybindings are re-read via `resetKeybindings` on config reload, same as the other confirm keys)
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
