### PR TITLE
Add keybinding to focus secondary main view

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -622,6 +622,7 @@ keybinding:
       - "4"
       - "5"
     focusMainView: "0"
+    focusSecondaryView: "9"
     nextMatch: "n"
     prevMatch: "N"
     startSearch: /

--- a/docs-master/keybindings/Keybindings_en.md
+++ b/docs-master/keybindings/Keybindings_en.md
@@ -68,6 +68,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Collapse all files | Collapse all directories in the files tree |
 | `` = `` | Expand all files | Expand all directories in the file tree |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Filter the current view by text |  |
 
 ## Commit summary
@@ -115,6 +116,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | View files |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Search the current view by text |  |
@@ -158,6 +160,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Collapse all files | Collapse all directories in the files tree |
 | `` = `` | Expand all files | Expand all directories in the file tree |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Filter the current view by text |  |
 
 ## Input prompt
@@ -194,6 +197,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` u `` | View upstream options | View options relating to the branch's upstream e.g. setting/unsetting the upstream and resetting to the upstream. |
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | View commits |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -223,6 +227,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | Switch view | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Search the current view by text |  |
 
 ## Main panel (patch building)
@@ -287,6 +292,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | View commits |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -306,6 +312,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | Reset | View reset options (soft/mixed/hard) for resetting onto selected item. |
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | View commits |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -329,6 +336,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | Switch view | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Search the current view by text |  |
 
 ## Stash
@@ -341,6 +349,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` n `` | New branch | Create a new branch from the selected stash entry. This works by git checking out the commit that the stash entry was created from, creating a new branch from that commit, then applying the stash entry to the new branch as an additional commit. |
 | `` r `` | Rename stash |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | View files |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -356,6 +365,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` a `` | Show/cycle all branch logs |  |
 | `` A `` | Show/cycle all branch logs (reverse) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 
 ## Sub-commits
 
@@ -373,6 +383,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | View files |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Search the current view by text |  |
@@ -403,6 +414,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | Reset | View reset options (soft/mixed/hard) for resetting onto selected item. |
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | View commits |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |

--- a/docs-master/keybindings/Keybindings_en.md
+++ b/docs-master/keybindings/Keybindings_en.md
@@ -222,6 +222,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <mouse wheel up> (fn+down) `` | Scroll up |  |
 | `` <tab> `` | Switch view | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focus main view |  |
 | `` / `` | Search the current view by text |  |
 
 ## Main panel (patch building)
@@ -327,6 +328,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 |-----|--------|-------------|
 | `` <tab> `` | Switch view | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focus main view |  |
 | `` / `` | Search the current view by text |  |
 
 ## Stash

--- a/docs-master/keybindings/Keybindings_ja.md
+++ b/docs-master/keybindings/Keybindings_ja.md
@@ -192,6 +192,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 |-----|--------|-------------|
 | `` <tab> `` | ビューを切り替え | 他のビュー（ステージされた変更/ステージされていない変更）に切り替えます。 |
 | `` <esc> `` | サイドパネルに戻る |  |
+| `` 0 `` | メインビューにフォーカス |  |
 | `` / `` | 現在のビューをテキストで検索 |  |
 
 ## タグ
@@ -305,6 +306,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <mouse wheel up> (fn+down) `` | 上にスクロール |  |
 | `` <tab> `` | ビューを切り替え | 他のビュー（ステージされた変更/ステージされていない変更）に切り替えます。 |
 | `` <esc> `` | サイドパネルに戻る |  |
+| `` 0 `` | メインビューにフォーカス |  |
 | `` / `` | 現在のビューをテキストで検索 |  |
 
 ## メニュー

--- a/docs-master/keybindings/Keybindings_ja.md
+++ b/docs-master/keybindings/Keybindings_ja.md
@@ -95,6 +95,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | 外部差分ツールを開く（git difftool） |  |
 | `` * `` | 現在のブランチのコミットを選択 |  |
 | `` 0 `` | メインビューにフォーカス |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | ファイルを表示 |  |
 | `` w `` | ワークツリーオプションを表示 |  |
 | `` / `` | 現在のビューをテキストで検索 |  |
@@ -117,6 +118,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | すべてのファイルを折りたたむ | ファイルツリー内のすべてのディレクトリを折りたたみます |
 | `` = `` | すべてのファイルを展開 | ファイルツリー内のすべてのディレクトリを展開します |
 | `` 0 `` | メインビューにフォーカス |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 現在のビューをテキストでフィルタリング |  |
 
 ## コミット概要
@@ -142,6 +144,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | 外部差分ツールを開く（git difftool） |  |
 | `` * `` | 現在のブランチのコミットを選択 |  |
 | `` 0 `` | メインビューにフォーカス |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | ファイルを表示 |  |
 | `` w `` | ワークツリーオプションを表示 |  |
 | `` / `` | 現在のビューをテキストで検索 |  |
@@ -170,6 +173,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` n `` | 新しいブランチ | 選択したスタッシュエントリから新しいブランチを作成します。これは、スタッシュエントリが作成されたコミットをgitがチェックアウトし、そのコミットから新しいブランチを作成した後、スタッシュエントリを追加のコミットとして新しいブランチに適用することで機能します。 |
 | `` r `` | スタッシュの名前を変更 |  |
 | `` 0 `` | メインビューにフォーカス |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | ファイルを表示 |  |
 | `` w `` | ワークツリーオプションを表示 |  |
 | `` / `` | 現在のビューをテキストでフィルタリング |  |
@@ -185,6 +189,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` a `` | ブランチログの表示モードを順に切り替え |  |
 | `` A `` | Show/cycle all branch logs (reverse) |  |
 | `` 0 `` | メインビューにフォーカス |  |
+| `` 9 `` | Focus secondary view |  |
 
 ## セカンダリ
 
@@ -193,6 +198,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | ビューを切り替え | 他のビュー（ステージされた変更/ステージされていない変更）に切り替えます。 |
 | `` <esc> `` | サイドパネルに戻る |  |
 | `` 0 `` | メインビューにフォーカス |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 現在のビューをテキストで検索 |  |
 
 ## タグ
@@ -207,6 +213,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | リセット | 選択した項目へのリセットオプション（ソフト/ミックス/ハード）を表示します。各リセットタイプの詳細は次の通りです：<br>- ソフトリセット：変更を保持し、ステージされた状態にします<br>- ミックスリセット：変更を保持し、ステージされていない状態にします<br>- ハードリセット：すべての変更を破棄します |
 | `` <ctrl+t> `` | 外部差分ツールを開く（git difftool） |  |
 | `` 0 `` | メインビューにフォーカス |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | コミットを表示 |  |
 | `` w `` | ワークツリーオプションを表示 |  |
 | `` / `` | 現在のビューをテキストでフィルタリング |  |
@@ -242,6 +249,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | すべてのファイルを折りたたむ | ファイルツリー内のすべてのディレクトリを折りたたみます |
 | `` = `` | すべてのファイルを展開 | ファイルツリー内のすべてのディレクトリを展開します |
 | `` 0 `` | メインビューにフォーカス |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 現在のビューをテキストでフィルタリング |  |
 
 ## メインパネル（ステージング）
@@ -307,6 +315,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | ビューを切り替え | 他のビュー（ステージされた変更/ステージされていない変更）に切り替えます。 |
 | `` <esc> `` | サイドパネルに戻る |  |
 | `` 0 `` | メインビューにフォーカス |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 現在のビューをテキストで検索 |  |
 
 ## メニュー
@@ -333,6 +342,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | 外部差分ツールを開く（git difftool） |  |
 | `` * `` | 現在のブランチのコミットを選択 |  |
 | `` 0 `` | メインビューにフォーカス |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | コミットを表示 |  |
 | `` w `` | ワークツリーオプションを表示 |  |
 | `` / `` | 現在のビューをテキストでフィルタリング |  |
@@ -364,6 +374,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | リセット | 選択した項目へのリセットオプション（ソフト/ミックス/ハード）を表示します。各リセットタイプの詳細は次の通りです：<br>- ソフトリセット：変更を保持し、ステージされた状態にします<br>- ミックスリセット：変更を保持し、ステージされていない状態にします<br>- ハードリセット：すべての変更を破棄します |
 | `` <ctrl+t> `` | 外部差分ツールを開く（git difftool） |  |
 | `` 0 `` | メインビューにフォーカス |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | コミットを表示 |  |
 | `` w `` | ワークツリーオプションを表示 |  |
 | `` / `` | 現在のビューをテキストでフィルタリング |  |
@@ -395,6 +406,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` u `` | アップストリームオプションを表示 | ブランチのアップストリームに関連するオプションを表示します（例：アップストリームの設定/解除やアップストリームへのリセット）。 |
 | `` <ctrl+t> `` | 外部差分ツールを開く（git difftool） |  |
 | `` 0 `` | メインビューにフォーカス |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | コミットを表示 |  |
 | `` w `` | ワークツリーオプションを表示 |  |
 | `` / `` | 現在のビューをテキストでフィルタリング |  |

--- a/docs-master/keybindings/Keybindings_ko.md
+++ b/docs-master/keybindings/Keybindings_ko.md
@@ -83,6 +83,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 |-----|--------|-------------|
 | `` <tab> `` | 패널 전환 | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focus main view |  |
 | `` / `` | 검색 시작 |  |
 
 ## Stash
@@ -161,6 +162,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <mouse wheel up> (fn+down) `` | 위로 스크롤 |  |
 | `` <tab> `` | 패널 전환 | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focus main view |  |
 | `` / `` | 검색 시작 |  |
 
 ## 메인 패널 (Patch Building)

--- a/docs-master/keybindings/Keybindings_ko.md
+++ b/docs-master/keybindings/Keybindings_ko.md
@@ -73,6 +73,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 커밋 보기 |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -84,6 +85,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | 패널 전환 | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 검색 시작 |  |
 
 ## Stash
@@ -96,6 +98,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` n `` | 새 브랜치 생성 | Create a new branch from the selected stash entry. This works by git checking out the commit that the stash entry was created from, creating a new branch from that commit, then applying the stash entry to the new branch as an additional commit. |
 | `` r `` | Rename stash |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | View selected item's files |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -116,6 +119,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | View selected item's files |  |
 | `` w `` | View worktree options |  |
 | `` / `` | 검색 시작 |  |
@@ -163,6 +167,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | 패널 전환 | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 검색 시작 |  |
 
 ## 메인 패널 (Patch Building)
@@ -230,6 +235,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` u `` | View upstream options | View options relating to the branch's upstream e.g. setting/unsetting the upstream and resetting to the upstream. |
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 커밋 보기 |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -245,6 +251,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` a `` | Show/cycle all branch logs |  |
 | `` A `` | Show/cycle all branch logs (reverse) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 
 ## 서브모듈
 
@@ -287,6 +294,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | View reset options | View reset options (soft/mixed/hard) for resetting onto selected item. |
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 커밋 보기 |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -329,6 +337,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | View selected item's files |  |
 | `` w `` | View worktree options |  |
 | `` / `` | 검색 시작 |  |
@@ -351,6 +360,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Collapse all files | Collapse all directories in the files tree |
 | `` = `` | Expand all files | Expand all directories in the file tree |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Filter the current view by text |  |
 
 ## 커밋메시지
@@ -372,6 +382,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | 초기화 | View reset options (soft/mixed/hard) for resetting onto selected item. |
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 커밋 보기 |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -407,6 +418,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Collapse all files | Collapse all directories in the files tree |
 | `` = `` | Expand all files | Expand all directories in the file tree |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Filter the current view by text |  |
 
 ## 확인 패널

--- a/docs-master/keybindings/Keybindings_nl.md
+++ b/docs-master/keybindings/Keybindings_nl.md
@@ -81,6 +81,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Collapse all files | Collapse all directories in the files tree |
 | `` = `` | Expand all files | Expand all directories in the file tree |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Filter the current view by text |  |
 
 ## Bevestigingspaneel
@@ -118,6 +119,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` u `` | View upstream options | View options relating to the branch's upstream e.g. setting/unsetting the upstream and resetting to the upstream. |
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Bekijk commits |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -147,6 +149,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Collapse all files | Collapse all directories in the files tree |
 | `` = `` | Expand all files | Expand all directories in the file tree |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Filter the current view by text |  |
 
 ## Commits
@@ -187,6 +190,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Bekijk gecommite bestanden |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Start met zoeken |  |
@@ -231,6 +235,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | Ga naar een ander paneel | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Start met zoeken |  |
 
 ## Patch bouwen
@@ -265,6 +270,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Bekijk commits |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -284,6 +290,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | Bekijk reset opties | View reset options (soft/mixed/hard) for resetting onto selected item. |
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Bekijk commits |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -307,6 +314,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | Ga naar een ander paneel | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Start met zoeken |  |
 
 ## Staging
@@ -341,6 +349,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` n `` | Nieuwe branch | Create a new branch from the selected stash entry. This works by git checking out the commit that the stash entry was created from, creating a new branch from that commit, then applying the stash entry to the new branch as an additional commit. |
 | `` r `` | Rename stash |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Bekijk gecommite bestanden |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -356,6 +365,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` a `` | Show/cycle all branch logs |  |
 | `` A `` | Show/cycle all branch logs (reverse) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 
 ## Sub-commits
 
@@ -373,6 +383,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Bekijk gecommite bestanden |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Start met zoeken |  |
@@ -403,6 +414,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | Reset | View reset options (soft/mixed/hard) for resetting onto selected item. |
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Bekijk commits |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |

--- a/docs-master/keybindings/Keybindings_nl.md
+++ b/docs-master/keybindings/Keybindings_nl.md
@@ -230,6 +230,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <mouse wheel up> (fn+down) `` | Scroll omhoog |  |
 | `` <tab> `` | Ga naar een ander paneel | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focus main view |  |
 | `` / `` | Start met zoeken |  |
 
 ## Patch bouwen
@@ -305,6 +306,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 |-----|--------|-------------|
 | `` <tab> `` | Ga naar een ander paneel | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focus main view |  |
 | `` / `` | Start met zoeken |  |
 
 ## Staging

--- a/docs-master/keybindings/Keybindings_pl.md
+++ b/docs-master/keybindings/Keybindings_pl.md
@@ -88,6 +88,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Otwórz zewnętrzne narzędzie różnic (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Wyświetl pliki |  |
 | `` w `` | Zobacz opcje drzewa pracy |  |
 | `` / `` | Szukaj w bieżącym widoku po tekście |  |
@@ -99,6 +100,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | Przełącz widok | Przełącz na inny widok (zatwierdzone/niezatwierdzone zmiany). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Szukaj w bieżącym widoku po tekście |  |
 
 ## Drzewa pracy
@@ -127,6 +129,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Otwórz zewnętrzne narzędzie różnic (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Pokaż commity |  |
 | `` w `` | Zobacz opcje drzewa pracy |  |
 | `` / `` | Filtruj bieżący widok po tekście |  |
@@ -181,6 +184,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` u `` | Pokaż opcje upstream | Pokaż opcje dotyczące upstream gałęzi, np. ustawianie/usuwanie upstream i resetowanie do upstream. |
 | `` <ctrl+t> `` | Otwórz zewnętrzne narzędzie różnic (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Pokaż commity |  |
 | `` w `` | Zobacz opcje drzewa pracy |  |
 | `` / `` | Filtruj bieżący widok po tekście |  |
@@ -202,6 +206,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | Przełącz widok | Przełącz na inny widok (zatwierdzone/niezatwierdzone zmiany). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Szukaj w bieżącym widoku po tekście |  |
 
 ## Panel główny (scalanie)
@@ -281,6 +286,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Collapse all files | Collapse all directories in the files tree |
 | `` = `` | Expand all files | Expand all directories in the file tree |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Filtruj bieżący widok po tekście |  |
 
 ## Pliki commita
@@ -301,6 +307,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Collapse all files | Collapse all directories in the files tree |
 | `` = `` | Expand all files | Expand all directories in the file tree |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Filtruj bieżący widok po tekście |  |
 
 ## Podsumowanie commita
@@ -320,6 +327,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` n `` | Nowa gałąź | Utwórz nową gałąź z wybranego wpisu schowka. Działa poprzez przełączenie git na commit, na którym wpis schowka został utworzony, tworzenie nowej gałęzi z tego commita, a następnie zastosowanie wpisu schowka do nowej gałęzi jako dodatkowego commita. |
 | `` r `` | Zmień nazwę schowka |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Wyświetl pliki |  |
 | `` w `` | Zobacz opcje drzewa pracy |  |
 | `` / `` | Filtruj bieżący widok po tekście |  |
@@ -335,6 +343,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` a `` | Show/cycle all branch logs |  |
 | `` A `` | Show/cycle all branch logs (reverse) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 
 ## Sub-commity
 
@@ -352,6 +361,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Otwórz zewnętrzne narzędzie różnic (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Wyświetl pliki |  |
 | `` w `` | Zobacz opcje drzewa pracy |  |
 | `` / `` | Szukaj w bieżącym widoku po tekście |  |
@@ -382,6 +392,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | Reset | Wyświetl opcje resetu (miękki/mieszany/twardy) do wybranego elementu. |
 | `` <ctrl+t> `` | Otwórz zewnętrzne narzędzie różnic (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Pokaż commity |  |
 | `` w `` | Zobacz opcje drzewa pracy |  |
 | `` / `` | Filtruj bieżący widok po tekście |  |
@@ -413,6 +424,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | Reset | Wyświetl opcje resetu (miękki/mieszany/twardy) do wybranego elementu. |
 | `` <ctrl+t> `` | Otwórz zewnętrzne narzędzie różnic (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Pokaż commity |  |
 | `` w `` | Zobacz opcje drzewa pracy |  |
 | `` / `` | Filtruj bieżący widok po tekście |  |

--- a/docs-master/keybindings/Keybindings_pl.md
+++ b/docs-master/keybindings/Keybindings_pl.md
@@ -98,6 +98,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 |-----|--------|-------------|
 | `` <tab> `` | Przełącz widok | Przełącz na inny widok (zatwierdzone/niezatwierdzone zmiany). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focus main view |  |
 | `` / `` | Szukaj w bieżącym widoku po tekście |  |
 
 ## Drzewa pracy
@@ -200,6 +201,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <mouse wheel up> (fn+down) `` | Przewiń w górę |  |
 | `` <tab> `` | Przełącz widok | Przełącz na inny widok (zatwierdzone/niezatwierdzone zmiany). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focus main view |  |
 | `` / `` | Szukaj w bieżącym widoku po tekście |  |
 
 ## Panel główny (scalanie)

--- a/docs-master/keybindings/Keybindings_pt.md
+++ b/docs-master/keybindings/Keybindings_pt.md
@@ -81,6 +81,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Recolher todos os arquivos | Recolher todos os diretórios na árvore de arquivos |
 | `` = `` | Expandir todos os arquivos | Expandir todos os diretórios na árvore do arquivo |
 | `` 0 `` | Focar visualização principal |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Filtrar a visualização atual por texto |  |
 
 ## Branches locais
@@ -110,6 +111,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` u `` | View upstream options | View options relating to the branch's upstream e.g. setting/unsetting the upstream and resetting to the upstream. |
 | `` <ctrl+t> `` | Abrir ferramenta de diff externa (git difftool) |  |
 | `` 0 `` | Focar visualização principal |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Ver commits |  |
 | `` w `` | Ver opções da árvore de trabalho |  |
 | `` / `` | Filtrar a visualização atual por texto |  |
@@ -129,6 +131,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | Restaurar | Ver opções de redefinição (soft/mixed/hard) para redefinir para o item selecionado. |
 | `` <ctrl+t> `` | Abrir ferramenta de diff externa (git difftool) |  |
 | `` 0 `` | Focar visualização principal |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Ver commits |  |
 | `` w `` | Ver opções da árvore de trabalho |  |
 | `` / `` | Filtrar a visualização atual por texto |  |
@@ -151,6 +154,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Recolher todos os arquivos | Recolher todos os diretórios na árvore de arquivos |
 | `` = `` | Expandir todos os arquivos | Expandir todos os diretórios na árvore do arquivo |
 | `` 0 `` | Focar visualização principal |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Filtrar a visualização atual por texto |  |
 
 ## Commits
@@ -191,6 +195,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Abrir ferramenta de diff externa (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focar visualização principal |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Ver arquivos |  |
 | `` w `` | Ver opções da árvore de trabalho |  |
 | `` / `` | Pesquisar na visualização atual por texto |  |
@@ -207,6 +212,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | Restaurar | Ver opções de redefinição (soft/mixed/hard) para redefinir para o item selecionado. |
 | `` <ctrl+t> `` | Abrir ferramenta de diff externa (git difftool) |  |
 | `` 0 `` | Focar visualização principal |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Ver commits |  |
 | `` w `` | Ver opções da árvore de trabalho |  |
 | `` / `` | Filtrar a visualização atual por texto |  |
@@ -235,6 +241,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | Mudar de visão | Alternar para outra visão (staged/não processadas alterações). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focar visualização principal |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Pesquisar na visualização atual por texto |  |
 
 ## Painel Principal (preparação)
@@ -315,6 +322,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Abrir ferramenta de diff externa (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focar visualização principal |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Ver commits |  |
 | `` w `` | Ver opções da árvore de trabalho |  |
 | `` / `` | Filtrar a visualização atual por texto |  |
@@ -338,6 +346,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | Mudar de visão | Alternar para outra visão (staged/não processadas alterações). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focar visualização principal |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Pesquisar na visualização atual por texto |  |
 
 ## Stash
@@ -350,6 +359,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` n `` | Nova branch | Criar um novo ramo a partir da entrada de lixo selecionada. Isso funciona verificando o commit do qual a entrada de lixo foi criada, criar um novo branch a partir desse commit e, em seguida, aplicar a entrada de lixo ao novo branch como um commit adicional. |
 | `` r `` | Renomear o stash |  |
 | `` 0 `` | Focar visualização principal |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Ver arquivos |  |
 | `` w `` | Ver opções da árvore de trabalho |  |
 | `` / `` | Filtrar a visualização atual por texto |  |
@@ -365,6 +375,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` a `` | Mostrar/ciclo todos os logs de filiais |  |
 | `` A `` | Show/cycle all branch logs (reverse) |  |
 | `` 0 `` | Focar visualização principal |  |
+| `` 9 `` | Focus secondary view |  |
 
 ## Sub-commits
 
@@ -382,6 +393,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Abrir ferramenta de diff externa (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focar visualização principal |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Ver arquivos |  |
 | `` w `` | Ver opções da árvore de trabalho |  |
 | `` / `` | Pesquisar na visualização atual por texto |  |

--- a/docs-master/keybindings/Keybindings_pt.md
+++ b/docs-master/keybindings/Keybindings_pt.md
@@ -234,6 +234,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <mouse wheel up> (fn+down) `` | Rolar para cima |  |
 | `` <tab> `` | Mudar de visão | Alternar para outra visão (staged/não processadas alterações). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focar visualização principal |  |
 | `` / `` | Pesquisar na visualização atual por texto |  |
 
 ## Painel Principal (preparação)
@@ -336,6 +337,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 |-----|--------|-------------|
 | `` <tab> `` | Mudar de visão | Alternar para outra visão (staged/não processadas alterações). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focar visualização principal |  |
 | `` / `` | Pesquisar na visualização atual por texto |  |
 
 ## Stash

--- a/docs-master/keybindings/Keybindings_ru.md
+++ b/docs-master/keybindings/Keybindings_ru.md
@@ -73,6 +73,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 |-----|--------|-------------|
 | `` <tab> `` | Переключиться на другую панель (проиндексированные/непроиндексированные изменения) | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focus main view |  |
 | `` / `` | Найти |  |
 
 ## Главная панель (Индексирование)
@@ -105,6 +106,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <mouse wheel up> (fn+down) `` | Прокрутить вверх |  |
 | `` <tab> `` | Переключиться на другую панель (проиндексированные/непроиндексированные изменения) | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focus main view |  |
 | `` / `` | Найти |  |
 
 ## Главная панель (Слияние)

--- a/docs-master/keybindings/Keybindings_ru.md
+++ b/docs-master/keybindings/Keybindings_ru.md
@@ -74,6 +74,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | Переключиться на другую панель (проиндексированные/непроиндексированные изменения) | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Найти |  |
 
 ## Главная панель (Индексирование)
@@ -107,6 +108,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | Переключиться на другую панель (проиндексированные/непроиндексированные изменения) | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Найти |  |
 
 ## Главная панель (Слияние)
@@ -157,6 +159,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Просмотреть коммиты |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -199,6 +202,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Просмотреть файлы выбранного элемента |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Найти |  |
@@ -230,6 +234,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` u `` | View upstream options | View options relating to the branch's upstream e.g. setting/unsetting the upstream and resetting to the upstream. |
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Просмотреть коммиты |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -266,6 +271,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Просмотреть файлы выбранного элемента |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Найти |  |
@@ -309,6 +315,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Collapse all files | Collapse all directories in the files tree |
 | `` = `` | Expand all files | Expand all directories in the file tree |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Filter the current view by text |  |
 
 ## Статус
@@ -322,6 +329,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` a `` | Show/cycle all branch logs |  |
 | `` A `` | Show/cycle all branch logs (reverse) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 
 ## Теги
 
@@ -335,6 +343,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | Reset | View reset options (soft/mixed/hard) for resetting onto selected item. |
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Просмотреть коммиты |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -354,6 +363,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | Просмотреть параметры сброса | View reset options (soft/mixed/hard) for resetting onto selected item. |
 | `` <ctrl+t> `` | Open external diff tool (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Просмотреть коммиты |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |
@@ -401,6 +411,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Collapse all files | Collapse all directories in the files tree |
 | `` = `` | Expand all files | Expand all directories in the file tree |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | Filter the current view by text |  |
 
 ## Хранилище
@@ -413,6 +424,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` n `` | Новая ветка | Create a new branch from the selected stash entry. This works by git checking out the commit that the stash entry was created from, creating a new branch from that commit, then applying the stash entry to the new branch as an additional commit. |
 | `` r `` | Переименовать хранилище |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | Просмотреть файлы выбранного элемента |  |
 | `` w `` | View worktree options |  |
 | `` / `` | Filter the current view by text |  |

--- a/docs-master/keybindings/Keybindings_zh-CN.md
+++ b/docs-master/keybindings/Keybindings_zh-CN.md
@@ -285,6 +285,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 |-----|--------|-------------|
 | `` <tab> `` | 切换到其他面板 | 切换到其他视图（已暂存/未暂存的变更） |
 | `` <esc> `` | 退出回到侧边面板 |  |
+| `` 0 `` | 聚焦主视图 |  |
 | `` / `` | 开始搜索 |  |
 
 ## 正在合并
@@ -333,6 +334,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <mouse wheel up> (fn+down) `` | 向上滚动 |  |
 | `` <tab> `` | 切换到其他面板 | 切换到其他视图（已暂存/未暂存的变更） |
 | `` <esc> `` | 退出回到侧边面板 |  |
+| `` 0 `` | 聚焦主视图 |  |
 | `` / `` | 开始搜索 |  |
 
 ## 状态

--- a/docs-master/keybindings/Keybindings_zh-CN.md
+++ b/docs-master/keybindings/Keybindings_zh-CN.md
@@ -66,6 +66,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | 使用外部差异比较工具(git difftool) |  |
 | `` * `` | 选择当前分支的提交 |  |
 | `` 0 `` | 聚焦主视图 |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 查看提交的文件 |  |
 | `` w `` | 查看工作区选项 |  |
 | `` / `` | 开始搜索 |  |
@@ -110,6 +111,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | 使用外部差异比较工具(git difftool) |  |
 | `` * `` | 选择当前分支的提交 |  |
 | `` 0 `` | 聚焦主视图 |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 查看提交 |  |
 | `` w `` | 查看工作区选项 |  |
 | `` / `` | 通过文本过滤当前视图 |  |
@@ -152,6 +154,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | 使用外部差异比较工具(git difftool) |  |
 | `` * `` | 选择当前分支的提交 |  |
 | `` 0 `` | 聚焦主视图 |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 查看提交的文件 |  |
 | `` w `` | 查看工作区选项 |  |
 | `` / `` | 开始搜索 |  |
@@ -181,6 +184,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | 折叠全部文件 | 折叠文件树中的全部目录 |
 | `` = `` | 展开全部文件 | 展开文件树中的全部目录 |
 | `` 0 `` | 聚焦主视图 |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 通过文本过滤当前视图 |  |
 
 ## 文件
@@ -214,6 +218,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | 折叠全部文件 | 折叠文件树中的全部目录 |
 | `` = `` | 展开全部文件 | 展开文件树中的全部目录 |
 | `` 0 `` | 聚焦主视图 |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 通过文本过滤当前视图 |  |
 
 ## 本地分支
@@ -243,6 +248,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` u `` | 查看上游选项 | 查看与分支上游相关的选项，例如设置/取消设置上游和重置为上游。 |
 | `` <ctrl+t> `` | 使用外部差异比较工具(git difftool) |  |
 | `` 0 `` | 聚焦主视图 |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 查看提交 |  |
 | `` w `` | 查看工作区选项 |  |
 | `` / `` | 通过文本过滤当前视图 |  |
@@ -275,6 +281,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | 重置 | 查看重置选项 (soft/mixed/hard) 用于重置到选择项 |
 | `` <ctrl+t> `` | 使用外部差异比较工具(git difftool) |  |
 | `` 0 `` | 聚焦主视图 |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 查看提交 |  |
 | `` w `` | 查看工作区选项 |  |
 | `` / `` | 通过文本过滤当前视图 |  |
@@ -286,6 +293,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | 切换到其他面板 | 切换到其他视图（已暂存/未暂存的变更） |
 | `` <esc> `` | 退出回到侧边面板 |  |
 | `` 0 `` | 聚焦主视图 |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 开始搜索 |  |
 
 ## 正在合并
@@ -335,6 +343,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | 切换到其他面板 | 切换到其他视图（已暂存/未暂存的变更） |
 | `` <esc> `` | 退出回到侧边面板 |  |
 | `` 0 `` | 聚焦主视图 |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 开始搜索 |  |
 
 ## 状态
@@ -348,6 +357,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` a `` | 显示/循环所有分支日志 |  |
 | `` A `` | 显示/循环所有分支日志（反向） |  |
 | `` 0 `` | 聚焦主视图 |  |
+| `` 9 `` | Focus secondary view |  |
 
 ## 确认面板
 
@@ -375,6 +385,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` n `` | 新分支 | 从选定的贮藏项创建一个新分支。这是通过 git 检查创建贮藏项的提交，从该提交创建一个新分支，然后将贮藏项作为附加提交应用到新分支来实现的。 |
 | `` r `` | 重命名贮藏 |  |
 | `` 0 `` | 聚焦主视图 |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 查看提交的文件 |  |
 | `` w `` | 查看工作区选项 |  |
 | `` / `` | 通过文本过滤当前视图 |  |
@@ -413,6 +424,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | 查看重置选项 | 查看重置选项 (soft/mixed/hard) 用于重置到选择项 |
 | `` <ctrl+t> `` | 使用外部差异比较工具(git difftool) |  |
 | `` 0 `` | 聚焦主视图 |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 查看提交 |  |
 | `` w `` | 查看工作区选项 |  |
 | `` / `` | 通过文本过滤当前视图 |  |

--- a/docs-master/keybindings/Keybindings_zh-TW.md
+++ b/docs-master/keybindings/Keybindings_zh-TW.md
@@ -81,6 +81,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <mouse wheel up> (fn+down) `` | 向上捲動 |  |
 | `` <tab> `` | 切換至另一個面板 (已預存/未預存更改) | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focus main view |  |
 | `` / `` | 搜尋 |  |
 
 ## 主面板（合併）
@@ -362,6 +363,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 |-----|--------|-------------|
 | `` <tab> `` | 切換至另一個面板 (已預存/未預存更改) | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
+| `` 0 `` | Focus main view |  |
 | `` / `` | 搜尋 |  |
 
 ## 狀態

--- a/docs-master/keybindings/Keybindings_zh-TW.md
+++ b/docs-master/keybindings/Keybindings_zh-TW.md
@@ -82,6 +82,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | 切換至另一個面板 (已預存/未預存更改) | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 搜尋 |  |
 
 ## 主面板（合併）
@@ -146,6 +147,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | 開啟外部差異工具 (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 檢視所選項目的檔案 |  |
 | `` w `` | 檢視工作目錄選項 |  |
 | `` / `` | 搜尋 |  |
@@ -212,6 +214,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | 開啟外部差異工具 (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 檢視所選項目的檔案 |  |
 | `` w `` | 檢視工作目錄選項 |  |
 | `` / `` | 搜尋 |  |
@@ -241,6 +244,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Collapse all files | Collapse all directories in the files tree |
 | `` = `` | Expand all files | Expand all directories in the file tree |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 搜尋 |  |
 
 ## 收藏 (Stash)
@@ -253,6 +257,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` n `` | 新分支 | Create a new branch from the selected stash entry. This works by git checking out the commit that the stash entry was created from, creating a new branch from that commit, then applying the stash entry to the new branch as an additional commit. |
 | `` r `` | 重新命名收藏 |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 檢視所選項目的檔案 |  |
 | `` w `` | 檢視工作目錄選項 |  |
 | `` / `` | 搜尋 |  |
@@ -273,6 +278,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <ctrl+t> `` | 開啟外部差異工具 (git difftool) |  |
 | `` * `` | Select commits of current branch |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 檢視提交 |  |
 | `` w `` | 檢視工作目錄選項 |  |
 | `` / `` | 搜尋 |  |
@@ -304,6 +310,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` u `` | 檢視遠端設定 | 檢視有關遠端分支的設定（例如重設至遠端） |
 | `` <ctrl+t> `` | 開啟外部差異工具 (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 檢視提交 |  |
 | `` w `` | 檢視工作目錄選項 |  |
 | `` / `` | 搜尋 |  |
@@ -320,6 +327,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | 重設 | View reset options (soft/mixed/hard) for resetting onto selected item. |
 | `` <ctrl+t> `` | 開啟外部差異工具 (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 檢視提交 |  |
 | `` w `` | 檢視工作目錄選項 |  |
 | `` / `` | 搜尋 |  |
@@ -355,6 +363,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` - `` | Collapse all files | Collapse all directories in the files tree |
 | `` = `` | Expand all files | Expand all directories in the file tree |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 搜尋 |  |
 
 ## 次要
@@ -364,6 +373,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` <tab> `` | 切換至另一個面板 (已預存/未預存更改) | Switch to other view (staged/unstaged changes). |
 | `` <esc> `` | Exit back to side panel |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` / `` | 搜尋 |  |
 
 ## 狀態
@@ -377,6 +387,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` a `` | Show/cycle all branch logs |  |
 | `` A `` | Show/cycle all branch logs (reverse) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 
 ## 確認面板
 
@@ -413,6 +424,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` g `` | 檢視重設選項 | View reset options (soft/mixed/hard) for resetting onto selected item. |
 | `` <ctrl+t> `` | 開啟外部差異工具 (git difftool) |  |
 | `` 0 `` | Focus main view |  |
+| `` 9 `` | Focus secondary view |  |
 | `` <enter> `` | 檢視提交 |  |
 | `` w `` | 檢視工作目錄選項 |  |
 | `` / `` | 搜尋 |  |

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -458,23 +458,24 @@ type KeybindingUniversalConfig struct {
 	// Deprecated: add the key to `nextBlock` instead.
 	NextBlockAlt2 Keybinding `yaml:"nextBlock-alt2"`
 	// Deprecated: add the key to `prevBlock` instead.
-	PrevBlockAlt2     Keybinding   `yaml:"prevBlock-alt2"`
-	JumpToBlock       []Keybinding `yaml:"jumpToBlock"`
-	FocusMainView     Keybinding   `yaml:"focusMainView"`
-	NextMatch         Keybinding   `yaml:"nextMatch"`
-	PrevMatch         Keybinding   `yaml:"prevMatch"`
-	StartSearch       Keybinding   `yaml:"startSearch"`
-	MoveWordLeft      Keybinding   `yaml:"moveWordLeft"`      // <alt+left> on Mac
-	MoveWordRight     Keybinding   `yaml:"moveWordRight"`     // <alt+right> on Mac
-	BackspaceWord     Keybinding   `yaml:"backspaceWord"`     // <alt+backspace> on Mac
-	ForwardDeleteWord Keybinding   `yaml:"forwardDeleteWord"` // <alt+delete> on Mac
-	OptionMenu        Keybinding   `yaml:"optionMenu"`
-	Select            Keybinding   `yaml:"select"`
-	GoInto            Keybinding   `yaml:"goInto"`
-	Confirm           Keybinding   `yaml:"confirm"`
-	ConfirmMenu       Keybinding   `yaml:"confirmMenu"`
-	ConfirmSuggestion Keybinding   `yaml:"confirmSuggestion"`
-	ConfirmInEditor   Keybinding   `yaml:"confirmInEditor"` // <meta+enter> on Mac
+	PrevBlockAlt2      Keybinding   `yaml:"prevBlock-alt2"`
+	JumpToBlock        []Keybinding `yaml:"jumpToBlock"`
+	FocusMainView      Keybinding   `yaml:"focusMainView"`
+	FocusSecondaryView Keybinding   `yaml:"focusSecondaryView"`
+	NextMatch          Keybinding   `yaml:"nextMatch"`
+	PrevMatch          Keybinding   `yaml:"prevMatch"`
+	StartSearch        Keybinding   `yaml:"startSearch"`
+	MoveWordLeft       Keybinding   `yaml:"moveWordLeft"`      // <alt+left> on Mac
+	MoveWordRight      Keybinding   `yaml:"moveWordRight"`     // <alt+right> on Mac
+	BackspaceWord      Keybinding   `yaml:"backspaceWord"`     // <alt+backspace> on Mac
+	ForwardDeleteWord  Keybinding   `yaml:"forwardDeleteWord"` // <alt+delete> on Mac
+	OptionMenu         Keybinding   `yaml:"optionMenu"`
+	Select             Keybinding   `yaml:"select"`
+	GoInto             Keybinding   `yaml:"goInto"`
+	Confirm            Keybinding   `yaml:"confirm"`
+	ConfirmMenu        Keybinding   `yaml:"confirmMenu"`
+	ConfirmSuggestion  Keybinding   `yaml:"confirmSuggestion"`
+	ConfirmInEditor    Keybinding   `yaml:"confirmInEditor"` // <meta+enter> on Mac
 	// Deprecated: add the key to `confirmInEditor` instead.
 	ConfirmInEditorAlt Keybinding `yaml:"confirmInEditor-alt"`
 	Remove             Keybinding `yaml:"remove"`
@@ -973,6 +974,7 @@ func GetDefaultConfigForPlatform(platform string) *UserConfig {
 				NextBlockAlt2:                     Keybinding{"<tab>"},
 				JumpToBlock:                       []Keybinding{{"1"}, {"2"}, {"3"}, {"4"}, {"5"}},
 				FocusMainView:                     Keybinding{"0"},
+				FocusSecondaryView:                Keybinding{"9"},
 				NextMatch:                         Keybinding{"n"},
 				PrevMatch:                         Keybinding{"N"},
 				StartSearch:                       Keybinding{"/"},

--- a/pkg/gui/controllers.go
+++ b/pkg/gui/controllers.go
@@ -270,6 +270,8 @@ func (gui *Gui) resetHelpersAndControllers() {
 		gui.State.Contexts.SubCommits,
 		gui.State.Contexts.CommitFiles,
 		gui.State.Contexts.Stash,
+		gui.State.Contexts.Normal,
+		gui.State.Contexts.NormalSecondary,
 	} {
 		controllers.AttachControllers(context, controllers.NewSwitchToFocusedMainViewController(
 			common, context,

--- a/pkg/gui/controllers/switch_to_focused_main_view_controller.go
+++ b/pkg/gui/controllers/switch_to_focused_main_view_controller.go
@@ -5,7 +5,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 )
 
-// This controller is for all contexts that can focus their main view.
+// This controller is for all contexts that can focus their main or secondary view.
 
 var _ types.IController = &SwitchToFocusedMainViewController{}
 
@@ -32,6 +32,12 @@ func (self *SwitchToFocusedMainViewController) GetKeybindings(opts types.Keybind
 			Keys:        opts.GetKeys(opts.Config.Universal.FocusMainView),
 			Handler:     self.handleFocusMainView,
 			Description: self.c.Tr.FocusMainView,
+			Tag:         "global",
+		},
+		{
+			Keys:        opts.GetKeys(opts.Config.Universal.FocusSecondaryView),
+			Handler:     self.handleFocusSecondaryView,
+			Description: self.c.Tr.FocusSecondaryView,
 			Tag:         "global",
 		},
 	}
@@ -70,6 +76,13 @@ func (self *SwitchToFocusedMainViewController) onClickSecondary(opts gocui.ViewM
 
 func (self *SwitchToFocusedMainViewController) handleFocusMainView() error {
 	return self.focusMainView(self.c.Contexts().Normal)
+}
+
+func (self *SwitchToFocusedMainViewController) handleFocusSecondaryView() error {
+	if !self.c.State().GetRepoState().GetSplitMainPanel() {
+		return nil
+	}
+	return self.focusMainView(self.c.Contexts().NormalSecondary)
 }
 
 func (self *SwitchToFocusedMainViewController) focusMainView(mainViewContext types.Context) error {

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -238,6 +238,7 @@ func (gui *Gui) configureViewProperties() {
 		gui.Views.Stash.TitlePrefix = jumpLabels[4]
 
 		gui.Views.Main.TitlePrefix = keyToTitlePrefix(gui.c.UserConfig().Keybinding.Universal.FocusMainView)
+		gui.Views.Secondary.TitlePrefix = keyToTitlePrefix(gui.c.UserConfig().Keybinding.Universal.FocusSecondaryView)
 	} else {
 		gui.Views.Status.TitlePrefix = ""
 
@@ -255,6 +256,7 @@ func (gui *Gui) configureViewProperties() {
 		gui.Views.Stash.TitlePrefix = ""
 
 		gui.Views.Main.TitlePrefix = ""
+		gui.Views.Secondary.TitlePrefix = ""
 	}
 
 	for _, view := range gui.g.Views() {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -265,6 +265,7 @@ type TranslationSet struct {
 	ExcludeFile                           string
 	RefreshFiles                          string
 	FocusMainView                         string
+	FocusSecondaryView                    string
 	Merge                                 string
 	MergeBranchTooltip                    string
 	RegularMergeFastForward               string
@@ -1383,6 +1384,7 @@ func EnglishTranslationSet() *TranslationSet {
 		ExcludeFile:                          `Add to .git/info/exclude`,
 		RefreshFiles:                         `Refresh files`,
 		FocusMainView:                        "Focus main view",
+		FocusSecondaryView:                   "Focus secondary view",
 		Merge:                                `Merge`,
 		MergeBranchTooltip:                   "View options for merging the selected item into the current branch (regular merge, squash merge)",
 		RegularMergeFastForward:              "Regular merge (fast-forward)",

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -467,6 +467,7 @@ var tests = []*components.IntegrationTest{
 	ui.DisableSwitchTabWithPanelJumpKeys,
 	ui.EmptyMenu,
 	ui.FocusMainViewFromSecondary,
+	ui.FocusSecondaryView,
 	ui.KeybindingSuggestionsDontCrashOnDisabledBindings,
 	ui.KeybindingSuggestionsWhenSwitchingRepos,
 	ui.ModeSpecificKeybindingSuggestions,

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -466,6 +466,7 @@ var tests = []*components.IntegrationTest{
 	ui.Accordion,
 	ui.DisableSwitchTabWithPanelJumpKeys,
 	ui.EmptyMenu,
+	ui.FocusMainViewFromSecondary,
 	ui.KeybindingSuggestionsDontCrashOnDisabledBindings,
 	ui.KeybindingSuggestionsWhenSwitchingRepos,
 	ui.ModeSpecificKeybindingSuggestions,

--- a/pkg/integration/tests/ui/focus_main_view_from_secondary.go
+++ b/pkg/integration/tests/ui/focus_main_view_from_secondary.go
@@ -1,0 +1,53 @@
+package ui
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var FocusMainViewFromSecondary = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Focus the primary main view with its keybinding while the secondary main view is focused",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		// Two separate hunks so we can stage one and leave the other unstaged,
+		// splitting the main panel into a primary (unstaged) and secondary (staged) view
+		shell.
+			CreateFileAndAdd("file1", "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n").
+			Commit("initial commit").
+			UpdateFile("file1", "line1-changed\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10-changed\n")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		// Stage the first hunk so file1 is partially staged and the main panel splits
+		t.Views().Files().
+			IsFocused().
+			Lines(
+				Contains("file1").IsSelected(),
+			).
+			PressEnter()
+
+		t.Views().Staging().
+			IsFocused().
+			PressPrimaryAction(). // stage first hunk
+			PressEscape()
+
+		// Focus the primary main view from the side panel
+		t.Views().Files().
+			IsFocused().
+			Press(keys.Universal.FocusMainView)
+
+		// Toggle across to the secondary main view
+		t.Views().Main().
+			IsFocused().
+			Press(keys.Universal.TogglePanel)
+
+		// The focus-main-view key returns focus to the primary view from the secondary
+		t.Views().Secondary().
+			IsFocused().
+			Press(keys.Universal.FocusMainView)
+
+		t.Views().Main().
+			IsFocused()
+	},
+})

--- a/pkg/integration/tests/ui/focus_secondary_view.go
+++ b/pkg/integration/tests/ui/focus_secondary_view.go
@@ -1,0 +1,72 @@
+package ui
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var FocusSecondaryView = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Focus the secondary main view with the keybinding and switch between main views",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		// Two separate hunks so we can stage one and leave the other unstaged
+		shell.
+			CreateFileAndAdd("file1", "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n").
+			Commit("initial commit").
+			UpdateFile("file1", "line1-changed\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10-changed\n")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		// No secondary view yet — pressing the focus-secondary key is a no-op
+		t.Views().Files().
+			IsFocused().
+			Press(keys.Universal.FocusSecondaryView).
+			IsFocused()
+
+		// Enter staging view and stage first hunk to create a partially staged file
+		t.Views().Files().
+			IsFocused().
+			Lines(
+				Contains("file1").IsSelected(),
+			).
+			PressEnter()
+
+		t.Views().Staging().
+			IsFocused().
+			PressPrimaryAction(). // stage first hunk
+			PressEscape()
+
+		// Back in Files panel with file1 partially staged — split main panel is visible
+		t.Views().Files().
+			IsFocused()
+
+		// Focus secondary view from side panel
+		t.Views().Files().
+			Press(keys.Universal.FocusSecondaryView)
+
+		t.Views().Secondary().
+			IsFocused()
+
+		// Switch from secondary to primary main view
+		t.Views().Secondary().
+			Press(keys.Universal.FocusMainView)
+
+		t.Views().Main().
+			IsFocused()
+
+		// Switch from primary back to secondary main view
+		t.Views().Main().
+			Press(keys.Universal.FocusSecondaryView)
+
+		t.Views().Secondary().
+			IsFocused()
+
+		// Escape back to side panel
+		t.Views().Secondary().
+			PressEscape()
+
+		t.Views().Files().
+			IsFocused()
+	},
+})

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -2600,6 +2600,20 @@
           ],
           "default": "0"
         },
+        "focusSecondaryView": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "default": "9"
+        },
         "nextMatch": {
           "oneOf": [
             {


### PR DESCRIPTION
### PR Description

Adds a `focusSecondaryView` keybinding (default `9`) to focus the secondary main view directly, mirroring the existing `focusMainView` (`0`). `0` focuses the primary main view and `9` the secondar, forming a natural pair, adjacent on the number row. The secondary panel title shows `[9]` when `showPanelJumps` is enabled, and the binding is configurable via `keybinding.universal.focusSecondaryView`.

#### Motivation: Jump straight to staged
Reaching the secondary main view (for example the staged diff of a partially-staged file) otherwise takes multiple key presses, whereas the primary already has a direct key. While using lazygit I often found myself wanting to jump straight to staged changes. Beyond just staged vs unstaged, the pattern is also extensible to any lazygit view with a primary and secondary panel.

#### Fix: Main View 
The first commit is a small, separable pre-existing fix: `SwitchToFocusedMainViewController` was only attached to the side panels, so the focus-main-view key (`0`) did nothing once a main view itself was focused. The keybinding still appears in the view title, so it seemed reasonable that it would still move focus. Attaching it to the `Normal`/`NormalSecondary` contexts makes `0` (and the new `9`) work from within the main view, e.g. returning to the primary from the secondary. I isolated this change to its own commit with its own regression test.

#### Testing
Integration tests added for both the *fix* (focus the primary from the secondary via the keybinding) and the *feature*(focus the secondary from a side panel, switch between the two main views, and no-op when no secondary view is visible). Manually verified with `showPanelJumps` on and off, with a custom key, and with `<disabled>`. Keybinding tips page also verified.

#### Requirements Check:

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted
* [x] Tests have been added/updated
* [x] Text is internationalised
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
