### PR TITLE
Don't let integration tests race a background git repack

### DIFF
--- a/pkg/integration/components/runner.go
+++ b/pkg/integration/components/runner.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -159,9 +160,7 @@ func prepareTestDir(
 		return "", err
 	}
 
-	workingDir := createFixture(test, paths, rootDir)
-
-	return workingDir, nil
+	return createFixture(test, paths, rootDir)
 }
 
 func buildLazygit(testArgs RunTestArgs) error {
@@ -182,22 +181,41 @@ func buildLazygit(testArgs RunTestArgs) error {
 	return osCommand.Cmd.New(args).Run()
 }
 
+// A failing setup step panics with this so that the remaining steps, which
+// would only produce follow-on failures, are skipped.
+type fixtureFailure string
+
 // Sets up the fixture for test and returns the working directory to invoke
 // lazygit in.
-func createFixture(test *IntegrationTest, paths Paths, rootDir string) string {
+func createFixture(test *IntegrationTest, paths Paths, rootDir string) (workingDir string, err error) {
+	// Tests run as parallel subtests, and a panic escaping one of them takes
+	// down the whole test binary, discarding every other test's result along
+	// with it. Report a broken fixture as this test's error instead.
+	defer func() {
+		panicValue := recover()
+		if panicValue == nil {
+			return
+		}
+		failure, ok := panicValue.(fixtureFailure)
+		if !ok {
+			panic(panicValue)
+		}
+		err = errors.New(string(failure))
+	}()
+
 	env := NewTestEnvironment(rootDir)
 
 	env = append(env, fmt.Sprintf("%s=%s", PWD, paths.ActualRepo()))
 	shell := NewShell(
 		paths.ActualRepo(),
 		env,
-		func(errorMsg string) { panic(errorMsg) },
+		func(errorMsg string) { panic(fixtureFailure(errorMsg)) },
 	)
 	shell.Init()
 
 	test.SetupRepo(shell)
 
-	return shell.dir
+	return shell.dir, nil
 }
 
 func testPath(rootdir string) string {

--- a/pkg/integration/components/test_test.go
+++ b/pkg/integration/components/test_test.go
@@ -1,8 +1,11 @@
 package components
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	lazycoreUtils "github.com/jesseduffield/lazycore/pkg/utils"
 	"github.com/jesseduffield/lazygit/pkg/commands/git_commands"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/config"
@@ -156,6 +159,27 @@ func TestSuccess(t *testing.T) {
 	assert.EqualValues(t, []coordinate{{2, 3}, {2, 3}}, driver.movedCoordinates)
 	assert.EqualValues(t, []coordinate{{2, 3}}, driver.releasedCoordinates)
 	assert.Equal(t, "", driver.failureMessage)
+}
+
+func TestFailingFixture(t *testing.T) {
+	test := NewIntegrationTest(NewIntegrationTestArgs{
+		Description: unitTestDescription,
+		SetupRepo: func(shell *Shell) {
+			shell.RunCommand([]string{"git", "checkout", "no-such-branch"})
+			shell.CreateFile("reached.txt", "")
+		},
+		Run: func(t *TestDriver, keys config.KeybindingConfig) {},
+	})
+
+	paths := NewPaths(t.TempDir())
+	assert.NoError(t, os.MkdirAll(paths.ActualRepo(), 0o777))
+
+	workingDir, err := createFixture(test, paths, lazycoreUtils.GetLazyRootDirectory())
+
+	assert.ErrorContains(t, err, "git checkout no-such-branch")
+	assert.Empty(t, workingDir)
+	// the steps following the failing one are skipped
+	assert.NoFileExists(t, filepath.Join(paths.ActualRepo(), "reached.txt"))
 }
 
 func TestGitVersionRestriction(t *testing.T) {

--- a/test/global_git_config
+++ b/test/global_git_config
@@ -8,3 +8,12 @@
 	allow = always
 [commit]
 	gpgSign = false
+[maintenance]
+	# Every `git commit` forks `git maintenance run --auto --detach`. Since git
+	# 2.54 that repacks as soon as two objects share the objects/17 fanout
+	# directory, which happens readily in a fixture repo, and `git repack -d`
+	# prunes loose objects while the next fixture command -- or lazygit itself --
+	# is still working in the same repo. That surfaces as
+	# "error: invalid object <hash> for 'file09.txt'" / "Error building trees".
+	# Tests must never race a background repack.
+	auto = false


### PR DESCRIPTION
This fixes spurious test failures caused by git's auto maintenance running concurrently with a test's fixture setup; see the first commit's message for details.

In addition, we change the test harness so that such a failure in a setup method doesn't take down the whole test binary.