### PR TITLE
Adds: prompt to allow empty commit messages

### DIFF
--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -135,6 +135,10 @@ func (self *CommitCommands) commitMessageArgs(summary string, description string
 		args = append(args, "-m", description)
 	}
 
+	if strings.TrimSpace(summary) == "" && strings.TrimSpace(description) == "" {
+		args = append(args, "--allow-empty-message")
+	}
+
 	return args
 }
 

--- a/pkg/commands/git_commands/commit_test.go
+++ b/pkg/commands/git_commands/commit_test.go
@@ -28,6 +28,12 @@ func TestCommitRewordCommit(t *testing.T) {
 			"test",
 			"line 2\nline 3",
 		},
+		{
+			"Empty reword",
+			oscommands.NewFakeRunner(t).ExpectGitArgs([]string{"commit", "--allow-empty", "--amend", "--only", "-m", "", "--allow-empty-message"}, "", nil),
+			"",
+			"",
+		},
 	}
 	for _, s := range scenarios {
 		t.Run(s.testName, func(t *testing.T) {
@@ -117,6 +123,22 @@ func TestCommitCommitCmdObj(t *testing.T) {
 			configSignoff:        true,
 			configSkipHookPrefix: "WIP",
 			expectedArgs:         []string{"commit", "--no-verify", "--signoff", "-m", "WIP: test"},
+		},
+		{
+			testName:             "Commit with empty message",
+			summary:              "",
+			forceSkipHooks:       false,
+			configSignoff:        false,
+			configSkipHookPrefix: "",
+			expectedArgs:         []string{"commit", "-m", "", "--allow-empty-message"},
+		},
+		{
+			testName:             "Commit with whitespace-only message",
+			summary:              "  ",
+			forceSkipHooks:       false,
+			configSignoff:        false,
+			configSkipHookPrefix: "",
+			expectedArgs:         []string{"commit", "-m", "  ", "--allow-empty-message"},
 		},
 	}
 

--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -1,7 +1,6 @@
 package helpers
 
 import (
-	"errors"
 	"path/filepath"
 	"strings"
 	"time"
@@ -183,7 +182,29 @@ func (self *CommitsHelper) HandleCommitConfirm() error {
 	summary, description := self.getCommitSummary(), self.getCommitDescription()
 
 	if strings.TrimSpace(summary) == "" {
-		return errors.New(self.c.Tr.CommitWithoutMessageErr)
+		self.c.Menu(types.CreateMenuOptions{
+			Title:      self.c.Tr.Confirm,
+			Prompt:     self.c.Tr.CommitWithoutMessagePrompt,
+			HideCancel: true,
+			Items: []*types.MenuItem{
+				{
+					Label: self.c.Tr.Confirm,
+					OnPress: func() error {
+						self.CloseCommitMessagePanel()
+						return self.c.Contexts().CommitMessage.OnConfirm(summary, description)
+					},
+					Keys: menuKey('y'),
+				},
+				{
+					Label: self.c.Tr.Close,
+					OnPress: func() error {
+						return nil
+					},
+					Keys: menuKey('n'),
+				},
+			},
+		})
+		return nil
 	}
 
 	err := self.c.Contexts().CommitMessage.OnConfirm(summary, description)

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -155,6 +155,7 @@ type TranslationSet struct {
 	CannotMoveCommitsNoUnpushedCommits    string
 	NoBranchesThisRepo                    string
 	CommitWithoutMessageErr               string
+	CommitWithoutMessagePrompt            string
 	Close                                 string
 	CloseCancel                           string
 	Confirm                               string
@@ -1280,6 +1281,7 @@ func EnglishTranslationSet() *TranslationSet {
 		CannotMoveCommitsNoUnpushedCommits:   "There are no unpushed commits to move to a new branch",
 		NoBranchesThisRepo:                   "No branches for this repo",
 		CommitWithoutMessageErr:              "You cannot commit without a commit message",
+		CommitWithoutMessagePrompt:           "You have not entered a commit message. Commit anyway with an empty message?",
 		Close:                                "Close",
 		CloseCancel:                          "Close/Cancel",
 		Confirm:                              "Confirm",


### PR DESCRIPTION
This change introduces #5641 a confirmation prompt when attempting to commit without a message. Instead of blocking the commit with an error, lazygit now presents a menu allowing you to proceed with an empty message (automatically adding the --allow empty-message flag) or return to the editor.

   - I18n: Added CommitWithoutMessagePrompt to the translation set.
   - UI: Updated HandleCommitConfirm to show a menu with explicit 'y' (confirm) and 'n' (close) bindings when the commit summary is empty.
   - Git Commands: Modified commitMessageArgs to append the --allow-empty-message flag when both summary and description are empty or
     whitespace-only.
   - Tests: Added unit tests to pkg/commands/git_commands/commit_test.go to verify the correct construction of git commands for empty commits
     and rewords.