### PR TITLE
Add a hint about how to use diff `--color-words` or `--word-diff` in lazygit

### DIFF
--- a/docs-master/Custom_Pagers.md
+++ b/docs-master/Custom_Pagers.md
@@ -79,6 +79,22 @@ git:
     - externalDiffCommand: difft --color=always --display=inline --syntax-highlight=off
 ```
 
+This can also be used for normal git diffs with custom parameters, such as `--color-words` or `--word-diff` which some people find useful. To do that, save a script like this to, say, `~/bin/color-words.sh`:
+
+```sh
+#!/bin/sh
+
+git diff --color-words --no-index --color=always --no-ext-diff "$2" "$5"
+```
+
+And then use it in your git config like so:
+
+```yaml
+git:
+  pagers:
+    - externalDiffCommand: ~/bin/color-words.sh
+```
+
 Instead of setting this command in lazygit's `externalDiffCommand` config, you can also tell lazygit to use the external diff command that is configured in git itself (`diff.external`), by using
 
 ```yaml

--- a/docs/Custom_Pagers.md
+++ b/docs/Custom_Pagers.md
@@ -79,6 +79,22 @@ git:
     - externalDiffCommand: difft --color=always --display=inline --syntax-highlight=off
 ```
 
+This can also be used for normal git diffs with custom parameters, such as `--color-words` or `--word-diff` which some people find useful. To do that, save a script like this to, say, `~/bin/color-words.sh`:
+
+```sh
+#!/bin/sh
+
+git diff --color-words --no-index --color=always --no-ext-diff "$2" "$5"
+```
+
+And then use it in your git config like so:
+
+```yaml
+git:
+  pagers:
+    - externalDiffCommand: ~/bin/color-words.sh
+```
+
 Instead of setting this command in lazygit's `externalDiffCommand` config, you can also tell lazygit to use the external diff command that is configured in git itself (`diff.external`), by using
 
 ```yaml


### PR DESCRIPTION
Since this frequently comes up as a feature request (but there are reasons why we don't want to add it), explain how to do this in lazygit today.

See https://github.com/jesseduffield/lazygit/pull/5784#issuecomment-4925324150.