### PR TITLE
Add word-diffing support

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -468,6 +468,11 @@ git:
   # `<ctrl+w>`.
   ignoreWhitespaceInDiffView: false
 
+  # If true, git diffs are rendered with the `--word-diff=color` flag, which
+  # highlights changes at word granularity rather than line granularity. Can be
+  # toggled from within Lazygit with `<ctrl+g>`.
+  wordDiffInDiffView: false
+
   # The number of lines of context to show around each diff hunk. Can be changed
   # from within Lazygit with the `{` and `}` keys.
   diffContextSize: 3
@@ -725,6 +730,7 @@ keybinding:
     submitEditorText: <enter>
     extrasMenu: '@'
     toggleWhitespaceInDiffView: <ctrl+w>
+    toggleWordDiffInDiffView: <c-g>
     increaseContextInDiffView: '}'
     decreaseContextInDiffView: '{'
     increaseRenameSimilarityThreshold: )

--- a/docs-master/keybindings/Keybindings_en.md
+++ b/docs-master/keybindings/Keybindings_en.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | Quit |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | Toggle whitespace | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <ctrl+g> `` | Toggle word diff | Toggle between line-level and word-level highlighting of changes in the diff view (git's --word-diff=color).<br><br>The default can be changed in the config file with the key 'git.wordDiffInDiffView'. |
 | `` <alt+shift+c> `` | Edit config file | Open file in external editor. |
 | `` z `` | Undo | The reflog will be used to determine what git command to run to undo the last git command. This does not include changes to the working tree; only commits are taken into consideration. |
 | `` Z `` | Redo | The reflog will be used to determine what git command to run to redo the last git command. This does not include changes to the working tree; only commits are taken into consideration. |

--- a/docs-master/keybindings/Keybindings_ja.md
+++ b/docs-master/keybindings/Keybindings_ja.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | 終了 |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | 空白表示の切り替え | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <ctrl+g> `` | Toggle word diff | Toggle between line-level and word-level highlighting of changes in the diff view (git's --word-diff=color).<br><br>The default can be changed in the config file with the key 'git.wordDiffInDiffView'. |
 | `` <alt+shift+c> `` | 設定ファイルを編集 | 外部エディタでファイルを開きます。 |
 | `` z `` | 元に戻す | 最後のgitコマンドを元に戻すために実行するgitコマンドを決定するためにreflogが使用されます。これにはワーキングツリーへの変更は含まれません。コミットのみが考慮されます。 |
 | `` Z `` | やり直す | 最後のgitコマンドをやり直すために実行するgitコマンドを決定するためにreflogが使用されます。これにはワーキングツリーへの変更は含まれません。コミットのみが考慮されます。 |

--- a/docs-master/keybindings/Keybindings_ko.md
+++ b/docs-master/keybindings/Keybindings_ko.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | 종료 |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | 공백문자를 Diff 뷰에서 표시 여부 전환 | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <ctrl+g> `` | Toggle word diff | Toggle between line-level and word-level highlighting of changes in the diff view (git's --word-diff=color).<br><br>The default can be changed in the config file with the key 'git.wordDiffInDiffView'. |
 | `` <alt+shift+c> `` | 설정 파일 수정 | Open file in external editor. |
 | `` z `` | 되돌리기 (reflog) (실험적) | The reflog will be used to determine what git command to run to undo the last git command. This does not include changes to the working tree; only commits are taken into consideration. |
 | `` Z `` | 다시 실행 (reflog) (실험적) | The reflog will be used to determine what git command to run to redo the last git command. This does not include changes to the working tree; only commits are taken into consideration. |

--- a/docs-master/keybindings/Keybindings_nl.md
+++ b/docs-master/keybindings/Keybindings_nl.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | Afsluiten |  |
 | `` <ctrl+z> `` | Pauzeer de applicatie |  |
 | `` <ctrl+w> `` | Toggle whitespace | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <ctrl+g> `` | Toggle word diff | Toggle between line-level and word-level highlighting of changes in the diff view (git's --word-diff=color).<br><br>The default can be changed in the config file with the key 'git.wordDiffInDiffView'. |
 | `` <alt+shift+c> `` | Verander config bestand | Open bestand in externe editor. |
 | `` z `` | Ongedaan maken (via reflog) (experimenteel) | The reflog will be used to determine what git command to run to undo the last git command. This does not include changes to the working tree; only commits are taken into consideration. |
 | `` Z `` | Redo (via reflog) (experimenteel) | The reflog will be used to determine what git command to run to redo the last git command. This does not include changes to the working tree; only commits are taken into consideration. |

--- a/docs-master/keybindings/Keybindings_pl.md
+++ b/docs-master/keybindings/Keybindings_pl.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | Wyjdź |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | Przełącz białe znaki | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <ctrl+g> `` | Toggle word diff | Toggle between line-level and word-level highlighting of changes in the diff view (git's --word-diff=color).<br><br>The default can be changed in the config file with the key 'git.wordDiffInDiffView'. |
 | `` <alt+shift+c> `` | Edytuj plik konfiguracyjny | Otwórz plik w zewnętrznym edytorze. |
 | `` z `` | Cofnij | Dziennik reflog zostanie użyty do określenia, jakie polecenie git należy uruchomić, aby cofnąć ostatnie polecenie git. Nie obejmuje to zmian w drzewie roboczym; brane są pod uwagę tylko commity. |
 | `` Z `` | Ponów | Dziennik reflog zostanie użyty do określenia, jakie polecenie git należy uruchomić, aby ponowić ostatnie polecenie git. Nie obejmuje to zmian w drzewie roboczym; brane są pod uwagę tylko commity. |

--- a/docs-master/keybindings/Keybindings_pt.md
+++ b/docs-master/keybindings/Keybindings_pt.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | Sair |  |
 | `` <ctrl+z> `` | Suspender a aplicação |  |
 | `` <ctrl+w> `` | Toggle whitespace | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <ctrl+g> `` | Toggle word diff | Toggle between line-level and word-level highlighting of changes in the diff view (git's --word-diff=color).<br><br>The default can be changed in the config file with the key 'git.wordDiffInDiffView'. |
 | `` <alt+shift+c> `` | Editar arquivo de configuração | Abrir arquivo no editor externo. |
 | `` z `` | Desfazer | O reflog será usado para determinar qual comando git para executar para desfazer o último comando git. Isto não inclui mudanças na árvore de trabalho; apenas compromissos são tidos em consideração. |
 | `` Z `` | Refazer | O reflog será usado para determinar qual comando git para executar para refazer o último comando git. Isto não inclui mudanças na árvore de trabalho; apenas compromissos são tidos em consideração. |

--- a/docs-master/keybindings/Keybindings_ru.md
+++ b/docs-master/keybindings/Keybindings_ru.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | Выйти |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | Переключить отображение изменении пробелов в просмотрщике сравнении | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <ctrl+g> `` | Toggle word diff | Toggle between line-level and word-level highlighting of changes in the diff view (git's --word-diff=color).<br><br>The default can be changed in the config file with the key 'git.wordDiffInDiffView'. |
 | `` <alt+shift+c> `` | Редактировать файл конфигурации | Open file in external editor. |
 | `` z `` | Отменить (через reflog) (экспериментальный) | Журнал ссылок (reflog) будет использоваться для определения того, какую команду git запустить, чтобы отменить последнюю команду git. Сюда не входят изменения в рабочем дереве; учитываются только коммиты. |
 | `` Z `` | Повторить (через reflog) (экспериментальный) | Журнал ссылок (reflog) будет использоваться для определения того, какую команду git нужно запустить, чтобы повторить последнюю команду git. Сюда не входят изменения в рабочем дереве; учитываются только коммиты. |

--- a/docs-master/keybindings/Keybindings_zh-CN.md
+++ b/docs-master/keybindings/Keybindings_zh-CN.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | 退出 |  |
 | `` <ctrl+z> `` | 挂起应用程序 |  |
 | `` <ctrl+w> `` | 切换是否在差异视图中显示空白字符差异 | 切换是否在差异视图中显示空白字符更改。<br><br>默认值可在配置文件中通过键 'git.ignoreWhitespaceInDiffView' 更改。 |
+| `` <ctrl+g> `` | Toggle word diff | Toggle between line-level and word-level highlighting of changes in the diff view (git's --word-diff=color).<br><br>The default can be changed in the config file with the key 'git.wordDiffInDiffView'. |
 | `` <alt+shift+c> `` | 编辑配置文件 | 使用外部编辑器打开文件 |
 | `` z `` | 撤销 | Reflog将用于确定运行哪个git命令来撤消最后一个git命令。这并不包括对工作树的更改，只考虑提交。 |
 | `` Z `` | 重做 | Reflog将用于确定运行哪个git命令来重做上一个git命令。这并不包括对工作树的更改，只考虑提交。 |

--- a/docs-master/keybindings/Keybindings_zh-TW.md
+++ b/docs-master/keybindings/Keybindings_zh-TW.md
@@ -31,6 +31,7 @@ _This file is auto-generated. To update, make the changes in the pkg/i18n direct
 | `` q, <ctrl+c> `` | 結束 |  |
 | `` <ctrl+z> `` | Suspend the application |  |
 | `` <ctrl+w> `` | 切換是否在差異檢視中顯示空格變更 | Toggle whether or not whitespace changes are shown in the diff view.<br><br>The default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'. |
+| `` <ctrl+g> `` | Toggle word diff | Toggle between line-level and word-level highlighting of changes in the diff view (git's --word-diff=color).<br><br>The default can be changed in the config file with the key 'git.wordDiffInDiffView'. |
 | `` <alt+shift+c> `` | 編輯設定檔案 | 使用外部編輯器開啟 |
 | `` z `` | 復原 | 將使用 reflog 確任 git 指令以復原。這不包括工作區更改；只考慮提交。 |
 | `` Z `` | 取消復原 | 將使用 reflog 確任 git 指令以重作。這不包括工作區更改；只考慮提交。 |

--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -257,6 +257,7 @@ func (self *CommitCommands) ShowCmdObj(hash string, filterPaths []string) *oscom
 		Arg("-p").
 		Arg(hash).
 		ArgIf(self.UserConfig().Git.IgnoreWhitespaceInDiffView, "--ignore-all-space").
+		ArgIf(self.UserConfig().Git.WordDiffInDiffView, "--word-diff=color").
 		Arg(fmt.Sprintf("--find-renames=%d%%", self.UserConfig().Git.RenameSimilarityThreshold)).
 		Arg("--").
 		Arg(filterPaths...).

--- a/pkg/commands/git_commands/commit_test.go
+++ b/pkg/commands/git_commands/commit_test.go
@@ -255,6 +255,7 @@ func TestCommitShowCmdObj(t *testing.T) {
 		contextSize         uint64
 		similarityThreshold int
 		ignoreWhitespace    bool
+		wordDiff            bool
 		pagerConfig         *config.PagingConfig
 		expected            []string
 	}
@@ -306,6 +307,15 @@ func TestCommitShowCmdObj(t *testing.T) {
 			expected:            []string{"-C", "/path/to/worktree", "-c", "diff.noprefix=false", "show", "--no-ext-diff", "--submodule", "--color=always", "--unified=77", "--stat", "--decorate", "-p", "1234567890", "--ignore-all-space", "--find-renames=50%", "--"},
 		},
 		{
+			testName:            "Show diff with word diff",
+			filterPaths:         []string{},
+			contextSize:         3,
+			similarityThreshold: 50,
+			wordDiff:            true,
+			pagerConfig:         nil,
+			expected:            []string{"-C", "/path/to/worktree", "-c", "diff.noprefix=false", "show", "--no-ext-diff", "--submodule", "--color=always", "--unified=3", "--stat", "--decorate", "-p", "1234567890", "--word-diff=color", "--find-renames=50%", "--"},
+		},
+		{
 			testName:            "Show diff with external diff command",
 			filterPaths:         []string{},
 			contextSize:         3,
@@ -332,6 +342,7 @@ func TestCommitShowCmdObj(t *testing.T) {
 				userConfig.Git.Pagers = []config.PagingConfig{*s.pagerConfig}
 			}
 			userConfig.Git.IgnoreWhitespaceInDiffView = s.ignoreWhitespace
+			userConfig.Git.WordDiffInDiffView = s.wordDiff
 			userConfig.Git.DiffContextSize = s.contextSize
 			userConfig.Git.RenameSimilarityThreshold = s.similarityThreshold
 

--- a/pkg/commands/git_commands/diff.go
+++ b/pkg/commands/git_commands/diff.go
@@ -23,6 +23,7 @@ func (self *DiffCommands) DiffCmdObj(diffArgs []string) *oscommands.CmdObj {
 	useExtDiff := extDiffCmd != ""
 	useExtDiffGitConfig := self.pagerConfig.GetUseExternalDiffGitConfig()
 	ignoreWhitespace := self.UserConfig().Git.IgnoreWhitespaceInDiffView
+	wordDiff := self.UserConfig().Git.WordDiffInDiffView
 
 	return self.cmd.New(
 		NewGitCmd("diff").
@@ -32,6 +33,7 @@ func (self *DiffCommands) DiffCmdObj(diffArgs []string) *oscommands.CmdObj {
 			Arg("--submodule").
 			Arg(fmt.Sprintf("--color=%s", self.pagerConfig.GetColorArg())).
 			ArgIf(ignoreWhitespace, "--ignore-all-space").
+			ArgIf(wordDiff, "--word-diff=color").
 			Arg(fmt.Sprintf("--unified=%d", self.UserConfig().Git.DiffContextSize)).
 			Arg(diffArgs...).
 			Dir(self.repoPaths.worktreePath).

--- a/pkg/commands/git_commands/stash.go
+++ b/pkg/commands/git_commands/stash.go
@@ -94,6 +94,7 @@ func (self *StashCommands) ShowStashEntryCmdObj(index int) *oscommands.CmdObj {
 		Arg(fmt.Sprintf("--color=%s", self.pagerConfig.GetColorArg())).
 		Arg(fmt.Sprintf("--unified=%d", self.UserConfig().Git.DiffContextSize)).
 		ArgIf(self.UserConfig().Git.IgnoreWhitespaceInDiffView, "--ignore-all-space").
+		ArgIf(self.UserConfig().Git.WordDiffInDiffView, "--word-diff=color").
 		Arg(fmt.Sprintf("--find-renames=%d%%", self.UserConfig().Git.RenameSimilarityThreshold)).
 		Arg(fmt.Sprintf("refs/stash@{%d}", index)).
 		Dir(self.repoPaths.worktreePath).

--- a/pkg/commands/git_commands/stash_test.go
+++ b/pkg/commands/git_commands/stash_test.go
@@ -103,6 +103,7 @@ func TestStashStashEntryCmdObj(t *testing.T) {
 		contextSize         uint64
 		similarityThreshold int
 		ignoreWhitespace    bool
+		wordDiff            bool
 		pagerConfig         *config.PagingConfig
 		expected            []string
 	}
@@ -158,12 +159,21 @@ func TestStashStashEntryCmdObj(t *testing.T) {
 			ignoreWhitespace:    true,
 			expected:            []string{"git", "-C", "/path/to/worktree", "stash", "show", "-p", "--stat", "-u", "--no-ext-diff", "--color=always", "--unified=3", "--ignore-all-space", "--find-renames=50%", "refs/stash@{5}"},
 		},
+		{
+			testName:            "Show diff with word diff",
+			index:               5,
+			contextSize:         3,
+			similarityThreshold: 50,
+			wordDiff:            true,
+			expected:            []string{"git", "-C", "/path/to/worktree", "stash", "show", "-p", "--stat", "-u", "--no-ext-diff", "--color=always", "--unified=3", "--word-diff=color", "--find-renames=50%", "refs/stash@{5}"},
+		},
 	}
 
 	for _, s := range scenarios {
 		t.Run(s.testName, func(t *testing.T) {
 			userConfig := config.GetDefaultConfig()
 			userConfig.Git.IgnoreWhitespaceInDiffView = s.ignoreWhitespace
+			userConfig.Git.WordDiffInDiffView = s.wordDiff
 			userConfig.Git.DiffContextSize = s.contextSize
 			userConfig.Git.RenameSimilarityThreshold = s.similarityThreshold
 			if s.pagerConfig != nil {

--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -417,6 +417,7 @@ func (self *WorkingTreeCommands) WorktreeFileDiffCmdObj(node models.IFile, plain
 		Arg(fmt.Sprintf("--unified=%d", contextSize)).
 		Arg(fmt.Sprintf("--color=%s", colorArg)).
 		ArgIf(!plain && self.UserConfig().Git.IgnoreWhitespaceInDiffView, "--ignore-all-space").
+		ArgIf(!plain && self.UserConfig().Git.WordDiffInDiffView, "--word-diff=color").
 		Arg(fmt.Sprintf("--find-renames=%d%%", self.UserConfig().Git.RenameSimilarityThreshold)).
 		ArgIf(cached, "--cached").
 		ArgIf(noIndex, "--no-index").
@@ -466,6 +467,7 @@ func (self *WorkingTreeCommands) ShowFileDiffCmdObj(from string, to string, reve
 		Arg(to).
 		ArgIf(reverse, "-R").
 		ArgIf(!plain && self.UserConfig().Git.IgnoreWhitespaceInDiffView, "--ignore-all-space").
+		ArgIf(!plain && self.UserConfig().Git.WordDiffInDiffView, "--word-diff=color").
 		Arg("--").
 		Arg(fileNames...).
 		Dir(self.repoPaths.worktreePath).

--- a/pkg/commands/git_commands/working_tree_test.go
+++ b/pkg/commands/git_commands/working_tree_test.go
@@ -200,6 +200,7 @@ func TestWorkingTreeDiff(t *testing.T) {
 		plain               bool
 		cached              bool
 		ignoreWhitespace    bool
+		wordDiff            bool
 		contextSize         uint64
 		similarityThreshold int
 		runner              *oscommands.FakeCmdObjRunner
@@ -284,6 +285,21 @@ func TestWorkingTreeDiff(t *testing.T) {
 				ExpectGitArgs([]string{"-C", "/path/to/worktree", "diff", "--no-ext-diff", "--submodule", "--unified=3", "--color=always", "--ignore-all-space", "--find-renames=50%", "--", "test.txt"}, expectedResult, nil),
 		},
 		{
+			testName: "Default case (word diff)",
+			file: &models.File{
+				Path:             "test.txt",
+				HasStagedChanges: false,
+				Tracked:          true,
+			},
+			plain:               false,
+			cached:              false,
+			wordDiff:            true,
+			contextSize:         3,
+			similarityThreshold: 50,
+			runner: oscommands.NewFakeRunner(t).
+				ExpectGitArgs([]string{"-C", "/path/to/worktree", "diff", "--no-ext-diff", "--submodule", "--unified=3", "--color=always", "--word-diff=color", "--find-renames=50%", "--", "test.txt"}, expectedResult, nil),
+		},
+		{
 			testName: "Show diff with custom context size",
 			file: &models.File{
 				Path:             "test.txt",
@@ -319,6 +335,7 @@ func TestWorkingTreeDiff(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			userConfig := config.GetDefaultConfig()
 			userConfig.Git.IgnoreWhitespaceInDiffView = s.ignoreWhitespace
+			userConfig.Git.WordDiffInDiffView = s.wordDiff
 			userConfig.Git.DiffContextSize = s.contextSize
 			userConfig.Git.RenameSimilarityThreshold = s.similarityThreshold
 			repoPaths := RepoPaths{
@@ -343,6 +360,7 @@ func TestWorkingTreeShowFileDiff(t *testing.T) {
 		previousPath     string
 		plain            bool
 		ignoreWhitespace bool
+		wordDiff         bool
 		contextSize      uint64
 		runner           *oscommands.FakeCmdObjRunner
 	}
@@ -387,6 +405,18 @@ func TestWorkingTreeShowFileDiff(t *testing.T) {
 				ExpectGitArgs([]string{"-C", "/path/to/worktree", "-c", "diff.noprefix=false", "diff", "--no-ext-diff", "--submodule", "--unified=3", "--find-renames=50%", "--color=always", "1234567890", "0987654321", "--ignore-all-space", "--", "test.txt"}, expectedResult, nil),
 		},
 		{
+			testName:    "Default case (word diff)",
+			from:        "1234567890",
+			to:          "0987654321",
+			reverse:     false,
+			fileName:    "test.txt",
+			plain:       false,
+			wordDiff:    true,
+			contextSize: 3,
+			runner: oscommands.NewFakeRunner(t).
+				ExpectGitArgs([]string{"-C", "/path/to/worktree", "-c", "diff.noprefix=false", "diff", "--no-ext-diff", "--submodule", "--unified=3", "--find-renames=50%", "--color=always", "1234567890", "0987654321", "--word-diff=color", "--", "test.txt"}, expectedResult, nil),
+		},
+		{
 			testName:         "Renamed file passes both paths so the rename is detected",
 			from:             "1234567890",
 			to:               "0987654321",
@@ -405,6 +435,7 @@ func TestWorkingTreeShowFileDiff(t *testing.T) {
 		t.Run(s.testName, func(t *testing.T) {
 			userConfig := config.GetDefaultConfig()
 			userConfig.Git.IgnoreWhitespaceInDiffView = s.ignoreWhitespace
+			userConfig.Git.WordDiffInDiffView = s.wordDiff
 			userConfig.Git.DiffContextSize = s.contextSize
 			repoPaths := RepoPaths{
 				worktreePath: "/path/to/worktree",

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -327,6 +327,8 @@ type GitConfig struct {
 	AllBranchesLogCmds []string `yaml:"allBranchesLogCmds"`
 	// If true, git diffs are rendered with the `--ignore-all-space` flag, which ignores whitespace changes. Can be toggled from within Lazygit with `<ctrl+w>`.
 	IgnoreWhitespaceInDiffView bool `yaml:"ignoreWhitespaceInDiffView"`
+	// If true, git diffs are rendered with the `--word-diff=color` flag, which highlights changes at word granularity rather than line granularity. Can be toggled from within Lazygit with `<ctrl+g>`.
+	WordDiffInDiffView bool `yaml:"wordDiffInDiffView"`
 	// The number of lines of context to show around each diff hunk. Can be changed from within Lazygit with the `{` and `}` keys.
 	DiffContextSize uint64 `yaml:"diffContextSize"`
 	// The threshold for considering a file to be renamed, in percent. Can be changed from within Lazygit with the `(` and `)` keys.
@@ -548,6 +550,7 @@ type KeybindingUniversalConfig struct {
 	SubmitEditorText                  Keybinding `yaml:"submitEditorText"`
 	ExtrasMenu                        Keybinding `yaml:"extrasMenu"`
 	ToggleWhitespaceInDiffView        Keybinding `yaml:"toggleWhitespaceInDiffView"`
+	ToggleWordDiffInDiffView          Keybinding `yaml:"toggleWordDiffInDiffView"`
 	IncreaseContextInDiffView         Keybinding `yaml:"increaseContextInDiffView"`
 	DecreaseContextInDiffView         Keybinding `yaml:"decreaseContextInDiffView"`
 	IncreaseRenameSimilarityThreshold Keybinding `yaml:"increaseRenameSimilarityThreshold"`
@@ -959,6 +962,7 @@ func GetDefaultConfigForPlatform(platform string) *UserConfig {
 			BranchLogCmd:                 "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",
 			AllBranchesLogCmds:           []string{"git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium"},
 			IgnoreWhitespaceInDiffView:   false,
+			WordDiffInDiffView:           false,
 			DiffContextSize:              3,
 			RenameSimilarityThreshold:    50,
 			DisableForcePushing:          false,
@@ -1066,6 +1070,7 @@ func GetDefaultConfigForPlatform(platform string) *UserConfig {
 				SubmitEditorText:                  Keybinding{"<enter>"},
 				ExtrasMenu:                        Keybinding{"@"},
 				ToggleWhitespaceInDiffView:        Keybinding{"<ctrl+w>"},
+				ToggleWordDiffInDiffView:          Keybinding{"<c-g>"},
 				IncreaseContextInDiffView:         Keybinding{"}"},
 				DecreaseContextInDiffView:         Keybinding{"{"},
 				IncreaseRenameSimilarityThreshold: Keybinding{")"},

--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -183,7 +183,7 @@ func (self *CommitFilesController) GetOnRenderToMain() func() {
 			Pair: self.c.MainViewPairs().Normal,
 			Main: &types.ViewUpdateOpts{
 				Title:    self.c.Tr.Patch,
-				SubTitle: self.c.Helpers().Diff.IgnoringWhitespaceSubTitle(),
+				SubTitle: self.c.Helpers().Diff.DiffViewSubtitle(),
 				Task:     task,
 			},
 			Secondary: secondaryPatchPanelUpdateOpts(self.c),

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -291,7 +291,7 @@ func (self *FilesController) renderToMainWithTask(task types.UpdateTask) {
 		Pair: self.c.MainViewPairs().Normal,
 		Main: &types.ViewUpdateOpts{
 			Title:    self.c.Tr.DiffTitle,
-			SubTitle: self.c.Helpers().Diff.IgnoringWhitespaceSubTitle(),
+			SubTitle: self.c.Helpers().Diff.DiffViewSubtitle(),
 			Task:     task,
 		},
 	})
@@ -387,7 +387,7 @@ func (self *FilesController) renderWorkingTreeDiff(node *filetree.FileNode) {
 		Pair: self.c.MainViewPairs().Normal,
 		Main: &types.ViewUpdateOpts{
 			Task:     types.NewRunPtyTask(cmdObj.GetCmd()),
-			SubTitle: self.c.Helpers().Diff.IgnoringWhitespaceSubTitle(),
+			SubTitle: self.c.Helpers().Diff.DiffViewSubtitle(),
 			Title:    title,
 		},
 	}
@@ -402,7 +402,7 @@ func (self *FilesController) renderWorkingTreeDiff(node *filetree.FileNode) {
 
 		refreshOpts.Secondary = &types.ViewUpdateOpts{
 			Title:    title,
-			SubTitle: self.c.Helpers().Diff.IgnoringWhitespaceSubTitle(),
+			SubTitle: self.c.Helpers().Diff.DiffViewSubtitle(),
 			Task:     types.NewRunPtyTask(cmdObj.GetCmd()),
 		}
 	}

--- a/pkg/gui/controllers/global_controller.go
+++ b/pkg/gui/controllers/global_controller.go
@@ -137,6 +137,12 @@ func (self *GlobalController) GetKeybindings(opts types.KeybindingsOpts) []*type
 			Tooltip:     self.c.Tr.ToggleWhitespaceInDiffViewTooltip,
 		},
 		{
+			Keys:        opts.GetKeys(opts.Config.Universal.ToggleWordDiffInDiffView),
+			Handler:     self.toggleWordDiff,
+			Description: self.c.Tr.ToggleWordDiff,
+			Tooltip:     self.c.Tr.ToggleWordDiffTooltip,
+		},
+		{
 			Keys:        opts.GetKeys(opts.Config.Universal.EditConfig),
 			Handler:     self.editConfig,
 			Description: self.c.Tr.EditConfig,
@@ -271,6 +277,10 @@ func (self *GlobalController) escapeEnabled() *types.DisabledReason {
 
 func (self *GlobalController) toggleWhitespace() error {
 	return (&ToggleWhitespaceAction{c: self.c}).Call()
+}
+
+func (self *GlobalController) toggleWordDiff() error {
+	return (&ToggleWordDiffAction{c: self.c}).Call()
 }
 
 func (self *GlobalController) editConfig() error {

--- a/pkg/gui/controllers/helpers/diff_helper.go
+++ b/pkg/gui/controllers/helpers/diff_helper.go
@@ -112,7 +112,7 @@ func (self *DiffHelper) RenderDiff() {
 		Pair: self.c.MainViewPairs().Normal,
 		Main: &types.ViewUpdateOpts{
 			Title:    "Diff",
-			SubTitle: self.IgnoringWhitespaceSubTitle(),
+			SubTitle: self.DiffViewSubtitle(),
 			Task:     task,
 		},
 	})
@@ -166,12 +166,19 @@ func (self *DiffHelper) WithDiffModeCheck(f func()) {
 	}
 }
 
-func (self *DiffHelper) IgnoringWhitespaceSubTitle() string {
+// DiffViewSubtitle reports which diff-view rendering options are currently
+// active (ignoring whitespace, word-diff), as a subtitle for the main diff
+// view. Returns the empty string when none are active.
+func (self *DiffHelper) DiffViewSubtitle() string {
+	var tags []string
 	if self.c.UserConfig().Git.IgnoreWhitespaceInDiffView {
-		return self.c.Tr.IgnoreWhitespaceDiffViewSubTitle
+		tags = append(tags, self.c.Tr.IgnoreWhitespaceDiffViewSubTitle)
+	}
+	if self.c.UserConfig().Git.WordDiffInDiffView {
+		tags = append(tags, self.c.Tr.WordDiffDiffViewSubTitle)
 	}
 
-	return ""
+	return strings.Join(tags, " ")
 }
 
 func (self *DiffHelper) OpenDiffToolForRef(selectedRef models.Ref) error {

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -309,7 +309,7 @@ func (self *LocalCommitsController) GetOnRenderToMain() func() {
 				Pair: self.c.MainViewPairs().Normal,
 				Main: &types.ViewUpdateOpts{
 					Title:    "Patch",
-					SubTitle: self.c.Helpers().Diff.IgnoringWhitespaceSubTitle(),
+					SubTitle: self.c.Helpers().Diff.DiffViewSubtitle(),
 					Task:     task,
 				},
 				Secondary: secondaryPatchPanelUpdateOpts(self.c),

--- a/pkg/gui/controllers/stash_controller.go
+++ b/pkg/gui/controllers/stash_controller.go
@@ -102,7 +102,7 @@ func (self *StashController) GetOnRenderToMain() func() {
 				Pair: self.c.MainViewPairs().Normal,
 				Main: &types.ViewUpdateOpts{
 					Title:    "Stash",
-					SubTitle: self.c.Helpers().Diff.IgnoringWhitespaceSubTitle(),
+					SubTitle: self.c.Helpers().Diff.DiffViewSubtitle(),
 					Task:     task,
 				},
 			})

--- a/pkg/gui/controllers/sub_commits_controller.go
+++ b/pkg/gui/controllers/sub_commits_controller.go
@@ -53,7 +53,7 @@ func (self *SubCommitsController) GetOnRenderToMain() func() {
 				Pair: self.c.MainViewPairs().Normal,
 				Main: &types.ViewUpdateOpts{
 					Title:    "Commit",
-					SubTitle: self.c.Helpers().Diff.IgnoringWhitespaceSubTitle(),
+					SubTitle: self.c.Helpers().Diff.DiffViewSubtitle(),
 					Task:     task,
 				},
 			})

--- a/pkg/gui/controllers/toggle_whitespace_action.go
+++ b/pkg/gui/controllers/toggle_whitespace_action.go
@@ -8,18 +8,21 @@ import (
 	"github.com/samber/lo"
 )
 
+// These contexts render their diff for line-by-line staging, so diff-view
+// rendering options like ignoring whitespace or word-diff can't be applied to
+// them: those options rewrite the diff in ways that break line selection.
+var contextsThatDontSupportDiffViewOptions = []types.ContextKey{
+	context.STAGING_MAIN_CONTEXT_KEY,
+	context.STAGING_SECONDARY_CONTEXT_KEY,
+	context.PATCH_BUILDING_MAIN_CONTEXT_KEY,
+}
+
 type ToggleWhitespaceAction struct {
 	c *ControllerCommon
 }
 
 func (self *ToggleWhitespaceAction) Call() error {
-	contextsThatDontSupportIgnoringWhitespace := []types.ContextKey{
-		context.STAGING_MAIN_CONTEXT_KEY,
-		context.STAGING_SECONDARY_CONTEXT_KEY,
-		context.PATCH_BUILDING_MAIN_CONTEXT_KEY,
-	}
-
-	if lo.Contains(contextsThatDontSupportIgnoringWhitespace, self.c.Context().Current().GetKey()) {
+	if lo.Contains(contextsThatDontSupportDiffViewOptions, self.c.Context().Current().GetKey()) {
 		// Ignoring whitespace is not supported in these views. Let the user
 		// know that it's not going to work in case they try to turn it on.
 		return errors.New(self.c.Tr.IgnoreWhitespaceNotSupportedHere)

--- a/pkg/gui/controllers/toggle_word_diff_action.go
+++ b/pkg/gui/controllers/toggle_word_diff_action.go
@@ -1,0 +1,26 @@
+package controllers
+
+import (
+	"errors"
+
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/samber/lo"
+)
+
+type ToggleWordDiffAction struct {
+	c *ControllerCommon
+}
+
+func (self *ToggleWordDiffAction) Call() error {
+	if lo.Contains(contextsThatDontSupportDiffViewOptions, self.c.Context().Current().GetKey()) {
+		// Word-diff collapses the +/- lines that line-by-line staging needs, so
+		// it can't be applied in these views. Let the user know rather than
+		// silently doing nothing.
+		return errors.New(self.c.Tr.WordDiffNotSupportedHere)
+	}
+
+	self.c.UserConfig().Git.WordDiffInDiffView = !self.c.UserConfig().Git.WordDiffInDiffView
+
+	self.c.Context().CurrentSide().HandleFocus(types.OnFocusOpts{})
+	return nil
+}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -778,6 +778,7 @@ type TranslationSet struct {
 	ToggleWordDiff                           string
 	ToggleWordDiffTooltip                    string
 	IgnoreWhitespaceDiffViewSubTitle         string
+	WordDiffDiffViewSubTitle                 string
 	IgnoreWhitespaceNotSupportedHere         string
 	WordDiffNotSupportedHere                 string
 	IncreaseContextInDiffView                string
@@ -1931,6 +1932,7 @@ func EnglishTranslationSet() *TranslationSet {
 		ToggleWordDiff:                           "Toggle word diff",
 		ToggleWordDiffTooltip:                    "Toggle between line-level and word-level highlighting of changes in the diff view (git's --word-diff=color).\n\nThe default can be changed in the config file with the key 'git.wordDiffInDiffView'.",
 		IgnoreWhitespaceDiffViewSubTitle:         "(ignoring whitespace)",
+		WordDiffDiffViewSubTitle:                 "(word diff)",
 		IgnoreWhitespaceNotSupportedHere:         "Ignoring whitespace is not supported in this view",
 		WordDiffNotSupportedHere:                 "Word diff is not supported in this view",
 		IncreaseContextInDiffView:                "Increase diff context size",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -775,8 +775,11 @@ type TranslationSet struct {
 	RandomTip                                string
 	ToggleWhitespaceInDiffView               string
 	ToggleWhitespaceInDiffViewTooltip        string
+	ToggleWordDiff                           string
+	ToggleWordDiffTooltip                    string
 	IgnoreWhitespaceDiffViewSubTitle         string
 	IgnoreWhitespaceNotSupportedHere         string
+	WordDiffNotSupportedHere                 string
 	IncreaseContextInDiffView                string
 	IncreaseContextInDiffViewTooltip         string
 	DecreaseContextInDiffView                string
@@ -1925,8 +1928,11 @@ func EnglishTranslationSet() *TranslationSet {
 		RandomTip:                                "Random tip",
 		ToggleWhitespaceInDiffView:               "Toggle whitespace",
 		ToggleWhitespaceInDiffViewTooltip:        "Toggle whether or not whitespace changes are shown in the diff view.\n\nThe default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'.",
+		ToggleWordDiff:                           "Toggle word diff",
+		ToggleWordDiffTooltip:                    "Toggle between line-level and word-level highlighting of changes in the diff view (git's --word-diff=color).\n\nThe default can be changed in the config file with the key 'git.wordDiffInDiffView'.",
 		IgnoreWhitespaceDiffViewSubTitle:         "(ignoring whitespace)",
 		IgnoreWhitespaceNotSupportedHere:         "Ignoring whitespace is not supported in this view",
+		WordDiffNotSupportedHere:                 "Word diff is not supported in this view",
 		IncreaseContextInDiffView:                "Increase diff context size",
 		IncreaseContextInDiffViewTooltip:         "Increase the amount of the context shown around changes in the diff view.\n\nThe default can be changed in the config file with the key 'git.diffContextSize'.",
 		DecreaseContextInDiffView:                "Decrease diff context size",

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -403,6 +403,11 @@
           "description": "If true, git diffs are rendered with the `--ignore-all-space` flag, which ignores whitespace changes. Can be toggled from within Lazygit with `\u003cctrl+w\u003e`.",
           "default": false
         },
+        "wordDiffInDiffView": {
+          "type": "boolean",
+          "description": "If true, git diffs are rendered with the `--word-diff=color` flag, which highlights changes at word granularity rather than line granularity. Can be toggled from within Lazygit with `\u003cctrl+g\u003e`.",
+          "default": false
+        },
         "diffContextSize": {
           "type": "integer",
           "description": "The number of lines of context to show around each diff hunk. Can be changed from within Lazygit with the `{` and `}` keys.",
@@ -3334,6 +3339,20 @@
             }
           ],
           "default": "\u003cctrl+w\u003e"
+        },
+        "toggleWordDiffInDiffView": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "default": "\u003cc-g\u003e"
         },
         "increaseContextInDiffView": {
           "oneOf": [


### PR DESCRIPTION
### PR Description

Press ctrl+g to toggle the patch view between show diffs line-wise vs word-wise. Similarly to the ctlr+w ignore-whitespace toggle, the word-diff state is shown alongside the `(ignoring whitespace)` status flag. 


### Please check if the PR fulfills these requirements

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->

This PR is a draft because the PR checklist is incomplete. The main code has undergone human review, but the tests have not. 

This PR is potentially a duplicate of: 
* https://github.com/jesseduffield/lazygit/pull/4921 <-- this seems to be the place of active development
* https://github.com/jesseduffield/lazygit/pull/5209
* https://github.com/jesseduffield/lazygit/issues/5147