### PR TITLE
Fix breaking changes note

### DIFF
--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -2266,7 +2266,7 @@ keybinding:
 
 keybinding:
   universal:
-    confirmInEditor: <a-enter>
+    confirmInEditor: [<alt+enter>, <ctrl+s>]
 `,
 		},
 	}


### PR DESCRIPTION
Ctrl+s used to be a separate binding confirmInEditor-alt, but now that it was folded into the main confirmInEditor, we need to mention both bindings here.

Also use the new syntax while we're at it.
