### PR TITLE
Fix multi-selection of files with common prefix not working in commit files panel

### DIFF
--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -645,9 +645,13 @@ func isDescendentOfSelectedCommitFileNodes(node *filetree.CommitFileNode, select
 	nodePath := node.GetInternalPath()
 
 	for _, selectedNode := range selectedNodes {
+		if selectedNode.IsFile() {
+			continue
+		}
+
 		selectedNodePath := selectedNode.GetInternalPath()
 
-		if strings.HasPrefix(nodePath, selectedNodePath) && nodePath != selectedNodePath {
+		if strings.HasPrefix(nodePath, selectedNodePath+"/") {
 			return true
 		}
 	}

--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -642,10 +642,10 @@ func normalisedSelectedCommitFileNodes(selectedNodes []*filetree.CommitFileNode)
 }
 
 func isDescendentOfSelectedCommitFileNodes(node *filetree.CommitFileNode, selectedNodes []*filetree.CommitFileNode) bool {
-	nodePath := node.GetPath()
+	nodePath := node.GetInternalPath()
 
 	for _, selectedNode := range selectedNodes {
-		selectedNodePath := selectedNode.GetPath()
+		selectedNodePath := selectedNode.GetInternalPath()
 
 		if strings.HasPrefix(nodePath, selectedNodePath) && nodePath != selectedNodePath {
 			return true

--- a/pkg/gui/controllers/commits_files_controller.go
+++ b/pkg/gui/controllers/commits_files_controller.go
@@ -642,9 +642,10 @@ func normalisedSelectedCommitFileNodes(selectedNodes []*filetree.CommitFileNode)
 }
 
 func isDescendentOfSelectedCommitFileNodes(node *filetree.CommitFileNode, selectedNodes []*filetree.CommitFileNode) bool {
+	nodePath := node.GetPath()
+
 	for _, selectedNode := range selectedNodes {
 		selectedNodePath := selectedNode.GetPath()
-		nodePath := node.GetPath()
 
 		if strings.HasPrefix(nodePath, selectedNodePath) && nodePath != selectedNodePath {
 			return true

--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -1552,6 +1552,8 @@ func normalisedSelectedNodes(selectedNodes []*filetree.FileNode) []*filetree.Fil
 	})
 }
 
+// NOTE: there's a duplicate of this function in commits_files_controller.go; if you make
+// changes here, make them there, too. (We should unify them using generics.)
 func isDescendentOfSelectedNodes(node *filetree.FileNode, selectedNodes []*filetree.FileNode) bool {
 	nodePath := node.GetInternalPath()
 

--- a/pkg/integration/tests/patch_building/select_direcories_sharing_prefix.go
+++ b/pkg/integration/tests/patch_building/select_direcories_sharing_prefix.go
@@ -41,19 +41,13 @@ var SelectDirecoriesSharingPrefix = NewIntegrationTest(NewIntegrationTestArgs{
 				Equals("  ▼ foo").IsSelected(),
 				Equals("    ● file").IsSelected(),
 				Equals("  ▼ foobar").IsSelected(),
-				/* EXPECTED:
 				Equals("    ● file"),
-				ACTUAL: */
-				Equals("    A file"),
 			)
 
 		t.Views().Information().Content(Contains("Building patch"))
 
 		t.Views().Secondary().Content(
-			/* EXPECTED:
 			Contains("foo/file").Contains("foobar/file"),
-			ACTUAL: */
-			Contains("foo/file").DoesNotContain("foobar/file"),
 		)
 	},
 })

--- a/pkg/integration/tests/patch_building/select_direcories_sharing_prefix.go
+++ b/pkg/integration/tests/patch_building/select_direcories_sharing_prefix.go
@@ -1,0 +1,59 @@
+package patch_building
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var SelectDirecoriesSharingPrefix = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Select directories sharing a prefix in the commit files view and add them to a custom patch",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFileAndAdd("foo/file", "file1 content")
+		shell.CreateFileAndAdd("foobar/file", "file2 content")
+		shell.Commit("first commit")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Commits().
+			Focus().
+			Lines(
+				Contains("first commit").IsSelected(),
+			).
+			PressEnter()
+
+		t.Views().CommitFiles().
+			IsFocused().
+			Lines(
+				Equals("▼ /").IsSelected(),
+				Equals("  ▼ foo"),
+				Equals("    A file"),
+				Equals("  ▼ foobar"),
+				Equals("    A file"),
+			).
+			SelectNextItem().
+			Press(keys.Universal.ToggleRangeSelect).
+			NavigateToLine(Contains("foobar")).
+			PressPrimaryAction().
+			Lines(
+				Equals("▼ /"),
+				Equals("  ▼ foo").IsSelected(),
+				Equals("    ● file").IsSelected(),
+				Equals("  ▼ foobar").IsSelected(),
+				/* EXPECTED:
+				Equals("    ● file"),
+				ACTUAL: */
+				Equals("    A file"),
+			)
+
+		t.Views().Information().Content(Contains("Building patch"))
+
+		t.Views().Secondary().Content(
+			/* EXPECTED:
+			Contains("foo/file").Contains("foobar/file"),
+			ACTUAL: */
+			Contains("foo/file").DoesNotContain("foobar/file"),
+		)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -382,6 +382,7 @@ var tests = []*components.IntegrationTest{
 	patch_building.RenamedFileWhole,
 	patch_building.ResetWithEscape,
 	patch_building.SelectAllFiles,
+	patch_building.SelectDirecoriesSharingPrefix,
 	patch_building.SpecificSelection,
 	patch_building.StartNewPatch,
 	patch_building.ToggleDirectory,


### PR DESCRIPTION
When selecting sibling directories sharing a common prefix, trying to add them to a custom patch or discarding them from the commit would only add one, not both. We had the same bug in the files panel and fixed it in #3599, but forgot to make the equivalent change in the commit files panel.

Fixes #5866.