### PR TITLE
feat: restore commit message when undoing commits

### DIFF
--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -179,6 +179,22 @@ func (self *CommitsHelper) ClearPreservedCommitMessage() {
 	self.c.Contexts().CommitMessage.SetPreservedMessageAndLogError("")
 }
 
+func (self *CommitsHelper) PreserveCommitMessageForCommit(commitHash string) error {
+	message, err := self.c.Git().Commit.GetCommitMessage(commitHash)
+	if err != nil {
+		return err
+	}
+
+	summary, description := self.SplitCommitMessageAndDescription(message)
+	preservedMessage := summary
+	if description != "" {
+		preservedMessage += "\n" + description
+	}
+
+	self.c.Contexts().CommitMessage.SetPreservedMessageAndLogError(preservedMessage)
+	return nil
+}
+
 func (self *CommitsHelper) HandleCommitConfirm() error {
 	summary, description := self.getCommitSummary(), self.getCommitDescription()
 

--- a/pkg/gui/controllers/undo_controller.go
+++ b/pkg/gui/controllers/undo_controller.go
@@ -48,6 +48,7 @@ type reflogAction struct {
 	kind ReflogActionKind
 	from string
 	to   string
+	msg  bool
 }
 
 func (self *UndoController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
@@ -94,7 +95,15 @@ func (self *UndoController) reflogUndo() error {
 				HandleConfirm: func() error {
 					self.c.LogAction(self.c.Tr.Actions.Undo)
 					return self.c.WithWaitingStatus(undoingStatus, func(gocui.Task) error {
-						return self.c.Helpers().Refs.ResetToRef(action.from, "soft", undoEnvVars)
+						if err := self.c.Helpers().Refs.ResetToRef(action.from, "soft", undoEnvVars); err != nil {
+							return err
+						}
+
+						if action.msg {
+							return self.c.Helpers().Commits.PreserveCommitMessageForCommit(action.to)
+						}
+
+						return nil
 					})
 				},
 			})
@@ -160,10 +169,18 @@ func (self *UndoController) reflogRedo() error {
 				Prompt: fmt.Sprintf(self.c.Tr.HardResetAutostashPrompt, utils.ShortHash(action.to)),
 				HandleConfirm: func() error {
 					self.c.LogAction(self.c.Tr.Actions.Redo)
-					return self.hardResetWithAutoStash(action.to, hardResetOptions{
+					if err := self.hardResetWithAutoStash(action.to, hardResetOptions{
 						EnvVars:       redoEnvVars,
 						WaitingStatus: redoingStatus,
-					})
+					}); err != nil {
+						return err
+					}
+
+					if action.msg {
+						self.c.Helpers().Commits.ClearPreservedCommitMessage()
+					}
+
+					return nil
 				},
 			})
 			return true, nil
@@ -219,7 +236,9 @@ func (self *UndoController) parseReflogForActions(onUserAction func(counter int,
 				rebaseFinishCommitHash = reflogCommit.Hash()
 			} else if ok, match := utils.FindStringSubmatch(reflogCommit.Name, `^checkout: moving from ([\S]+) to ([\S]+)`); ok {
 				action = &reflogAction{kind: CHECKOUT, from: match[1], to: match[2]}
-			} else if ok, _ := utils.FindStringSubmatch(reflogCommit.Name, `^commit|^reset: moving to|^pull`); ok {
+			} else if ok, _ := utils.FindStringSubmatch(reflogCommit.Name, `^commit`); ok {
+				action = &reflogAction{kind: COMMIT, from: prevCommitHash, to: reflogCommit.Hash(), msg: true}
+			} else if ok, _ := utils.FindStringSubmatch(reflogCommit.Name, `^reset: moving to|^pull`); ok {
 				action = &reflogAction{kind: COMMIT, from: prevCommitHash, to: reflogCommit.Hash()}
 			} else if ok, _ := utils.FindStringSubmatch(reflogCommit.Name, `^rebase (-i )?\(start\)`); ok {
 				// if we're here then we must be currently inside an interactive rebase

--- a/pkg/integration/tests/undo/undo_commit.go
+++ b/pkg/integration/tests/undo/undo_commit.go
@@ -14,7 +14,7 @@ var UndoCommit = NewIntegrationTest(NewIntegrationTestArgs{
 		shell.CreateFileAndAdd("other-file", "other-file-1")
 		shell.Commit("one")
 		shell.CreateFileAndAdd("file", "file-1")
-		shell.Commit("two")
+		shell.RunCommand([]string{"git", "commit", "-m", "two", "-m", "first paragraph\n\nsecond paragraph"})
 		shell.UpdateFile("other-file", "other-file-2")
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
@@ -62,6 +62,15 @@ var UndoCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Equals("   M other-file"),
 			)
 
+		t.Views().Files().Focus().
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			Content(Equals("two")).
+			SwitchToDescription().
+			Content(Equals("first paragraph\n\nsecond paragraph")).
+			Cancel()
+
 		t.Views().Commits().Focus().
 			Press(keys.Universal.Redo).
 			Tap(confirmRedo).
@@ -69,6 +78,8 @@ var UndoCommit = NewIntegrationTest(NewIntegrationTestArgs{
 				Contains("two").IsSelected(),
 				Contains("one"),
 			)
+
+		t.FileSystem().PathNotPresent(".git/LAZYGIT_PENDING_COMMIT")
 
 		t.Views().Files().
 			Lines(
@@ -98,7 +109,7 @@ var UndoCommit = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Universal.Redo).
 			Tap(confirmRedo)
 
-		t.Views().Commits().
+		t.Views().Commits().Focus().
 			Lines(
 				Contains("two"),
 				Contains("one"),


### PR DESCRIPTION
### PR Description
#### Summary
Undoing a commit should leave the user as close as possible to the moment before they pressed commit. This change makes that workflow smoother by restoring the undone commit’s message into the commit panel after the soft reset, so the user can immediately review, tweak, and recommit without reconstructing the message manually.

#### Changes
- Preserve the commit message from the undone commit when the undo action corresponds to a real commit.
- Store the restored message using Lazygit’s existing `LAZYGIT_PENDING_COMMIT` draft mechanism, so subject/body behavior stays consistent with normal commit-message preservation.
- Clear the restored message when the commit is redone, preventing stale messages from leaking into later commits.
- Extend the undo integration test to verify staged changes remain available and the previous subject/body reappear in the commit panel.

#### Why
A soft reset already puts the committed changes back into a recommittable state, but losing the commit message makes “undo, adjust, recommit” more expensive than it needs to be. Preserving the message completes that workflow: the content and intent of the commit both come back together.


### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
