### PR TITLE
Fix files with a shared name prefix being dropped from a commit file selection

### DIFF
--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -642,11 +642,16 @@ func normalisedSelectedCommitFileNodes(selectedNodes []*filetree.CommitFileNode)
 }
 
 func isDescendentOfSelectedCommitFileNodes(node *filetree.CommitFileNode, selectedNodes []*filetree.CommitFileNode) bool {
-	for _, selectedNode := range selectedNodes {
-		selectedNodePath := selectedNode.GetPath()
-		nodePath := node.GetPath()
+	nodePath := node.GetInternalPath()
 
-		if strings.HasPrefix(nodePath, selectedNodePath) && nodePath != selectedNodePath {
+	for _, selectedNode := range selectedNodes {
+		if selectedNode.IsFile() {
+			continue
+		}
+
+		selectedNodePath := selectedNode.GetInternalPath()
+
+		if strings.HasPrefix(nodePath, selectedNodePath+"/") {
 			return true
 		}
 	}

--- a/pkg/gui/controllers/commits_files_controller_test.go
+++ b/pkg/gui/controllers/commits_files_controller_test.go
@@ -20,15 +20,13 @@ func Test_normalisedSelectedCommitFileNodes(t *testing.T) {
 			name:          "sibling directories whose names share a prefix are both kept",
 			files:         []string{"foo/file", "foobar/file"},
 			selectedPaths: []string{"foo", "foobar"},
-			// wrong: foobar is not inside foo, so it should be kept
-			expectedPaths: []string{"foo"},
+			expectedPaths: []string{"foo", "foobar"},
 		},
 		{
 			name:          "sibling files whose names share a prefix are both kept",
 			files:         []string{"a.txt", "a.txt.orig"},
 			selectedPaths: []string{"a.txt", "a.txt.orig"},
-			// wrong: a.txt.orig is not inside a.txt, so it should be kept
-			expectedPaths: []string{"a.txt"},
+			expectedPaths: []string{"a.txt", "a.txt.orig"},
 		},
 		{
 			name:          "a file inside a selected directory is dropped",
@@ -40,15 +38,13 @@ func Test_normalisedSelectedCommitFileNodes(t *testing.T) {
 			name:          "a directory inside a selected directory is dropped",
 			files:         []string{"foo/bar/file", "foo/baz/file", "foobar/file"},
 			selectedPaths: []string{"foo", "foo/bar", "foobar"},
-			// wrong: foobar is not inside foo, so it should be kept
-			expectedPaths: []string{"foo"},
+			expectedPaths: []string{"foo", "foobar"},
 		},
 		{
 			name:          "the root item drops everything below it",
 			files:         []string{"foo/file", "foobar/file"},
 			selectedPaths: []string{".", "foo", "foobar/file"},
-			// wrong: foo is inside the root item, so it should be dropped
-			expectedPaths: []string{".", "foo"},
+			expectedPaths: []string{"."},
 		},
 	}
 

--- a/pkg/gui/controllers/commits_files_controller_test.go
+++ b/pkg/gui/controllers/commits_files_controller_test.go
@@ -1,0 +1,96 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/jesseduffield/lazygit/pkg/commands/models"
+	"github.com/jesseduffield/lazygit/pkg/gui/filetree"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_normalisedSelectedCommitFileNodes(t *testing.T) {
+	scenarios := []struct {
+		name          string
+		files         []string
+		selectedPaths []string
+		expectedPaths []string
+	}{
+		{
+			name:          "sibling directories whose names share a prefix are both kept",
+			files:         []string{"foo/file", "foobar/file"},
+			selectedPaths: []string{"foo", "foobar"},
+			// wrong: foobar is not inside foo, so it should be kept
+			expectedPaths: []string{"foo"},
+		},
+		{
+			name:          "sibling files whose names share a prefix are both kept",
+			files:         []string{"a.txt", "a.txt.orig"},
+			selectedPaths: []string{"a.txt", "a.txt.orig"},
+			// wrong: a.txt.orig is not inside a.txt, so it should be kept
+			expectedPaths: []string{"a.txt"},
+		},
+		{
+			name:          "a file inside a selected directory is dropped",
+			files:         []string{"foo/file", "foobar/file"},
+			selectedPaths: []string{"foo", "foo/file"},
+			expectedPaths: []string{"foo"},
+		},
+		{
+			name:          "a directory inside a selected directory is dropped",
+			files:         []string{"foo/bar/file", "foo/baz/file", "foobar/file"},
+			selectedPaths: []string{"foo", "foo/bar", "foobar"},
+			// wrong: foobar is not inside foo, so it should be kept
+			expectedPaths: []string{"foo"},
+		},
+		{
+			name:          "the root item drops everything below it",
+			files:         []string{"foo/file", "foobar/file"},
+			selectedPaths: []string{".", "foo", "foobar/file"},
+			// wrong: foo is inside the root item, so it should be dropped
+			expectedPaths: []string{".", "foo"},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			nodesByPath := commitFileNodesByPath(s.files)
+
+			selectedNodes := lo.Map(s.selectedPaths, func(path string, _ int) *filetree.CommitFileNode {
+				node, ok := nodesByPath[path]
+				assert.True(t, ok, "no node for path %q", path)
+				return node
+			})
+
+			actualPaths := lo.Map(normalisedSelectedCommitFileNodes(selectedNodes),
+				func(node *filetree.CommitFileNode, _ int) string { return node.GetPath() })
+
+			assert.Equal(t, s.expectedPaths, actualPaths)
+		})
+	}
+}
+
+// builds a commit file tree from the given paths and indexes every node by its
+// logical path, so that scenarios can name the nodes they select
+func commitFileNodesByPath(paths []string) map[string]*filetree.CommitFileNode {
+	files := lo.Map(paths, func(path string, _ int) *models.CommitFile {
+		return &models.CommitFile{Path: path}
+	})
+
+	root := filetree.BuildTreeFromCommitFiles(files, true,
+		filetree.NodeSortComparator[models.CommitFile]("mixed", false))
+
+	nodesByPath := map[string]*filetree.CommitFileNode{}
+	var collect func(node *filetree.Node[models.CommitFile])
+	collect = func(node *filetree.Node[models.CommitFile]) {
+		if node.GetInternalPath() != "" {
+			nodesByPath[node.GetPath()] = filetree.NewCommitFileNode(node)
+		}
+		for _, child := range node.Children {
+			collect(child)
+		}
+	}
+	collect(root)
+
+	return nodesByPath
+}


### PR DESCRIPTION
### PR Description

Fixes #5866.

`isDescendentOfSelectedCommitFileNodes` filters a node out of a multi-selection when it is already covered by another selected node, but it tested containment with a bare prefix check:

```go
if strings.HasPrefix(nodePath, selectedNodePath) && nodePath != selectedNodePath {
```

That also matches siblings whose names merely start with the same characters, so range-selecting `foo` and `foobar` (or `a.txt` and `a.txt.orig`, `app.js` and `app.js.map`) silently drops the longer-named one. It affects both call sites: adding a selection to a custom patch, and discarding changes from a commit.

The `NOTE` above these helpers says they're "identical to those in `files_controller.go`", but the two had drifted — the working-tree version (`isDescendentOfSelectedNodes`) skips selected files and requires the `/` separator. This makes the commit-file version match it, which also fixes a second inconsistency: because the root item's logical path is `"."`, it was never a prefix of `"foo"`, so selecting the root item together with something below it processed that path twice. Comparing internal paths (`"."` vs `"./foo"`) makes the root item behave like any other directory, exactly as it already does in the working-tree panel.

Split into two commits: the first adds the test recording the current (wrong) behaviour, the second fixes it and corrects the expectations.

Verified with `go build ./...`, `go vet`, `go tool gofumpt -l .` and `go test ./... -short` (no failures).

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`) — no keybinding or config changes
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation)) — no user-facing strings
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded — n/a
* [x] Docs have been updated if necessary — n/a
* [x] You've read through your own file changes for silly mistakes etc
