### PR TITLE
Fix: Show error when stashing with only untracked files

### DIFF
--- a/pkg/gui/controllers/files_controller.go
+++ b/pkg/gui/controllers/files_controller.go
@@ -1477,6 +1477,9 @@ func (self *FilesController) hasPathStagedChanges(node *filetree.FileNode) bool 
 }
 
 func (self *FilesController) stash() error {
+	if !self.c.Helpers().WorkingTree.IsWorkingTreeDirtyExceptSubmodules() {
+		return errors.New(self.c.Tr.NoFilesToStash)
+	}
 	return self.handleStashSave(self.c.Git().Stash.Push, self.c.Tr.Actions.StashAllChanges)
 }
 

--- a/pkg/integration/tests/stash/stash_no_tracked_changes.go
+++ b/pkg/integration/tests/stash/stash_no_tracked_changes.go
@@ -1,0 +1,33 @@
+package stash
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var StashNoTrackedChanges = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Pressing stash with only untracked files shows an error",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig:  func(config *config.AppConfig) {},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFile("untracked", "content")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			Lines(
+				Contains("untracked"),
+			).
+			Press(keys.Files.StashAllChanges)
+
+		t.ExpectPopup().Alert().
+			Title(Equals("Error")).
+			Content(Contains("You have no files to stash")).
+			Confirm()
+
+		t.Views().Files().
+			Lines(
+				Contains("untracked"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -434,6 +434,7 @@ var tests = []*components.IntegrationTest{
 	stash.StashAll,
 	stash.StashAndKeepIndex,
 	stash.StashIncludingUntrackedFiles,
+	stash.StashNoTrackedChanges,
 	stash.StashStaged,
 	stash.StashStagedPartialFile,
 	stash.StashUnstaged,


### PR DESCRIPTION
### PR Description
Resolves: https://github.com/jesseduffield/lazygit/issues/5883

When only untracked files exist and the user presses `s` to stash, lazygit shows the "Stash name" prompt, accepts a name, then silently does nothing — because `git stash push` ignores untracked files. This adds a guard that shows an error alert ("You have no files to stash") when there are no stashable (tracked/staged) changes, matching the existing check in the "Stash all changes" menu item.

## Please check if the PR fulfills these requirements:
* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc