### PR TITLE
Make integration tests using commits more robust

### DIFF
--- a/pkg/integration/components/shell.go
+++ b/pkg/integration/components/shell.go
@@ -256,7 +256,7 @@ func (self *Shell) CreateNCommitsStartingAt(n, startIndex int) *Shell {
 			fmt.Sprintf("file%02d.txt", i),
 			fmt.Sprintf("file%02d content", i),
 		).
-			Commit(fmt.Sprintf("commit %02d", i))
+			Commit(fmt.Sprintf("commit-%02d", i))
 	}
 
 	return self

--- a/pkg/integration/tests/bisect/basic.go
+++ b/pkg/integration/tests/bisect/basic.go
@@ -34,29 +34,29 @@ var Basic = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Commits().
 			Focus().
-			SelectedLine(Contains("CI commit 10")).
-			NavigateToLine(Contains("CI commit 09")).
+			SelectedLine(Contains("CI commit-10")).
+			NavigateToLine(Contains("CI commit-09")).
 			Tap(func() {
 				markCommitAsBad()
 
 				t.Views().Information().Content(Contains("Bisecting"))
 			}).
 			SelectedLine(Contains("<-- bad")).
-			NavigateToLine(Contains("CI commit 02")).
+			NavigateToLine(Contains("CI commit-02")).
 			Tap(markCommitAsGood).
-			TopLines(Contains("CI commit 10")).
+			TopLines(Contains("CI commit-10")).
 			// lazygit will land us in the commit between our good and bad commits.
-			SelectedLine(Contains("CI commit 05").Contains("<-- current")).
+			SelectedLine(Contains("CI commit-05").Contains("<-- current")).
 			Tap(markCommitAsBad).
-			SelectedLine(Contains("CI commit 04").Contains("<-- current")).
+			SelectedLine(Contains("CI commit-04").Contains("<-- current")).
 			Tap(func() {
 				markCommitAsGood()
 
 				// commit 5 is the culprit because we marked 4 as good and 5 as bad.
-				t.ExpectPopup().Alert().Title(Equals("Bisect complete")).Content(MatchesRegexp("(?s)commit 05.*Do you want to reset")).Confirm()
+				t.ExpectPopup().Alert().Title(Equals("Bisect complete")).Content(MatchesRegexp("(?s)commit-05.*Do you want to reset")).Confirm()
 			}).
 			IsFocused().
-			Content(Contains("CI commit 04"))
+			Content(Contains("CI commit-04"))
 
 		t.Views().Information().Content(DoesNotContain("Bisecting"))
 	},

--- a/pkg/integration/tests/bisect/choose_terms.go
+++ b/pkg/integration/tests/bisect/choose_terms.go
@@ -34,40 +34,40 @@ var ChooseTerms = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Commits().
 			Focus().
-			SelectedLine(Contains("CI commit 10")).
+			SelectedLine(Contains("CI commit-10")).
 			Press(keys.Commits.ViewBisectOptions).
 			Tap(func() {
 				t.ExpectPopup().Menu().Title(Equals("Bisect")).Select(Contains("Choose bisect terms")).Confirm()
 				t.ExpectPopup().Prompt().Title(Equals("Term for old/good commit:")).Type("broken").Confirm()
 				t.ExpectPopup().Prompt().Title(Equals("Term for new/bad commit:")).Type("fixed").Confirm()
 			}).
-			NavigateToLine(Contains("CI commit 09")).
+			NavigateToLine(Contains("CI commit-09")).
 			Tap(markCommitAsFixed).
 			SelectedLine(Contains("<-- fixed")).
-			NavigateToLine(Contains("CI commit 02")).
+			NavigateToLine(Contains("CI commit-02")).
 			Tap(markCommitAsBroken).
 			Lines(
-				Contains("CI commit 10").DoesNotContain("<--"),
-				Contains("CI commit 09").Contains("<-- fixed"),
-				Contains("CI commit 08").DoesNotContain("<--"),
-				Contains("CI commit 07").DoesNotContain("<--"),
-				Contains("CI commit 06").DoesNotContain("<--"),
-				Contains("CI commit 05").Contains("<-- current").IsSelected(),
-				Contains("CI commit 04").DoesNotContain("<--"),
-				Contains("CI commit 03").DoesNotContain("<--"),
-				Contains("CI commit 02").Contains("<-- broken"),
-				Contains("CI commit 01").DoesNotContain("<--"),
+				Contains("CI commit-10").DoesNotContain("<--"),
+				Contains("CI commit-09").Contains("<-- fixed"),
+				Contains("CI commit-08").DoesNotContain("<--"),
+				Contains("CI commit-07").DoesNotContain("<--"),
+				Contains("CI commit-06").DoesNotContain("<--"),
+				Contains("CI commit-05").Contains("<-- current").IsSelected(),
+				Contains("CI commit-04").DoesNotContain("<--"),
+				Contains("CI commit-03").DoesNotContain("<--"),
+				Contains("CI commit-02").Contains("<-- broken"),
+				Contains("CI commit-01").DoesNotContain("<--"),
 			).
 			Tap(markCommitAsFixed).
-			SelectedLine(Contains("CI commit 04").Contains("<-- current")).
+			SelectedLine(Contains("CI commit-04").Contains("<-- current")).
 			Tap(func() {
 				markCommitAsBroken()
 
 				// commit 5 is the culprit because we marked 4 as broken and 5 as fixed.
-				t.ExpectPopup().Alert().Title(Equals("Bisect complete")).Content(MatchesRegexp("(?s)commit 05.*Do you want to reset")).Confirm()
+				t.ExpectPopup().Alert().Title(Equals("Bisect complete")).Content(MatchesRegexp("(?s)commit-05.*Do you want to reset")).Confirm()
 			}).
 			IsFocused().
-			Content(Contains("CI commit 04"))
+			Content(Contains("CI commit-04"))
 
 		t.Views().Information().Content(DoesNotContain("Bisecting"))
 	},

--- a/pkg/integration/tests/bisect/from_other_branch.go
+++ b/pkg/integration/tests/bisect/from_other_branch.go
@@ -24,17 +24,17 @@ var FromOtherBranch = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			TopLines(
-				MatchesRegexp(`<-- bad.*commit 08`),
-				MatchesRegexp(`<-- current.*commit 07`),
-				MatchesRegexp(`\?.*commit 06`),
-				MatchesRegexp(`<-- good.*commit 05`),
+				MatchesRegexp(`<-- bad.*commit-08`),
+				MatchesRegexp(`<-- current.*commit-07`),
+				MatchesRegexp(`\?.*commit-06`),
+				MatchesRegexp(`<-- good.*commit-05`),
 			).
 			SelectNextItem().
 			Press(keys.Commits.ViewBisectOptions).
 			Tap(func() {
 				t.ExpectPopup().Menu().Title(Equals("Bisect")).Select(MatchesRegexp(`Mark .* as good`)).Confirm()
 
-				t.ExpectPopup().Alert().Title(Equals("Bisect complete")).Content(MatchesRegexp("(?s)commit 08.*Do you want to reset")).Confirm()
+				t.ExpectPopup().Alert().Title(Equals("Bisect complete")).Content(MatchesRegexp("(?s)commit-08.*Do you want to reset")).Confirm()
 
 				t.Views().Information().Content(DoesNotContain("Bisecting"))
 			}).

--- a/pkg/integration/tests/bisect/skip.go
+++ b/pkg/integration/tests/bisect/skip.go
@@ -19,28 +19,28 @@ var Skip = NewIntegrationTest(NewIntegrationTestArgs{
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().
 			Focus().
-			SelectedLine(Contains("commit 10")).
+			SelectedLine(Contains("commit-10")).
 			Press(keys.Commits.ViewBisectOptions).
 			Tap(func() {
 				t.ExpectPopup().Menu().Title(Equals("Bisect")).Select(MatchesRegexp(`Mark .* as bad`)).Confirm()
 			}).
-			NavigateToLine(Contains("commit 01")).
+			NavigateToLine(Contains("commit-01")).
 			Press(keys.Commits.ViewBisectOptions).
 			Tap(func() {
 				t.ExpectPopup().Menu().Title(Equals("Bisect")).Select(MatchesRegexp(`Mark .* as good`)).Confirm()
 				t.Views().Information().Content(Contains("Bisecting"))
 			}).
 			Lines(
-				Contains("CI commit 10").Contains("<-- bad"),
-				Contains("CI commit 09").DoesNotContain("<--"),
-				Contains("CI commit 08").DoesNotContain("<--"),
-				Contains("CI commit 07").DoesNotContain("<--"),
-				Contains("CI commit 06").DoesNotContain("<--"),
-				Contains("CI commit 05").Contains("<-- current").IsSelected(),
-				Contains("CI commit 04").DoesNotContain("<--"),
-				Contains("CI commit 03").DoesNotContain("<--"),
-				Contains("CI commit 02").DoesNotContain("<--"),
-				Contains("CI commit 01").Contains("<-- good"),
+				Contains("CI commit-10").Contains("<-- bad"),
+				Contains("CI commit-09").DoesNotContain("<--"),
+				Contains("CI commit-08").DoesNotContain("<--"),
+				Contains("CI commit-07").DoesNotContain("<--"),
+				Contains("CI commit-06").DoesNotContain("<--"),
+				Contains("CI commit-05").Contains("<-- current").IsSelected(),
+				Contains("CI commit-04").DoesNotContain("<--"),
+				Contains("CI commit-03").DoesNotContain("<--"),
+				Contains("CI commit-02").DoesNotContain("<--"),
+				Contains("CI commit-01").Contains("<-- good"),
 			).
 			Press(keys.Commits.ViewBisectOptions).
 			Tap(func() {
@@ -57,18 +57,18 @@ var Skip = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			// Skipping the current commit selects the new current commit:
 			Lines(
-				Contains("CI commit 10").Contains("<-- bad"),
-				Contains("CI commit 09").DoesNotContain("<--"),
-				Contains("CI commit 08").DoesNotContain("<--"),
-				Contains("CI commit 07").DoesNotContain("<--"),
-				Contains("CI commit 06").Contains("<-- current").IsSelected(),
-				Contains("CI commit 05").Contains("<-- skipped"),
-				Contains("CI commit 04").DoesNotContain("<--"),
-				Contains("CI commit 03").DoesNotContain("<--"),
-				Contains("CI commit 02").DoesNotContain("<--"),
-				Contains("CI commit 01").Contains("<-- good"),
+				Contains("CI commit-10").Contains("<-- bad"),
+				Contains("CI commit-09").DoesNotContain("<--"),
+				Contains("CI commit-08").DoesNotContain("<--"),
+				Contains("CI commit-07").DoesNotContain("<--"),
+				Contains("CI commit-06").Contains("<-- current").IsSelected(),
+				Contains("CI commit-05").Contains("<-- skipped"),
+				Contains("CI commit-04").DoesNotContain("<--"),
+				Contains("CI commit-03").DoesNotContain("<--"),
+				Contains("CI commit-02").DoesNotContain("<--"),
+				Contains("CI commit-01").Contains("<-- good"),
 			).
-			NavigateToLine(Contains("commit 07")).
+			NavigateToLine(Contains("commit-07")).
 			Press(keys.Commits.ViewBisectOptions).
 			Tap(func() {
 				t.ExpectPopup().Menu().Title(Equals("Bisect")).
@@ -85,6 +85,6 @@ var Skip = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			// Skipping a selected, non-current commit keeps the selection
 			// there:
-			SelectedLine(Contains("CI commit 07").Contains("<-- skipped"))
+			SelectedLine(Contains("CI commit-07").Contains("<-- skipped"))
 	},
 })

--- a/pkg/integration/tests/branch/select_commits_of_current_branch.go
+++ b/pkg/integration/tests/branch/select_commits_of_current_branch.go
@@ -22,25 +22,25 @@ var SelectCommitsOfCurrentBranch = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 03").IsSelected(),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
 				Contains("master 02"),
 				Contains("master 01"),
 			).
 			Press(keys.Commits.SelectCommitsOfCurrentBranch).
 			Lines(
-				Contains("commit 03").IsSelected(),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01").IsSelected(),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01").IsSelected(),
 				Contains("master 02"),
 				Contains("master 01"),
 			).
 			PressEscape().
 			Lines(
-				Contains("commit 03").IsSelected(),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
 				Contains("master 02"),
 				Contains("master 01"),
 			)
@@ -58,15 +58,15 @@ var SelectCommitsOfCurrentBranch = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().SubCommits().
 			IsFocused().
 			Lines(
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 				Contains("master 02"),
 				Contains("master 01"),
 			).
 			Press(keys.Commits.SelectCommitsOfCurrentBranch).
 			Lines(
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01").IsSelected(),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01").IsSelected(),
 				Contains("master 02"),
 				Contains("master 01"),
 			)

--- a/pkg/integration/tests/commit/create_amend_commit.go
+++ b/pkg/integration/tests/commit/create_amend_commit.go
@@ -19,11 +19,11 @@ var CreateAmendCommit = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Commits.CreateFixupCommit).
 			Tap(func() {
 				t.ExpectPopup().Menu().
@@ -31,14 +31,14 @@ var CreateAmendCommit = NewIntegrationTest(NewIntegrationTestArgs{
 					Select(Contains("amend! commit with changes")).
 					Confirm()
 				t.ExpectPopup().CommitMessagePanel().
-					Content(Equals("commit 02")).
+					Content(Equals("commit-02")).
 					Type(" amended").Confirm()
 			}).
 			Lines(
-				Contains("amend! commit 02"),
-				Contains("commit 03"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("amend! commit-02"),
+				Contains("commit-03"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			)
 
 		t.Views().Commits().
@@ -50,9 +50,9 @@ var CreateAmendCommit = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02 amended").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02 amended").IsSelected(),
+				Contains("commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/custom_commands/selected_commit.go
+++ b/pkg/integration/tests/custom_commands/selected_commit.go
@@ -24,44 +24,44 @@ var SelectedCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		// Select different commits in each of the commit views
 		t.Views().Commits().Focus().
-			NavigateToLine(Contains("commit 01"))
+			NavigateToLine(Contains("commit-01"))
 		t.Views().ReflogCommits().Focus().
-			NavigateToLine(Contains("commit 02"))
+			NavigateToLine(Contains("commit-02"))
 		t.Views().Branches().Focus().
 			Lines(Contains("master").IsSelected()).
 			PressEnter()
 		t.Views().SubCommits().IsFocused().
-			NavigateToLine(Contains("commit 03"))
+			NavigateToLine(Contains("commit-03"))
 
 		// SubCommits
 		t.GlobalPress(config.Keybinding{"X"})
-		t.FileSystem().FileContent("file.txt", Equals("commit 03"))
+		t.FileSystem().FileContent("file.txt", Equals("commit-03"))
 
 		t.Views().SubCommits().PressEnter()
 		t.GlobalPress(config.Keybinding{"X"})
-		t.FileSystem().FileContent("file.txt", Equals("commit 03"))
+		t.FileSystem().FileContent("file.txt", Equals("commit-03"))
 
 		// ReflogCommits
 		t.Views().ReflogCommits().Focus()
 		t.GlobalPress(config.Keybinding{"X"})
-		t.FileSystem().FileContent("file.txt", Equals("commit: commit 02"))
+		t.FileSystem().FileContent("file.txt", Equals("commit: commit-02"))
 
 		t.Views().ReflogCommits().PressEnter()
 		t.GlobalPress(config.Keybinding{"X"})
-		t.FileSystem().FileContent("file.txt", Equals("commit: commit 02"))
+		t.FileSystem().FileContent("file.txt", Equals("commit: commit-02"))
 
 		// LocalCommits
 		t.Views().Commits().Focus()
 		t.GlobalPress(config.Keybinding{"X"})
-		t.FileSystem().FileContent("file.txt", Equals("commit 01"))
+		t.FileSystem().FileContent("file.txt", Equals("commit-01"))
 
 		t.Views().Commits().PressEnter()
 		t.GlobalPress(config.Keybinding{"X"})
-		t.FileSystem().FileContent("file.txt", Equals("commit 01"))
+		t.FileSystem().FileContent("file.txt", Equals("commit-01"))
 
 		// None of these
 		t.Views().Files().Focus()
 		t.GlobalPress(config.Keybinding{"X"})
-		t.FileSystem().FileContent("file.txt", Equals("commit 01"))
+		t.FileSystem().FileContent("file.txt", Equals("commit-01"))
 	},
 })

--- a/pkg/integration/tests/custom_commands/selected_commit_range.go
+++ b/pkg/integration/tests/custom_commands/selected_commit_range.go
@@ -24,18 +24,18 @@ var SelectedCommitRange = NewIntegrationTest(NewIntegrationTestArgs{
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().Focus().
 			Lines(
-				Contains("commit 03").IsSelected(),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			)
 
 		t.GlobalPress(config.Keybinding{"X"})
-		t.FileSystem().FileContent("file.txt", Equals("commit 03\n"))
+		t.FileSystem().FileContent("file.txt", Equals("commit-03\n"))
 
 		t.Views().Commits().Focus().
 			Press(keys.Universal.RangeSelectDown)
 
 		t.GlobalPress(config.Keybinding{"X"})
-		t.FileSystem().FileContent("file.txt", Equals("commit 03\ncommit 02\n"))
+		t.FileSystem().FileContent("file.txt", Equals("commit-03\ncommit-02\n"))
 	},
 })

--- a/pkg/integration/tests/filter_by_author/select_author.go
+++ b/pkg/integration/tests/filter_by_author/select_author.go
@@ -29,14 +29,14 @@ var SelectAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			IsFocused().
 			Lines(
-				Contains("commit 7"),
-				Contains("commit 6"),
-				Contains("commit 5"),
-				Contains("commit 4"),
-				Contains("commit 3"),
-				Contains("commit 2"),
-				Contains("commit 1"),
-				Contains("commit 0"),
+				Contains("commit-7"),
+				Contains("commit-6"),
+				Contains("commit-5"),
+				Contains("commit-4"),
+				Contains("commit-3"),
+				Contains("commit-2"),
+				Contains("commit-1"),
+				Contains("commit-0"),
 			)
 
 		t.Views().Information().Content(Contains("Filtering by 'Paul Oberstein <paul.oberstein@email.com>'"))
@@ -51,7 +51,7 @@ var SelectAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 
 		t.Views().Commits().
 			IsFocused().
-			NavigateToLine(Contains("SK commit 0")).
+			NavigateToLine(Contains("SK commit-0")).
 			Press(keys.Universal.FilteringMenu)
 
 		t.ExpectPopup().Menu().
@@ -62,7 +62,7 @@ var SelectAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			IsFocused().
 			Lines(
-				Contains("commit 0"),
+				Contains("commit-0"),
 			)
 
 		t.Views().Information().Content(Contains("Filtering by 'Siegfried Kircheis <siegfried.kircheis@email.com>'"))

--- a/pkg/integration/tests/filter_by_author/shared.go
+++ b/pkg/integration/tests/filter_by_author/shared.go
@@ -20,7 +20,7 @@ func commonSetup(shell *Shell) {
 	for _, authorInfo := range authors {
 		for i := range authorInfo.numberOfCommits {
 			authorEmail := strings.ToLower(strings.ReplaceAll(authorInfo.name, " ", ".")) + "@email.com"
-			commitMessage := fmt.Sprintf("commit %d", i)
+			commitMessage := fmt.Sprintf("commit-%d", i)
 
 			shell.SetAuthor(authorInfo.name, authorEmail)
 			shell.EmptyCommitDaysAgo(commitMessage, repoStartDaysAgo-totalCommits)

--- a/pkg/integration/tests/filter_by_author/type_author.go
+++ b/pkg/integration/tests/filter_by_author/type_author.go
@@ -33,9 +33,9 @@ var TypeAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			IsFocused().
 			Lines(
-				Contains("commit 2"),
-				Contains("commit 1"),
-				Contains("commit 0"),
+				Contains("commit-2"),
+				Contains("commit-1"),
+				Contains("commit-0"),
 			)
 
 		t.Views().Information().Content(Contains("Filtering by 'Yang Wen-li <yang.wen-li@email.com>'"))
@@ -58,7 +58,7 @@ var TypeAuthor = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			IsFocused().
 			Lines(
-				Contains("commit 0"),
+				Contains("commit-0"),
 			)
 
 		t.Views().Information().Content(Contains("Filtering by 'Siegfried Kircheis <siegfried.kircheis@email.com>'"))

--- a/pkg/integration/tests/interactive_rebase/amend_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/amend_first_commit.go
@@ -19,10 +19,10 @@ var AmendFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 01")).
+			NavigateToLine(Contains("commit-01")).
 			Press(keys.Commits.AmendToCommit).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
@@ -31,8 +31,8 @@ var AmendFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			Lines(
-				Contains("commit 02"),
-				Contains("commit 01").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01").IsSelected(),
 			)
 
 		t.Views().Main().

--- a/pkg/integration/tests/interactive_rebase/amend_fixup_commit.go
+++ b/pkg/integration/tests/interactive_rebase/amend_fixup_commit.go
@@ -13,22 +13,22 @@ var AmendFixupCommit = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupRepo: func(shell *Shell) {
 		shell.
 			CreateNCommits(1).
-			CreateFileAndAdd("first-fixup-file", "").Commit("fixup! commit 01").
+			CreateFileAndAdd("first-fixup-file", "").Commit("fixup! commit-01").
 			CreateNCommitsStartingAt(2, 2).
-			CreateFileAndAdd("unrelated-fixup-file", "fixup 03").Commit("fixup! commit 03").
+			CreateFileAndAdd("unrelated-fixup-file", "fixup 03").Commit("fixup! commit-03").
 			CreateFileAndAdd("fixup-file", "fixup 01")
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("fixup! commit 03"),
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("fixup! commit 01"),
-				Contains("commit 01"),
+				Contains("fixup! commit-03"),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("fixup! commit-01"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("fixup! commit 01")).
+			NavigateToLine(Contains("fixup! commit-01")).
 			Press(keys.Commits.AmendToCommit).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
@@ -37,11 +37,11 @@ var AmendFixupCommit = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			Lines(
-				Contains("fixup! commit 03"),
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("fixup! commit 01").IsSelected(),
-				Contains("commit 01"),
+				Contains("fixup! commit-03"),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("fixup! commit-01").IsSelected(),
+				Contains("commit-01"),
 			)
 
 		t.Views().Main().

--- a/pkg/integration/tests/interactive_rebase/amend_head_commit_during_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/amend_head_commit_during_rebase.go
@@ -17,18 +17,18 @@ var AmendHeadCommitDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 03"),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			)
 
 		t.Shell().CreateFile("fixup-file", "fixup content")
@@ -51,10 +51,10 @@ var AmendHeadCommitDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 03"),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			)
 
 		t.Views().Main().

--- a/pkg/integration/tests/interactive_rebase/amend_non_head_commit_during_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/amend_non_head_commit_during_rebase.go
@@ -17,21 +17,21 @@ var AmendNonHeadCommitDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 03"),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			)
 
-		for _, commit := range []string{"commit 01", "commit 03"} {
+		for _, commit := range []string{"commit-01", "commit-03"} {
 			t.Views().Commits().
 				NavigateToLine(Contains(commit)).
 				Press(keys.Commits.AmendToCommit)

--- a/pkg/integration/tests/interactive_rebase/delete_update_ref_todo.go
+++ b/pkg/integration/tests/interactive_rebase/delete_update_ref_todo.go
@@ -23,18 +23,18 @@ var DeleteUpdateRefTodo = NewIntegrationTest(NewIntegrationTestArgs{
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().
 			Focus().
-			NavigateToLine(Contains("commit 01")).
+			NavigateToLine(Contains("commit-01")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("CI commit 06"),
-				Contains("pick").Contains("CI commit 05"),
-				Contains("pick").Contains("CI commit 04"),
+				Contains("pick").Contains("CI commit-06"),
+				Contains("pick").Contains("CI commit-05"),
+				Contains("pick").Contains("CI commit-04"),
 				Contains("update-ref").Contains("branch1"),
-				Contains("pick").Contains("CI commit 03"),
-				Contains("pick").Contains("CI commit 02"),
+				Contains("pick").Contains("CI commit-03"),
+				Contains("pick").Contains("CI commit-02"),
 				Contains("--- Commits ---"),
-				Contains("CI ○ commit 01"),
+				Contains("CI ○ commit-01"),
 			).
 			NavigateToLine(Contains("update-ref")).
 			Press(keys.Universal.Remove).
@@ -46,25 +46,25 @@ var DeleteUpdateRefTodo = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("CI commit 06"),
-				Contains("pick").Contains("CI commit 05"),
-				Contains("pick").Contains("CI commit 04"),
-				Contains("pick").Contains("CI commit 03").IsSelected(),
-				Contains("pick").Contains("CI commit 02"),
+				Contains("pick").Contains("CI commit-06"),
+				Contains("pick").Contains("CI commit-05"),
+				Contains("pick").Contains("CI commit-04"),
+				Contains("pick").Contains("CI commit-03").IsSelected(),
+				Contains("pick").Contains("CI commit-02"),
 				Contains("--- Commits ---"),
-				Contains("CI ○ commit 01"),
+				Contains("CI ○ commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Universal.Remove).
 			Tap(func() {
 				t.Common().ContinueRebase()
 			}).
 			Lines(
-				Contains("CI ○ commit 06"),
-				Contains("CI ○ commit 05"),
-				Contains("CI ○ commit 04"),
-				Contains("CI ○ commit 03"), // No star on this commit, so there's no branch head here
-				Contains("CI ○ commit 01"),
+				Contains("CI ○ commit-06"),
+				Contains("CI ○ commit-05"),
+				Contains("CI ○ commit-04"),
+				Contains("CI ○ commit-03"), // No star on this commit, so there's no branch head here
+				Contains("CI ○ commit-01"),
 			)
 
 		t.Views().Branches().

--- a/pkg/integration/tests/interactive_rebase/dont_show_branch_heads_for_todo_items.go
+++ b/pkg/integration/tests/interactive_rebase/dont_show_branch_heads_for_todo_items.go
@@ -28,31 +28,31 @@ var DontShowBranchHeadsForTodoItems = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("CI commit 09"),
-				Contains("CI commit 08"),
-				Contains("CI commit 07"),
-				Contains("CI * commit 06"),
-				Contains("CI commit 05"),
-				Contains("CI commit 04"),
-				Contains("CI commit 03"),
-				Contains("CI * commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI commit-09"),
+				Contains("CI commit-08"),
+				Contains("CI commit-07"),
+				Contains("CI * commit-06"),
+				Contains("CI commit-05"),
+				Contains("CI commit-04"),
+				Contains("CI commit-03"),
+				Contains("CI * commit-02"),
+				Contains("CI commit-01"),
 			).
-			NavigateToLine(Contains("commit 04")).
+			NavigateToLine(Contains("commit-04")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("CI commit 09"),
-				Contains("pick").Contains("CI commit 08"),
-				Contains("pick").Contains("CI commit 07"),
+				Contains("pick").Contains("CI commit-09"),
+				Contains("pick").Contains("CI commit-08"),
+				Contains("pick").Contains("CI commit-07"),
 				Contains("update-ref").Contains("branch2"),
-				Contains("pick").Contains("CI commit 06"), // no star on this entry, even though branch2 points to it
-				Contains("pick").Contains("CI commit 05"),
+				Contains("pick").Contains("CI commit-06"), // no star on this entry, even though branch2 points to it
+				Contains("pick").Contains("CI commit-05"),
 				Contains("--- Commits ---"),
-				Contains("CI commit 04"),
-				Contains("CI commit 03"),
-				Contains("CI * commit 02"), // this star is fine though
-				Contains("CI commit 01"),
+				Contains("CI commit-04"),
+				Contains("CI commit-03"),
+				Contains("CI * commit-02"), // this star is fine though
+				Contains("CI commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/drop_commit_in_copied_branch_with_update_ref.go
+++ b/pkg/integration/tests/interactive_rebase/drop_commit_in_copied_branch_with_update_ref.go
@@ -25,11 +25,11 @@ var DropCommitInCopiedBranchWithUpdateRef = NewIntegrationTest(NewIntegrationTes
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("CI * commit 03").IsSelected(),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI * commit-03").IsSelected(),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Universal.Remove).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
@@ -38,8 +38,8 @@ var DropCommitInCopiedBranchWithUpdateRef = NewIntegrationTest(NewIntegrationTes
 					Confirm()
 			}).
 			Lines(
-				Contains("CI commit 03"), // no start on this commit because branch1 is no longer pointing to it
-				Contains("CI commit 01"),
+				Contains("CI commit-03"), // no start on this commit because branch1 is no longer pointing to it
+				Contains("CI commit-01"),
 			)
 
 		t.Views().Branches().
@@ -48,9 +48,9 @@ var DropCommitInCopiedBranchWithUpdateRef = NewIntegrationTest(NewIntegrationTes
 			PressPrimaryAction()
 
 		t.Views().Commits().Lines(
-			Contains("CI commit 03"),
-			Contains("CI commit 02"),
-			Contains("CI commit 01"),
+			Contains("CI commit-03"),
+			Contains("CI commit-02"),
+			Contains("CI commit-01"),
 		)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
+++ b/pkg/integration/tests/interactive_rebase/drop_todo_commit_with_update_ref.go
@@ -28,32 +28,32 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("CI commit 07").IsSelected(),
-				Contains("CI commit 06"),
-				Contains("CI commit 05"),
-				Contains("CI * commit 04"),
-				Contains("CI commit 03"),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI commit-07").IsSelected(),
+				Contains("CI commit-06"),
+				Contains("CI commit-05"),
+				Contains("CI * commit-04"),
+				Contains("CI commit-03"),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("CI commit 07"),
-				Contains("pick").Contains("CI commit 06"),
-				Contains("pick").Contains("CI commit 05"),
+				Contains("pick").Contains("CI commit-07"),
+				Contains("pick").Contains("CI commit-06"),
+				Contains("pick").Contains("CI commit-05"),
 				Contains("update-ref").Contains("branch1").DoesNotContain("*"),
-				Contains("pick").Contains("CI commit 04"),
-				Contains("pick").Contains("CI commit 03"),
+				Contains("pick").Contains("CI commit-04"),
+				Contains("pick").Contains("CI commit-03"),
 				Contains("--- Commits ---"),
-				Contains("CI commit 02").IsSelected(),
-				Contains("CI commit 01"),
+				Contains("CI commit-02").IsSelected(),
+				Contains("CI commit-01"),
 			).
 			Tap(func() {
-				t.Views().Main().Content(Contains("commit 02"))
+				t.Views().Main().Content(Contains("commit-02"))
 			}).
-			NavigateToLine(Contains("commit 06")).
+			NavigateToLine(Contains("commit-06")).
 			Press(keys.Universal.Remove)
 
 		t.Common().ContinueRebase()
@@ -61,12 +61,12 @@ var DropTodoCommitWithUpdateRef = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			IsFocused().
 			Lines(
-				Contains("CI commit 07"),
-				Contains("CI commit 05"),
-				Contains("CI * commit 04"),
-				Contains("CI commit 03"),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI commit-07"),
+				Contains("CI commit-05"),
+				Contains("CI * commit-04"),
+				Contains("CI commit-03"),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/drop_with_custom_comment_char.go
+++ b/pkg/integration/tests/interactive_rebase/drop_with_custom_comment_char.go
@@ -17,8 +17,8 @@ var DropWithCustomCommentChar = NewIntegrationTest(NewIntegrationTestArgs{
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().Focus().
 			Lines(
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			).
 			Press(keys.Universal.Remove).
 			Tap(func() {
@@ -28,7 +28,7 @@ var DropWithCustomCommentChar = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			Lines(
-				Contains("commit 01").IsSelected(),
+				Contains("commit-01").IsSelected(),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/edit_and_auto_amend.go
+++ b/pkg/integration/tests/interactive_rebase/edit_and_auto_amend.go
@@ -18,18 +18,18 @@ var EditAndAutoAmend = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 03"),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			)
 
 		t.Shell().CreateFile("fixup-file", "fixup content")
@@ -46,9 +46,9 @@ var EditAndAutoAmend = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			)
 
 		t.Views().Main().

--- a/pkg/integration/tests/interactive_rebase/edit_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/edit_first_commit.go
@@ -18,23 +18,23 @@ var EditFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 01")).
+			NavigateToLine(Contains("commit-01")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 02"),
+				Contains("commit-02"),
 				Contains("--- Commits ---"),
-				Contains("commit 01").IsSelected(),
+				Contains("commit-01").IsSelected(),
 			).
 			Tap(func() {
 				t.Common().ContinueRebase()
 			}).
 			Lines(
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/edit_last_commit_of_stacked_branch.go
+++ b/pkg/integration/tests/interactive_rebase/edit_last_commit_of_stacked_branch.go
@@ -28,23 +28,23 @@ var EditLastCommitOfStackedBranch = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("CI commit 05").IsSelected(),
-				Contains("CI commit 04"),
-				Contains("CI * commit 03"),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI commit-05").IsSelected(),
+				Contains("CI commit-04"),
+				Contains("CI * commit-03"),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			).
-			NavigateToLine(Contains("commit 03")).
+			NavigateToLine(Contains("commit-03")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("CI commit 05"),
-				Contains("pick").Contains("CI commit 04"),
+				Contains("pick").Contains("CI commit-05"),
+				Contains("pick").Contains("CI commit-04"),
 				Contains("update-ref").Contains("branch1"),
 				Contains("--- Commits ---"),
-				Contains("CI * commit 03").IsSelected(),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI * commit-03").IsSelected(),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			)
 
 		t.Shell().CreateFile("fixup-file", "fixup content")
@@ -66,11 +66,11 @@ var EditLastCommitOfStackedBranch = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("CI commit 05"),
-				Contains("CI commit 04"),
-				Contains("CI * commit 03"),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI commit-05"),
+				Contains("CI commit-04"),
+				Contains("CI * commit-03"),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/edit_non_todo_commit_during_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/edit_non_todo_commit_during_rebase.go
@@ -18,17 +18,17 @@ var EditNonTodoCommitDuringRebase = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
 				Contains("--- Commits ---"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 01")).
+			NavigateToLine(Contains("commit-01")).
 			Press(keys.Universal.Edit)
 
 		t.ExpectToast(Contains("Disabled: When rebasing, this action only works on a selection of TODO commits."))

--- a/pkg/integration/tests/interactive_rebase/edit_range_select_down_to_merge_outside_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/edit_range_select_down_to_merge_outside_rebase.go
@@ -19,8 +19,8 @@ var EditRangeSelectDownToMergeOutsideRebase = NewIntegrationTest(NewIntegrationT
 		t.Views().Commits().
 			Focus().
 			TopLines(
-				Contains("CI ○ commit 02").IsSelected(),
-				Contains("CI ○ commit 01"),
+				Contains("CI ○ commit-02").IsSelected(),
+				Contains("CI ○ commit-01"),
 				Contains("Merge branch 'second-change-branch' into first-change-branch"),
 			).
 			Press(keys.Universal.RangeSelectDown).
@@ -28,8 +28,8 @@ var EditRangeSelectDownToMergeOutsideRebase = NewIntegrationTest(NewIntegrationT
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("edit CI commit 02").IsSelected(),
-				Contains("edit CI commit 01").IsSelected(),
+				Contains("edit CI commit-02").IsSelected(),
+				Contains("edit CI commit-01").IsSelected(),
 				Contains("--- Commits ---").IsSelected(),
 				Contains("     CI ◎─╮ Merge branch 'second-change-branch' into first-change-branch").IsSelected(),
 				Contains("     CI │ ○ * second-change-branch unrelated change"),

--- a/pkg/integration/tests/interactive_rebase/fixup_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/fixup_first_commit.go
@@ -18,17 +18,17 @@ var FixupFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 01")).
+			NavigateToLine(Contains("commit-01")).
 			Press(keys.Commits.MarkCommitAsFixup).
 			Tap(func() {
 				t.ExpectToast(Equals("Disabled: There's no commit below to squash into"))
 			}).
 			Lines(
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/interactive_rebase_of_copied_branch.go
+++ b/pkg/integration/tests/interactive_rebase/interactive_rebase_of_copied_branch.go
@@ -25,19 +25,19 @@ var InteractiveRebaseOfCopiedBranch = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("CI * commit 03"),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI * commit-03"),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			).
-			NavigateToLine(Contains("commit 01")).
+			NavigateToLine(Contains("commit-01")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
 				// No update-ref todo for branch1 here, even though command-line git would have added it
-				Contains("pick").Contains("CI commit 03"),
-				Contains("pick").Contains("CI commit 02"),
+				Contains("pick").Contains("CI commit-03"),
+				Contains("pick").Contains("CI commit-02"),
 				Contains("--- Commits ---"),
-				Contains("CI commit 01"),
+				Contains("CI commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/interactive_rebase_with_conflict_for_edit_command.go
+++ b/pkg/integration/tests/interactive_rebase/interactive_rebase_with_conflict_for_edit_command.go
@@ -24,9 +24,9 @@ var InteractiveRebaseWithConflictForEditCommand = NewIntegrationTest(NewIntegrat
 			Focus().
 			Lines(
 				Contains("this will conflict").IsSelected(),
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 				Contains("initial commit"),
 			)
 
@@ -55,9 +55,9 @@ var InteractiveRebaseWithConflictForEditCommand = NewIntegrationTest(NewIntegrat
 				Contains("--- Pending rebase todos ---"),
 				Contains("edit").Contains("<-- CONFLICT --- this will conflict").IsSelected(),
 				Contains("--- Commits ---"),
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 				Contains("master commit"),
 				Contains("initial commit"),
 			)

--- a/pkg/integration/tests/interactive_rebase/mid_rebase_range_select.go
+++ b/pkg/integration/tests/interactive_rebase/mid_rebase_range_select.go
@@ -18,95 +18,95 @@ var MidRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			TopLines(
-				Contains("commit 10").IsSelected(),
+				Contains("commit-10").IsSelected(),
 			).
-			NavigateToLine(Contains("commit 05")).
+			NavigateToLine(Contains("commit-05")).
 			// Start a rebase
 			Press(keys.Universal.Edit).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("commit 10"),
-				Contains("pick").Contains("commit 09"),
-				Contains("pick").Contains("commit 08"),
-				Contains("pick").Contains("commit 07"),
-				Contains("pick").Contains("commit 06"),
+				Contains("pick").Contains("commit-10"),
+				Contains("pick").Contains("commit-09"),
+				Contains("pick").Contains("commit-08"),
+				Contains("pick").Contains("commit-07"),
+				Contains("pick").Contains("commit-06"),
 				Contains("--- Commits ---"),
-				Contains("commit 05").IsSelected(),
-				Contains("commit 04"),
+				Contains("commit-05").IsSelected(),
+				Contains("commit-04"),
 			).
 			SelectPreviousItem().
 			// perform various actions on a range of commits
 			Press(keys.Universal.RangeSelectUp).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("commit 10"),
-				Contains("pick").Contains("commit 09"),
-				Contains("pick").Contains("commit 08"),
-				Contains("pick").Contains("commit 07").IsSelected(),
-				Contains("pick").Contains("commit 06").IsSelected(),
+				Contains("pick").Contains("commit-10"),
+				Contains("pick").Contains("commit-09"),
+				Contains("pick").Contains("commit-08"),
+				Contains("pick").Contains("commit-07").IsSelected(),
+				Contains("pick").Contains("commit-06").IsSelected(),
 				Contains("--- Commits ---"),
-				Contains("commit 05"),
-				Contains("commit 04"),
+				Contains("commit-05"),
+				Contains("commit-04"),
 			).
 			Press(keys.Commits.MarkCommitAsFixup).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("commit 10"),
-				Contains("pick").Contains("commit 09"),
-				Contains("pick").Contains("commit 08"),
-				Contains("fixup").Contains("commit 07").IsSelected(),
-				Contains("fixup").Contains("commit 06").IsSelected(),
+				Contains("pick").Contains("commit-10"),
+				Contains("pick").Contains("commit-09"),
+				Contains("pick").Contains("commit-08"),
+				Contains("fixup").Contains("commit-07").IsSelected(),
+				Contains("fixup").Contains("commit-06").IsSelected(),
 				Contains("--- Commits ---"),
-				Contains("commit 05"),
-				Contains("commit 04"),
+				Contains("commit-05"),
+				Contains("commit-04"),
 			).
 			Press(keys.Commits.PickCommit).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("commit 10"),
-				Contains("pick").Contains("commit 09"),
-				Contains("pick").Contains("commit 08"),
-				Contains("pick").Contains("commit 07").IsSelected(),
-				Contains("pick").Contains("commit 06").IsSelected(),
+				Contains("pick").Contains("commit-10"),
+				Contains("pick").Contains("commit-09"),
+				Contains("pick").Contains("commit-08"),
+				Contains("pick").Contains("commit-07").IsSelected(),
+				Contains("pick").Contains("commit-06").IsSelected(),
 				Contains("--- Commits ---"),
-				Contains("commit 05"),
-				Contains("commit 04"),
+				Contains("commit-05"),
+				Contains("commit-04"),
 			).
 			Press(keys.Universal.Edit).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("commit 10"),
-				Contains("pick").Contains("commit 09"),
-				Contains("pick").Contains("commit 08"),
-				Contains("edit").Contains("commit 07").IsSelected(),
-				Contains("edit").Contains("commit 06").IsSelected(),
+				Contains("pick").Contains("commit-10"),
+				Contains("pick").Contains("commit-09"),
+				Contains("pick").Contains("commit-08"),
+				Contains("edit").Contains("commit-07").IsSelected(),
+				Contains("edit").Contains("commit-06").IsSelected(),
 				Contains("--- Commits ---"),
-				Contains("commit 05"),
-				Contains("commit 04"),
+				Contains("commit-05"),
+				Contains("commit-04"),
 			).
 			Press(keys.Commits.SquashDown).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("commit 10"),
-				Contains("pick").Contains("commit 09"),
-				Contains("pick").Contains("commit 08"),
-				Contains("squash").Contains("commit 07").IsSelected(),
-				Contains("squash").Contains("commit 06").IsSelected(),
+				Contains("pick").Contains("commit-10"),
+				Contains("pick").Contains("commit-09"),
+				Contains("pick").Contains("commit-08"),
+				Contains("squash").Contains("commit-07").IsSelected(),
+				Contains("squash").Contains("commit-06").IsSelected(),
 				Contains("--- Commits ---"),
-				Contains("commit 05"),
-				Contains("commit 04"),
+				Contains("commit-05"),
+				Contains("commit-04"),
 			).
 			Press(keys.Commits.MoveDownCommit).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("commit 10"),
-				Contains("pick").Contains("commit 09"),
-				Contains("pick").Contains("commit 08"),
-				Contains("squash").Contains("commit 07").IsSelected(),
-				Contains("squash").Contains("commit 06").IsSelected(),
+				Contains("pick").Contains("commit-10"),
+				Contains("pick").Contains("commit-09"),
+				Contains("pick").Contains("commit-08"),
+				Contains("squash").Contains("commit-07").IsSelected(),
+				Contains("squash").Contains("commit-06").IsSelected(),
 				Contains("--- Commits ---"),
-				Contains("commit 05"),
-				Contains("commit 04"),
+				Contains("commit-05"),
+				Contains("commit-04"),
 			).
 			Tap(func() {
 				t.ExpectToast(Contains("Disabled: Cannot move any further"))
@@ -114,38 +114,38 @@ var MidRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Commits.MoveUpCommit).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("commit 10"),
-				Contains("pick").Contains("commit 09"),
-				Contains("squash").Contains("commit 07").IsSelected(),
-				Contains("squash").Contains("commit 06").IsSelected(),
-				Contains("pick").Contains("commit 08"),
+				Contains("pick").Contains("commit-10"),
+				Contains("pick").Contains("commit-09"),
+				Contains("squash").Contains("commit-07").IsSelected(),
+				Contains("squash").Contains("commit-06").IsSelected(),
+				Contains("pick").Contains("commit-08"),
 				Contains("--- Commits ---"),
-				Contains("commit 05"),
-				Contains("commit 04"),
+				Contains("commit-05"),
+				Contains("commit-04"),
 			).
 			Press(keys.Commits.MoveUpCommit).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("commit 10"),
-				Contains("squash").Contains("commit 07").IsSelected(),
-				Contains("squash").Contains("commit 06").IsSelected(),
-				Contains("pick").Contains("commit 09"),
-				Contains("pick").Contains("commit 08"),
+				Contains("pick").Contains("commit-10"),
+				Contains("squash").Contains("commit-07").IsSelected(),
+				Contains("squash").Contains("commit-06").IsSelected(),
+				Contains("pick").Contains("commit-09"),
+				Contains("pick").Contains("commit-08"),
 				Contains("--- Commits ---"),
-				Contains("commit 05"),
-				Contains("commit 04"),
+				Contains("commit-05"),
+				Contains("commit-04"),
 			).
 			Press(keys.Commits.MoveUpCommit).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("squash").Contains("commit 07").IsSelected(),
-				Contains("squash").Contains("commit 06").IsSelected(),
-				Contains("pick").Contains("commit 10"),
-				Contains("pick").Contains("commit 09"),
-				Contains("pick").Contains("commit 08"),
+				Contains("squash").Contains("commit-07").IsSelected(),
+				Contains("squash").Contains("commit-06").IsSelected(),
+				Contains("pick").Contains("commit-10"),
+				Contains("pick").Contains("commit-09"),
+				Contains("pick").Contains("commit-08"),
 				Contains("--- Commits ---"),
-				Contains("commit 05"),
-				Contains("commit 04"),
+				Contains("commit-05"),
+				Contains("commit-04"),
 			).
 			Press(keys.Commits.MoveUpCommit).
 			Tap(func() {
@@ -153,29 +153,29 @@ var MidRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("squash").Contains("commit 07").IsSelected(),
-				Contains("squash").Contains("commit 06").IsSelected(),
-				Contains("pick").Contains("commit 10"),
-				Contains("pick").Contains("commit 09"),
-				Contains("pick").Contains("commit 08"),
+				Contains("squash").Contains("commit-07").IsSelected(),
+				Contains("squash").Contains("commit-06").IsSelected(),
+				Contains("pick").Contains("commit-10"),
+				Contains("pick").Contains("commit-09"),
+				Contains("pick").Contains("commit-08"),
 				Contains("--- Commits ---"),
-				Contains("commit 05"),
-				Contains("commit 04"),
+				Contains("commit-05"),
+				Contains("commit-04"),
 			).
 			// Verify we can't perform an action on a range that includes both
 			// TODO and non-TODO commits
-			NavigateToLine(Contains("commit 08")).
+			NavigateToLine(Contains("commit-08")).
 			Press(keys.Universal.RangeSelectDown).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("squash").Contains("commit 07"),
-				Contains("squash").Contains("commit 06"),
-				Contains("pick").Contains("commit 10"),
-				Contains("pick").Contains("commit 09"),
-				Contains("pick").Contains("commit 08").IsSelected(),
+				Contains("squash").Contains("commit-07"),
+				Contains("squash").Contains("commit-06"),
+				Contains("pick").Contains("commit-10"),
+				Contains("pick").Contains("commit-09"),
+				Contains("pick").Contains("commit-08").IsSelected(),
 				Contains("--- Commits ---").IsSelected(),
-				Contains("commit 05").IsSelected(),
-				Contains("commit 04"),
+				Contains("commit-05").IsSelected(),
+				Contains("commit-04"),
 			).
 			Press(keys.Commits.MarkCommitAsFixup).
 			Tap(func() {
@@ -183,28 +183,28 @@ var MidRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			TopLines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("squash").Contains("commit 07"),
-				Contains("squash").Contains("commit 06"),
-				Contains("pick").Contains("commit 10"),
-				Contains("pick").Contains("commit 09"),
-				Contains("pick").Contains("commit 08").IsSelected(),
+				Contains("squash").Contains("commit-07"),
+				Contains("squash").Contains("commit-06"),
+				Contains("pick").Contains("commit-10"),
+				Contains("pick").Contains("commit-09"),
+				Contains("pick").Contains("commit-08").IsSelected(),
 				Contains("--- Commits ---").IsSelected(),
-				Contains("commit 05").IsSelected(),
-				Contains("commit 04"),
+				Contains("commit-05").IsSelected(),
+				Contains("commit-04"),
 			).
 			// continue the rebase
 			Tap(func() {
 				t.Common().ContinueRebase()
 			}).
 			TopLines(
-				Contains("commit 10"),
-				Contains("commit 09"),
-				Contains("commit 08"),
-				Contains("commit 05"),
+				Contains("commit-10"),
+				Contains("commit-09"),
+				Contains("commit-08"),
+				Contains("commit-05"),
 				// selected indexes are retained, though we may want to clear it
 				// in future (not sure what the best behaviour is right now)
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03").IsSelected(),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03").IsSelected(),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/move.go
+++ b/pkg/integration/tests/interactive_rebase/move.go
@@ -17,31 +17,31 @@ var Move = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.MoveDownCommit).
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 04").IsSelected(),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.MoveDownCommit).
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 04").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.MoveDownCommit).
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
-				Contains("commit 04").IsSelected(),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
+				Contains("commit-04").IsSelected(),
 			).
 			// assert nothing happens upon trying to move beyond the last commit
 			Press(keys.Commits.MoveDownCommit).
@@ -49,31 +49,31 @@ var Move = NewIntegrationTest(NewIntegrationTestArgs{
 				t.ExpectToast(Contains("Disabled: Cannot move any further"))
 			}).
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
-				Contains("commit 04").IsSelected(),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
+				Contains("commit-04").IsSelected(),
 			).
 			Press(keys.Commits.MoveUpCommit).
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 04").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.MoveUpCommit).
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 04").IsSelected(),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.MoveUpCommit).
 			Lines(
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
 			// assert nothing happens upon trying to move beyond the first commit
 			Press(keys.Commits.MoveUpCommit).
@@ -81,10 +81,10 @@ var Move = NewIntegrationTest(NewIntegrationTestArgs{
 				t.ExpectToast(Contains("Disabled: Cannot move any further"))
 			}).
 			Lines(
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/move_across_branch_boundary_outside_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/move_across_branch_boundary_outside_rebase.go
@@ -28,20 +28,20 @@ var MoveAcrossBranchBoundaryOutsideRebase = NewIntegrationTest(NewIntegrationTes
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("CI commit 05").IsSelected(),
-				Contains("CI commit 04"),
-				Contains("CI * commit 03"),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI commit-05").IsSelected(),
+				Contains("CI commit-04"),
+				Contains("CI * commit-03"),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			).
-			NavigateToLine(Contains("commit 04")).
+			NavigateToLine(Contains("commit-04")).
 			Press(keys.Commits.MoveDownCommit).
 			Lines(
-				Contains("CI commit 05"),
-				Contains("CI * commit 03"),
-				Contains("CI commit 04").IsSelected(),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI commit-05"),
+				Contains("CI * commit-03"),
+				Contains("CI commit-04").IsSelected(),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/move_in_rebase.go
+++ b/pkg/integration/tests/interactive_rebase/move_in_rebase.go
@@ -17,39 +17,39 @@ var MoveInRebase = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 01")).
+			NavigateToLine(Contains("commit-01")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 04"),
-				Contains("commit 03"),
-				Contains("commit 02"),
+				Contains("commit-04"),
+				Contains("commit-03"),
+				Contains("commit-02"),
 				Contains("--- Commits ---"),
-				Contains("commit 01").IsSelected(),
+				Contains("commit-01").IsSelected(),
 			).
 			SelectPreviousItem().
 			Press(keys.Commits.MoveUpCommit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 04"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 03"),
+				Contains("commit-04"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
-				Contains("commit 01"),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.MoveUpCommit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 04"),
-				Contains("commit 03"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-04"),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
-				Contains("commit 01"),
+				Contains("commit-01"),
 			).
 			// assert we can't move past the top
 			Press(keys.Commits.MoveUpCommit).
@@ -58,29 +58,29 @@ var MoveInRebase = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 04"),
-				Contains("commit 03"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-04"),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
-				Contains("commit 01"),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.MoveDownCommit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 04"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 03"),
+				Contains("commit-04"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
-				Contains("commit 01"),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.MoveDownCommit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 04"),
-				Contains("commit 03"),
-				Contains("commit 02").IsSelected(),
+				Contains("commit-04"),
+				Contains("commit-03"),
+				Contains("commit-02").IsSelected(),
 				Contains("--- Commits ---"),
-				Contains("commit 01"),
+				Contains("commit-01"),
 			).
 			// assert we can't move past the bottom
 			Press(keys.Commits.MoveDownCommit).
@@ -89,30 +89,30 @@ var MoveInRebase = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 04"),
-				Contains("commit 03"),
-				Contains("commit 02").IsSelected(),
+				Contains("commit-04"),
+				Contains("commit-03"),
+				Contains("commit-02").IsSelected(),
 				Contains("--- Commits ---"),
-				Contains("commit 01"),
+				Contains("commit-01"),
 			).
 			// move it back up one so that we land in a different order than we started with
 			Press(keys.Commits.MoveUpCommit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 04"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 03"),
+				Contains("commit-04"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
-				Contains("commit 01"),
+				Contains("commit-01"),
 			).
 			Tap(func() {
 				t.Common().ContinueRebase()
 			}).
 			Lines(
-				Contains("commit 04"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 03"),
-				Contains("commit 01"),
+				Contains("commit-04"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-03"),
+				Contains("commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/move_update_ref_todo.go
+++ b/pkg/integration/tests/interactive_rebase/move_update_ref_todo.go
@@ -23,43 +23,43 @@ var MoveUpdateRefTodo = NewIntegrationTest(NewIntegrationTestArgs{
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().
 			Focus().
-			NavigateToLine(Contains("commit 01")).
+			NavigateToLine(Contains("commit-01")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("CI commit 06"),
-				Contains("pick").Contains("CI commit 05"),
-				Contains("pick").Contains("CI commit 04"),
+				Contains("pick").Contains("CI commit-06"),
+				Contains("pick").Contains("CI commit-05"),
+				Contains("pick").Contains("CI commit-04"),
 				Contains("update-ref").Contains("branch1"),
-				Contains("pick").Contains("CI commit 03"),
-				Contains("pick").Contains("CI commit 02"),
+				Contains("pick").Contains("CI commit-03"),
+				Contains("pick").Contains("CI commit-02"),
 				Contains("--- Commits ---"),
-				Contains("CI ○ commit 01"),
+				Contains("CI ○ commit-01"),
 			).
 			NavigateToLine(Contains("update-ref")).
 			Press(keys.Commits.MoveUpCommit).
 			Press(keys.Commits.MoveUpCommit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("CI commit 06"),
+				Contains("pick").Contains("CI commit-06"),
 				Contains("update-ref").Contains("branch1"),
-				Contains("pick").Contains("CI commit 05"),
-				Contains("pick").Contains("CI commit 04"),
-				Contains("pick").Contains("CI commit 03"),
-				Contains("pick").Contains("CI commit 02"),
+				Contains("pick").Contains("CI commit-05"),
+				Contains("pick").Contains("CI commit-04"),
+				Contains("pick").Contains("CI commit-03"),
+				Contains("pick").Contains("CI commit-02"),
 				Contains("--- Commits ---"),
-				Contains("CI ○ commit 01"),
+				Contains("CI ○ commit-01"),
 			).
 			Tap(func() {
 				t.Common().ContinueRebase()
 			}).
 			Lines(
-				Contains("CI ○ commit 06"),
-				Contains("CI ○ * commit 05"),
-				Contains("CI ○ commit 04"),
-				Contains("CI ○ commit 03"),
-				Contains("CI ○ commit 02"),
-				Contains("CI ○ commit 01"),
+				Contains("CI ○ commit-06"),
+				Contains("CI ○ * commit-05"),
+				Contains("CI ○ commit-04"),
+				Contains("CI ○ commit-03"),
+				Contains("CI ○ commit-02"),
+				Contains("CI ○ commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/move_with_custom_comment_char.go
+++ b/pkg/integration/tests/interactive_rebase/move_with_custom_comment_char.go
@@ -17,18 +17,18 @@ var MoveWithCustomCommentChar = NewIntegrationTest(NewIntegrationTestArgs{
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().Focus().
 			Lines(
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.MoveDownCommit).
 			Lines(
-				Contains("commit 01"),
-				Contains("commit 02").IsSelected(),
+				Contains("commit-01"),
+				Contains("commit-02").IsSelected(),
 			).
 			Press(keys.Commits.MoveUpCommit).
 			Lines(
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/outside_rebase_range_select.go
+++ b/pkg/integration/tests/interactive_rebase/outside_rebase_range_select.go
@@ -18,13 +18,13 @@ var OutsideRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			TopLines(
-				Contains("commit 10").IsSelected(),
+				Contains("commit-10").IsSelected(),
 			).
 			Press(keys.Universal.RangeSelectDown).
 			TopLines(
-				Contains("commit 10").IsSelected(),
-				Contains("commit 09").IsSelected(),
-				Contains("commit 08"),
+				Contains("commit-10").IsSelected(),
+				Contains("commit-09").IsSelected(),
+				Contains("commit-08"),
 			).
 			// Drop commits
 			Press(keys.Universal.Remove).
@@ -35,14 +35,14 @@ var OutsideRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			TopLines(
-				Contains("commit 08").IsSelected(),
-				Contains("commit 07"),
+				Contains("commit-08").IsSelected(),
+				Contains("commit-07"),
 			).
 			Press(keys.Universal.RangeSelectDown).
 			TopLines(
-				Contains("commit 08").IsSelected(),
-				Contains("commit 07").IsSelected(),
-				Contains("commit 06"),
+				Contains("commit-08").IsSelected(),
+				Contains("commit-07").IsSelected(),
+				Contains("commit-06"),
 			).
 			// Squash commits
 			Press(keys.Commits.SquashDown).
@@ -53,27 +53,27 @@ var OutsideRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			TopLines(
-				Contains("commit 06").IsSelected(),
-				Contains("commit 05"),
-				Contains("commit 04"),
+				Contains("commit-06").IsSelected(),
+				Contains("commit-05"),
+				Contains("commit-04"),
 			).
 			// Verify commit messages are concatenated
 			Tap(func() {
 				t.Views().Main().
 					ContainsLines(
-						Contains("commit 06"),
+						Contains("commit-06"),
 						AnyString(),
-						Contains("commit 07"),
+						Contains("commit-07"),
 						AnyString(),
-						Contains("commit 08"),
+						Contains("commit-08"),
 					)
 			}).
 			// Fixup commits
 			Press(keys.Universal.RangeSelectDown).
 			TopLines(
-				Contains("commit 06").IsSelected(),
-				Contains("commit 05").IsSelected(),
-				Contains("commit 04"),
+				Contains("commit-06").IsSelected(),
+				Contains("commit-05").IsSelected(),
+				Contains("commit-04"),
 			).
 			Press(keys.Commits.MarkCommitAsFixup).
 			Tap(func() {
@@ -82,73 +82,73 @@ var OutsideRebaseRangeSelect = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			TopLines(
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03"),
-				Contains("commit 02"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03"),
+				Contains("commit-02"),
 			).
 			// Verify commit messages are dropped
 			Tap(func() {
 				t.Views().Main().
 					Content(
-						Contains("commit 04").
-							DoesNotContain("commit 06").
-							DoesNotContain("commit 05"),
+						Contains("commit-04").
+							DoesNotContain("commit-06").
+							DoesNotContain("commit-05"),
 					)
 			}).
 			Press(keys.Universal.RangeSelectDown).
 			TopLines(
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03").IsSelected(),
-				Contains("commit 02"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-02"),
 			).
 			// Move commits
 			Press(keys.Commits.MoveDownCommit).
 			TopLines(
-				Contains("commit 02"),
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.MoveDownCommit).
 			TopLines(
-				Contains("commit 02"),
-				Contains("commit 01"),
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03").IsSelected(),
 			).
 			Press(keys.Commits.MoveDownCommit).
 			TopLines(
-				Contains("commit 02"),
-				Contains("commit 01"),
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03").IsSelected(),
 			).
 			Tap(func() {
 				t.ExpectToast(Contains("Disabled: Cannot move any further"))
 			}).
 			Press(keys.Commits.MoveUpCommit).
 			TopLines(
-				Contains("commit 02"),
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.MoveUpCommit).
 			TopLines(
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03").IsSelected(),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.MoveUpCommit).
 			Tap(func() {
 				t.ExpectToast(Contains("Disabled: Cannot move any further"))
 			}).
 			TopLines(
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03").IsSelected(),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/quick_start_keep_selection.go
+++ b/pkg/integration/tests/interactive_rebase/quick_start_keep_selection.go
@@ -28,27 +28,27 @@ var QuickStartKeepSelection = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("CI commit 07").IsSelected(),
-				Contains("CI commit 06"),
-				Contains("CI commit 05"),
-				Contains("CI * commit 04"),
-				Contains("CI commit 03"),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI commit-07").IsSelected(),
+				Contains("CI commit-06"),
+				Contains("CI commit-05"),
+				Contains("CI * commit-04"),
+				Contains("CI commit-03"),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Commits.StartInteractiveRebase).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("CI commit 07"),
-				Contains("pick").Contains("CI commit 06"),
-				Contains("pick").Contains("CI commit 05"),
+				Contains("pick").Contains("CI commit-07"),
+				Contains("pick").Contains("CI commit-06"),
+				Contains("pick").Contains("CI commit-05"),
 				Contains("update-ref").Contains("branch1"),
-				Contains("pick").Contains("CI commit 04"),
-				Contains("pick").Contains("CI commit 03"),
-				Contains("CI commit 02").IsSelected(),
+				Contains("pick").Contains("CI commit-04"),
+				Contains("pick").Contains("CI commit-03"),
+				Contains("CI commit-02").IsSelected(),
 				Contains("--- Commits ---"),
-				Contains("CI commit 01"),
+				Contains("CI commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/quick_start_keep_selection_range.go
+++ b/pkg/integration/tests/interactive_rebase/quick_start_keep_selection_range.go
@@ -29,31 +29,31 @@ var QuickStartKeepSelectionRange = NewIntegrationTest(NewIntegrationTestArgs{
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().
 			Focus().
-			NavigateToLine(Contains("commit 04")).
+			NavigateToLine(Contains("commit-04")).
 			Press(keys.Universal.RangeSelectDown).
 			Press(keys.Universal.RangeSelectDown).
 			Lines(
-				Contains("CI commit 07"),
-				Contains("CI commit 06"),
-				Contains("CI * commit 05"),
-				Contains("CI commit 04").IsSelected(),
-				Contains("CI * commit 03").IsSelected(),
-				Contains("CI commit 02").IsSelected(),
-				Contains("CI commit 01"),
+				Contains("CI commit-07"),
+				Contains("CI commit-06"),
+				Contains("CI * commit-05"),
+				Contains("CI commit-04").IsSelected(),
+				Contains("CI * commit-03").IsSelected(),
+				Contains("CI commit-02").IsSelected(),
+				Contains("CI commit-01"),
 			).
 			Press(keys.Commits.StartInteractiveRebase).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("CI commit 07"),
-				Contains("CI commit 06"),
+				Contains("CI commit-07"),
+				Contains("CI commit-06"),
 				Contains("update-ref").Contains("branch2"),
-				Contains("CI commit 05"),
-				Contains("CI commit 04").IsSelected(),
+				Contains("CI commit-05"),
+				Contains("CI commit-04").IsSelected(),
 				Contains("update-ref").Contains("branch1").IsSelected(),
-				Contains("CI commit 03").IsSelected(),
-				Contains("CI commit 02").IsSelected(),
+				Contains("CI commit-03").IsSelected(),
+				Contains("CI commit-02").IsSelected(),
 				Contains("--- Commits ---"),
-				Contains("CI commit 01"),
+				Contains("CI commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/revert_during_rebase_when_stopped_on_edit.go
+++ b/pkg/integration/tests/interactive_rebase/revert_during_rebase_when_stopped_on_edit.go
@@ -20,22 +20,22 @@ var RevertDuringRebaseWhenStoppedOnEdit = NewIntegrationTest(NewIntegrationTestA
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 04").IsSelected(),
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-04").IsSelected(),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 				Contains("master commit 2"),
 				Contains("master commit 1"),
 			).
-			NavigateToLine(Contains("commit 03")).
+			NavigateToLine(Contains("commit-03")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("commit 04"),
+				Contains("pick").Contains("commit-04"),
 				Contains("--- Commits ---"),
-				Contains("commit 03").IsSelected(),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
 				Contains("master commit 2"),
 				Contains("master commit 1"),
 			).
@@ -50,13 +50,13 @@ var RevertDuringRebaseWhenStoppedOnEdit = NewIntegrationTest(NewIntegrationTestA
 			}).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("commit 04"),
+				Contains("pick").Contains("commit-04"),
 				Contains("--- Commits ---"),
-				Contains(`Revert "commit 01"`),
-				Contains(`Revert "commit 02"`),
-				Contains("commit 03"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01").IsSelected(),
+				Contains(`Revert "commit-01"`),
+				Contains(`Revert "commit-02"`),
+				Contains("commit-03"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01").IsSelected(),
 				Contains("master commit 2"),
 				Contains("master commit 1"),
 			)

--- a/pkg/integration/tests/interactive_rebase/reword_commit_with_editor_and_fail.go
+++ b/pkg/integration/tests/interactive_rebase/reword_commit_with_editor_and_fail.go
@@ -20,11 +20,11 @@ var RewordCommitWithEditorAndFail = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 03").IsSelected(),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Commits.RenameCommitWithEditor).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
@@ -34,10 +34,10 @@ var RewordCommitWithEditorAndFail = NewIntegrationTest(NewIntegrationTestArgs{
 			}).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 03"),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			)
 
 		t.ExpectPopup().Alert().

--- a/pkg/integration/tests/interactive_rebase/reword_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/reword_first_commit.go
@@ -21,21 +21,21 @@ var RewordFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 01")).
+			NavigateToLine(Contains("commit-01")).
 			Press(keys.Commits.RenameCommit).
 			Tap(func() {
 				t.ExpectPopup().CommitMessagePanel().
 					Title(Equals("Reword commit")).
-					InitialText(Equals("commit 01")).
+					InitialText(Equals("commit-01")).
 					Clear().
 					Type("renamed 01").
 					Confirm()
 			}).
 			Lines(
-				Contains("commit 02"),
+				Contains("commit-02"),
 				Contains("renamed 01"),
 			)
 	},

--- a/pkg/integration/tests/interactive_rebase/reword_last_commit.go
+++ b/pkg/integration/tests/interactive_rebase/reword_last_commit.go
@@ -18,21 +18,21 @@ var RewordLastCommit = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.RenameCommit).
 			Tap(func() {
 				t.ExpectPopup().CommitMessagePanel().
 					Title(Equals("Reword commit")).
-					InitialText(Equals("commit 02")).
+					InitialText(Equals("commit-02")).
 					Clear().
 					Type("renamed 02").
 					Confirm()
 			}).
 			Lines(
 				Contains("renamed 02"),
-				Contains("commit 01"),
+				Contains("commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/reword_last_commit_of_stacked_branch.go
+++ b/pkg/integration/tests/interactive_rebase/reword_last_commit_of_stacked_branch.go
@@ -28,28 +28,28 @@ var RewordLastCommitOfStackedBranch = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("CI commit 05").IsSelected(),
-				Contains("CI commit 04"),
-				Contains("CI * commit 03"),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI commit-05").IsSelected(),
+				Contains("CI commit-04"),
+				Contains("CI * commit-03"),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			).
-			NavigateToLine(Contains("commit 03")).
+			NavigateToLine(Contains("commit-03")).
 			Press(keys.Commits.RenameCommit).
 			Tap(func() {
 				t.ExpectPopup().CommitMessagePanel().
 					Title(Equals("Reword commit")).
-					InitialText(Equals("commit 03")).
+					InitialText(Equals("commit-03")).
 					Clear().
 					Type("renamed 03").
 					Confirm()
 			}).
 			Lines(
-				Contains("CI commit 05"),
-				Contains("CI commit 04"),
+				Contains("CI commit-05"),
+				Contains("CI commit-04"),
 				Contains("CI * renamed 03"),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/reword_you_are_here_commit.go
+++ b/pkg/integration/tests/interactive_rebase/reword_you_are_here_commit.go
@@ -18,34 +18,34 @@ var RewordYouAreHereCommit = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 03").IsSelected(),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 03"),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.RenameCommit).
 			Tap(func() {
 				t.ExpectPopup().CommitMessagePanel().
 					Title(Equals("Reword commit")).
-					InitialText(Equals("commit 02")).
+					InitialText(Equals("commit-02")).
 					Clear().
 					Type("renamed 02").
 					Confirm()
 			}).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 03"),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
 				Contains("renamed 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/reword_you_are_here_commit_with_editor.go
+++ b/pkg/integration/tests/interactive_rebase/reword_you_are_here_commit_with_editor.go
@@ -20,18 +20,18 @@ var RewordYouAreHereCommitWithEditor = NewIntegrationTest(NewIntegrationTestArgs
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 03").IsSelected(),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Universal.Edit).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 03"),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.RenameCommitWithEditor).
 			Tap(func() {
@@ -42,10 +42,10 @@ var RewordYouAreHereCommitWithEditor = NewIntegrationTest(NewIntegrationTestArgs
 			}).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("commit 03"),
+				Contains("commit-03"),
 				Contains("--- Commits ---"),
 				Contains("renamed 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/show_exec_todos.go
+++ b/pkg/integration/tests/interactive_rebase/show_exec_todos.go
@@ -33,10 +33,10 @@ var ShowExecTodos = NewIntegrationTest(NewIntegrationTestArgs{
 			Lines(
 				Contains("--- Pending rebase todos ---"),
 				Contains("exec").Contains("false"),
-				Contains("pick").Contains("CI commit 03"),
+				Contains("pick").Contains("CI commit-03"),
 				Contains("--- Commits ---"),
-				Contains("CI ○ commit 02"),
-				Contains("CI ○ commit 01"),
+				Contains("CI ○ commit-02"),
+				Contains("CI ○ commit-01"),
 			).
 			Tap(func() {
 				t.Common().ContinueRebase()
@@ -45,17 +45,17 @@ var ShowExecTodos = NewIntegrationTest(NewIntegrationTestArgs{
 			Lines(
 				Contains("--- Pending rebase todos ---"),
 				Contains("--- Commits ---"),
-				Contains("CI ○ commit 03"),
-				Contains("CI ○ commit 02"),
-				Contains("CI ○ commit 01"),
+				Contains("CI ○ commit-03"),
+				Contains("CI ○ commit-02"),
+				Contains("CI ○ commit-01"),
 			).
 			Tap(func() {
 				t.Common().ContinueRebase()
 			}).
 			Lines(
-				Contains("CI ○ commit 03"),
-				Contains("CI ○ commit 02"),
-				Contains("CI ○ commit 01"),
+				Contains("CI ○ commit-03"),
+				Contains("CI ○ commit-02"),
+				Contains("CI ○ commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/squash_down_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/squash_down_first_commit.go
@@ -18,17 +18,17 @@ var SquashDownFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 01")).
+			NavigateToLine(Contains("commit-01")).
 			Press(keys.Commits.SquashDown).
 			Tap(func() {
 				t.ExpectToast(Equals("Disabled: There's no commit below to squash into"))
 			}).
 			Lines(
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/interactive_rebase/squash_down_second_commit.go
+++ b/pkg/integration/tests/interactive_rebase/squash_down_second_commit.go
@@ -18,11 +18,11 @@ var SquashDownSecondCommit = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Commits.SquashDown).
 			Tap(func() {
 				t.ExpectPopup().Confirmation().
@@ -31,12 +31,12 @@ var SquashDownSecondCommit = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 01").IsSelected(),
+				Contains("commit-03"),
+				Contains("commit-01").IsSelected(),
 			)
 
 		t.Views().Main().
-			Content(Contains("    commit 01\n    \n    commit 02")).
+			Content(Contains("    commit-01\n    \n    commit-02")).
 			Content(Contains("+file01 content")).
 			Content(Contains("+file02 content"))
 	},

--- a/pkg/integration/tests/interactive_rebase/squash_fixups_above.go
+++ b/pkg/integration/tests/interactive_rebase/squash_fixups_above.go
@@ -19,11 +19,11 @@ var SquashFixupsAbove = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 02")).
+			NavigateToLine(Contains("commit-02")).
 			Press(keys.Commits.CreateFixupCommit).
 			Tap(func() {
 				t.ExpectPopup().Menu().
@@ -32,10 +32,10 @@ var SquashFixupsAbove = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			Lines(
-				Contains("fixup! commit 02"),
-				Contains("commit 03"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("fixup! commit-02"),
+				Contains("commit-03"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			).
 			Press(keys.Commits.SquashAboveCommits).
 			Tap(func() {
@@ -45,9 +45,9 @@ var SquashFixupsAbove = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			Lines(
-				Contains("commit 03"),
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-03"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			)
 
 		t.Views().Main().

--- a/pkg/integration/tests/interactive_rebase/squash_fixups_above_first_commit.go
+++ b/pkg/integration/tests/interactive_rebase/squash_fixups_above_first_commit.go
@@ -19,10 +19,10 @@ var SquashFixupsAboveFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 02"),
-				Contains("commit 01"),
+				Contains("commit-02"),
+				Contains("commit-01"),
 			).
-			NavigateToLine(Contains("commit 01")).
+			NavigateToLine(Contains("commit-01")).
 			Press(keys.Commits.CreateFixupCommit).
 			Tap(func() {
 				t.ExpectPopup().Menu().
@@ -30,7 +30,7 @@ var SquashFixupsAboveFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 					Select(Contains("fixup! commit")).
 					Confirm()
 			}).
-			NavigateToLine(Contains("commit 01").DoesNotContain("fixup!")).
+			NavigateToLine(Contains("commit-01").DoesNotContain("fixup!")).
 			Press(keys.Commits.SquashAboveCommits).
 			Tap(func() {
 				t.ExpectPopup().Menu().
@@ -39,8 +39,8 @@ var SquashFixupsAboveFirstCommit = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			Lines(
-				Contains("commit 02"),
-				Contains("commit 01").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01").IsSelected(),
 			)
 
 		t.Views().Main().

--- a/pkg/integration/tests/interactive_rebase/squash_fixups_in_current_branch.go
+++ b/pkg/integration/tests/interactive_rebase/squash_fixups_in_current_branch.go
@@ -22,7 +22,7 @@ var SquashFixupsInCurrentBranch = NewIntegrationTest(NewIntegrationTestArgs{
 			Commit("fixup! master commit").
 			CreateNCommits(2).
 			CreateFileAndAdd("fixup-file", "fixup content").
-			Commit("fixup! commit 01")
+			Commit("fixup! commit-01")
 	},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {
 		t.Views().Commits().
@@ -30,9 +30,9 @@ var SquashFixupsInCurrentBranch = NewIntegrationTest(NewIntegrationTestArgs{
 			SelectNextItem().
 			SelectNextItem().
 			Lines(
-				Contains("fixup! commit 01"),
-				Contains("commit 02"),
-				Contains("commit 01").IsSelected(),
+				Contains("fixup! commit-01"),
+				Contains("commit-02"),
+				Contains("commit-01").IsSelected(),
 				Contains("fixup! master commit"),
 				Contains("master commit"),
 			).
@@ -44,8 +44,8 @@ var SquashFixupsInCurrentBranch = NewIntegrationTest(NewIntegrationTestArgs{
 					Confirm()
 			}).
 			Lines(
-				Contains("commit 02"),
-				Contains("commit 01").IsSelected(),
+				Contains("commit-02"),
+				Contains("commit-01").IsSelected(),
 				Contains("fixup! master commit"),
 				Contains("master commit"),
 			)

--- a/pkg/integration/tests/interactive_rebase/view_files_of_todo_entries.go
+++ b/pkg/integration/tests/interactive_rebase/view_files_of_todo_entries.go
@@ -29,11 +29,11 @@ var ViewFilesOfTodoEntries = NewIntegrationTest(NewIntegrationTestArgs{
 			Press(keys.Commits.StartInteractiveRebase).
 			Lines(
 				Contains("--- Pending rebase todos ---"),
-				Contains("pick").Contains("CI commit 03").IsSelected(),
+				Contains("pick").Contains("CI commit-03").IsSelected(),
 				Contains("update-ref").Contains("branch1"),
-				Contains("pick").Contains("CI commit 02"),
+				Contains("pick").Contains("CI commit-02"),
 				Contains("--- Commits ---"),
-				Contains("CI commit 01"),
+				Contains("CI commit-01"),
 			).
 			Press(keys.Universal.GoInto)
 

--- a/pkg/integration/tests/patch_building/move_to_new_commit_in_last_commit_of_stacked_branch.go
+++ b/pkg/integration/tests/patch_building/move_to_new_commit_in_last_commit_of_stacked_branch.go
@@ -15,12 +15,12 @@ var MoveToNewCommitInLastCommitOfStackedBranch = NewIntegrationTest(NewIntegrati
 	},
 	SetupRepo: func(shell *Shell) {
 		shell.
-			EmptyCommit("commit 01").
+			EmptyCommit("commit-01").
 			NewBranch("branch1").
-			EmptyCommit("commit 02").
+			EmptyCommit("commit-02").
 			CreateFileAndAdd("file1", "file1 content").
 			CreateFileAndAdd("file2", "file2 content").
-			Commit("commit 03").
+			Commit("commit-03").
 			NewBranch("branch2").
 			CreateNCommitsStartingAt(2, 4)
 
@@ -30,13 +30,13 @@ var MoveToNewCommitInLastCommitOfStackedBranch = NewIntegrationTest(NewIntegrati
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("CI commit 05").IsSelected(),
-				Contains("CI commit 04"),
-				Contains("CI * commit 03"),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI commit-05").IsSelected(),
+				Contains("CI commit-04"),
+				Contains("CI * commit-03"),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			).
-			NavigateToLine(Contains("commit 03")).
+			NavigateToLine(Contains("commit-03")).
 			PressEnter()
 
 		t.Views().CommitFiles().
@@ -61,12 +61,12 @@ var MoveToNewCommitInLastCommitOfStackedBranch = NewIntegrationTest(NewIntegrati
 		t.Views().Commits().
 			IsFocused().
 			Lines(
-				Contains("CI commit 05"),
-				Contains("CI commit 04"),
+				Contains("CI commit-05"),
+				Contains("CI commit-04"),
 				Contains("CI * new commit").IsSelected(),
-				Contains("CI commit 03"),
-				Contains("CI commit 02"),
-				Contains("CI commit 01"),
+				Contains("CI commit-03"),
+				Contains("CI commit-02"),
+				Contains("CI commit-01"),
 			)
 	},
 })

--- a/pkg/integration/tests/ui/accordion.go
+++ b/pkg/integration/tests/ui/accordion.go
@@ -11,9 +11,9 @@ import (
 // ╶─Files - Submodules──────0 of 0─╴│commit 6e56dd04b70e548976f7f2928c4d9c359574e2bc                 ▲
 // ╶─Local branches - Remotes1 of 1─╴│Author: CI <CI@example.com>                                     █
 // ┌─Commits - Reflog───────────────┐│Date:   Wed Jul 19 22:00:03 2023 +1000                          │
-// │7fe02805 CI commit 12           ▲│                                                                ▼
-// │6e56dd04 CI commit 11           █└────────────────────────────────────────────────────────────────┘
-// │a35c687d CI commit 10           ▼┌─Command log────────────────────────────────────────────────────┐
+// │7fe02805 CI commit-12           ▲│                                                                ▼
+// │6e56dd04 CI commit-11           █└────────────────────────────────────────────────────────────────┘
+// │a35c687d CI commit-10           ▼┌─Command log────────────────────────────────────────────────────┐
 // └───────────────────────10 of 20─┘│Random tip: To filter commits by path, press '<ctrl+s>'         │
 // ╶─Stash───────────────────0 of 0─╴└────────────────────────────────────────────────────────────────┘
 //  <pgup>/<pgdown>: Scroll, <esc>: Cancel, q: Quit, ?: Keybindings, 1-Donate Ask Question unversioned
@@ -32,18 +32,18 @@ var Accordion = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			VisibleLines(
-				Contains("commit 20").IsSelected(),
-				Contains("commit 19"),
-				Contains("commit 18"),
+				Contains("commit-20").IsSelected(),
+				Contains("commit-19"),
+				Contains("commit-18"),
 			).
 			// go past commit 11, then come back, so that it ends up in the centre of the viewport
-			NavigateToLine(Contains("commit 11")).
-			NavigateToLine(Contains("commit 10")).
-			NavigateToLine(Contains("commit 11")).
+			NavigateToLine(Contains("commit-11")).
+			NavigateToLine(Contains("commit-10")).
+			NavigateToLine(Contains("commit-11")).
 			VisibleLines(
-				Contains("commit 12"),
-				Contains("commit 11").IsSelected(),
-				Contains("commit 10"),
+				Contains("commit-12"),
+				Contains("commit-11").IsSelected(),
+				Contains("commit-10"),
 			)
 
 		t.Views().Files().
@@ -53,9 +53,9 @@ var Accordion = NewIntegrationTest(NewIntegrationTestArgs{
 		t.Views().Commits().
 			Focus().
 			VisibleLines(
-				Contains("commit 12"),
-				Contains("commit 11").IsSelected(),
-				Contains("commit 10"),
+				Contains("commit-12"),
+				Contains("commit-11").IsSelected(),
+				Contains("commit-10"),
 			)
 	},
 })

--- a/pkg/integration/tests/ui/mode_specific_keybinding_suggestions.go
+++ b/pkg/integration/tests/ui/mode_specific_keybinding_suggestions.go
@@ -27,8 +27,8 @@ var ModeSpecificKeybindingSuggestions = NewIntegrationTest(NewIntegrationTestArg
 		t.Views().Commits().
 			Focus().
 			Lines(
-				Contains("commit 02").IsSelected(),
-				Contains("commit 01"),
+				Contains("commit-02").IsSelected(),
+				Contains("commit-01"),
 			).
 			Tap(func() {
 				// These suggestions are mode-specific so are not shown by default


### PR DESCRIPTION
Some tests assert that a specific commit subject does or doesn't occur in the main view; interactive_rebase/outside_rebase_range_select.go is an example for this, it asserts `t.Views().Main().Content( DoesNotContain("commit 06"))`. The problem with this kind of assertion and our test commit naming scheme is that the diff view begins with a "commit <hash>" line, and when that hash happens to start with "06" the assertion matched it and failed spuriously. This was usually masked by our MaxAttempts=2 that we currently use for integration tests (it's quite unlikely that the commit gets a hash beginning with "06" twice in a row). However, we want to get to a state where we can set MaxAttempts to 1, so make this more robust by changing our naming scheme.
