### PR TITLE
Allow releasing from a branch other than master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Get Latest Tag
         run: |
-          latest_tag=$(git describe --tags $(git rev-list --tags --max-count=1) || echo "v0.0.0")
+          latest_tag=$(git describe --tags --abbrev=0 || echo "v0.0.0")
 
           if ! [[ $latest_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Tag format is invalid. Expected format: vX.X.X"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ on:
         description: 'Version bump type'
         type: choice
         required: true
-        default: 'patch'
+        default: 'minor (normal)'
         options:
-          - minor
-          - patch
+          - minor (normal)
+          - patch (hotfix)
       branch:
         description: 'Branch to release from'
         type: string
@@ -127,7 +127,7 @@ jobs:
           IFS='.' read -r major minor patch <<< "$LATEST_TAG"
 
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            if [[ "$VERSION_BUMP" == "patch" ]]; then
+            if [[ "$VERSION_BUMP" == "patch (hotfix)" ]]; then
               patch=$((patch + 1))
             else
               minor=$((minor + 1))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "$NEW_TAG" -a -m "Release $NEW_TAG"
-          git push origin "$NEW_TAG"
+          git push origin "refs/tags/$NEW_TAG"
 
       - name: Setup Go
         uses: actions/setup-go@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ on:
         options:
           - minor
           - patch
+      branch:
+        description: 'Branch to release from'
+        type: string
+        required: true
+        default: 'master'
       ignore_blocks:
         description: 'Ignore blocking PRs/issues'
         type: boolean
@@ -49,6 +54,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: jesseduffield/lazygit
+          ref: ${{ inputs.branch }}
           token: ${{ secrets.LAZYGIT_RELEASE_PAT }}
           fetch-depth: 0
 


### PR DESCRIPTION
This is useful for cutting a patch release for the previous version when master already contains work that shouldn't be released yet.

Scheduled runs are unaffected: with no input provided, the ref is empty and the checkout falls back to the default branch.