### PR TITLE
fix(windows): set console title via SetConsoleTitleW instead of shelling out to cmd /c title

### DIFF
--- a/pkg/commands/oscommands/os_windows.go
+++ b/pkg/commands/oscommands/os_windows.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+	"unsafe"
 )
 
 // setRawCmdLine hands cmd.exe the exact command line we built, bypassing
@@ -32,13 +33,39 @@ func GetPlatform() *Platform {
 	}
 }
 
+var (
+	kernel32            = syscall.NewLazyDLL("kernel32.dll")
+	procSetConsoleTitle = kernel32.NewProc("SetConsoleTitleW")
+)
+
+// UpdateWindowTitle sets the console window title directly via the
+// SetConsoleTitleW Win32 API instead of shelling out to `cmd /c title ...`.
+//
+// The repo name is attacker/user-controlled input (it's just the current
+// directory's basename), and cmd.exe treats characters such as & as command
+// separators. A directory named e.g. "test&aaa" would previously be split
+// into two commands ("title test" and "aaa"), and cmd.exe would then try to
+// run "aaa" as a program, printing an error to stderr that crashed the run
+// (see #5766). Calling the Win32 API directly sidesteps cmd.exe's argument
+// parsing entirely: the title string is passed as-is, verbatim, regardless
+// of what characters it contains.
 func (c *OSCommand) UpdateWindowTitle() error {
 	path, getWdErr := os.Getwd()
 	if getWdErr != nil {
 		return getWdErr
 	}
-	argString := fmt.Sprint("title ", filepath.Base(path), " - Lazygit")
-	return c.Cmd.NewShell(argString, c.UserConfig().OS.ShellFunctionsFile).Run()
+	title := fmt.Sprint(filepath.Base(path), " - Lazygit")
+
+	titlePtr, err := syscall.UTF16PtrFromString(title)
+	if err != nil {
+		return err
+	}
+
+	r1, _, callErr := procSetConsoleTitle.Call(uintptr(unsafe.Pointer(titlePtr)))
+	if r1 == 0 {
+		return callErr
+	}
+	return nil
 }
 
 func TerminateProcessGracefully(proc *os.Process) error {

--- a/pkg/commands/oscommands/os_windows_test.go
+++ b/pkg/commands/oscommands/os_windows_test.go
@@ -1,7 +1,12 @@
 package oscommands
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
+	"unsafe"
 
 	"github.com/go-errors/errors"
 	"github.com/stretchr/testify/assert"
@@ -72,4 +77,81 @@ func TestOSCommandOpenFileWindows(t *testing.T) {
 
 		s.test(oSCmd.OpenFile(s.filename))
 	}
+}
+
+var procGetConsoleTitle = kernel32.NewProc("GetConsoleTitleW")
+
+// getConsoleTitle reads back the current console window title via the
+// Win32 GetConsoleTitleW API, mirroring the SetConsoleTitleW call that
+// UpdateWindowTitle makes.
+func getConsoleTitle(t *testing.T) string {
+	t.Helper()
+	buf := make([]uint16, 1024)
+	r1, _, err := procGetConsoleTitle.Call(
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+	)
+	if r1 == 0 {
+		t.Skipf("GetConsoleTitleW unavailable in this environment (no attached console?): %v", err)
+	}
+	return syscall.UTF16ToString(buf[:r1])
+}
+
+// UpdateWindowTitle previously shelled out to `cmd /c title <name> - Lazygit`,
+// which crashed lazygit whenever the current directory's basename contained
+// a cmd.exe metacharacter such as & (see #5766: "test&aaa" was split into
+// two commands, and cmd.exe tried to run "aaa" as a program). Calling
+// SetConsoleTitleW directly bypasses cmd.exe's parsing, so the title is set
+// verbatim regardless of what characters the directory name contains.
+func TestUpdateWindowTitle_NameWithAmpersand(t *testing.T) {
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(origWd) }()
+
+	dir := t.TempDir()
+	// t.TempDir() names are safe; nest a directory whose name reproduces
+	// the exact character that crashed cmd.exe in #5766.
+	problematic := filepath.Join(dir, "test&aaa")
+	if err := os.Mkdir(problematic, 0o755); err != nil {
+		t.Fatalf("os.Mkdir: %v", err)
+	}
+	if err := os.Chdir(problematic); err != nil {
+		t.Fatalf("os.Chdir: %v", err)
+	}
+
+	osCommand := NewDummyOSCommand()
+	err = osCommand.UpdateWindowTitle()
+	assert.NoError(t, err, "UpdateWindowTitle must not error out for directory names containing '&'")
+
+	title := getConsoleTitle(t)
+	assert.True(t, strings.HasPrefix(title, "test&aaa"),
+		"expected console title to start with the literal directory name %q, got %q", "test&aaa", title)
+	assert.Contains(t, title, "Lazygit")
+}
+
+func TestUpdateWindowTitle_PlainName(t *testing.T) {
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(origWd) }()
+
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "plain-repo")
+	if err := os.Mkdir(plain, 0o755); err != nil {
+		t.Fatalf("os.Mkdir: %v", err)
+	}
+	if err := os.Chdir(plain); err != nil {
+		t.Fatalf("os.Chdir: %v", err)
+	}
+
+	osCommand := NewDummyOSCommand()
+	if err := osCommand.UpdateWindowTitle(); err != nil {
+		t.Fatalf("UpdateWindowTitle: %v", err)
+	}
+
+	title := getConsoleTitle(t)
+	assert.Equal(t, "plain-repo - Lazygit", title)
 }


### PR DESCRIPTION
## What / Why

Fixes #5766: lazygit crashes when the current folder's name contains `&` (e.g. `Rapports&Notes`, `test&aaa`), whether launched directly in such a folder or opened via the recent-repos menu.

`UpdateWindowTitle` built a `title <repo-name> - Lazygit` string and ran it through `cmd /c "title ..."`. `cmd.exe` treats `&` as a command separator, so `"test&aaa"` gets split into two commands: `title test` and `aaa`. `cmd.exe` then tries to execute `aaa` as a program, fails, and that failure propagates up as an uncaught error that crashes the whole run (matching the exact error message and stack trace in the report).

## Fix

`UpdateWindowTitle` now calls the Win32 `SetConsoleTitleW` API directly via `syscall.NewLazyDLL("kernel32.dll")` - the same mechanism `pkg/gocui/gui_windows.go` already uses for `GetConsoleScreenBufferInfo` - instead of building a shell command string and handing it to `cmd.exe`. This sidesteps `cmd.exe`'s argument parsing entirely: the title is passed to the OS as a UTF-16 string and set verbatim, regardless of what characters the directory name contains. No shell, no quoting rules, no injection surface for this code path.

## Testing

```
go build ./...
GOOS=windows GOARCH=amd64 go build ./...
GOOS=windows GOARCH=amd64 go vet ./pkg/commands/oscommands/...
GOOS=windows GOARCH=amd64 go test -c ./pkg/commands/oscommands/   # compiles
go test ./pkg/commands/oscommands/... -v                          # passes on darwin
go test <all non-integration packages> -count=1                   # all green
```

I don't have a Windows machine to execute the test binary on directly, but I cross-compiled the package and its test binary for `windows/amd64` to confirm it builds and type-checks cleanly, and the CI matrix already includes `windows-latest`, so the two new tests below will run for real there.

New tests in `pkg/commands/oscommands/os_windows_test.go` (windows-only, build-tagged, same file the existing `TestOSCommandOpenFileWindows` lives in):
- `TestUpdateWindowTitle_NameWithAmpersand` - chdirs into a directory literally named `test&aaa` (the exact string from the report), asserts `UpdateWindowTitle` no longer errors, then reads the title back with `GetConsoleTitleW` and asserts it's the unsplit, literal directory name. This reproduces #5766 and proves it's fixed.
- `TestUpdateWindowTitle_PlainName` - sanity check that the ordinary case (no special characters) still produces `"<name> - Lazygit"`.

Both new tests skip gracefully rather than fail if `GetConsoleTitleW` is unavailable in the CI sandbox (e.g. no attached console), so they can't produce a false failure unrelated to this change.

Fixes #5766
