### PR TITLE
Fix crash when keybindings are disabled that normally show in the status bar

### DIFF
--- a/pkg/gui/options_map.go
+++ b/pkg/gui/options_map.go
@@ -46,7 +46,7 @@ func (self *OptionsMapMgr) renderContextOptionsMap() {
 		}))
 
 	allBindings := append(currentContextBindings, lo.Filter(globalBindings, func(b *types.Binding, _ int) bool {
-		return len(b.Keys) == 0 || !currentContextKeys.Includes(b.Keys[0])
+		return len(b.Keys) > 0 && !currentContextKeys.Includes(b.Keys[0])
 	})...)
 
 	bindingsToDisplay := lo.Filter(allBindings, func(binding *types.Binding, _ int) bool {

--- a/pkg/gui/options_map.go
+++ b/pkg/gui/options_map.go
@@ -50,7 +50,7 @@ func (self *OptionsMapMgr) renderContextOptionsMap() {
 	})...)
 
 	bindingsToDisplay := lo.Filter(allBindings, func(binding *types.Binding, _ int) bool {
-		return binding.DisplayOnScreen && !binding.IsDisabled()
+		return len(binding.Keys) > 0 && binding.DisplayOnScreen && !binding.IsDisabled()
 	})
 
 	optionsMap := lo.Map(bindingsToDisplay, func(binding *types.Binding, _ int) bindingInfo {

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -466,6 +466,7 @@ var tests = []*components.IntegrationTest{
 	ui.Accordion,
 	ui.DisableSwitchTabWithPanelJumpKeys,
 	ui.EmptyMenu,
+	ui.KeybindingSuggestionsDontCrashOnDisabledBindings,
 	ui.KeybindingSuggestionsWhenSwitchingRepos,
 	ui.ModeSpecificKeybindingSuggestions,
 	ui.OpenLinkFailure,

--- a/pkg/integration/tests/ui/keybinding_suggestions_dont_crash_on_disabled_bindings.go
+++ b/pkg/integration/tests/ui/keybinding_suggestions_dont_crash_on_disabled_bindings.go
@@ -1,0 +1,21 @@
+package ui
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var KeybindingSuggestionsDontCrashOnDisabledBindings = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Filter out keybinding suggestions whose bindings are disabled",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Keybinding.Files.StashAllChanges = []string{}
+	},
+	SetupRepo: func(shell *Shell) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().Focus()
+		t.Views().Options().Content(
+			Equals("Commit: c | Reset: D | Keybindings: ?"))
+	},
+})


### PR DESCRIPTION
If a keybinding that we want to display in the options bar was set to `<disabled>` by the user, in pre-0.62 versions we would still display the command, but with no keybinding. This was arguably not very useful before, but now it actually crashes because we would now try to display the first key of the slice of configured keys (crash introduced in 3d18ee8f91c7). Fix the crash by not showing those commands at all.