### PR TITLE
Simplify the run_integration_tests.sh script

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -2,16 +2,6 @@
 
 echo "Running integration tests with $(git --version)"
 
-# This is ugly, but older versions of git don't support the GIT_CONFIG_GLOBAL
-# env var; the only way to run tests for these old versions is to copy our test
-# config file to the actual global location. Move an existing file out of the
-# way so that we can restore it at the end.
-if test -f ~/.gitconfig; then
-  mv ~/.gitconfig ~/.gitconfig.lazygit.bak
-fi
-
-cp test/global_git_config ~/.gitconfig
-
 # if the LAZYGIT_GOCOVERDIR env var is set, we'll capture code coverage data
 if [ -n "$LAZYGIT_GOCOVERDIR" ]; then
   # Go expects us to either be running the test binary directly or running `go test`, but because
@@ -31,10 +21,6 @@ if [ -n "$LAZYGIT_GOCOVERDIR" ]; then
 else
   go test -timeout 30m pkg/integration/clients/*.go
   EXITCODE=$?
-fi
-
-if test -f ~/.gitconfig.lazygit.bak; then
-  mv ~/.gitconfig.lazygit.bak ~/.gitconfig
 fi
 
 # If per-test timings were collected (LAZYGIT_TEST_TIMING points at the file the


### PR DESCRIPTION
Our minimum required git version is 2.32.0, which is the first version that does support the GIT_CONFIG_GLOBAL env var, so we don't need the ~/.gitconfig dance any more.
