### PR TITLE
fix(gitArbor TUI link): removed the broken github link and replaced i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,4 +634,4 @@ If you find that lazygit doesn't quite satisfy your requirements, these may be a
 
 - [GitUI](https://github.com/Extrawurst/gitui)
 - [tig](https://github.com/jonas/tig)
-- [GitArbor TUI](https://github.com/cadamsdev/gitarbor-tui)
+- [GitArbor TUI](https://gitarbor.com/)


### PR DESCRIPTION
…t with the website link.

### PR Description
-- Removed the broken github link and replaced it with https://gitarbor.com/
