### PR TITLE
Support a `{{diffContext}}` template variable in external diff command

### DIFF
--- a/docs-master/Custom_Pagers.md
+++ b/docs-master/Custom_Pagers.md
@@ -66,17 +66,17 @@ These can be used in lazygit by using the `externalDiffCommand` config; in the c
 ```yaml
 git:
   pagers:
-    - externalDiffCommand: difft --color=always
+    - externalDiffCommand: difft --color=always --context={{diffContext}}
 ```
 
-The `colorArg` option is not used in this case.
+The `colorArg` option is not used in this case. You can include the `{{diffContext}}` template variable to pass lazygit's current diff context size (the value controlled by the `{`/`}` keybindings) to the diff tool.
 
 You can add whatever extra arguments you prefer for your difftool; for instance
 
 ```yaml
 git:
   pagers:
-    - externalDiffCommand: difft --color=always --display=inline --syntax-highlight=off
+    - externalDiffCommand: difft --color=always --context={{diffContext}} --display=inline --syntax-highlight=off
 ```
 
 This can also be used for normal git diffs with custom parameters, such as `--color-words` or `--word-diff` which some people find useful. To do that, save a script like this to, say, `~/bin/color-words.sh`:
@@ -84,7 +84,7 @@ This can also be used for normal git diffs with custom parameters, such as `--co
 ```sh
 #!/bin/sh
 
-git diff --color-words --no-index --color=always --no-ext-diff "$2" "$5"
+git diff --color-words --no-index --color=always --no-ext-diff --unified=$LAZYGIT_DIFF_CONTEXT "$2" "$5"
 ```
 
 And then use it in your git config like so:
@@ -92,7 +92,7 @@ And then use it in your git config like so:
 ```yaml
 git:
   pagers:
-    - externalDiffCommand: ~/bin/color-words.sh
+    - externalDiffCommand: LAZYGIT_DIFF_CONTEXT={{diffContext}} ~/bin/color-words.sh
 ```
 
 Instead of setting this command in lazygit's `externalDiffCommand` config, you can also tell lazygit to use the external diff command that is configured in git itself (`diff.external`), by using

--- a/pkg/commands/git_commands/commit.go
+++ b/pkg/commands/git_commands/commit.go
@@ -243,7 +243,7 @@ func (self *CommitCommands) AmendHeadCmdObj() *oscommands.CmdObj {
 func (self *CommitCommands) ShowCmdObj(hash string, filterPaths []string) *oscommands.CmdObj {
 	contextSize := self.UserConfig().Git.DiffContextSize
 
-	extDiffCmd := self.pagerConfig.GetExternalDiffCommand()
+	extDiffCmd := self.pagerConfig.GetExternalDiffCommand(contextSize)
 	useExtDiffGitConfig := self.pagerConfig.GetUseExternalDiffGitConfig()
 	cmdArgs := NewGitCmd("show").
 		Config("diff.noprefix=false").

--- a/pkg/commands/git_commands/diff.go
+++ b/pkg/commands/git_commands/diff.go
@@ -19,7 +19,8 @@ func NewDiffCommands(gitCommon *GitCommon) *DiffCommands {
 // This is for generating diffs to be shown in the UI (e.g. rendering a range
 // diff to the main view). It uses a custom pager if one is configured.
 func (self *DiffCommands) DiffCmdObj(diffArgs []string) *oscommands.CmdObj {
-	extDiffCmd := self.pagerConfig.GetExternalDiffCommand()
+	contextSize := self.UserConfig().Git.DiffContextSize
+	extDiffCmd := self.pagerConfig.GetExternalDiffCommand(contextSize)
 	useExtDiff := extDiffCmd != ""
 	useExtDiffGitConfig := self.pagerConfig.GetUseExternalDiffGitConfig()
 	ignoreWhitespace := self.UserConfig().Git.IgnoreWhitespaceInDiffView
@@ -32,7 +33,7 @@ func (self *DiffCommands) DiffCmdObj(diffArgs []string) *oscommands.CmdObj {
 			Arg("--submodule").
 			Arg(fmt.Sprintf("--color=%s", self.pagerConfig.GetColorArg())).
 			ArgIf(ignoreWhitespace, "--ignore-all-space").
-			Arg(fmt.Sprintf("--unified=%d", self.UserConfig().Git.DiffContextSize)).
+			Arg(fmt.Sprintf("--unified=%d", contextSize)).
 			Arg(diffArgs...).
 			Dir(self.repoPaths.worktreePath).
 			ToArgv(),

--- a/pkg/commands/git_commands/stash.go
+++ b/pkg/commands/git_commands/stash.go
@@ -81,7 +81,8 @@ func (self *StashCommands) Hash(index int) (string, error) {
 }
 
 func (self *StashCommands) ShowStashEntryCmdObj(index int) *oscommands.CmdObj {
-	extDiffCmd := self.pagerConfig.GetExternalDiffCommand()
+	contextSize := self.UserConfig().Git.DiffContextSize
+	extDiffCmd := self.pagerConfig.GetExternalDiffCommand(contextSize)
 	useExtDiffGitConfig := self.pagerConfig.GetUseExternalDiffGitConfig()
 
 	// "-u" is the same as "--include-untracked", but the latter fails in older git versions for some reason
@@ -92,7 +93,7 @@ func (self *StashCommands) ShowStashEntryCmdObj(index int) *oscommands.CmdObj {
 		ConfigIf(extDiffCmd != "", "diff.external="+extDiffCmd).
 		ArgIfElse(extDiffCmd != "" || useExtDiffGitConfig, "--ext-diff", "--no-ext-diff").
 		Arg(fmt.Sprintf("--color=%s", self.pagerConfig.GetColorArg())).
-		Arg(fmt.Sprintf("--unified=%d", self.UserConfig().Git.DiffContextSize)).
+		Arg(fmt.Sprintf("--unified=%d", contextSize)).
 		ArgIf(self.UserConfig().Git.IgnoreWhitespaceInDiffView, "--ignore-all-space").
 		Arg(fmt.Sprintf("--find-renames=%d%%", self.UserConfig().Git.RenameSimilarityThreshold)).
 		Arg(fmt.Sprintf("refs/stash@{%d}", index)).

--- a/pkg/commands/git_commands/working_tree.go
+++ b/pkg/commands/git_commands/working_tree.go
@@ -401,7 +401,7 @@ func (self *WorkingTreeCommands) WorktreeFileDiffCmdObj(node models.IFile, plain
 	contextSize := self.UserConfig().Git.DiffContextSize
 	prevPath := node.GetPreviousPath()
 	noIndex := !node.GetIsTracked() && !node.GetHasStagedChanges() && !cached && node.GetIsFile()
-	extDiffCmd := self.pagerConfig.GetExternalDiffCommand()
+	extDiffCmd := self.pagerConfig.GetExternalDiffCommand(contextSize)
 	useExtDiff := extDiffCmd != "" && !plain
 	useExtDiffGitConfig := self.pagerConfig.GetUseExternalDiffGitConfig() && !plain
 
@@ -450,7 +450,7 @@ func (self *WorkingTreeCommands) ShowFileDiffCmdObj(from string, to string, reve
 		colorArg = "never"
 	}
 
-	extDiffCmd := self.pagerConfig.GetExternalDiffCommand()
+	extDiffCmd := self.pagerConfig.GetExternalDiffCommand(contextSize)
 	useExtDiff := extDiffCmd != "" && !plain
 	useExtDiffGitConfig := self.pagerConfig.GetUseExternalDiffGitConfig() && !plain
 

--- a/pkg/config/pager_config.go
+++ b/pkg/config/pager_config.go
@@ -58,12 +58,17 @@ func (self *PagerConfig) GetColorArg() string {
 	return colorArg
 }
 
-func (self *PagerConfig) GetExternalDiffCommand() string {
+func (self *PagerConfig) GetExternalDiffCommand(diffContext uint64) string {
 	currentPagerConfig := self.currentPagerConfig()
 	if currentPagerConfig == nil {
 		return ""
 	}
-	return currentPagerConfig.ExternalDiffCommand
+
+	templateValues := map[string]string{
+		"diffContext": strconv.Itoa(int(diffContext)),
+	}
+
+	return utils.ResolvePlaceholderString(currentPagerConfig.ExternalDiffCommand, templateValues)
 }
 
 func (self *PagerConfig) GetUseExternalDiffGitConfig() bool {

--- a/pkg/gui/pty.go
+++ b/pkg/gui/pty.go
@@ -58,6 +58,7 @@ func (p ptyCmd) GetProcess() *os.Process { return p.process }
 // command.
 func (gui *Gui) newPtyTask(view *gocui.View, cmd *exec.Cmd, prefix string) error {
 	width := view.InnerWidth()
+	diffContext := gui.UserConfig().Git.DiffContextSize
 
 	// LAZYGIT_COLUMNS is documented in docs/Custom_Pagers.md for pager
 	// scripts that can't query the terminal width directly. We set it on
@@ -65,7 +66,7 @@ func (gui *Gui) newPtyTask(view *gocui.View, cmd *exec.Cmd, prefix string) error
 	cmd.Env = append(cmd.Env, fmt.Sprintf("LAZYGIT_COLUMNS=%d", width))
 
 	pager := gui.stateAccessor.GetPagerConfig().GetPagerCommand(width)
-	externalDiffCommand := gui.stateAccessor.GetPagerConfig().GetExternalDiffCommand()
+	externalDiffCommand := gui.stateAccessor.GetPagerConfig().GetExternalDiffCommand(diffContext)
 	useExtDiffGitConfig := gui.stateAccessor.GetPagerConfig().GetUseExternalDiffGitConfig()
 
 	if pager == "" && externalDiffCommand == "" && !useExtDiffGitConfig {


### PR DESCRIPTION
Useful for passing the context size to external diff commands like difftastic, like so:

```yml
git:
  pagers:
    - externalDiffCommand: difft --color=always --context={{diffContext}}
```

See https://github.com/jesseduffield/lazygit/issues/5527#issuecomment-5026444795.