### PR TITLE
Refresh main branch cache after branch deletion

### DIFF
--- a/pkg/commands/git_commands/main_branches.go
+++ b/pkg/commands/git_commands/main_branches.go
@@ -46,10 +46,17 @@ func (self *MainBranches) Get() []string {
 
 	if self.existingMainBranches == nil || !slices.Equal(self.previousMainBranches, configuredMainBranches) {
 		self.existingMainBranches = self.determineMainBranches(configuredMainBranches)
-		self.previousMainBranches = configuredMainBranches
+		self.previousMainBranches = slices.Clone(configuredMainBranches)
 	}
 
 	return self.existingMainBranches
+}
+
+func (self *MainBranches) Invalidate() {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	self.existingMainBranches = nil
 }
 
 // Return the merge base of the given refName with the closest main branch.
@@ -66,8 +73,8 @@ func (self *MainBranches) GetMergeBase(refName string) string {
 	// error is because one of the main branches has been deleted since the last
 	// call to determineMainBranches, or because the refName has no common
 	// history with any of the main branches. Since the former should happen
-	// very rarely, users must quit and restart lazygit to fix it; the latter is
-	// also not very common, but can totally happen and is not an error.
+	// very rarely and will be fixed on the next branch/commit refresh, we treat
+	// both cases as no merge base for now.
 
 	output, _, _ := self.cmd.New(
 		NewGitCmd("merge-base").Arg(refName).Arg(mainBranches...).

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -136,6 +136,7 @@ func (self *RefreshHelper) Refresh(options types.RefreshOptions) {
 		// refreshing; the risk is one potential extra refresh, but capturing the
 		// snapshot at the end would risk missing one, which is worse.
 		self.updateRefsSnapshotIfRelevant(scopeSet)
+		self.invalidateMainBranchesIfRelevant(scopeSet)
 
 		wg := sync.WaitGroup{}
 		refresh := func(name string, f func()) {
@@ -306,7 +307,7 @@ func (self *RefreshHelper) RefsSnapshotChangedSince(snapshot string) bool {
 // top of Refresh has already added these whenever REFLOG or BISECT_INFO are
 // in scope, and whenever a nil scope was passed.
 func (self *RefreshHelper) updateRefsSnapshotIfRelevant(scopeSet *set.Set[types.RefreshableView]) {
-	if !scopeSet.Includes(types.COMMITS) && !scopeSet.Includes(types.BRANCHES) {
+	if !refreshesRefs(scopeSet) {
 		return
 	}
 
@@ -316,6 +317,16 @@ func (self *RefreshHelper) updateRefsSnapshotIfRelevant(scopeSet *set.Set[types.
 		return
 	}
 	self.SetRefsSnapshot(snapshot)
+}
+
+func (self *RefreshHelper) invalidateMainBranchesIfRelevant(scopeSet *set.Set[types.RefreshableView]) {
+	if refreshesRefs(scopeSet) {
+		self.c.Model().MainBranches.Invalidate()
+	}
+}
+
+func refreshesRefs(scopeSet *set.Set[types.RefreshableView]) bool {
+	return scopeSet.Includes(types.COMMITS) || scopeSet.Includes(types.BRANCHES)
 }
 
 func getScopeNames(scopes []types.RefreshableView) []string {

--- a/pkg/integration/tests/branch/delete_after_main_branch.go
+++ b/pkg/integration/tests/branch/delete_after_main_branch.go
@@ -1,0 +1,49 @@
+package branch
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var DeleteAfterMainBranch = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Delete a local branch after deleting one of the configured main branches",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.
+			EmptyCommit("first commit").
+			NewBranch("main").
+			Checkout("master").
+			NewBranch("dev").
+			Checkout("master")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			NavigateToLine(Contains("main")).
+			Press(keys.Universal.Remove).
+			Tap(func() {
+				t.ExpectPopup().
+					Menu().
+					Title(Equals("Delete branch 'main'?")).
+					Select(Contains("Delete local branch")).
+					Confirm()
+			}).
+			Lines(
+				Contains("master"),
+				Contains("dev").IsSelected(),
+			).
+			Press(keys.Universal.Remove).
+			Tap(func() {
+				t.ExpectPopup().
+					Menu().
+					Title(Equals("Delete branch 'dev'?")).
+					Select(Contains("Delete local branch")).
+					Confirm()
+			}).
+			Lines(
+				Contains("master").IsSelected(),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -44,6 +44,7 @@ var tests = []*components.IntegrationTest{
 	branch.CheckoutPreviousBranch,
 	branch.CreateTag,
 	branch.Delete,
+	branch.DeleteAfterMainBranch,
 	branch.DeleteMultiple,
 	branch.DeleteRemoteBranchWhenTagWithSameNameExists,
 	branch.DeleteRemoteBranchWithCredentialPrompt,


### PR DESCRIPTION
### PR Description

Fixes https://github.com/jesseduffield/lazygit/issues/5196.

Handles stale main-branch state after deleting a configured main branch by invalidating the cached main branches whenever refs are refreshed via commits or branches. This lets subsequent branch operations recompute existing main branches instead of requiring a restart.

Also clones configured main branch names before caching them to avoid aliasing config slices, and adds an integration test covering deleting another local branch after deleting a configured main branch.

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
