### PR TITLE
Honour core.worktree when the git dir is entered directly

### DIFF
--- a/pkg/commands/git.go
+++ b/pkg/commands/git.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/go-errors/errors"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/patch"
 	"github.com/jesseduffield/lazygit/pkg/common"
 	"github.com/jesseduffield/lazygit/pkg/config"
+	"github.com/jesseduffield/lazygit/pkg/env"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
@@ -65,6 +67,15 @@ func NewGitCommand(
 	repoPaths, err := git_commands.GetRepoPaths(osCommand.Cmd, version)
 	if err != nil {
 		return nil, errors.Errorf("Error getting repo paths: %v", err)
+	}
+
+	// When the worktree is set through the `core.worktree` config, it contains
+	// no `.git` entry, so once we chdir into it git can no longer discover the
+	// repo on its own. Point it at the git dir explicitly in that case.
+	if env.GetGitDirEnv() == "" && repoPaths.WorktreePath() != "" {
+		if _, err := os.Stat(filepath.Join(repoPaths.WorktreePath(), ".git")); err != nil {
+			env.SetGitDirEnv(repoPaths.WorktreeGitDirPath())
+		}
 	}
 
 	err = os.Chdir(repoPaths.WorktreePath())


### PR DESCRIPTION
Fixes #5895.

### Root cause

When `core.worktree` is set in a repo's local git config (rather than `$GIT_WORK_TREE`) to point the work tree somewhere other than alongside `.git`, lazygit chdirs into the resolved work tree directory before running any git commands. Since that directory has no `.git` entry of its own (the repo lives in a separate git dir), every subsequent git invocation fails with `fatal: not a git repository`, which surfaces as a panic in `obtainBranches`.

The `$GIT_WORK_TREE` case already works because lazygit picks up `$GIT_DIR`/`$GIT_WORK_TREE` from the environment and git itself knows where to look. The `core.worktree`-from-config case has no equivalent — nothing tells git where the git dir is once we've chdir'd away from it.

### Fix

After resolving the repo paths, if `$GIT_DIR` isn't already set and the resolved work tree doesn't itself contain a `.git` entry (i.e. we're in the core.worktree case, not the normal case), explicitly set `$GIT_DIR` to the actual git dir before chdir'ing, so subsequent git invocations can still find the repo.

### Verification

`go build ./...` passes. I wasn't able to set up the exact reproduction environment (separate work tree and git dir per the issue's directory layout) in this session to run an end-to-end check, so please treat this as a reasoned fix based on tracing the panic's root cause rather than a verified-by-repro one.