### PR TITLE
Make justfile commands available in the Nix development shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,7 @@
               # Development tools
               git
               gnumake
+              just
             ];
 
             # Environment variables for development


### PR DESCRIPTION
### Description

Add `just` to the default Nix development shell so contributors can use the repository's `justfile` without installing `just` separately. Keep GNU Make available as the existing fallback.

no `flake.lock` update required. `just` comes from the already-pinned `nixpkgs` input, and no flake input changes.

Closes #5881.

### Testing

- `nix-instantiate --parse flake.nix`
- `nix flake check`
- `nix develop --ignore-environment -c just --version`
- `nix develop --ignore-environment -c go version`
- `nix develop --ignore-environment -c just format`
- `nix develop --ignore-environment -c just build`
- `nix develop --ignore-environment -c just lint`
- `nix develop --ignore-environment -c just unit-test`
- `nix-shell --run 'just --version'`

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide) — no test-code change needed; validated with the commands above
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation)) — no user-facing strings changed
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig)) — no UserConfig entry added
* [x] Docs have been updated if necessary — no documentation change needed
* [x] You've read through your own file changes for silly mistakes etc