### PR TITLE
fix(app): restore panel keys in Vim/Neovim :term on Windows

### DIFF
--- a/pkg/app/entry_point.go
+++ b/pkg/app/entry_point.go
@@ -51,6 +51,8 @@ type BuildInfo struct {
 }
 
 func Start(buildInfo *BuildInfo, integrationTest integrationTypes.IntegrationTest) {
+	applyNestedTerminalKeyboardWorkaround()
+
 	cliArgs := parseCliArgsAndEnvVars()
 	mergeBuildInfo(buildInfo)
 

--- a/pkg/app/nested_terminal_keyboard.go
+++ b/pkg/app/nested_terminal_keyboard.go
@@ -1,0 +1,26 @@
+package app
+
+import (
+	"os"
+	"runtime"
+)
+
+// shouldForceWin32KeyboardProtocol returns true when lazygit is running inside a
+// nested editor terminal on Windows. tcell's multi-protocol keyboard negotiation
+// can break panel navigation in Vim/Neovim :term buffers; win32-input-mode alone
+// is the reliable path there.
+func shouldForceWin32KeyboardProtocol(goos string, getenv func(string) string) bool {
+	if goos != "windows" {
+		return false
+	}
+	if getenv("TCELL_KEYBOARD_PROTOCOL") != "" {
+		return false
+	}
+	return getenv("VIM_TERMINAL") != "" || getenv("NVIM") != ""
+}
+
+func applyNestedTerminalKeyboardWorkaround() {
+	if shouldForceWin32KeyboardProtocol(runtime.GOOS, os.Getenv) {
+		_ = os.Setenv("TCELL_KEYBOARD_PROTOCOL", "win32")
+	}
+}

--- a/pkg/app/nested_terminal_keyboard_test.go
+++ b/pkg/app/nested_terminal_keyboard_test.go
@@ -1,0 +1,57 @@
+package app
+
+import "testing"
+
+func TestShouldForceWin32KeyboardProtocol(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		env  map[string]string
+		want bool
+	}{
+		{
+			name: "linux ignores nested editor terminals",
+			goos: "linux",
+			env:  map[string]string{"VIM_TERMINAL": "1"},
+			want: false,
+		},
+		{
+			name: "windows vim terminal",
+			goos: "windows",
+			env:  map[string]string{"VIM_TERMINAL": "1"},
+			want: true,
+		},
+		{
+			name: "windows neovim terminal",
+			goos: "windows",
+			env:  map[string]string{"NVIM": "/tmp/nvim.sock"},
+			want: true,
+		},
+		{
+			name: "windows standalone terminal",
+			goos: "windows",
+			env:  map[string]string{},
+			want: false,
+		},
+		{
+			name: "respects explicit override",
+			goos: "windows",
+			env: map[string]string{
+				"VIM_TERMINAL":            "1",
+				"TCELL_KEYBOARD_PROTOCOL": "legacy",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getenv := func(key string) string {
+				return tt.env[key]
+			}
+			if got := shouldForceWin32KeyboardProtocol(tt.goos, getenv); got != tt.want {
+				t.Fatalf("shouldForceWin32KeyboardProtocol() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #5679

## Problem

Panel navigation (tab, hjkl, escape) breaks when lazygit runs inside Vim/Neovim `:term` on Windows, while the same build works in a normal terminal emulator.

Regression window: **v0.57.0 OK → v0.58.0+ broken**, coinciding with the tcell 2.13 / gocui bump (`fec7e9ce6`).

## Root cause (hypothesis)

tcell negotiates multiple keyboard protocols when `TERM` is xterm-like. Nested editor terminals appear to mishandle that negotiation, while standalone Windows terminals do not.

## Fix

On Windows, when running inside a nested Vim/Neovim terminal (`VIM_TERMINAL` or `NVIM` set) and the user has not already set `TCELL_KEYBOARD_PROTOCOL`, force `win32` so tcell uses win32-input-mode only.

## Workaround (pre-fix)

```cmd
set TCELL_KEYBOARD_PROTOCOL=win32
lazygit
```

## Tests

- `pkg/app/nested_terminal_keyboard_test.go` covers detection logic (platform, env markers, explicit override).

## Verification needed

I do not have Windows + Vim `:term` in this environment. Before marking ready for review, could someone confirm:

1. The workaround above restores panel switching in `:term`
2. This branch does the same without the manual env var
3. Standalone Windows Terminal / Alacritty behavior is unchanged

Happy to adjust detection heuristics based on feedback.