### PR TITLE
Localize command log random tips for internationalization

### DIFF
--- a/pkg/gui/command_log_panel.go
+++ b/pkg/gui/command_log_panel.go
@@ -6,9 +6,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/constants"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
+	"github.com/jesseduffield/lazygit/pkg/i18n"
 	"github.com/jesseduffield/lazygit/pkg/theme"
+	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
 // our UI command log looks like this:
@@ -85,120 +88,84 @@ func (gui *Gui) printCommandLogHeader() {
 }
 
 func (gui *Gui) getRandomTip() string {
-	config := gui.c.UserConfig().Keybinding
-
-	tips := []string{
-		// keybindings and lazygit-specific advice
-		fmt.Sprintf(
-			"To force push, press '%s' and then if the push is rejected you will be asked if you want to force push",
-			config.Universal.Push,
-		),
-		fmt.Sprintf(
-			"To filter commits by path, press '%s'",
-			config.Universal.FilteringMenu,
-		),
-		fmt.Sprintf(
-			"To start an interactive rebase, press '%s' on a commit. You can always abort the rebase by pressing '%s' and selecting 'abort'",
-			config.Universal.Edit,
-			config.Universal.CreateRebaseOptionsMenu,
-		),
-		fmt.Sprintf(
-			"In flat file view, merge conflicts are sorted to the top. To switch to flat file view press '%s'",
-			config.Files.ToggleTreeView,
-		),
-		"If you want to learn Go and can think of ways to improve lazygit, join the team! Click 'Ask Question' and express your interest",
-		fmt.Sprintf(
-			"If you press '%s'/'%s' you can undo/redo your changes. Be wary though, this only applies to branches/commits, so only do this if your worktree is clear.\nDocs: %s",
-			config.Universal.Undo,
-			config.Universal.Redo,
-			constants.Links.Docs.Undoing,
-		),
-		fmt.Sprintf(
-			"to hard reset onto your current upstream branch, press '%s' in the files panel",
-			config.Commits.ViewResetOptions,
-		),
-		fmt.Sprintf(
-			"To push a tag, navigate to the tag in the tags tab and press '%s'",
-			config.Branches.PushTag,
-		),
-		fmt.Sprintf(
-			"You can view the individual files of a stash entry by pressing '%s'",
-			config.Universal.GoInto,
-		),
-		fmt.Sprintf(
-			"You can diff two commits by pressing '%s' on one commit and then navigating to the other. You can then press '%s' to view the files of the diff",
-			config.Universal.DiffingMenu,
-			config.Universal.GoInto,
-		),
-		fmt.Sprintf(
-			"press '%s' on a commit to drop it (delete it)",
-			config.Universal.Remove,
-		),
-		fmt.Sprintf(
-			"If you need to pull out the big guns to resolve merge conflicts, you can press '%s' in the files panel to open merge options",
-			config.Files.OpenMergeOptions,
-		),
-		fmt.Sprintf(
-			"To revert a commit, press '%s' on that commit",
-			config.Commits.RevertCommit,
-		),
-		fmt.Sprintf(
-			"To escape a mode, for example cherry-picking, patch-building, diffing, or filtering mode, you can just spam the '%s' button. Unless of course you have `quitOnTopLevelReturn` enabled in your config",
-			config.Universal.Return,
-		),
-		fmt.Sprintf(
-			"You can page through the items of a panel using '%s' and '%s'",
-			config.Universal.PrevPage,
-			config.Universal.NextPage,
-		),
-		fmt.Sprintf(
-			"You can jump to the top/bottom of a panel using '%s' and '%s'",
-			config.Universal.GotoTop, config.Universal.GotoBottom,
-		),
-		fmt.Sprintf(
-			"To collapse/expand a directory, press '%s'",
-			config.Universal.GoInto,
-		),
-		fmt.Sprintf(
-			"You can append your staged changes to an older commit by pressing '%s' on that commit",
-			config.Commits.AmendToCommit,
-		),
-		fmt.Sprintf(
-			"You can amend the last commit with your new file changes by pressing '%s' in the files panel",
-			config.Files.AmendLastCommit,
-		),
-		fmt.Sprintf(
-			"You can now navigate the side panels with '%s' and '%s'",
-			config.Universal.NextBlockAlt2,
-			config.Universal.PrevBlockAlt2,
-		),
-
-		"You can use lazygit with a bare repo by passing the --git-dir and --work-tree arguments as you would for the git CLI",
-
-		// general advice
-		"`git commit` is really just the programmer equivalent of saving your game. Always do it before embarking on an ambitious change!",
-		"Try to separate commits that refactor code from commits that add new functionality: if they're squashed into one commit, it can be hard to spot what's new.",
-		"If you ever want to experiment, it's easy to create a new branch off your current one and go nuts, then delete it afterwards",
-		"Always read through the diff of your changes before assigning somebody to review your code. Better for you to catch any silly mistakes than your colleagues!",
-		"If something goes wrong, you can always checkout a commit from your reflog to return to an earlier state",
-		"The stash is a good place to save snippets of code that you always find yourself adding when debugging.",
-
-		// links
-		fmt.Sprintf(
-			"If you want a git diff with syntax colouring, check out lazygit's integration with delta:\n%s",
-			constants.Links.Docs.CustomPagers,
-		),
-		fmt.Sprintf(
-			"You can build your own custom menus and commands to run from within lazygit. For examples see:\n%s",
-			constants.Links.Docs.CustomCommands,
-		),
-		fmt.Sprintf(
-			"If you ever find a bug, do not hesitate to raise an issue on the repo:\n%s",
-			constants.Links.Issues,
-		),
-	}
+	tips := randomTips(gui.c.Tr, gui.c.UserConfig().Keybinding)
 
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
-	randomIndex := rnd.Intn(len(tips))
-	return tips[randomIndex]
+	return tips[rnd.Intn(len(tips))]
+}
+
+func randomTips(translationSet *i18n.TranslationSet, keybindings config.KeybindingConfig) []string {
+	key := func(binding config.Keybinding) string {
+		return binding.String()
+	}
+
+	values := map[string]string{
+		"pushKey":                key(keybindings.Universal.Push),
+		"filteringMenuKey":       key(keybindings.Universal.FilteringMenu),
+		"editKey":                key(keybindings.Universal.Edit),
+		"rebaseOptionsKey":       key(keybindings.Universal.CreateRebaseOptionsMenu),
+		"toggleTreeViewKey":      key(keybindings.Files.ToggleTreeView),
+		"undoKey":                key(keybindings.Universal.Undo),
+		"redoKey":                key(keybindings.Universal.Redo),
+		"undoingDocsLink":        constants.Links.Docs.Undoing,
+		"resetOptionsKey":        key(keybindings.Commits.ViewResetOptions),
+		"pushTagKey":             key(keybindings.Branches.PushTag),
+		"goIntoKey":              key(keybindings.Universal.GoInto),
+		"diffingMenuKey":         key(keybindings.Universal.DiffingMenu),
+		"removeKey":              key(keybindings.Universal.Remove),
+		"mergeOptionsKey":        key(keybindings.Files.OpenMergeOptions),
+		"revertKey":              key(keybindings.Commits.RevertCommit),
+		"returnKey":              key(keybindings.Universal.Return),
+		"prevPageKey":            key(keybindings.Universal.PrevPage),
+		"nextPageKey":            key(keybindings.Universal.NextPage),
+		"gotoTopKey":             key(keybindings.Universal.GotoTop),
+		"gotoBottomKey":          key(keybindings.Universal.GotoBottom),
+		"amendToCommitKey":       key(keybindings.Commits.AmendToCommit),
+		"amendLastCommitKey":     key(keybindings.Files.AmendLastCommit),
+		"nextBlockAlt2Key":       key(keybindings.Universal.NextBlockAlt2),
+		"prevBlockAlt2Key":       key(keybindings.Universal.PrevBlockAlt2),
+		"customPagersDocsLink":   constants.Links.Docs.CustomPagers,
+		"customCommandsDocsLink": constants.Links.Docs.CustomCommands,
+		"issuesLink":             constants.Links.Issues,
+	}
+
+	templates := []string{
+		translationSet.RandomTipForcePush,
+		translationSet.RandomTipFilterCommitsByPath,
+		translationSet.RandomTipStartInteractiveRebase,
+		translationSet.RandomTipFlatFileView,
+		translationSet.RandomTipJoinTeam,
+		translationSet.RandomTipUndoRedo,
+		translationSet.RandomTipHardReset,
+		translationSet.RandomTipPushTag,
+		translationSet.RandomTipViewStashFiles,
+		translationSet.RandomTipDiffCommits,
+		translationSet.RandomTipDropCommit,
+		translationSet.RandomTipResolveMergeConflicts,
+		translationSet.RandomTipRevertCommit,
+		translationSet.RandomTipExitMode,
+		translationSet.RandomTipPagePanel,
+		translationSet.RandomTipJumpPanel,
+		translationSet.RandomTipToggleDirectory,
+		translationSet.RandomTipAmendToCommit,
+		translationSet.RandomTipAmendLastCommit,
+		translationSet.RandomTipNavigateSidePanels,
+		translationSet.RandomTipBareRepo,
+		translationSet.RandomTipCommitSaveGame,
+		translationSet.RandomTipSeparateRefactors,
+		translationSet.RandomTipExperimentBranch,
+		translationSet.RandomTipReviewDiff,
+		translationSet.RandomTipReflog,
+		translationSet.RandomTipStashDebugSnippets,
+		translationSet.RandomTipDelta,
+		translationSet.RandomTipCustomCommands,
+		translationSet.RandomTipReportBug,
+	}
+
+	tips := make([]string, len(templates))
+	for index, tipTemplate := range templates {
+		tips[index] = utils.ResolvePlaceholderString(tipTemplate, values)
+	}
+
+	return tips
 }

--- a/pkg/gui/command_log_panel_test.go
+++ b/pkg/gui/command_log_panel_test.go
@@ -1,0 +1,22 @@
+package gui
+
+import (
+	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/config"
+	"github.com/jesseduffield/lazygit/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandomTipsResolveLocalizedTemplates(t *testing.T) {
+	translationSet := i18n.EnglishTranslationSet()
+	translationSet.RandomTipForcePush = "按 '{{.pushKey}}' 强制推送"
+
+	tips := randomTips(translationSet, config.KeybindingConfig{
+		Universal: config.KeybindingUniversalConfig{
+			Push: config.Keybinding{"P"},
+		},
+	})
+
+	assert.Equal(t, "按 'P' 强制推送", tips[0])
+}

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -775,6 +775,36 @@ type TranslationSet struct {
 	FocusCommandLog                          string
 	CommandLogHeader                         string
 	RandomTip                                string
+	RandomTipForcePush                       string
+	RandomTipFilterCommitsByPath             string
+	RandomTipStartInteractiveRebase          string
+	RandomTipFlatFileView                    string
+	RandomTipJoinTeam                        string
+	RandomTipUndoRedo                        string
+	RandomTipHardReset                       string
+	RandomTipPushTag                         string
+	RandomTipViewStashFiles                  string
+	RandomTipDiffCommits                     string
+	RandomTipDropCommit                      string
+	RandomTipResolveMergeConflicts           string
+	RandomTipRevertCommit                    string
+	RandomTipExitMode                        string
+	RandomTipPagePanel                       string
+	RandomTipJumpPanel                       string
+	RandomTipToggleDirectory                 string
+	RandomTipAmendToCommit                   string
+	RandomTipAmendLastCommit                 string
+	RandomTipNavigateSidePanels              string
+	RandomTipBareRepo                        string
+	RandomTipCommitSaveGame                  string
+	RandomTipSeparateRefactors               string
+	RandomTipExperimentBranch                string
+	RandomTipReviewDiff                      string
+	RandomTipReflog                          string
+	RandomTipStashDebugSnippets              string
+	RandomTipDelta                           string
+	RandomTipCustomCommands                  string
+	RandomTipReportBug                       string
 	ToggleWhitespaceInDiffView               string
 	ToggleWhitespaceInDiffViewTooltip        string
 	IgnoreWhitespaceDiffViewSubTitle         string
@@ -1927,6 +1957,36 @@ func EnglishTranslationSet() *TranslationSet {
 		FocusCommandLog:                          "Focus command log",
 		CommandLogHeader:                         "You can hide/focus this panel by pressing '%s'\n",
 		RandomTip:                                "Random tip",
+		RandomTipForcePush:                       "To force push, press '{{.pushKey}}' and then if the push is rejected you will be asked if you want to force push",
+		RandomTipFilterCommitsByPath:             "To filter commits by path, press '{{.filteringMenuKey}}'",
+		RandomTipStartInteractiveRebase:          "To start an interactive rebase, press '{{.editKey}}' on a commit. You can always abort the rebase by pressing '{{.rebaseOptionsKey}}' and selecting 'abort'",
+		RandomTipFlatFileView:                    "In flat file view, merge conflicts are sorted to the top. To switch to flat file view press '{{.toggleTreeViewKey}}'",
+		RandomTipJoinTeam:                        "If you want to learn Go and can think of ways to improve lazygit, join the team! Click 'Ask Question' and express your interest",
+		RandomTipUndoRedo:                        "If you press '{{.undoKey}}'/'{{.redoKey}}' you can undo/redo your changes. Be wary though, this only applies to branches/commits, so only do this if your worktree is clear.\nDocs: {{.undoingDocsLink}}",
+		RandomTipHardReset:                       "to hard reset onto your current upstream branch, press '{{.resetOptionsKey}}' in the files panel",
+		RandomTipPushTag:                         "To push a tag, navigate to the tag in the tags tab and press '{{.pushTagKey}}'",
+		RandomTipViewStashFiles:                  "You can view the individual files of a stash entry by pressing '{{.goIntoKey}}'",
+		RandomTipDiffCommits:                     "You can diff two commits by pressing '{{.diffingMenuKey}}' on one commit and then navigating to the other. You can then press '{{.goIntoKey}}' to view the files of the diff",
+		RandomTipDropCommit:                      "press '{{.removeKey}}' on a commit to drop it (delete it)",
+		RandomTipResolveMergeConflicts:           "If you need to pull out the big guns to resolve merge conflicts, you can press '{{.mergeOptionsKey}}' in the files panel to open merge options",
+		RandomTipRevertCommit:                    "To revert a commit, press '{{.revertKey}}' on that commit",
+		RandomTipExitMode:                        "To escape a mode, for example cherry-picking, patch-building, diffing, or filtering mode, you can just spam the '{{.returnKey}}' button. Unless of course you have `quitOnTopLevelReturn` enabled in your config",
+		RandomTipPagePanel:                       "You can page through the items of a panel using '{{.prevPageKey}}' and '{{.nextPageKey}}'",
+		RandomTipJumpPanel:                       "You can jump to the top/bottom of a panel using '{{.gotoTopKey}}' and '{{.gotoBottomKey}}'",
+		RandomTipToggleDirectory:                 "To collapse/expand a directory, press '{{.goIntoKey}}'",
+		RandomTipAmendToCommit:                   "You can append your staged changes to an older commit by pressing '{{.amendToCommitKey}}' on that commit",
+		RandomTipAmendLastCommit:                 "You can amend the last commit with your new file changes by pressing '{{.amendLastCommitKey}}' in the files panel",
+		RandomTipNavigateSidePanels:              "You can now navigate the side panels with '{{.nextBlockAlt2Key}}' and '{{.prevBlockAlt2Key}}'",
+		RandomTipBareRepo:                        "You can use lazygit with a bare repo by passing the --git-dir and --work-tree arguments as you would for the git CLI",
+		RandomTipCommitSaveGame:                  "`git commit` is really just the programmer equivalent of saving your game. Always do it before embarking on an ambitious change!",
+		RandomTipSeparateRefactors:               "Try to separate commits that refactor code from commits that add new functionality: if they're squashed into one commit, it can be hard to spot what's new.",
+		RandomTipExperimentBranch:                "If you ever want to experiment, it's easy to create a new branch off your current one and go nuts, then delete it afterwards",
+		RandomTipReviewDiff:                      "Always read through the diff of your changes before assigning somebody to review your code. Better for you to catch any silly mistakes than your colleagues!",
+		RandomTipReflog:                          "If something goes wrong, you can always checkout a commit from your reflog to return to an earlier state",
+		RandomTipStashDebugSnippets:              "The stash is a good place to save snippets of code that you always find yourself adding when debugging.",
+		RandomTipDelta:                           "If you want a git diff with syntax colouring, check out lazygit's integration with delta:\n{{.customPagersDocsLink}}",
+		RandomTipCustomCommands:                  "You can build your own custom menus and commands to run from within lazygit. For examples see:\n{{.customCommandsDocsLink}}",
+		RandomTipReportBug:                       "If you ever find a bug, do not hesitate to raise an issue on the repo:\n{{.issuesLink}}",
 		ToggleWhitespaceInDiffView:               "Toggle whitespace",
 		ToggleWhitespaceInDiffViewTooltip:        "Toggle whether or not whitespace changes are shown in the diff view.\n\nThe default can be changed in the config file with the key 'git.ignoreWhitespaceInDiffView'.",
 		IgnoreWhitespaceDiffViewSubTitle:         "(ignoring whitespace)",


### PR DESCRIPTION
This PR localizes lazygit's command-log random tips by moving the 30 hard-coded English strings into the translation set.

    The implementation:

    - Keeps English as the source language for Crowdin synchronization.
    - Resolves keybinding placeholders using the user's configured keybindings.
    - Resolves documentation and issue links at render time.
    - Adds a focused test covering localized template resolution.

    This approach was discussed with the maintainer and approved by email.

    Relates to #5794

    Validation

    - go test ./... -short
    - go vet ./...
    - go build ./...