### PR TITLE
Add missing test cases `newCursorForMoveRightWord()`

### DIFF
--- a/pkg/gocui/text_area_test.go
+++ b/pkg/gocui/text_area_test.go
@@ -634,6 +634,26 @@ func TestTextArea(t *testing.T) {
 		},
 		{
 			actions: func(textarea *TextArea) {
+				textarea.TypeString(`(abc)def`)
+				textarea.GoToStartOfLine()
+				textarea.ForwardDeleteWord()
+			},
+			expectedContent:   "abc)def",
+			expectedCursor:    0,
+			expectedClipboard: "(",
+		},
+		{
+			actions: func(textarea *TextArea) {
+				textarea.TypeString(`abc)def`)
+				textarea.GoToStartOfLine()
+				textarea.ForwardDeleteWord()
+			},
+			expectedContent:   ")def",
+			expectedCursor:    0,
+			expectedClipboard: "abc",
+		},
+		{
+			actions: func(textarea *TextArea) {
 				textarea.TypeString(`abc`)
 				textarea.GoToStartOfLine()
 				textarea.BackSpaceWord()


### PR DESCRIPTION
### PR Description
I noticed that [pkg/gocui/text_area.go#L357-L359](https://github.com/jesseduffield/lazygit/blob/5aa9847fd2827bc59f6d4c68970c5c93c8721b0c/pkg/gocui/text_area.go#L357-L359) is not covered by unit test when I was implementing https://github.com/jesseduffield/lazygit/pull/5804.

So I added insufficient test cases.

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->

