### PR TITLE
Add a global keybinding for editing the config file

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -715,6 +715,7 @@ keybinding:
     increaseRenameSimilarityThreshold: )
     decreaseRenameSimilarityThreshold: (
     openDiffTool: <ctrl+t>
+    editConfig: <alt+shift+c>
   status:
     checkForUpdate: u
     recentRepos: <enter>

--- a/docs-master/keybindings/Keybindings_en.md
+++ b/docs-master/keybindings/Keybindings_en.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | Quit |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | Toggle whitespace | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <alt+shift+c> `` | Edit config file | Open file in external editor. |
 | `` z `` | Undo | The reflog will be used to determine what git command to run to undo the last git command. This does not include changes to the working tree; only commits are taken into consideration. |
 | `` Z `` | Redo | The reflog will be used to determine what git command to run to redo the last git command. This does not include changes to the working tree; only commits are taken into consideration. |
 

--- a/docs-master/keybindings/Keybindings_en.md
+++ b/docs-master/keybindings/Keybindings_en.md
@@ -348,7 +348,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` o `` | Open config file | Open file in default application. |
 | `` e `` | Edit config file | Open file in external editor. |
 | `` u `` | Check for update |  |
 | `` <enter> `` | Switch to a recent repo |  |

--- a/docs-master/keybindings/Keybindings_ja.md
+++ b/docs-master/keybindings/Keybindings_ja.md
@@ -179,7 +179,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` o `` | 設定ファイルを開く | デフォルトのアプリケーションでファイルを開きます。 |
 | `` e `` | 設定ファイルを編集 | 外部エディタでファイルを開きます。 |
 | `` u `` | 更新を確認 |  |
 | `` <enter> `` | 最近のリポジトリをチェックアウト |  |

--- a/docs-master/keybindings/Keybindings_ja.md
+++ b/docs-master/keybindings/Keybindings_ja.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | 終了 |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | 空白表示の切り替え | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <alt+shift+c> `` | 設定ファイルを編集 | 外部エディタでファイルを開きます。 |
 | `` z `` | 元に戻す | 最後のgitコマンドを元に戻すために実行するgitコマンドを決定するためにreflogが使用されます。これにはワーキングツリーへの変更は含まれません。コミットのみが考慮されます。 |
 | `` Z `` | やり直す | 最後のgitコマンドをやり直すために実行するgitコマンドを決定するためにreflogが使用されます。これにはワーキングツリーへの変更は含まれません。コミットのみが考慮されます。 |
 

--- a/docs-master/keybindings/Keybindings_ko.md
+++ b/docs-master/keybindings/Keybindings_ko.md
@@ -237,7 +237,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` o `` | 설정 파일 열기 | Open file in default application. |
 | `` e `` | 설정 파일 수정 | Open file in external editor. |
 | `` u `` | 업데이트 확인 |  |
 | `` <enter> `` | 최근에 사용한 저장소로 전환 |  |

--- a/docs-master/keybindings/Keybindings_ko.md
+++ b/docs-master/keybindings/Keybindings_ko.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | 종료 |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | 공백문자를 Diff 뷰에서 표시 여부 전환 | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <alt+shift+c> `` | 설정 파일 수정 | Open file in external editor. |
 | `` z `` | 되돌리기 (reflog) (실험적) | The reflog will be used to determine what git command to run to undo the last git command. This does not include changes to the working tree; only commits are taken into consideration. |
 | `` Z `` | 다시 실행 (reflog) (실험적) | The reflog will be used to determine what git command to run to redo the last git command. This does not include changes to the working tree; only commits are taken into consideration. |
 

--- a/docs-master/keybindings/Keybindings_nl.md
+++ b/docs-master/keybindings/Keybindings_nl.md
@@ -348,7 +348,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` o `` | Open config bestand | Open file in default application. |
 | `` e `` | Verander config bestand | Open file in external editor. |
 | `` u `` | Check voor updates |  |
 | `` <enter> `` | Wissel naar een recente repo |  |

--- a/docs-master/keybindings/Keybindings_nl.md
+++ b/docs-master/keybindings/Keybindings_nl.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | Quit |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | Toggle whitespace | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <alt+shift+c> `` | Verander config bestand | Open file in external editor. |
 | `` z `` | Ongedaan maken (via reflog) (experimenteel) | The reflog will be used to determine what git command to run to undo the last git command. This does not include changes to the working tree; only commits are taken into consideration. |
 | `` Z `` | Redo (via reflog) (experimenteel) | The reflog will be used to determine what git command to run to redo the last git command. This does not include changes to the working tree; only commits are taken into consideration. |
 

--- a/docs-master/keybindings/Keybindings_pl.md
+++ b/docs-master/keybindings/Keybindings_pl.md
@@ -327,7 +327,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` o `` | Otwórz plik konfiguracyjny | Otwórz plik w domyślnej aplikacji. |
 | `` e `` | Edytuj plik konfiguracyjny | Otwórz plik w zewnętrznym edytorze. |
 | `` u `` | Sprawdź aktualizacje |  |
 | `` <enter> `` | Przełącz na ostatnie repozytorium |  |

--- a/docs-master/keybindings/Keybindings_pl.md
+++ b/docs-master/keybindings/Keybindings_pl.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | Wyjdź |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | Przełącz białe znaki | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <alt+shift+c> `` | Edytuj plik konfiguracyjny | Otwórz plik w zewnętrznym edytorze. |
 | `` z `` | Cofnij | Dziennik reflog zostanie użyty do określenia, jakie polecenie git należy uruchomić, aby cofnąć ostatnie polecenie git. Nie obejmuje to zmian w drzewie roboczym; brane są pod uwagę tylko commity. |
 | `` Z `` | Ponów | Dziennik reflog zostanie użyty do określenia, jakie polecenie git należy uruchomić, aby ponowić ostatnie polecenie git. Nie obejmuje to zmian w drzewie roboczym; brane są pod uwagę tylko commity. |
 

--- a/docs-master/keybindings/Keybindings_pt.md
+++ b/docs-master/keybindings/Keybindings_pt.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | Sair |  |
 | `` <ctrl+z> `` | Suspender a aplicação |  |
 | `` <ctrl+w> `` | Toggle whitespace | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <alt+shift+c> `` | Editar arquivo de configuração | Abrir arquivo no editor externo. |
 | `` z `` | Desfazer | O reflog será usado para determinar qual comando git para executar para desfazer o último comando git. Isto não inclui mudanças na árvore de trabalho; apenas compromissos são tidos em consideração. |
 | `` Z `` | Refazer | O reflog será usado para determinar qual comando git para executar para refazer o último comando git. Isto não inclui mudanças na árvore de trabalho; apenas compromissos são tidos em consideração. |
 

--- a/docs-master/keybindings/Keybindings_pt.md
+++ b/docs-master/keybindings/Keybindings_pt.md
@@ -357,7 +357,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` o `` | Abrir o ficheiro de config | Abrir arquivo no aplicativo padrão. |
 | `` e `` | Editar arquivo de configuração | Abrir arquivo no editor externo. |
 | `` u `` | Verificar atualização |  |
 | `` <enter> `` | Mudar para um repositório recente |  |

--- a/docs-master/keybindings/Keybindings_ru.md
+++ b/docs-master/keybindings/Keybindings_ru.md
@@ -314,7 +314,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` o `` | Открыть файл конфигурации | Open file in default application. |
 | `` e `` | Редактировать файл конфигурации | Open file in external editor. |
 | `` u `` | Проверить обновления |  |
 | `` <enter> `` | Переключиться на последний репозиторий |  |

--- a/docs-master/keybindings/Keybindings_ru.md
+++ b/docs-master/keybindings/Keybindings_ru.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | Выйти |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | Переключить отображение изменении пробелов в просмотрщике сравнении | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <alt+shift+c> `` | Редактировать файл конфигурации | Open file in external editor. |
 | `` z `` | Отменить (через reflog) (экспериментальный) | Журнал ссылок (reflog) будет использоваться для определения того, какую команду git запустить, чтобы отменить последнюю команду git. Сюда не входят изменения в рабочем дереве; учитываются только коммиты. |
 | `` Z `` | Повторить (через reflog) (экспериментальный) | Журнал ссылок (reflog) будет использоваться для определения того, какую команду git нужно запустить, чтобы повторить последнюю команду git. Сюда не входят изменения в рабочем дереве; учитываются только коммиты. |
 

--- a/docs-master/keybindings/Keybindings_zh-CN.md
+++ b/docs-master/keybindings/Keybindings_zh-CN.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | 退出 |  |
 | `` <ctrl+z> `` | 挂起应用程序 |  |
 | `` <ctrl+w> `` | 切换是否在差异视图中显示空白字符差异 | 切换是否在差异视图中显示空白字符更改。<br><br>默认值可在配置文件中通过键 'git.ignoreWhitespaceInDiffView' 更改。 |
+| `` <alt+shift+c> `` | 编辑配置文件 | 使用外部编辑器打开文件 |
 | `` z `` | 撤销 | Reflog将用于确定运行哪个git命令来撤消最后一个git命令。这并不包括对工作树的更改，只考虑提交。 |
 | `` Z `` | 重做 | Reflog将用于确定运行哪个git命令来重做上一个git命令。这并不包括对工作树的更改，只考虑提交。 |
 

--- a/docs-master/keybindings/Keybindings_zh-CN.md
+++ b/docs-master/keybindings/Keybindings_zh-CN.md
@@ -340,7 +340,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` o `` | 打开配置文件 | 使用默认程序打开该文件 |
 | `` e `` | 编辑配置文件 | 使用外部编辑器打开文件 |
 | `` u `` | 检查更新 |  |
 | `` <enter> `` | 切换到最近的仓库 |  |

--- a/docs-master/keybindings/Keybindings_zh-TW.md
+++ b/docs-master/keybindings/Keybindings_zh-TW.md
@@ -369,7 +369,6 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 
 | Key | Action | Info |
 |-----|--------|-------------|
-| `` o `` | 開啟設定檔案 | 使用預設軟體開啟 |
 | `` e `` | 編輯設定檔案 | 使用外部編輯器開啟 |
 | `` u `` | 檢查更新 |  |
 | `` <enter> `` | 切換到最近使用的版本庫 |  |

--- a/docs-master/keybindings/Keybindings_zh-TW.md
+++ b/docs-master/keybindings/Keybindings_zh-TW.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | 結束 |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | 切換是否在差異檢視中顯示空格變更 | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <alt+shift+c> `` | 編輯設定檔案 | 使用外部編輯器開啟 |
 | `` z `` | 復原 | 將使用 reflog 確任 git 指令以復原。這不包括工作區更改；只考慮提交。 |
 | `` Z `` | 取消復原 | 將使用 reflog 確任 git 指令以重作。這不包括工作區更改；只考慮提交。 |
 

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -542,6 +542,7 @@ type KeybindingUniversalConfig struct {
 	IncreaseRenameSimilarityThreshold Keybinding `yaml:"increaseRenameSimilarityThreshold"`
 	DecreaseRenameSimilarityThreshold Keybinding `yaml:"decreaseRenameSimilarityThreshold"`
 	OpenDiffTool                      Keybinding `yaml:"openDiffTool"`
+	EditConfig                        Keybinding `yaml:"editConfig"`
 }
 
 type KeybindingStatusConfig struct {
@@ -1058,6 +1059,7 @@ func GetDefaultConfigForPlatform(platform string) *UserConfig {
 				IncreaseRenameSimilarityThreshold: Keybinding{")"},
 				DecreaseRenameSimilarityThreshold: Keybinding{"("},
 				OpenDiffTool:                      Keybinding{"<ctrl+t>"},
+				EditConfig:                        Keybinding{"<alt+shift+c>"},
 			},
 			Status: KeybindingStatusConfig{
 				CheckForUpdate:             Keybinding{"u"},

--- a/pkg/gui/controllers/edit_config_action.go
+++ b/pkg/gui/controllers/edit_config_action.go
@@ -1,0 +1,36 @@
+package controllers
+
+import (
+	"errors"
+
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/samber/lo"
+)
+
+type EditConfigAction struct {
+	c *ControllerCommon
+}
+
+func (self *EditConfigAction) Call() error {
+	confPaths := self.c.GetConfig().GetUserConfigPaths()
+	switch len(confPaths) {
+	case 0:
+		return errors.New(self.c.Tr.NoConfigFileFoundErr)
+	case 1:
+		return self.c.Helpers().Files.EditFiles(confPaths)
+	default:
+		menuItems := lo.Map(confPaths, func(path string, _ int) *types.MenuItem {
+			return &types.MenuItem{
+				Label: path,
+				OnPress: func() error {
+					return self.c.Helpers().Files.EditFiles([]string{path})
+				},
+			}
+		})
+
+		return self.c.Menu(types.CreateMenuOptions{
+			Title: self.c.Tr.SelectConfigFile,
+			Items: menuItems,
+		})
+	}
+}

--- a/pkg/gui/controllers/global_controller.go
+++ b/pkg/gui/controllers/global_controller.go
@@ -136,6 +136,12 @@ func (self *GlobalController) GetKeybindings(opts types.KeybindingsOpts) []*type
 			Description: self.c.Tr.ToggleWhitespaceInDiffView,
 			Tooltip:     self.c.Tr.ToggleWhitespaceInDiffViewTooltip,
 		},
+		{
+			Keys:        opts.GetKeys(opts.Config.Universal.EditConfig),
+			Handler:     self.editConfig,
+			Description: self.c.Tr.EditConfig,
+			Tooltip:     self.c.Tr.EditFileTooltip,
+		},
 	}
 }
 
@@ -265,6 +271,10 @@ func (self *GlobalController) escapeEnabled() *types.DisabledReason {
 
 func (self *GlobalController) toggleWhitespace() error {
 	return (&ToggleWhitespaceAction{c: self.c}).Call()
+}
+
+func (self *GlobalController) editConfig() error {
+	return (&EditConfigAction{c: self.c}).Call()
 }
 
 func (self *GlobalController) canShowRebaseOptions() *types.DisabledReason {

--- a/pkg/gui/controllers/status_controller.go
+++ b/pkg/gui/controllers/status_controller.go
@@ -34,12 +34,6 @@ func NewStatusController(
 func (self *StatusController) GetKeybindings(opts types.KeybindingsOpts) []*types.Binding {
 	bindings := []*types.Binding{
 		{
-			Keys:        opts.GetKeys(opts.Config.Universal.OpenFile),
-			Handler:     self.openConfig,
-			Description: self.c.Tr.OpenConfig,
-			Tooltip:     self.c.Tr.OpenFileTooltip,
-		},
-		{
 			Keys:            opts.GetKeys(opts.Config.Universal.Edit),
 			Handler:         self.editConfig,
 			Description:     self.c.Tr.EditConfig,
@@ -170,10 +164,6 @@ func (self *StatusController) askForConfigFile(action func(file string) error) e
 			Items: menuItems,
 		})
 	}
-}
-
-func (self *StatusController) openConfig() error {
-	return self.askForConfigFile(self.c.Helpers().Files.OpenFile)
 }
 
 func (self *StatusController) editConfig() error {

--- a/pkg/gui/controllers/status_controller.go
+++ b/pkg/gui/controllers/status_controller.go
@@ -142,19 +142,19 @@ func lazygitTitle() string {
                |___/ |___/       `
 }
 
-func (self *StatusController) askForConfigFile(action func(file string) error) error {
+func (self *StatusController) editConfig() error {
 	confPaths := self.c.GetConfig().GetUserConfigPaths()
 	switch len(confPaths) {
 	case 0:
 		return errors.New(self.c.Tr.NoConfigFileFoundErr)
 	case 1:
-		return action(confPaths[0])
+		return self.c.Helpers().Files.EditFiles(confPaths)
 	default:
 		menuItems := lo.Map(confPaths, func(path string, _ int) *types.MenuItem {
 			return &types.MenuItem{
 				Label: path,
 				OnPress: func() error {
-					return action(path)
+					return self.c.Helpers().Files.EditFiles([]string{path})
 				},
 			}
 		})
@@ -164,12 +164,6 @@ func (self *StatusController) askForConfigFile(action func(file string) error) e
 			Items: menuItems,
 		})
 	}
-}
-
-func (self *StatusController) editConfig() error {
-	return self.askForConfigFile(func(file string) error {
-		return self.c.Helpers().Files.EditFiles([]string{file})
-	})
 }
 
 func (self *StatusController) showAllBranchLogs() {

--- a/pkg/gui/controllers/status_controller.go
+++ b/pkg/gui/controllers/status_controller.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -12,7 +11,6 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
-	"github.com/samber/lo"
 )
 
 type StatusController struct {
@@ -143,27 +141,7 @@ func lazygitTitle() string {
 }
 
 func (self *StatusController) editConfig() error {
-	confPaths := self.c.GetConfig().GetUserConfigPaths()
-	switch len(confPaths) {
-	case 0:
-		return errors.New(self.c.Tr.NoConfigFileFoundErr)
-	case 1:
-		return self.c.Helpers().Files.EditFiles(confPaths)
-	default:
-		menuItems := lo.Map(confPaths, func(path string, _ int) *types.MenuItem {
-			return &types.MenuItem{
-				Label: path,
-				OnPress: func() error {
-					return self.c.Helpers().Files.EditFiles([]string{path})
-				},
-			}
-		})
-
-		return self.c.Menu(types.CreateMenuOptions{
-			Title: self.c.Tr.SelectConfigFile,
-			Items: menuItems,
-		})
-	}
+	return (&EditConfigAction{c: self.c}).Call()
 }
 
 func (self *StatusController) showAllBranchLogs() {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -231,7 +231,6 @@ type TranslationSet struct {
 	StashChanges                          string
 	RenameStash                           string
 	RenameStashPrompt                     string
-	OpenConfig                            string
 	EditConfig                            string
 	ForcePush                             string
 	ForcePushPrompt                       string
@@ -1357,7 +1356,6 @@ func EnglishTranslationSet() *TranslationSet {
 		StashChanges:                         "Stash changes",
 		RenameStash:                          "Rename stash",
 		RenameStashPrompt:                    "Rename stash: {{.stashName}}",
-		OpenConfig:                           "Open config file",
 		EditConfig:                           "Edit config file",
 		ForcePush:                            "Force push",
 		ForcePushPrompt:                      "Your branch has diverged from the remote branch. Press {{.cancelKey}} to cancel, or {{.confirmKey}} to force push.",

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -3388,6 +3388,20 @@
             }
           ],
           "default": "\u003cctrl+t\u003e"
+        },
+        "editConfig": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "default": "\u003calt+shift+c\u003e"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
The status panel already binds the universal edit key to "edit config file", but that's only reachable while the status panel is focused. Add a dedicated global binding (alt+shift+c) so the config file can be opened from anywhere.