### PR TITLE
Fix data race with status string

### DIFF
--- a/pkg/gui/status/status_manager.go
+++ b/pkg/gui/status/status_manager.go
@@ -70,6 +70,9 @@ func (self *StatusManager) AddToastStatus(message string, kind types.ToastKind) 
 }
 
 func (self *StatusManager) GetStatusString(userConfig *config.UserConfig) (string, gocui.Attribute) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
 	if len(self.statuses) == 0 {
 		return "", gocui.ColorDefault
 	}
@@ -81,6 +84,9 @@ func (self *StatusManager) GetStatusString(userConfig *config.UserConfig) (strin
 }
 
 func (self *StatusManager) HasStatus() bool {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
 	return len(self.statuses) > 0
 }
 


### PR DESCRIPTION
GetStatusString and HasStatus read the statuses slice without holding the mutex that addStatus and removeStatus take when they mutate it. The readers run on the spinner-render worker (which polls GetStatusString every frame) while removeStatus fires from the waiting-status and toast-expiry goroutines, so the unguarded reads race the concurrent writes. Take the mutex in the readers too.

This doesn't fix any user-visible issue that I know of; labelling it as "maintenance" rather than "bug" for that reason. It is one of many steps that gets us closer to running our test suite with `-race`.