### PR TITLE
Allow rebase custom patch options for subcommits-started patch if from current branch

### DIFF
--- a/pkg/gui/context/local_commits_context.go
+++ b/pkg/gui/context/local_commits_context.go
@@ -161,7 +161,7 @@ func NewLocalCommitsViewModel(getModel func() []*models.Commit, c *ContextCommon
 	return self
 }
 
-func (self *LocalCommitsContext) CanRebase() bool {
+func (self *LocalCommitsContext) CanRebase(currentBranch *models.Branch) bool {
 	return true
 }
 

--- a/pkg/gui/context/reflog_commits_context.go
+++ b/pkg/gui/context/reflog_commits_context.go
@@ -66,7 +66,7 @@ func NewReflogCommitsContext(c *ContextCommon) *ReflogCommitsContext {
 	}
 }
 
-func (self *ReflogCommitsContext) CanRebase() bool {
+func (self *ReflogCommitsContext) CanRebase(currentBranch *models.Branch) bool {
 	return false
 }
 

--- a/pkg/gui/context/stash_context.go
+++ b/pkg/gui/context/stash_context.go
@@ -49,7 +49,7 @@ func NewStashContext(
 	}
 }
 
-func (self *StashContext) CanRebase() bool {
+func (self *StashContext) CanRebase(currentBranch *models.Branch) bool {
 	return false
 }
 

--- a/pkg/gui/context/sub_commits_context.go
+++ b/pkg/gui/context/sub_commits_context.go
@@ -171,8 +171,8 @@ func (self *SubCommitsViewModel) GetShowBranchHeads() bool {
 	return self.showBranchHeads
 }
 
-func (self *SubCommitsContext) CanRebase() bool {
-	return false
+func (self *SubCommitsContext) CanRebase(currentBranch *models.Branch) bool {
+	return self.GetRef() == currentBranch
 }
 
 func (self *SubCommitsContext) GetSelectedRef() models.Ref {

--- a/pkg/gui/controllers/switch_to_diff_files_controller.go
+++ b/pkg/gui/controllers/switch_to_diff_files_controller.go
@@ -13,7 +13,7 @@ var _ types.IController = &SwitchToDiffFilesController{}
 
 type CanSwitchToDiffFiles interface {
 	types.IListContext
-	CanRebase() bool
+	CanRebase(currentBranch *models.Branch) bool
 	GetSelectedRef() models.Ref
 	GetSelectedRefRangeForDiffFiles() *types.RefRange
 }
@@ -69,7 +69,7 @@ func (self *SwitchToDiffFilesController) enter() error {
 	refsRange := self.context.GetSelectedRefRangeForDiffFiles()
 	commitFilesContext := self.c.Contexts().CommitFiles
 
-	canRebase := self.context.CanRebase()
+	canRebase := self.context.CanRebase(self.c.Helpers().Refs.GetCheckedOutRef())
 	if canRebase {
 		if self.c.Modes().Diffing.Active() {
 			if self.c.Modes().Diffing.Ref != ref.RefName() {

--- a/pkg/integration/tests/patch_building/move_to_index_from_subcommit.go
+++ b/pkg/integration/tests/patch_building/move_to_index_from_subcommit.go
@@ -1,0 +1,58 @@
+package patch_building
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var MoveToIndexFromSubcommit = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Move a patch from a commit of the current branch to the index",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("file1", "file1 content\n")
+		shell.CreateFileAndAdd("file2", "file2 content\n")
+		shell.Commit("first commit")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Branches().
+			Focus().
+			Lines(
+				Contains("master").IsSelected(),
+			).
+			PressEnter()
+
+		t.Views().SubCommits().
+			IsFocused().
+			Lines(
+				Contains("first commit").IsSelected(),
+			).
+			PressEnter()
+
+		t.Views().CommitFiles().
+			IsFocused().
+			Lines(
+				Equals("▼ /").IsSelected(),
+				Contains("file1"),
+				Contains("file2"),
+			).
+			SelectNextItem().
+			PressPrimaryAction()
+
+		t.Views().Information().Content(Contains("Building patch"))
+
+		t.Views().Secondary().Content(Contains("+file1 content"))
+
+		t.Common().SelectPatchOption(Contains("Move patch out into index"))
+
+		t.Views().Files().
+			Lines(
+				Contains("A").Contains("file1"),
+			).
+			Focus()
+
+		t.Views().Main().
+			Content(Contains("file1 content"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -360,6 +360,7 @@ var tests = []*components.IntegrationTest{
 	patch_building.MoveToEarlierCommitFromAddedFile,
 	patch_building.MoveToIndex,
 	patch_building.MoveToIndexFromAddedFileWithConflict,
+	patch_building.MoveToIndexFromSubcommit,
 	patch_building.MoveToIndexPartOfAdjacentAddedLines,
 	patch_building.MoveToIndexPartial,
 	patch_building.MoveToIndexWithConflict,


### PR DESCRIPTION
### PR Description

I was really confused as to why sometimes after creating a custom patch, the custom patch options menu would be missing some options like "Remove patch from original commit" or "Move patch out into index" even though they should be possible.

After playing around some more and looking at the code, it turns out this was due to my inconsistent muscle memory sometimes starting the custom patch from the branches -> subcommits view of the currently checked-out branch vs directly from the commits panel.

I don't think this discrepancy should exist. The two views are essentially semantically identical when drilling down on the current branch and all the rebase-related operations work in one versus the other.

This code change matches the two in behavior for showing of options.

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
