### PR TITLE
add vim-style modal editing for text inputs

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -358,6 +358,12 @@ gui:
   # is already active, go to next tab instead
   switchTabsWithPanelJumpKeys: false
 
+  # If true, text inputs (commit message, prompts, search) use vim-style modal
+  # editing: they open in insert mode, and Escape switches to normal mode with
+  # motions, counts, d/c/y operators, text objects, visual mode, and undo/redo.
+  # Escape in normal mode closes the panel as usual.
+  vimStyleEditing: false
+
 # Config relating to git
 git:
   # Array of diff renderers. Each entry has the following format:

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -222,6 +222,8 @@ type GuiConfig struct {
 	SwitchToFilesAfterStashApply bool `yaml:"switchToFilesAfterStashApply"`
 	// If true, when using the panel jump keys (default 1 through 5) and target panel is already active, go to next tab instead
 	SwitchTabsWithPanelJumpKeys bool `yaml:"switchTabsWithPanelJumpKeys"`
+	// If true, text inputs (commit message, prompts, search) use vim-style modal editing: they open in insert mode, and Escape switches to normal mode with motions, counts, d/c/y operators, text objects, visual mode, and undo/redo. Escape in normal mode closes the panel as usual.
+	VimStyleEditing bool `yaml:"vimStyleEditing"`
 }
 
 func (c *GuiConfig) UseFuzzySearch() bool {
@@ -934,6 +936,7 @@ func GetDefaultConfigForPlatform(platform string) *UserConfig {
 			SwitchToFilesAfterStashPop:   true,
 			SwitchToFilesAfterStashApply: true,
 			SwitchTabsWithPanelJumpKeys:  false,
+			VimStyleEditing:              false,
 		},
 		Git: GitConfig{
 			Commit: CommitConfig{

--- a/pkg/gocui/gui.go
+++ b/pkg/gocui/gui.go
@@ -200,6 +200,10 @@ type Gui struct {
 	suspendedMutex sync.Mutex
 	suspended      bool
 
+	// last cursor style sent to the terminal, so redraws only re-send it on
+	// a mode change
+	lastCursorStyle tcell.CursorStyle
+
 	taskManager *TaskManager
 
 	// The task of the event currently being processed on the main goroutine, if
@@ -1589,6 +1593,25 @@ func (g *Gui) ForceFlushViewsContentOnly(views []*View) error {
 	return g.flushContentOnly(views)
 }
 
+// updateCursorStyle makes the terminal cursor reflect the vim mode of the
+// focused view: a bar in insert mode, a block otherwise. Views without a vim
+// editor keep the terminal's default. tcell restores the default style when
+// the screen disengages, so the style can't leak into the parent shell.
+func (g *Gui) updateCursorStyle(v *View) {
+	style := tcell.CursorStyleDefault
+	if v.vimEditor != nil {
+		if v.vimEditor.Mode() == VimModeInsert {
+			style = tcell.CursorStyleSteadyBar
+		} else {
+			style = tcell.CursorStyleSteadyBlock
+		}
+	}
+	if style != g.lastCursorStyle {
+		g.lastCursorStyle = style
+		Screen.SetCursorStyle(style)
+	}
+}
+
 // draw manages the cursor and calls the draw function of a view.
 func (g *Gui) draw(v *View) error {
 	if !v.Visible || v.y1 < v.y0 || v.x1 < v.x0 {
@@ -1601,6 +1624,7 @@ func (g *Gui) draw(v *View) error {
 			if curview.cx >= 0 && curview.cx < vMaxX && curview.cy >= 0 && curview.cy < vMaxY {
 				cx, cy := curview.x0+curview.cx+1, curview.y0+curview.cy+1
 				Screen.ShowCursor(cx, cy)
+				g.updateCursorStyle(curview)
 			} else {
 				Screen.HideCursor()
 			}

--- a/pkg/gocui/text_area_vim.go
+++ b/pkg/gocui/text_area_vim.go
@@ -324,6 +324,31 @@ func (self *TextArea) replaceGraphemeAt(cursor int, ch string) {
 	self.updateCells()
 }
 
+// selectionPositions maps a content range to rendered cell runs, in the
+// same coordinate convention as searcher.searchPositions (XEnd exclusive,
+// Y relative to the first content line).
+func (self *TextArea) selectionPositions(start, end int) []SearchPosition {
+	result := []SearchPosition{}
+	for i, cell := range self.cells {
+		if cell.char == "\n" && self.isSoftLineBreak(i) {
+			continue
+		}
+		if cell.contentIndex < start || cell.contentIndex >= end {
+			continue
+		}
+		// a zero-width cell still occupies one highlighted column; in
+		// particular a selected hard newline renders as one cell at the
+		// line's end, like vim's visual mode
+		width := max(cell.width, 1)
+		if last := len(result) - 1; last >= 0 && result[last].Y == cell.y && result[last].XEnd == cell.x {
+			result[last].XEnd = cell.x + width
+		} else {
+			result = append(result, SearchPosition{XStart: cell.x, XEnd: cell.x + width, Y: cell.y})
+		}
+	}
+	return result
+}
+
 func (self *TextArea) setState(content string, cursor int) {
 	self.content = content
 	self.updateCells()

--- a/pkg/gocui/text_area_vim.go
+++ b/pkg/gocui/text_area_vim.go
@@ -1,0 +1,339 @@
+package gocui
+
+import (
+	"strings"
+
+	"github.com/rivo/uniseg"
+)
+
+// Vim-style motions and range edits for TextArea. These are the primitives
+// that VimEditor composes into normal-mode commands; they are pure with
+// respect to the cursor (they return a new cursor position) unless the name
+// says otherwise.
+//
+// Character classes follow vim's small-word rules: whitespace, punctuation
+// (WORD_SEPARATORS), and word characters are distinct classes, and a motion
+// stops at every class boundary. Newlines are treated as whitespace; vim's
+// "an empty line is a word" special case is deliberately not implemented, as
+// it doesn't pull its weight in single-message editing.
+
+const (
+	charClassWhitespace = iota
+	charClassSeparator
+	charClassWord
+)
+
+func vimCharClass(ch string) int {
+	if ch == "\n" || strings.Contains(WHITESPACES, ch) {
+		return charClassWhitespace
+	}
+	if strings.Contains(WORD_SEPARATORS, ch) {
+		return charClassSeparator
+	}
+	return charClassWord
+}
+
+// cells excluding the synthetic soft-line-break cells, i.e. one cell per
+// grapheme of real content, with strictly increasing contentIndex.
+func (self *TextArea) realCells() []TextAreaCell {
+	result := make([]TextAreaCell, 0, len(self.cells))
+	for i, cell := range self.cells {
+		if cell.char == "\n" && self.isSoftLineBreak(i) {
+			continue
+		}
+		result = append(result, cell)
+	}
+	return result
+}
+
+func realCellIndex(cells []TextAreaCell, cursor int) int {
+	for i, cell := range cells {
+		if cell.contentIndex >= cursor {
+			return i
+		}
+	}
+	return len(cells)
+}
+
+func (self *TextArea) vimWordForward(cursor int, count int) int {
+	cells := self.realCells()
+	i := realCellIndex(cells, cursor)
+	for range count {
+		if i >= len(cells) {
+			break
+		}
+		class := vimCharClass(cells[i].char)
+		if class != charClassWhitespace {
+			for i < len(cells) && vimCharClass(cells[i].char) == class {
+				i++
+			}
+		}
+		for i < len(cells) && vimCharClass(cells[i].char) == charClassWhitespace {
+			i++
+		}
+	}
+	if i >= len(cells) {
+		return len(self.content)
+	}
+	return cells[i].contentIndex
+}
+
+func (self *TextArea) vimWordEnd(cursor int, count int) int {
+	cells := self.realCells()
+	i := realCellIndex(cells, cursor)
+	for range count {
+		i++
+		for i < len(cells) && vimCharClass(cells[i].char) == charClassWhitespace {
+			i++
+		}
+		if i >= len(cells) {
+			break
+		}
+		class := vimCharClass(cells[i].char)
+		for i+1 < len(cells) && vimCharClass(cells[i+1].char) == class {
+			i++
+		}
+	}
+	if i >= len(cells) {
+		i = len(cells) - 1
+	}
+	if i < 0 {
+		return cursor
+	}
+	return cells[i].contentIndex
+}
+
+func (self *TextArea) vimWordBack(cursor int, count int) int {
+	cells := self.realCells()
+	i := realCellIndex(cells, cursor)
+	for range count {
+		i--
+		for i >= 0 && vimCharClass(cells[i].char) == charClassWhitespace {
+			i--
+		}
+		if i < 0 {
+			break
+		}
+		class := vimCharClass(cells[i].char)
+		for i > 0 && vimCharClass(cells[i-1].char) == class {
+			i--
+		}
+	}
+	if i < 0 {
+		return 0
+	}
+	return cells[i].contentIndex
+}
+
+func (self *TextArea) hardLineStart(cursor int) int {
+	return strings.LastIndexByte(self.content[:cursor], '\n') + 1
+}
+
+func (self *TextArea) hardLineEnd(cursor int) int {
+	if idx := strings.IndexByte(self.content[cursor:], '\n'); idx != -1 {
+		return cursor + idx
+	}
+	return len(self.content)
+}
+
+func (self *TextArea) vimFirstNonBlank(cursor int) int {
+	start := self.hardLineStart(cursor)
+	end := self.hardLineEnd(cursor)
+	for i := start; i < end; i++ {
+		if !strings.Contains(WHITESPACES, string(self.content[i])) {
+			return i
+		}
+	}
+	return start
+}
+
+// start of the last grapheme of the line containing cursor; the line start
+// itself if the line is empty
+func (self *TextArea) vimLastCharOfLine(cursor int) int {
+	start := self.hardLineStart(cursor)
+	end := self.hardLineEnd(cursor)
+	if start == end {
+		return start
+	}
+	return self.prevGraphemeStart(end)
+}
+
+// start of the grapheme preceding cursor (0 if there is none)
+func (self *TextArea) prevGraphemeStart(cursor int) int {
+	cells := self.realCells()
+	i := realCellIndex(cells, cursor)
+	if i == 0 {
+		return 0
+	}
+	return cells[i-1].contentIndex
+}
+
+// start of the grapheme following cursor (end of content if there is none)
+func (self *TextArea) nextGraphemeStart(cursor int) int {
+	if cursor >= len(self.content) {
+		return len(self.content)
+	}
+	s, _, _, _ := uniseg.FirstGraphemeClusterInString(self.content[cursor:], -1)
+	return cursor + len(s)
+}
+
+func (self *TextArea) graphemeAt(cursor int) string {
+	if cursor >= len(self.content) {
+		return ""
+	}
+	s, _, _, _ := uniseg.FirstGraphemeClusterInString(self.content[cursor:], -1)
+	return s
+}
+
+// vimFindOnLine returns the cursor for f/F/t/T motions, or -1 if the target
+// does not occur count times on the cursor's line.
+func (self *TextArea) vimFindOnLine(cursor int, target string, forward bool, till bool, count int) int {
+	cells := self.realCells()
+	i := realCellIndex(cells, cursor)
+	lineStart := self.hardLineStart(cursor)
+	lineEnd := self.hardLineEnd(cursor)
+
+	step := -1
+	if forward {
+		step = 1
+	}
+	found := i
+	for range count {
+		j := found + step
+		for {
+			if j < 0 || j >= len(cells) {
+				return -1
+			}
+			idx := cells[j].contentIndex
+			if idx < lineStart || idx >= lineEnd {
+				return -1
+			}
+			if cells[j].char == target {
+				break
+			}
+			j += step
+		}
+		found = j
+	}
+	if till {
+		found -= step
+	}
+	return cells[found].contentIndex
+}
+
+// line number (0-based) and total line count, both over hard lines
+func (self *TextArea) vimLineNumber(cursor int) int {
+	return strings.Count(self.content[:cursor], "\n")
+}
+
+func (self *TextArea) vimLineCount() int {
+	return strings.Count(self.content, "\n") + 1
+}
+
+// start of the (0-based) line'th hard line, clamped to the last line
+func (self *TextArea) vimGotoLine(line int) int {
+	cursor := 0
+	for range line {
+		idx := strings.IndexByte(self.content[cursor:], '\n')
+		if idx == -1 {
+			break
+		}
+		cursor += idx + 1
+	}
+	return cursor
+}
+
+// vimWordBounds returns the [start, end) range of the word (or whitespace
+// run) under cursor. With around=true it extends over trailing whitespace,
+// or leading whitespace if there is none trailing, per vim's aw.
+func (self *TextArea) vimWordBounds(cursor int, around bool) (int, int) {
+	cells := self.realCells()
+	if len(cells) == 0 {
+		return 0, 0
+	}
+	i := realCellIndex(cells, cursor)
+	if i >= len(cells) {
+		i = len(cells) - 1
+	}
+	if cells[i].char == "\n" {
+		return cells[i].contentIndex, cells[i].contentIndex
+	}
+
+	class := vimCharClass(cells[i].char)
+	start := i
+	for start > 0 && cells[start-1].char != "\n" && vimCharClass(cells[start-1].char) == class {
+		start--
+	}
+	end := i
+	for end+1 < len(cells) && cells[end+1].char != "\n" && vimCharClass(cells[end+1].char) == class {
+		end++
+	}
+
+	if around && class != charClassWhitespace {
+		trailed := false
+		for end+1 < len(cells) && cells[end+1].char != "\n" && vimCharClass(cells[end+1].char) == charClassWhitespace {
+			end++
+			trailed = true
+		}
+		if !trailed {
+			for start > 0 && cells[start-1].char != "\n" && vimCharClass(cells[start-1].char) == charClassWhitespace {
+				start--
+			}
+		}
+	}
+
+	startIdx := cells[start].contentIndex
+	if end+1 < len(cells) {
+		return startIdx, cells[end+1].contentIndex
+	}
+	return startIdx, len(self.content)
+}
+
+func (self *TextArea) getRange(start, end int) string {
+	start = max(start, 0)
+	end = min(end, len(self.content))
+	if start >= end {
+		return ""
+	}
+	return self.content[start:end]
+}
+
+func (self *TextArea) deleteRange(start, end int) {
+	start = max(start, 0)
+	end = min(end, len(self.content))
+	if start >= end {
+		return
+	}
+	self.content = self.content[:start] + self.content[end:]
+	self.cursor = start
+	self.updateCells()
+}
+
+func (self *TextArea) insertAt(cursor int, str string) {
+	self.cursor = min(max(cursor, 0), len(self.content))
+	self.TypeString(str)
+}
+
+func (self *TextArea) replaceGraphemeAt(cursor int, ch string) {
+	old := self.graphemeAt(cursor)
+	if old == "" || old == "\n" {
+		return
+	}
+	self.content = self.content[:cursor] + ch + self.content[cursor+len(old):]
+	self.cursor = cursor
+	self.updateCells()
+}
+
+func (self *TextArea) setState(content string, cursor int) {
+	self.content = content
+	self.updateCells()
+	self.cursor = min(max(cursor, 0), len(content))
+}
+
+func (self *TextArea) SetCursor(cursor int) {
+	self.cursor = min(max(cursor, 0), len(self.content))
+}
+
+func (self *TextArea) GetCursor() int {
+	return self.cursor
+}

--- a/pkg/gocui/text_area_vim_test.go
+++ b/pkg/gocui/text_area_vim_test.go
@@ -1,0 +1,194 @@
+package gocui
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func makeTextArea(content string, cursor int) *TextArea {
+	textarea := &TextArea{}
+	textarea.TypeString(content)
+	textarea.cursor = cursor
+	return textarea
+}
+
+func TestVimWordMotions(t *testing.T) {
+	tests := []struct {
+		content  string
+		cursor   int
+		motion   func(*TextArea, int, int) int
+		count    int
+		expected int
+	}{
+		{"foo bar baz", 0, (*TextArea).vimWordForward, 1, 4},
+		{"foo bar baz", 0, (*TextArea).vimWordForward, 2, 8},
+		{"foo bar baz", 4, (*TextArea).vimWordForward, 5, 11},
+		{"foo.bar", 0, (*TextArea).vimWordForward, 1, 3},
+		{"foo.bar", 3, (*TextArea).vimWordForward, 1, 4},
+		{"foo\nbar", 0, (*TextArea).vimWordForward, 1, 4},
+		{"foo  \n  bar", 0, (*TextArea).vimWordForward, 1, 8},
+		{"字字 foo", 0, (*TextArea).vimWordForward, 1, 7},
+		{"", 0, (*TextArea).vimWordForward, 1, 0},
+
+		{"foo bar baz", 0, (*TextArea).vimWordEnd, 1, 2},
+		{"foo bar baz", 2, (*TextArea).vimWordEnd, 1, 6},
+		{"foo bar baz", 0, (*TextArea).vimWordEnd, 2, 6},
+		{"foo.bar", 0, (*TextArea).vimWordEnd, 2, 3},
+		{"foo\nbar", 2, (*TextArea).vimWordEnd, 1, 6},
+		{"foo", 2, (*TextArea).vimWordEnd, 1, 2},
+
+		{"foo bar baz", 8, (*TextArea).vimWordBack, 1, 4},
+		{"foo bar baz", 8, (*TextArea).vimWordBack, 2, 0},
+		{"foo bar", 6, (*TextArea).vimWordBack, 1, 4},
+		{"foo.bar", 4, (*TextArea).vimWordBack, 1, 3},
+		{"foo\nbar", 4, (*TextArea).vimWordBack, 1, 0},
+		{"foo bar", 0, (*TextArea).vimWordBack, 1, 0},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			textarea := makeTextArea(test.content, test.cursor)
+			assert.Equal(t, test.expected, test.motion(textarea, test.cursor, test.count))
+		})
+	}
+}
+
+func TestVimLineHelpers(t *testing.T) {
+	textarea := makeTextArea("foo\n  bar baz\n\nqux", 0)
+
+	assert.Equal(t, 0, textarea.hardLineStart(2))
+	assert.Equal(t, 3, textarea.hardLineEnd(2))
+	assert.Equal(t, 4, textarea.hardLineStart(8))
+	assert.Equal(t, 13, textarea.hardLineEnd(8))
+	assert.Equal(t, 14, textarea.hardLineStart(14))
+	assert.Equal(t, 14, textarea.hardLineEnd(14))
+
+	assert.Equal(t, 6, textarea.vimFirstNonBlank(4))
+	assert.Equal(t, 0, textarea.vimFirstNonBlank(1))
+	assert.Equal(t, 14, textarea.vimFirstNonBlank(14))
+
+	assert.Equal(t, 12, textarea.vimLastCharOfLine(4))
+	assert.Equal(t, 14, textarea.vimLastCharOfLine(14))
+
+	assert.Equal(t, 0, textarea.vimLineNumber(2))
+	assert.Equal(t, 1, textarea.vimLineNumber(8))
+	assert.Equal(t, 4, textarea.vimLineCount())
+	assert.Equal(t, 4, textarea.vimGotoLine(1))
+	assert.Equal(t, 14, textarea.vimGotoLine(2))
+	assert.Equal(t, 15, textarea.vimGotoLine(3))
+	assert.Equal(t, 15, textarea.vimGotoLine(99))
+}
+
+func TestVimFindOnLine(t *testing.T) {
+	tests := []struct {
+		content  string
+		cursor   int
+		target   string
+		forward  bool
+		till     bool
+		count    int
+		expected int
+	}{
+		{"abcabc", 0, "c", true, false, 1, 2},
+		{"abcabc", 0, "c", true, false, 2, 5},
+		{"abcabc", 0, "c", true, true, 1, 1},
+		{"abcabc", 5, "a", false, false, 1, 3},
+		{"abcabc", 5, "a", false, true, 1, 4},
+		{"abcabc", 0, "z", true, false, 1, -1},
+		{"abc\ncde", 0, "d", true, false, 1, -1},
+		{"abc\ncde", 5, "a", false, false, 1, -1},
+		{"abcabc", 2, "c", true, false, 1, 5},
+		{"a字c", 0, "c", true, false, 1, 4},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			textarea := makeTextArea(test.content, test.cursor)
+			actual := textarea.vimFindOnLine(test.cursor, test.target, test.forward, test.till, test.count)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestVimWordBounds(t *testing.T) {
+	tests := []struct {
+		content       string
+		cursor        int
+		around        bool
+		expectedStart int
+		expectedEnd   int
+	}{
+		{"foo bar baz", 5, false, 4, 7},
+		{"foo bar baz", 5, true, 4, 8},
+		{"foo bar", 5, true, 3, 7},
+		{"foo bar baz", 3, false, 3, 4},
+		{"foo.bar", 1, false, 0, 3},
+		{"foo.bar", 3, false, 3, 4},
+		{"foo.bar", 3, true, 3, 4},
+		{"one\ntwo\nthree", 5, false, 4, 7},
+		{"one\ntwo", 3, false, 3, 3},
+		{"字字 foo", 1, false, 0, 6},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			textarea := makeTextArea(test.content, test.cursor)
+			start, end := textarea.vimWordBounds(test.cursor, test.around)
+			assert.Equal(t, test.expectedStart, start)
+			assert.Equal(t, test.expectedEnd, end)
+		})
+	}
+}
+
+func TestVimRangeEdits(t *testing.T) {
+	textarea := makeTextArea("foo bar baz", 0)
+	assert.Equal(t, "bar", textarea.getRange(4, 7))
+	assert.Equal(t, "", textarea.getRange(7, 4))
+	assert.Equal(t, "baz", textarea.getRange(8, 99))
+
+	textarea.deleteRange(4, 8)
+	assert.Equal(t, "foo baz", textarea.GetUnwrappedContent())
+	assert.Equal(t, 4, textarea.cursor)
+
+	textarea.insertAt(4, "bar ")
+	assert.Equal(t, "foo bar baz", textarea.GetUnwrappedContent())
+	assert.Equal(t, 8, textarea.cursor)
+
+	textarea.replaceGraphemeAt(0, "g")
+	assert.Equal(t, "goo bar baz", textarea.GetUnwrappedContent())
+	assert.Equal(t, 0, textarea.cursor)
+
+	textarea = makeTextArea("a\nb", 1)
+	textarea.replaceGraphemeAt(1, "x")
+	assert.Equal(t, "a\nb", textarea.GetUnwrappedContent())
+
+	textarea = makeTextArea("字c", 0)
+	textarea.replaceGraphemeAt(0, "a")
+	assert.Equal(t, "ac", textarea.GetUnwrappedContent())
+}
+
+func TestVimGraphemeSteps(t *testing.T) {
+	textarea := makeTextArea("a字c", 0)
+	assert.Equal(t, 1, textarea.nextGraphemeStart(0))
+	assert.Equal(t, 4, textarea.nextGraphemeStart(1))
+	assert.Equal(t, 5, textarea.nextGraphemeStart(5))
+	assert.Equal(t, 4, textarea.prevGraphemeStart(5))
+	assert.Equal(t, 1, textarea.prevGraphemeStart(4))
+	assert.Equal(t, 0, textarea.prevGraphemeStart(1))
+	assert.Equal(t, "字", textarea.graphemeAt(1))
+	assert.Equal(t, "", textarea.graphemeAt(5))
+}
+
+func TestVimWordMotionsWithSoftWrap(t *testing.T) {
+	textarea := &TextArea{AutoWrap: true, AutoWrapWidth: 5}
+	textarea.TypeString("aaa bbb ccc")
+
+	assert.Equal(t, 4, textarea.vimWordForward(0, 1))
+	assert.Equal(t, 8, textarea.vimWordForward(4, 1))
+	assert.Equal(t, 4, textarea.vimWordBack(8, 1))
+	assert.Equal(t, 6, textarea.vimWordEnd(4, 1))
+	assert.Equal(t, 0, textarea.hardLineStart(8))
+	assert.Equal(t, 11, textarea.hardLineEnd(3))
+}

--- a/pkg/gocui/view.go
+++ b/pkg/gocui/view.go
@@ -66,6 +66,10 @@ type View struct {
 	// the location of the hyperlink that the mouse is currently hovering over; nil if none
 	hoveredHyperlink *SearchPosition
 
+	// character ranges to render reverse-video, used by VimEditor's visual
+	// mode; same coordinate conventions as searcher.searchPositions
+	vimSelection []SearchPosition
+
 	// internal representation of the view's buffer. We will keep viewLines around
 	// from a previous render until we explicitly set them to nil, allowing us to
 	// render the same content twice without flicker. Wherever we want to render
@@ -657,6 +661,10 @@ func (v *View) setCharacter(x, y int, ch string, fgColor, bgColor Attribute) {
 		} else {
 			bgColor = ColorYellow
 		}
+	}
+
+	if v.isVimSelectedRune(x, y) {
+		fgColor |= AttrReverse
 	}
 
 	if v.isHoveredHyperlink(x, y) {
@@ -1499,6 +1507,21 @@ func (v *View) isPatternMatchedRune(x, y int) (bool, bool) {
 		}
 	}
 	return false, false
+}
+
+func (v *View) SetVimSelection(positions []SearchPosition) {
+	v.vimSelection = positions
+}
+
+func (v *View) isVimSelectedRune(x, y int) bool {
+	for _, pos := range v.vimSelection {
+		adjustedY := y + v.oy
+		adjustedX := x + v.ox
+		if adjustedY == pos.Y && adjustedX >= pos.XStart && adjustedX < pos.XEnd {
+			return true
+		}
+	}
+	return false
 }
 
 func (v *View) isHoveredHyperlink(x, y int) bool {

--- a/pkg/gocui/view.go
+++ b/pkg/gocui/view.go
@@ -70,6 +70,10 @@ type View struct {
 	// mode; same coordinate conventions as searcher.searchPositions
 	vimSelection []SearchPosition
 
+	// modal editor state for this view; nil unless vim-style editing is
+	// enabled for it
+	vimEditor *VimEditor
+
 	// internal representation of the view's buffer. We will keep viewLines around
 	// from a previous render until we explicitly set them to nil, allowing us to
 	// render the same content twice without flicker. Wherever we want to render

--- a/pkg/gocui/vim_editor.go
+++ b/pkg/gocui/vim_editor.go
@@ -781,6 +781,11 @@ func (v *View) VimEditor() *VimEditor {
 	return v.vimEditor
 }
 
+func (v *View) DetachVimEditor() {
+	v.vimEditor = nil
+	v.SetVimSelection(nil)
+}
+
 // ResetVimEditor puts an attached vim editor back into the given mode and
 // clears any visual selection; panels reuse their views, so this must be
 // called whenever a panel opens. No-op when no editor is attached.

--- a/pkg/gocui/vim_editor.go
+++ b/pkg/gocui/vim_editor.go
@@ -766,3 +766,34 @@ func (self *VimEditor) clearPending() {
 	self.op = ""
 	self.pending = ""
 }
+
+// The vim editor is attached to the View rather than passed around the app:
+// escape handling, mode indicators, and per-panel resets all happen in
+// different layers that share nothing but the view.
+
+func (v *View) AttachVimEditor(register *VimRegister, allowMultiline bool) {
+	v.vimEditor = NewVimEditor(register, allowMultiline)
+}
+
+// VimEditor returns the attached vim editor, or nil when vim editing is not
+// enabled for this view.
+func (v *View) VimEditor() *VimEditor {
+	return v.vimEditor
+}
+
+// ResetVimEditor puts an attached vim editor back into the given mode and
+// clears any visual selection; panels reuse their views, so this must be
+// called whenever a panel opens. No-op when no editor is attached.
+func (v *View) ResetVimEditor(mode VimMode) {
+	if v.vimEditor == nil {
+		return
+	}
+	v.vimEditor.Reset(mode)
+	v.SetVimSelection(nil)
+}
+
+// VimEscape reports whether an attached vim editor consumed the Escape key;
+// the view's Escape keybinding must call this before closing its panel.
+func (v *View) VimEscape() bool {
+	return v.vimEditor != nil && v.vimEditor.HandleEscape(v)
+}

--- a/pkg/gocui/vim_editor.go
+++ b/pkg/gocui/vim_editor.go
@@ -1,0 +1,702 @@
+package gocui
+
+import "strings"
+
+type VimMode int
+
+const (
+	VimModeInsert VimMode = iota
+	VimModeNormal
+)
+
+// VimRegister is the yank/delete buffer. It is separate from TextArea's
+// readline clipboard so that a shared register can be passed to several
+// VimEditors, letting text yanked in one editable view be pasted in another
+// (e.g. commit summary <-> description).
+type VimRegister struct {
+	text     string
+	linewise bool
+}
+
+func (self *VimRegister) set(text string, linewise bool) {
+	if text == "" {
+		return
+	}
+	self.text = text
+	self.linewise = linewise
+}
+
+type vimSnapshot struct {
+	content string
+	cursor  int
+}
+
+const vimUndoLimit = 200
+
+type vimFind struct {
+	target  string
+	forward bool
+	till    bool
+}
+
+const (
+	motionExclusive = iota
+	motionInclusive
+)
+
+// VimEditor is a modal Editor: insert mode delegates to SimpleEditor, normal
+// mode interprets vim commands against the view's TextArea. One instance
+// holds the state for one view.
+type VimEditor struct {
+	allowMultiline bool
+	register       *VimRegister
+
+	mode     VimMode
+	count    int
+	opCount  int
+	op       string
+	pending  string
+	lastFind vimFind
+	undo     []vimSnapshot
+	redo     []vimSnapshot
+}
+
+func NewVimEditor(register *VimRegister, allowMultiline bool) *VimEditor {
+	if register == nil {
+		register = &VimRegister{}
+	}
+	return &VimEditor{
+		allowMultiline: allowMultiline,
+		register:       register,
+		mode:           VimModeInsert,
+	}
+}
+
+func (self *VimEditor) Mode() VimMode {
+	return self.mode
+}
+
+func (self *VimEditor) Reset(mode VimMode) {
+	self.mode = mode
+	self.clearPending()
+	self.undo = nil
+	self.redo = nil
+}
+
+// HandleEscape must be called by the Escape keybinding of a view using this
+// editor, because keybindings fire before the Editor sees a key: leaving
+// insert mode has to win over closing the panel. Returns true if the editor
+// consumed the key.
+func (self *VimEditor) HandleEscape(v *View) bool {
+	if !self.escape(v.TextArea) {
+		return false
+	}
+	v.RenderTextArea()
+	return true
+}
+
+func (self *VimEditor) escape(ta *TextArea) bool {
+	if self.mode == VimModeInsert {
+		self.enterNormalMode(ta)
+		return true
+	}
+	if self.op != "" || self.count != 0 || self.pending != "" {
+		self.clearPending()
+		return true
+	}
+	return false
+}
+
+func (self *VimEditor) Edit(v *View, key Key) bool {
+	if self.mode == VimModeInsert {
+		if key.Equals(NewKeyName(KeyEsc)) {
+			self.enterNormalMode(v.TextArea)
+			v.RenderTextArea()
+			return true
+		}
+		return SimpleEditor(v, key)
+	}
+
+	handled := self.normalKey(v.TextArea, key)
+	if handled {
+		v.RenderTextArea()
+	}
+	return handled
+}
+
+func (self *VimEditor) normalKey(ta *TextArea, key Key) bool {
+	if key.Equals(NewKeyStrMod("r", ModCtrl)) {
+		self.restoreRedo(ta)
+		return true
+	}
+	if key.Equals(NewKeyName(KeyEsc)) {
+		return self.escape(ta)
+	}
+
+	ch := ""
+	if key.Mod() == 0 && key.Str() != "" {
+		ch = key.Str()
+	}
+	if ch == "" {
+		switch {
+		case key.Equals(NewKeyName(KeyArrowLeft)):
+			ch = "h"
+		case key.Equals(NewKeyName(KeyArrowRight)):
+			ch = "l"
+		case key.Equals(NewKeyName(KeyArrowUp)):
+			ch = "k"
+		case key.Equals(NewKeyName(KeyArrowDown)):
+			ch = "j"
+		case key.Equals(NewKeyName(KeyHome)):
+			ch = "0"
+		case key.Equals(NewKeyName(KeyEnd)):
+			ch = "$"
+		case key.Equals(NewKeyName(KeyDelete)):
+			ch = "x"
+		case key.Equals(NewKeyName(KeyBackspace)):
+			ch = "h"
+		case key.Equals(NewKeyName(KeyEnter)):
+			ch = "j"
+		default:
+			return false
+		}
+	}
+
+	self.normalChar(ta, ch)
+	return true
+}
+
+// normalChar handles one normal-mode key. Unrecognized characters are
+// swallowed: on an editable view a plain character that fell through to a
+// global keybinding (q, ...) would be disastrous.
+func (self *VimEditor) normalChar(ta *TextArea, ch string) {
+	if self.pending != "" {
+		self.resolvePending(ta, ch)
+		return
+	}
+
+	if (ch >= "1" && ch <= "9") || (ch == "0" && self.count != 0) {
+		self.count = self.count*10 + int(ch[0]-'0')
+		return
+	}
+
+	switch ch {
+	case "d", "c", "y":
+		self.startOperator(ta, ch)
+		return
+	case "g", "f", "F", "t", "T":
+		self.pending = ch
+		return
+	case "r":
+		if self.op == "" {
+			self.pending = ch
+			return
+		}
+	case "i", "a":
+		if self.op != "" {
+			self.pending = "obj" + ch
+			return
+		}
+	}
+
+	if self.motion(ta, ch) {
+		return
+	}
+
+	if self.op != "" {
+		self.clearPending()
+		return
+	}
+
+	self.command(ta, ch)
+}
+
+func (self *VimEditor) motion(ta *TextArea, ch string) bool {
+	cur := ta.cursor
+	n := self.repeatCount()
+
+	var target int
+	kind := motionExclusive
+
+	switch ch {
+	case "h":
+		target = cur
+		lineStart := ta.hardLineStart(cur)
+		for range n {
+			if target == lineStart {
+				break
+			}
+			target = ta.prevGraphemeStart(target)
+		}
+	case "l", " ":
+		target = cur
+		lineEnd := ta.hardLineEnd(cur)
+		for range n {
+			next := ta.nextGraphemeStart(target)
+			if next > lineEnd {
+				break
+			}
+			target = next
+		}
+	case "j", "k":
+		self.motionUpDown(ta, ch, n)
+		return true
+	case "w":
+		if self.op == "c" && vimCharClass(ta.graphemeAt(cur)) != charClassWhitespace {
+			// vim's documented quirk: cw on a word acts like ce
+			target = ta.vimWordEnd(cur, n)
+			kind = motionInclusive
+		} else {
+			target = ta.vimWordForward(cur, n)
+			if self.op != "" {
+				// as an operator target, w stops at the end of the
+				// cursor's line rather than eating the newline
+				lineEnd := ta.hardLineEnd(cur)
+				if target > lineEnd && lineEnd > cur {
+					target = lineEnd
+				}
+			}
+		}
+	case "e":
+		target = ta.vimWordEnd(cur, n)
+		kind = motionInclusive
+	case "b":
+		target = ta.vimWordBack(cur, n)
+	case "0":
+		target = ta.hardLineStart(cur)
+	case "^":
+		target = ta.vimFirstNonBlank(cur)
+	case "$":
+		if self.op != "" {
+			target = ta.hardLineEnd(cur)
+		} else {
+			target = ta.vimLastCharOfLine(cur)
+		}
+	case "G":
+		line := ta.vimLineCount() - 1
+		if self.count != 0 || self.opCount != 0 {
+			line = n - 1
+		}
+		self.motionToLine(ta, line)
+		return true
+	case ";", ",":
+		if self.lastFind.target == "" {
+			self.clearPending()
+			return true
+		}
+		find := self.lastFind
+		if ch == "," {
+			find.forward = !find.forward
+		}
+		self.applyFind(ta, find, n)
+		return true
+	default:
+		return false
+	}
+
+	self.applyMotion(ta, target, kind)
+	return true
+}
+
+func (self *VimEditor) motionUpDown(ta *TextArea, ch string, n int) {
+	if self.op != "" {
+		delta := n
+		if ch == "k" {
+			delta = -n
+		}
+		line := ta.vimLineNumber(ta.cursor)
+		self.applyLinewise(ta, line, line+delta)
+		return
+	}
+	for range n {
+		if ch == "j" {
+			ta.MoveCursorDown()
+		} else {
+			ta.MoveCursorUp()
+		}
+	}
+	self.clearPending()
+	self.clampCursor(ta)
+}
+
+func (self *VimEditor) motionToLine(ta *TextArea, line int) {
+	target := ta.vimGotoLine(max(line, 0))
+	if self.op != "" {
+		self.applyLinewise(ta, ta.vimLineNumber(ta.cursor), ta.vimLineNumber(target))
+		return
+	}
+	ta.cursor = ta.vimFirstNonBlank(target)
+	self.clearPending()
+	self.clampCursor(ta)
+}
+
+func (self *VimEditor) applyMotion(ta *TextArea, target, kind int) {
+	if target < 0 {
+		self.clearPending()
+		return
+	}
+	if self.op == "" {
+		ta.cursor = target
+		self.clearPending()
+		self.clampCursor(ta)
+		return
+	}
+
+	start, end := ta.cursor, target
+	if end < start {
+		start, end = end, start
+	}
+	if kind == motionInclusive {
+		end = ta.nextGraphemeStart(end)
+	}
+	self.applyRange(ta, start, end)
+}
+
+func (self *VimEditor) applyRange(ta *TextArea, start, end int) {
+	op := self.op
+	self.clearPending()
+
+	self.register.set(ta.getRange(start, end), false)
+	switch op {
+	case "y":
+		ta.cursor = start
+	case "d":
+		self.pushUndo(ta)
+		ta.deleteRange(start, end)
+	case "c":
+		self.pushUndo(ta)
+		ta.deleteRange(start, end)
+		self.mode = VimModeInsert
+	}
+	self.clampCursor(ta)
+}
+
+func (self *VimEditor) applyLinewise(ta *TextArea, lineA, lineB int) {
+	op := self.op
+	self.clearPending()
+
+	if lineB < lineA {
+		lineA, lineB = lineB, lineA
+	}
+	lineA = max(lineA, 0)
+	lineB = min(lineB, ta.vimLineCount()-1)
+
+	start := ta.vimGotoLine(lineA)
+	end := ta.hardLineEnd(ta.vimGotoLine(lineB))
+
+	self.register.set(ta.getRange(start, end), true)
+	switch op {
+	case "y":
+	case "d":
+		self.pushUndo(ta)
+		delStart, delEnd := start, end
+		if delEnd < len(ta.content) {
+			delEnd++
+		} else if delStart > 0 {
+			delStart--
+		}
+		ta.deleteRange(delStart, delEnd)
+		ta.cursor = ta.vimFirstNonBlank(ta.cursor)
+	case "c":
+		self.pushUndo(ta)
+		ta.deleteRange(start, end)
+		self.mode = VimModeInsert
+	}
+	self.clampCursor(ta)
+}
+
+func (self *VimEditor) startOperator(ta *TextArea, ch string) {
+	if self.op == ch {
+		line := ta.vimLineNumber(ta.cursor)
+		self.applyLinewise(ta, line, line+self.repeatCount()-1)
+		return
+	}
+	if self.op != "" {
+		self.clearPending()
+		return
+	}
+	self.op = ch
+	self.opCount = self.count
+	self.count = 0
+}
+
+func (self *VimEditor) resolvePending(ta *TextArea, ch string) {
+	pending := self.pending
+	self.pending = ""
+
+	switch pending {
+	case "g":
+		if ch == "g" {
+			line := 0
+			if self.count != 0 || self.opCount != 0 {
+				line = self.repeatCount() - 1
+			}
+			self.motionToLine(ta, line)
+			return
+		}
+	case "r":
+		self.replaceChars(ta, ch)
+		return
+	case "f", "F", "t", "T":
+		find := vimFind{
+			target:  ch,
+			forward: pending == "f" || pending == "t",
+			till:    pending == "t" || pending == "T",
+		}
+		self.lastFind = find
+		self.applyFind(ta, find, self.repeatCount())
+		return
+	case "obji", "obja":
+		if ch == "w" {
+			start, end := ta.vimWordBounds(ta.cursor, pending == "obja")
+			self.applyRange(ta, start, end)
+			return
+		}
+	}
+	self.clearPending()
+}
+
+func (self *VimEditor) applyFind(ta *TextArea, find vimFind, n int) {
+	target := ta.vimFindOnLine(ta.cursor, find.target, find.forward, find.till, n)
+	if target == -1 {
+		self.clearPending()
+		return
+	}
+	kind := motionExclusive
+	if find.forward {
+		kind = motionInclusive
+	}
+	self.applyMotion(ta, target, kind)
+}
+
+func (self *VimEditor) replaceChars(ta *TextArea, ch string) {
+	n := self.repeatCount()
+	self.clearPending()
+	self.pushUndo(ta)
+
+	pos := ta.cursor
+	last := ta.cursor
+	for range n {
+		g := ta.graphemeAt(pos)
+		if g == "" || g == "\n" {
+			break
+		}
+		ta.replaceGraphemeAt(pos, ch)
+		last = pos
+		pos += len(ch)
+	}
+	ta.cursor = last
+}
+
+func (self *VimEditor) command(ta *TextArea, ch string) {
+	n := self.repeatCount()
+	self.clearPending()
+
+	switch ch {
+	case "i":
+		self.startInsert(ta)
+	case "I":
+		ta.cursor = ta.vimFirstNonBlank(ta.cursor)
+		self.startInsert(ta)
+	case "a":
+		ta.cursor = min(ta.nextGraphemeStart(ta.cursor), ta.hardLineEnd(ta.cursor))
+		self.startInsert(ta)
+	case "A":
+		ta.cursor = ta.hardLineEnd(ta.cursor)
+		self.startInsert(ta)
+	case "o", "O":
+		if !self.allowMultiline {
+			return
+		}
+		self.pushUndo(ta)
+		if ch == "o" {
+			ta.insertAt(ta.hardLineEnd(ta.cursor), "\n")
+		} else {
+			start := ta.hardLineStart(ta.cursor)
+			ta.insertAt(start, "\n")
+			ta.cursor = start
+		}
+		self.mode = VimModeInsert
+	case "x":
+		self.deleteForward(ta, n)
+	case "X":
+		self.deleteBackward(ta, n)
+	case "s":
+		self.deleteForward(ta, n)
+		self.startInsert(ta)
+	case "S":
+		self.op = "c"
+		line := ta.vimLineNumber(ta.cursor)
+		self.applyLinewise(ta, line, line+n-1)
+	case "D":
+		self.op = "d"
+		self.applyRange(ta, ta.cursor, ta.hardLineEnd(ta.cursor))
+	case "C":
+		self.op = "c"
+		self.applyRange(ta, ta.cursor, ta.hardLineEnd(ta.cursor))
+	case "Y":
+		self.op = "y"
+		line := ta.vimLineNumber(ta.cursor)
+		self.applyLinewise(ta, line, line+n-1)
+	case "p":
+		self.paste(ta, true, n)
+	case "P":
+		self.paste(ta, false, n)
+	case "u":
+		for range n {
+			self.restoreUndo(ta)
+		}
+	}
+}
+
+func (self *VimEditor) deleteForward(ta *TextArea, n int) {
+	end := ta.cursor
+	lineEnd := ta.hardLineEnd(ta.cursor)
+	for range n {
+		next := ta.nextGraphemeStart(end)
+		if next > lineEnd {
+			break
+		}
+		end = next
+	}
+	if end == ta.cursor {
+		return
+	}
+	self.register.set(ta.getRange(ta.cursor, end), false)
+	self.pushUndo(ta)
+	ta.deleteRange(ta.cursor, end)
+	self.clampCursor(ta)
+}
+
+func (self *VimEditor) deleteBackward(ta *TextArea, n int) {
+	start := ta.cursor
+	lineStart := ta.hardLineStart(ta.cursor)
+	for range n {
+		if start == lineStart {
+			break
+		}
+		start = ta.prevGraphemeStart(start)
+	}
+	if start == ta.cursor {
+		return
+	}
+	self.register.set(ta.getRange(start, ta.cursor), false)
+	self.pushUndo(ta)
+	ta.deleteRange(start, ta.cursor)
+}
+
+func (self *VimEditor) paste(ta *TextArea, after bool, n int) {
+	if self.register.text == "" {
+		return
+	}
+	self.pushUndo(ta)
+
+	if self.register.linewise && self.allowMultiline {
+		block := strings.Repeat(self.register.text+"\n", n)
+		if after {
+			lineEnd := ta.hardLineEnd(ta.cursor)
+			if lineEnd == len(ta.content) {
+				ta.insertAt(lineEnd, "\n"+strings.TrimSuffix(block, "\n"))
+				ta.cursor = min(lineEnd+1, len(ta.content))
+			} else {
+				ta.insertAt(lineEnd+1, block)
+				ta.cursor = lineEnd + 1
+			}
+		} else {
+			start := ta.hardLineStart(ta.cursor)
+			ta.insertAt(start, block)
+			ta.cursor = start
+		}
+		ta.cursor = ta.vimFirstNonBlank(ta.cursor)
+		self.clampCursor(ta)
+		return
+	}
+
+	text := self.register.text
+	if self.register.linewise {
+		// pasting a linewise register into a single-line view degrades
+		// to charwise so the paste isn't silently dropped
+		text = strings.ReplaceAll(text, "\n", " ")
+	}
+	text = strings.Repeat(text, n)
+	pos := ta.cursor
+	if after {
+		pos = min(ta.nextGraphemeStart(pos), ta.hardLineEnd(pos))
+	}
+	ta.insertAt(pos, text)
+	ta.cursor = ta.prevGraphemeStart(pos + len(text))
+	self.clampCursor(ta)
+}
+
+func (self *VimEditor) pushUndo(ta *TextArea) {
+	self.undo = append(self.undo, vimSnapshot{content: ta.content, cursor: ta.cursor})
+	if len(self.undo) > vimUndoLimit {
+		self.undo = self.undo[1:]
+	}
+	self.redo = nil
+}
+
+func (self *VimEditor) restoreUndo(ta *TextArea) {
+	for len(self.undo) > 0 {
+		snap := self.undo[len(self.undo)-1]
+		self.undo = self.undo[:len(self.undo)-1]
+		if snap.content == ta.content {
+			continue
+		}
+		self.redo = append(self.redo, vimSnapshot{content: ta.content, cursor: ta.cursor})
+		ta.setState(snap.content, snap.cursor)
+		self.clampCursor(ta)
+		return
+	}
+}
+
+func (self *VimEditor) restoreRedo(ta *TextArea) {
+	for len(self.redo) > 0 {
+		snap := self.redo[len(self.redo)-1]
+		self.redo = self.redo[:len(self.redo)-1]
+		if snap.content == ta.content {
+			continue
+		}
+		self.undo = append(self.undo, vimSnapshot{content: ta.content, cursor: ta.cursor})
+		ta.setState(snap.content, snap.cursor)
+		self.clampCursor(ta)
+		return
+	}
+}
+
+func (self *VimEditor) startInsert(ta *TextArea) {
+	self.pushUndo(ta)
+	self.mode = VimModeInsert
+}
+
+func (self *VimEditor) enterNormalMode(ta *TextArea) {
+	self.mode = VimModeNormal
+	self.clearPending()
+	if ta.cursor > ta.hardLineStart(ta.cursor) {
+		ta.cursor = ta.prevGraphemeStart(ta.cursor)
+	}
+}
+
+// vim's normal-mode cursor sits on a character, never on the newline after
+// the last one; the insertion-point cursor must be pulled back one grapheme
+// whenever a motion or edit leaves it hanging at a line end.
+func (self *VimEditor) clampCursor(ta *TextArea) {
+	if self.mode != VimModeNormal {
+		return
+	}
+	lineStart := ta.hardLineStart(ta.cursor)
+	if ta.cursor > lineStart && ta.cursor == ta.hardLineEnd(ta.cursor) {
+		ta.cursor = ta.prevGraphemeStart(ta.cursor)
+	}
+}
+
+func (self *VimEditor) repeatCount() int {
+	return max(self.count, 1) * max(self.opCount, 1)
+}
+
+func (self *VimEditor) clearPending() {
+	self.count = 0
+	self.opCount = 0
+	self.op = ""
+	self.pending = ""
+}

--- a/pkg/gocui/vim_editor.go
+++ b/pkg/gocui/vim_editor.go
@@ -7,6 +7,7 @@ type VimMode int
 const (
 	VimModeInsert VimMode = iota
 	VimModeNormal
+	VimModeVisual
 )
 
 // VimRegister is the yank/delete buffer. It is separate from TextArea's
@@ -51,14 +52,15 @@ type VimEditor struct {
 	allowMultiline bool
 	register       *VimRegister
 
-	mode     VimMode
-	count    int
-	opCount  int
-	op       string
-	pending  string
-	lastFind vimFind
-	undo     []vimSnapshot
-	redo     []vimSnapshot
+	mode         VimMode
+	count        int
+	opCount      int
+	op           string
+	pending      string
+	lastFind     vimFind
+	visualAnchor int
+	undo         []vimSnapshot
+	redo         []vimSnapshot
 }
 
 func NewVimEditor(register *VimRegister, allowMultiline bool) *VimEditor {
@@ -91,6 +93,7 @@ func (self *VimEditor) HandleEscape(v *View) bool {
 	if !self.escape(v.TextArea) {
 		return false
 	}
+	self.syncSelection(v)
 	v.RenderTextArea()
 	return true
 }
@@ -98,6 +101,12 @@ func (self *VimEditor) HandleEscape(v *View) bool {
 func (self *VimEditor) escape(ta *TextArea) bool {
 	if self.mode == VimModeInsert {
 		self.enterNormalMode(ta)
+		return true
+	}
+	if self.mode == VimModeVisual {
+		self.mode = VimModeNormal
+		self.clearPending()
+		self.clampCursor(ta)
 		return true
 	}
 	if self.op != "" || self.count != 0 || self.pending != "" {
@@ -119,9 +128,27 @@ func (self *VimEditor) Edit(v *View, key Key) bool {
 
 	handled := self.normalKey(v.TextArea, key)
 	if handled {
+		self.syncSelection(v)
 		v.RenderTextArea()
 	}
 	return handled
+}
+
+func (self *VimEditor) syncSelection(v *View) {
+	if self.mode != VimModeVisual {
+		v.SetVimSelection(nil)
+		return
+	}
+	start, end := self.visualRange(v.TextArea)
+	v.SetVimSelection(v.TextArea.selectionPositions(start, end))
+}
+
+func (self *VimEditor) visualRange(ta *TextArea) (int, int) {
+	start, end := self.visualAnchor, ta.cursor
+	if end < start {
+		start, end = end, start
+	}
+	return start, ta.nextGraphemeStart(end)
 }
 
 func (self *VimEditor) normalKey(ta *TextArea, key Key) bool {
@@ -180,6 +207,11 @@ func (self *VimEditor) normalChar(ta *TextArea, ch string) {
 		return
 	}
 
+	if self.mode == VimModeVisual {
+		self.visualChar(ta, ch)
+		return
+	}
+
 	switch ch {
 	case "d", "c", "y":
 		self.startOperator(ta, ch)
@@ -209,6 +241,37 @@ func (self *VimEditor) normalChar(ta *TextArea, ch string) {
 	}
 
 	self.command(ta, ch)
+}
+
+// visualChar handles one visual-mode key: operators act on the selection,
+// motions move its free end, everything else is swallowed.
+func (self *VimEditor) visualChar(ta *TextArea, ch string) {
+	switch ch {
+	case "v":
+		self.mode = VimModeNormal
+		self.clearPending()
+		self.clampCursor(ta)
+	case "o":
+		self.visualAnchor, ta.cursor = ta.cursor, self.visualAnchor
+	case "d", "x", "c", "s", "y":
+		op := ch
+		switch ch {
+		case "x":
+			op = "d"
+		case "s":
+			op = "c"
+		}
+		start, end := self.visualRange(ta)
+		self.mode = VimModeNormal
+		self.op = op
+		self.applyRange(ta, start, end)
+	case "g", "f", "F", "t", "T":
+		self.pending = ch
+	default:
+		if !self.motion(ta, ch) {
+			self.clearPending()
+		}
+	}
 }
 
 func (self *VimEditor) motion(ta *TextArea, ch string) bool {
@@ -538,6 +601,9 @@ func (self *VimEditor) command(ta *TextArea, ch string) {
 		self.op = "y"
 		line := ta.vimLineNumber(ta.cursor)
 		self.applyLinewise(ta, line, line+n-1)
+	case "v":
+		self.visualAnchor = ta.cursor
+		self.mode = VimModeVisual
 	case "p":
 		self.paste(ta, true, n)
 	case "P":

--- a/pkg/gocui/vim_editor_test.go
+++ b/pkg/gocui/vim_editor_test.go
@@ -120,6 +120,67 @@ func TestVimEditorCommands(t *testing.T) {
 	}
 }
 
+func TestVimEditorVisual(t *testing.T) {
+	tests := []struct {
+		content         string
+		cursor          int
+		keys            string
+		expectedContent string
+		expectedCursor  int
+	}{
+		{"foo bar", 0, "ved", " bar", 0},
+		{"foo bar", 0, "vex", " bar", 0},
+		{"foo bar", 0, "vwd", "ar", 0},
+		{"foo bar", 0, "v$d", "", 0},
+		{"foo bar", 4, "v" + esc + "x", "foo ar", 4},
+		{"foo bar", 2, "vod", "fo bar", 2},
+		{"foo bar", 2, "vhod", "f bar", 1},
+		{"foo bar", 0, "vecme" + esc, "me bar", 1},
+		{"foo bar", 0, "vfad", "r", 0},
+		{"a\nb\nc", 0, "vGd", "", 0},
+		{"foo", 1, "vp", "foo", 1},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			editor, ta := newVimFixture(test.content, test.cursor, true)
+			runVimKeys(editor, ta, test.keys)
+			assert.Equal(t, test.expectedContent, ta.GetUnwrappedContent())
+			assert.Equal(t, test.expectedCursor, ta.cursor)
+		})
+	}
+}
+
+func TestVimEditorVisualYank(t *testing.T) {
+	editor, ta := newVimFixture("foo bar", 0, true)
+	runVimKeys(editor, ta, "vey")
+	assert.Equal(t, VimModeNormal, editor.mode)
+	assert.Equal(t, "foo", editor.register.text)
+	assert.Equal(t, 0, ta.cursor)
+}
+
+func TestVimEditorVisualModeTransitions(t *testing.T) {
+	editor, ta := newVimFixture("foo", 0, true)
+	runVimKeys(editor, ta, "v")
+	assert.Equal(t, VimModeVisual, editor.mode)
+	runVimKeys(editor, ta, "v")
+	assert.Equal(t, VimModeNormal, editor.mode)
+	runVimKeys(editor, ta, "v")
+	assert.True(t, editor.escape(ta))
+	assert.Equal(t, VimModeNormal, editor.mode)
+}
+
+func TestVimSelectionPositions(t *testing.T) {
+	ta := makeTextArea("foo\nbar", 0)
+	assert.Equal(t,
+		[]SearchPosition{{XStart: 1, XEnd: 4, Y: 0}, {XStart: 0, XEnd: 2, Y: 1}},
+		ta.selectionPositions(1, 6))
+	assert.Equal(t,
+		[]SearchPosition{{XStart: 0, XEnd: 2, Y: 0}},
+		ta.selectionPositions(0, 2))
+	assert.Empty(t, ta.selectionPositions(3, 3))
+}
+
 func TestVimEditorRedo(t *testing.T) {
 	editor, ta := newVimFixture("foo bar", 0, true)
 	runVimKeys(editor, ta, "dwu")

--- a/pkg/gocui/vim_editor_test.go
+++ b/pkg/gocui/vim_editor_test.go
@@ -1,0 +1,204 @@
+package gocui
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const esc = "\x1b"
+
+func runVimKeys(editor *VimEditor, ta *TextArea, keys string) {
+	for _, r := range keys {
+		ch := string(r)
+		if ch == esc {
+			editor.escape(ta)
+			continue
+		}
+		if editor.mode == VimModeInsert {
+			ta.TypeCharacter(ch)
+			continue
+		}
+		editor.normalChar(ta, ch)
+	}
+}
+
+func newVimFixture(content string, cursor int, multiline bool) (*VimEditor, *TextArea) {
+	ta := makeTextArea(content, cursor)
+	editor := NewVimEditor(nil, multiline)
+	editor.mode = VimModeNormal
+	return editor, ta
+}
+
+func TestVimEditorCommands(t *testing.T) {
+	tests := []struct {
+		content         string
+		cursor          int
+		keys            string
+		expectedContent string
+		expectedCursor  int
+	}{
+		{"foo bar baz", 0, "dw", "bar baz", 0},
+		{"foo bar baz", 0, "d2w", "baz", 0},
+		{"foo bar baz", 0, "2dw", "baz", 0},
+		{"foo bar baz", 4, "diw", "foo  baz", 4},
+		{"foo bar baz", 4, "daw", "foo baz", 4},
+		{"foo bar baz", 4, "de", "foo  baz", 4},
+		{"foo bar baz", 4, "d$", "foo ", 3},
+		{"foo bar baz", 4, "D", "foo ", 3},
+		{"foo bar baz", 4, "d0", "bar baz", 0},
+		{"foo bar", 0, "dfa", "r", 0},
+		{"foo bar", 0, "dta", "ar", 0},
+		{"foo bar baz", 8, "db", "foo baz", 4},
+		{"foo\nbar", 0, "dw", "\nbar", 0},
+		{"foo\nbar", 0, "dd", "bar", 0},
+		{"foo\nbar", 4, "dd", "foo", 0},
+		{"a\nb\nc", 0, "2dd", "c", 0},
+		{"a\nb\nc", 0, "dG", "", 0},
+		{"a\nb\nc", 4, "dgg", "", 0},
+		{"a\nb\nc", 0, "dj", "c", 0},
+		{"a\nb\nc", 4, "dk", "a", 0},
+		{"foo", 0, "x", "oo", 0},
+		{"foo", 0, "3x", "", 0},
+		{"foo", 0, "5x", "", 0},
+		{"foo", 2, "X", "fo", 1},
+		{"foo", 2, "2X", "o", 0},
+		{"foo", 0, "rz", "zoo", 0},
+		{"foo", 0, "3rz", "zzz", 2},
+		{"foo", 0, "5rz", "zzz", 2},
+		{"foo bar", 0, "cwme" + esc, "me bar", 1},
+		{"foo bar", 0, "ciwme" + esc, "me bar", 1},
+		{"foo bar", 3, "cwx" + esc, "fooxbar", 3},
+		{"foo", 0, "cc" + "bar" + esc, "bar", 2},
+		{"a\nb\nc", 0, "2ccx" + esc, "x\nc", 0},
+		{"foo", 1, "C" + "x" + esc, "fx", 1},
+		{"foo", 1, "S" + "x" + esc, "x", 0},
+		{"foo", 1, "s" + "x" + esc, "fxo", 1},
+		{"foo", 0, "ibar" + esc, "barfoo", 2},
+		{"foo", 0, "abar" + esc, "fbaroo", 3},
+		{"foo bar", 4, "Ix" + esc, "xfoo bar", 0},
+		{"foo", 0, "Ax" + esc, "foox", 3},
+		{"foo", 0, "ox" + esc, "foo\nx", 4},
+		{"foo", 0, "Ox" + esc, "x\nfoo", 0},
+		{"foo bar", 0, "w", "foo bar", 4},
+		{"foo bar", 0, "ww", "foo bar", 6},
+		{"foo bar baz", 0, "2w", "foo bar baz", 8},
+		{"foo bar", 6, "bb", "foo bar", 0},
+		{"foo bar", 0, "$", "foo bar", 6},
+		{"foo bar", 6, "0", "foo bar", 0},
+		{"  foo", 4, "^", "  foo", 2},
+		{"foo bar", 0, "e", "foo bar", 2},
+		{"abcabc", 0, "2fc", "abcabc", 5},
+		{"abcabc", 0, "fc;", "abcabc", 5},
+		{"abcabc", 0, "2fc,", "abcabc", 2},
+		{"a\nb\nc", 0, "G", "a\nb\nc", 4},
+		{"a\nb\nc", 4, "gg", "a\nb\nc", 0},
+		{"a\nb\nc", 0, "2G", "a\nb\nc", 2},
+		{"foo", 2, "hh", "foo", 0},
+		{"foo", 0, "ll", "foo", 2},
+		{"foo", 0, "3l", "foo", 2},
+		{"foo bar", 0, "ywP", "foo foo bar", 3},
+		{"foo", 0, "xp", "ofo", 1},
+		{"foo", 0, "yiwp", "ffoooo", 3},
+		{"a\nb", 0, "yyp", "a\na\nb", 2},
+		{"a\nb", 2, "yyp", "a\nb\nb", 4},
+		{"a\nb", 2, "yyP", "a\nb\nb", 2},
+		{"foo bar", 0, "dwu", "foo bar", 0},
+		{"foo bar", 0, "dwdwuu", "foo bar", 0},
+		{"foo", 0, "ibar" + esc + "u", "foo", 0},
+		{"foo", 0, "xxu", "oo", 0},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			editor, ta := newVimFixture(test.content, test.cursor, true)
+			runVimKeys(editor, ta, test.keys)
+			assert.Equal(t, test.expectedContent, ta.GetUnwrappedContent())
+			assert.Equal(t, test.expectedCursor, ta.cursor)
+		})
+	}
+}
+
+func TestVimEditorRedo(t *testing.T) {
+	editor, ta := newVimFixture("foo bar", 0, true)
+	runVimKeys(editor, ta, "dwu")
+	assert.Equal(t, "foo bar", ta.GetUnwrappedContent())
+	editor.normalKey(ta, NewKeyStrMod("r", ModCtrl))
+	assert.Equal(t, "bar", ta.GetUnwrappedContent())
+	runVimKeys(editor, ta, "u")
+	assert.Equal(t, "foo bar", ta.GetUnwrappedContent())
+}
+
+func TestVimEditorRegisters(t *testing.T) {
+	editor, ta := newVimFixture("foo bar", 0, true)
+	runVimKeys(editor, ta, "yw")
+	assert.Equal(t, "foo ", editor.register.text)
+	assert.False(t, editor.register.linewise)
+
+	runVimKeys(editor, ta, "yy")
+	assert.Equal(t, "foo bar", editor.register.text)
+	assert.True(t, editor.register.linewise)
+
+	shared := &VimRegister{}
+	editorA := NewVimEditor(shared, true)
+	editorA.mode = VimModeNormal
+	taA := makeTextArea("hello", 0)
+	editorA.normalChar(taA, "y")
+	editorA.normalChar(taA, "w")
+
+	editorB := NewVimEditor(shared, true)
+	editorB.mode = VimModeNormal
+	taB := makeTextArea("x", 0)
+	editorB.normalChar(taB, "P")
+	assert.Equal(t, "hellox", taB.GetUnwrappedContent())
+}
+
+func TestVimEditorSingleLine(t *testing.T) {
+	editor, ta := newVimFixture("foo", 0, false)
+	runVimKeys(editor, ta, "o")
+	assert.Equal(t, "foo", ta.GetUnwrappedContent())
+	runVimKeys(editor, ta, "O")
+	assert.Equal(t, "foo", ta.GetUnwrappedContent())
+
+	editor.register.set("a\nb", true)
+	runVimKeys(editor, ta, "P")
+	assert.Equal(t, "a bfoo", ta.GetUnwrappedContent())
+}
+
+func TestVimEditorEscape(t *testing.T) {
+	editor, ta := newVimFixture("foo", 0, true)
+
+	editor.mode = VimModeInsert
+	assert.True(t, editor.escape(ta))
+	assert.Equal(t, VimModeNormal, editor.mode)
+
+	editor.normalChar(ta, "d")
+	assert.True(t, editor.escape(ta))
+	assert.Equal(t, "", editor.op)
+
+	editor.normalChar(ta, "3")
+	assert.True(t, editor.escape(ta))
+	assert.Equal(t, 0, editor.count)
+
+	assert.False(t, editor.escape(ta))
+}
+
+func TestVimEditorEscapeCursor(t *testing.T) {
+	editor, ta := newVimFixture("foo", 0, true)
+	runVimKeys(editor, ta, "A")
+	assert.Equal(t, 3, ta.cursor)
+	runVimKeys(editor, ta, esc)
+	assert.Equal(t, 2, ta.cursor)
+}
+
+func TestVimEditorReset(t *testing.T) {
+	editor, ta := newVimFixture("foo", 0, true)
+	runVimKeys(editor, ta, "x")
+	assert.NotEmpty(t, editor.undo)
+
+	editor.Reset(VimModeInsert)
+	assert.Equal(t, VimModeInsert, editor.Mode())
+	assert.Empty(t, editor.undo)
+	_ = ta
+}

--- a/pkg/gui/context/commit_message_context.go
+++ b/pkg/gui/context/commit_message_context.go
@@ -164,13 +164,17 @@ func (self *CommitMessageContext) SetPanelState(
 	self.GetView().Title = summaryTitle
 	self.c.Views().CommitDescription.Title = descriptionTitle
 
+	self.RenderDescriptionSubtitle()
+
+	self.c.Views().CommitDescription.Visible = true
+}
+
+func (self *CommitMessageContext) RenderDescriptionSubtitle() {
 	self.c.Views().CommitDescription.Subtitle = utils.ResolvePlaceholderString(self.c.Tr.CommitDescriptionSubTitle,
 		map[string]string{
 			"togglePanelKeyBinding": self.c.UserConfig().Keybinding.Universal.TogglePanel.String(),
 			"commitMenuKeybinding":  self.c.UserConfig().Keybinding.CommitMessage.CommitMenu.String(),
 		})
-
-	self.c.Views().CommitDescription.Visible = true
 }
 
 func (self *CommitMessageContext) RenderSubtitle() {

--- a/pkg/gui/context/commit_message_context.go
+++ b/pkg/gui/context/commit_message_context.go
@@ -176,7 +176,8 @@ func (self *CommitMessageContext) RenderDescriptionSubtitle() {
 			"togglePanelKeyBinding": self.c.UserConfig().Keybinding.Universal.TogglePanel.String(),
 			"commitMenuKeybinding":  self.c.UserConfig().Keybinding.CommitMessage.CommitMenu.String(),
 		})
-	if mode := presentation.VimModeSubTitle(self.c.Tr, self.c.Views().CommitDescription); mode != "" {
+	focused := self.c.Context().Current().GetViewName() == self.c.Views().CommitDescription.Name()
+	if mode := presentation.VimModeSubTitle(self.c.Tr, self.c.Views().CommitDescription, focused); mode != "" {
 		subtitle += "─" + mode
 	}
 	self.c.Views().CommitDescription.Subtitle = subtitle
@@ -195,7 +196,8 @@ func (self *CommitMessageContext) RenderSubtitle() {
 		}
 		subtitle += getBufferLength(subject)
 	}
-	if mode := presentation.VimModeSubTitle(self.c.Tr, self.c.Views().CommitMessage); mode != "" {
+	focused := self.c.Context().Current().GetViewName() == self.c.Views().CommitMessage.Name()
+	if mode := presentation.VimModeSubTitle(self.c.Tr, self.c.Views().CommitMessage, focused); mode != "" {
 		if subtitle != "" {
 			subtitle += "─"
 		}

--- a/pkg/gui/context/commit_message_context.go
+++ b/pkg/gui/context/commit_message_context.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/spf13/afero"
@@ -170,11 +171,15 @@ func (self *CommitMessageContext) SetPanelState(
 }
 
 func (self *CommitMessageContext) RenderDescriptionSubtitle() {
-	self.c.Views().CommitDescription.Subtitle = utils.ResolvePlaceholderString(self.c.Tr.CommitDescriptionSubTitle,
+	subtitle := utils.ResolvePlaceholderString(self.c.Tr.CommitDescriptionSubTitle,
 		map[string]string{
 			"togglePanelKeyBinding": self.c.UserConfig().Keybinding.Universal.TogglePanel.String(),
 			"commitMenuKeybinding":  self.c.UserConfig().Keybinding.CommitMessage.CommitMenu.String(),
 		})
+	if mode := presentation.VimModeSubTitle(self.c.Tr, self.c.Views().CommitDescription); mode != "" {
+		subtitle += "─" + mode
+	}
+	self.c.Views().CommitDescription.Subtitle = subtitle
 }
 
 func (self *CommitMessageContext) RenderSubtitle() {
@@ -189,6 +194,12 @@ func (self *CommitMessageContext) RenderSubtitle() {
 			subtitle += "─"
 		}
 		subtitle += getBufferLength(subject)
+	}
+	if mode := presentation.VimModeSubTitle(self.c.Tr, self.c.Views().CommitMessage); mode != "" {
+		if subtitle != "" {
+			subtitle += "─"
+		}
+		subtitle += mode
 	}
 	self.c.Views().CommitMessage.Subtitle = subtitle
 }

--- a/pkg/gui/controllers/commit_description_controller.go
+++ b/pkg/gui/controllers/commit_description_controller.go
@@ -113,6 +113,10 @@ func (self *CommitDescriptionController) handleTogglePanel() error {
 }
 
 func (self *CommitDescriptionController) close() error {
+	if self.c.Views().CommitDescription.VimEscape() {
+		self.c.Contexts().CommitMessage.RenderDescriptionSubtitle()
+		return nil
+	}
 	self.c.Helpers().Commits.CloseCommitMessagePanel()
 	return nil
 }

--- a/pkg/gui/controllers/commit_description_controller.go
+++ b/pkg/gui/controllers/commit_description_controller.go
@@ -72,6 +72,8 @@ func (self *CommitDescriptionController) GetOnFocus() func(types.OnFocusOpts) {
 				})
 		}
 		self.c.Views().CommitDescription.Footer = footer
+		self.c.Contexts().CommitMessage.RenderSubtitle()
+		self.c.Contexts().CommitMessage.RenderDescriptionSubtitle()
 	}
 }
 

--- a/pkg/gui/controllers/commit_message_controller.go
+++ b/pkg/gui/controllers/commit_message_controller.go
@@ -192,6 +192,10 @@ func (self *CommitMessageController) confirm() error {
 }
 
 func (self *CommitMessageController) close() error {
+	if self.c.Views().CommitMessage.VimEscape() {
+		self.context().RenderSubtitle()
+		return nil
+	}
 	self.c.Helpers().Commits.CloseCommitMessagePanel()
 	return nil
 }

--- a/pkg/gui/controllers/commit_message_controller.go
+++ b/pkg/gui/controllers/commit_message_controller.go
@@ -74,6 +74,8 @@ func (self *CommitMessageController) GetMouseKeybindings(opts types.KeybindingsO
 func (self *CommitMessageController) GetOnFocus() func(types.OnFocusOpts) {
 	return func(types.OnFocusOpts) {
 		self.c.Views().CommitDescription.Footer = ""
+		self.context().RenderSubtitle()
+		self.context().RenderDescriptionSubtitle()
 	}
 }
 

--- a/pkg/gui/controllers/helpers/commits_helper.go
+++ b/pkg/gui/controllers/helpers/commits_helper.go
@@ -172,6 +172,9 @@ func (self *CommitsHelper) OpenCommitMessagePanel(opts *OpenCommitMessagePanelOp
 		self.SetMessageAndDescriptionInView(initialMessage)
 	}
 
+	self.c.Views().CommitMessage.ResetVimEditor(gocui.VimModeInsert)
+	self.c.Views().CommitDescription.ResetVimEditor(gocui.VimModeInsert)
+
 	self.c.Context().Push(self.c.Contexts().CommitMessage, types.OnFocusOpts{})
 }
 

--- a/pkg/gui/controllers/helpers/confirmation_helper.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper.go
@@ -164,7 +164,7 @@ func (self *ConfirmationHelper) preparePromptPanel(
 	textArea.Clear()
 	textArea.TypeString(opts.Prompt)
 	self.c.Views().Prompt.ResetVimEditor(gocui.VimModeInsert)
-	self.c.Views().Prompt.Subtitle = presentation.VimModeSubTitle(self.c.Tr, self.c.Views().Prompt)
+	self.c.Views().Prompt.Subtitle = presentation.VimModeSubTitle(self.c.Tr, self.c.Views().Prompt, true)
 	self.c.Views().Prompt.RenderTextArea()
 
 	if opts.FindSuggestionsFunc != nil {

--- a/pkg/gui/controllers/helpers/confirmation_helper.go
+++ b/pkg/gui/controllers/helpers/confirmation_helper.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jesseduffield/lazygit/pkg/gocui"
+	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/style"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/theme"
@@ -161,6 +163,8 @@ func (self *ConfirmationHelper) preparePromptPanel(
 	textArea := self.c.Views().Prompt.TextArea
 	textArea.Clear()
 	textArea.TypeString(opts.Prompt)
+	self.c.Views().Prompt.ResetVimEditor(gocui.VimModeInsert)
+	self.c.Views().Prompt.Subtitle = presentation.VimModeSubTitle(self.c.Tr, self.c.Views().Prompt)
 	self.c.Views().Prompt.RenderTextArea()
 
 	if opts.FindSuggestionsFunc != nil {

--- a/pkg/gui/controllers/helpers/search_helper.go
+++ b/pkg/gui/controllers/helpers/search_helper.go
@@ -39,6 +39,7 @@ func (self *SearchHelper) OpenFilterPrompt(context types.IFilterableContext) err
 	self.searchPrefixView().SetContent(context.FilterPrefix(self.c.Tr))
 	promptView := self.promptView()
 	promptView.ClearTextArea()
+	promptView.ResetVimEditor(gocui.VimModeInsert)
 	self.OnPromptContentChanged("")
 	promptView.RenderTextArea()
 
@@ -57,6 +58,7 @@ func (self *SearchHelper) OpenSearchPrompt(context types.ISearchableContext) err
 	self.searchPrefixView().SetContent(self.c.Tr.SearchPrefix)
 	promptView := self.promptView()
 	promptView.ClearTextArea()
+	promptView.ResetVimEditor(gocui.VimModeInsert)
 	promptView.RenderTextArea()
 
 	self.c.Context().Push(self.c.Contexts().Search, types.OnFocusOpts{})

--- a/pkg/gui/controllers/prompt_controller.go
+++ b/pkg/gui/controllers/prompt_controller.go
@@ -37,7 +37,7 @@ func (self *PromptController) GetKeybindings(opts types.KeybindingsOpts) []*type
 			Keys: opts.GetKeys(opts.Config.Universal.Return),
 			Handler: func() error {
 				if self.c.Views().Prompt.VimEscape() {
-					self.c.Views().Prompt.Subtitle = presentation.VimModeSubTitle(self.c.Tr, self.c.Views().Prompt)
+					self.c.Views().Prompt.Subtitle = presentation.VimModeSubTitle(self.c.Tr, self.c.Views().Prompt, true)
 					return nil
 				}
 				return self.context().State.OnClose()

--- a/pkg/gui/controllers/prompt_controller.go
+++ b/pkg/gui/controllers/prompt_controller.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jesseduffield/lazygit/pkg/gocui"
 	"github.com/jesseduffield/lazygit/pkg/gui/context"
+	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
 )
 
@@ -33,8 +34,14 @@ func (self *PromptController) GetKeybindings(opts types.KeybindingsOpts) []*type
 			DisplayOnScreen: true,
 		},
 		{
-			Keys:            opts.GetKeys(opts.Config.Universal.Return),
-			Handler:         func() error { return self.context().State.OnClose() },
+			Keys: opts.GetKeys(opts.Config.Universal.Return),
+			Handler: func() error {
+				if self.c.Views().Prompt.VimEscape() {
+					self.c.Views().Prompt.Subtitle = presentation.VimModeSubTitle(self.c.Tr, self.c.Views().Prompt)
+					return nil
+				}
+				return self.context().State.OnClose()
+			},
 			Description:     self.c.Tr.CloseCancel,
 			DisplayOnScreen: true,
 		},

--- a/pkg/gui/controllers/search_prompt_controller.go
+++ b/pkg/gui/controllers/search_prompt_controller.go
@@ -55,6 +55,9 @@ func (self *SearchPromptController) confirm() error {
 }
 
 func (self *SearchPromptController) cancel() error {
+	if self.c.Views().Search.VimEscape() {
+		return nil
+	}
 	return self.c.Helpers().Search.CancelPrompt()
 }
 

--- a/pkg/gui/editors.go
+++ b/pkg/gui/editors.go
@@ -57,7 +57,7 @@ func (gui *Gui) promptEditor(v *gocui.View, key gocui.Key) bool {
 }
 
 func (gui *Gui) renderPromptVimMode(v *gocui.View) {
-	if mode := presentation.VimModeSubTitle(gui.c.Tr, v); mode != "" {
+	if mode := presentation.VimModeSubTitle(gui.c.Tr, v, true); mode != "" {
 		v.Subtitle = mode
 	}
 }

--- a/pkg/gui/editors.go
+++ b/pkg/gui/editors.go
@@ -2,9 +2,14 @@ package gui
 
 import (
 	"github.com/jesseduffield/lazygit/pkg/gocui"
+	"github.com/jesseduffield/lazygit/pkg/gui/presentation"
 )
 
 func (gui *Gui) handleEditorKeypress(v *gocui.View, key gocui.Key, allowMultiline bool) bool {
+	if vim := v.VimEditor(); vim != nil {
+		return vim.Edit(v, key)
+	}
+
 	if key.Equals(gocui.NewKeyName(gocui.KeyEnter)) && allowMultiline {
 		v.TextArea.TypeCharacter("\n")
 		v.RenderTextArea()
@@ -26,6 +31,7 @@ func (gui *Gui) commitMessageEditor(v *gocui.View, key gocui.Key) bool {
 func (gui *Gui) commitDescriptionEditor(v *gocui.View, key gocui.Key) bool {
 	matched := gui.handleEditorKeypress(v, key, true)
 	v.RenderTextArea()
+	gui.c.Contexts().CommitMessage.RenderDescriptionSubtitle()
 	return matched
 }
 
@@ -33,6 +39,7 @@ func (gui *Gui) promptEditor(v *gocui.View, key gocui.Key) bool {
 	matched := gui.handleEditorKeypress(v, key, false)
 
 	v.RenderTextArea()
+	gui.renderPromptVimMode(v)
 
 	suggestionsContext := gui.State.Contexts.Suggestions
 	// Capture the suggestions function and the input here, on the UI thread; the
@@ -47,6 +54,12 @@ func (gui *Gui) promptEditor(v *gocui.View, key gocui.Key) bool {
 	}
 
 	return matched
+}
+
+func (gui *Gui) renderPromptVimMode(v *gocui.View) {
+	if mode := presentation.VimModeSubTitle(gui.c.Tr, v); mode != "" {
+		v.Subtitle = mode
+	}
 }
 
 func (gui *Gui) searchEditor(v *gocui.View, key gocui.Key) bool {

--- a/pkg/gui/presentation/vim_mode.go
+++ b/pkg/gui/presentation/vim_mode.go
@@ -1,0 +1,25 @@
+package presentation
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/gocui"
+	"github.com/jesseduffield/lazygit/pkg/i18n"
+)
+
+// VimModeSubTitle returns the padded mode indicator segment (" NORMAL ")
+// for a view with vim-style editing attached, and "" for views without one.
+func VimModeSubTitle(tr *i18n.TranslationSet, view *gocui.View) string {
+	vim := view.VimEditor()
+	if vim == nil {
+		return ""
+	}
+	var label string
+	switch vim.Mode() {
+	case gocui.VimModeNormal:
+		label = tr.VimModeNormalSubTitle
+	case gocui.VimModeVisual:
+		label = tr.VimModeVisualSubTitle
+	default:
+		label = tr.VimModeInsertSubTitle
+	}
+	return " " + label + " "
+}

--- a/pkg/gui/presentation/vim_mode.go
+++ b/pkg/gui/presentation/vim_mode.go
@@ -7,9 +7,12 @@ import (
 
 // VimModeSubTitle returns the padded mode indicator segment (" NORMAL ")
 // for a view with vim-style editing attached, and "" for views without one.
-func VimModeSubTitle(tr *i18n.TranslationSet, view *gocui.View) string {
+// Like vim's single mode line, only the focused view shows an indicator;
+// with the commit summary and description each holding their own editor,
+// two simultaneous indicators would suggest a shared mode that isn't there.
+func VimModeSubTitle(tr *i18n.TranslationSet, view *gocui.View, focused bool) string {
 	vim := view.VimEditor()
-	if vim == nil {
+	if vim == nil || !focused {
 		return ""
 	}
 	var label string

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -135,16 +135,6 @@ func (gui *Gui) createAllViews() error {
 	gui.Views.Prompt.Editable = true
 	gui.Views.Prompt.Editor = gocui.EditorFunc(gui.promptEditor)
 
-	if gui.UserConfig().Gui.VimStyleEditing {
-		// one register shared across the editors so text can be yanked in
-		// one view and pasted in another
-		register := &gocui.VimRegister{}
-		gui.Views.CommitMessage.AttachVimEditor(register, false)
-		gui.Views.CommitDescription.AttachVimEditor(register, true)
-		gui.Views.Prompt.AttachVimEditor(register, false)
-		gui.Views.Search.AttachVimEditor(register, false)
-	}
-
 	gui.Views.Suggestions.Visible = false
 
 	gui.Views.Menu.Visible = false
@@ -281,4 +271,36 @@ func (gui *Gui) configureViewProperties() {
 		view.Tabs = vt.tabs
 		view.TabIndex = vt.index
 	}
+
+	gui.syncVimEditors()
+}
+
+// Called on every user config (re)load, so toggling gui.vimStyleEditing
+// takes effect without restarting.
+func (gui *Gui) syncVimEditors() {
+	editableViews := []*gocui.View{
+		gui.Views.CommitMessage,
+		gui.Views.CommitDescription,
+		gui.Views.Prompt,
+		gui.Views.Search,
+	}
+
+	if !gui.c.UserConfig().Gui.VimStyleEditing {
+		for _, view := range editableViews {
+			view.DetachVimEditor()
+		}
+		return
+	}
+
+	if gui.Views.CommitMessage.VimEditor() != nil {
+		return
+	}
+
+	// one register shared across the editors so text can be yanked in one
+	// view and pasted in another
+	register := &gocui.VimRegister{}
+	gui.Views.CommitMessage.AttachVimEditor(register, false)
+	gui.Views.CommitDescription.AttachVimEditor(register, true)
+	gui.Views.Prompt.AttachVimEditor(register, false)
+	gui.Views.Search.AttachVimEditor(register, false)
 }

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -135,6 +135,16 @@ func (gui *Gui) createAllViews() error {
 	gui.Views.Prompt.Editable = true
 	gui.Views.Prompt.Editor = gocui.EditorFunc(gui.promptEditor)
 
+	if gui.UserConfig().Gui.VimStyleEditing {
+		// one register shared across the editors so text can be yanked in
+		// one view and pasted in another
+		register := &gocui.VimRegister{}
+		gui.Views.CommitMessage.AttachVimEditor(register, false)
+		gui.Views.CommitDescription.AttachVimEditor(register, true)
+		gui.Views.Prompt.AttachVimEditor(register, false)
+		gui.Views.Search.AttachVimEditor(register, false)
+	}
+
 	gui.Views.Suggestions.Visible = false
 
 	gui.Views.Menu.Visible = false

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -341,6 +341,9 @@ type TranslationSet struct {
 	CommitDescriptionSubTitle             string
 	CommitDescriptionFooter               string
 	CommitHooksDisabledSubTitle           string
+	VimModeInsertSubTitle                 string
+	VimModeNormalSubTitle                 string
+	VimModeVisualSubTitle                 string
 	LocalBranchesTitle                    string
 	SearchTitle                           string
 	TagsTitle                             string
@@ -1498,6 +1501,9 @@ func EnglishTranslationSet() *TranslationSet {
 		CommitDescriptionSubTitle:            "Press {{.togglePanelKeyBinding}} to toggle focus, {{.commitMenuKeybinding}} to open menu",
 		CommitDescriptionFooter:              "Press {{.confirmInEditorKeybinding}} to submit",
 		CommitHooksDisabledSubTitle:          "(hooks disabled)",
+		VimModeInsertSubTitle:                "INSERT",
+		VimModeNormalSubTitle:                "NORMAL",
+		VimModeVisualSubTitle:                "VISUAL",
 		LocalBranchesTitle:                   "Local branches",
 		SearchTitle:                          "Search",
 		TagsTitle:                            "Tags",

--- a/pkg/integration/tests/commit/commit_vim_editing.go
+++ b/pkg/integration/tests/commit/commit_vim_editing.go
@@ -1,0 +1,47 @@
+package commit
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CommitVimEditing = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Commit using vim-style modal editing in the commit message panel",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupConfig: func(config *config.AppConfig) {
+		config.GetUserConfig().Gui.VimStyleEditing = true
+	},
+	SetupRepo: func(shell *Shell) {
+		shell.CreateFile("myfile", "myfile content")
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			IsFocused().
+			PressPrimaryAction().
+			Press(keys.Files.CommitChanges)
+
+		t.ExpectPopup().CommitMessagePanel().
+			Type("fix the the bug").
+			Content(Equals("fix the the bug"))
+
+		t.Views().CommitMessage().PressEscape()
+
+		t.ExpectPopup().CommitMessagePanel().
+			Type("0wdaw").
+			Content(Equals("fix the bug")).
+			Type("u").
+			Content(Equals("fix the the bug"))
+
+		t.Views().CommitMessage().Press(config.Keybinding{"<c-r>"})
+
+		t.ExpectPopup().CommitMessagePanel().
+			Content(Equals("fix the bug")).
+			Confirm()
+
+		t.Views().Commits().
+			Lines(
+				Contains("fix the bug"),
+			)
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -115,6 +115,7 @@ var tests = []*components.IntegrationTest{
 	commit.CommitSkipHooks,
 	commit.CommitSwitchToEditor,
 	commit.CommitSwitchToEditorSkipHooks,
+	commit.CommitVimEditing,
 	commit.CommitWipWithPrefix,
 	commit.CommitWithFallthroughPrefix,
 	commit.CommitWithGlobalPrefix,

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -925,6 +925,11 @@
           "type": "boolean",
           "description": "If true, when using the panel jump keys (default 1 through 5) and target panel is already active, go to next tab instead",
           "default": false
+        },
+        "vimStyleEditing": {
+          "type": "boolean",
+          "description": "If true, text inputs (commit message, prompts, search) use vim-style modal editing: they open in insert mode, and Escape switches to normal mode with motions, counts, d/c/y operators, text objects, visual mode, and undo/redo. Escape in normal mode closes the panel as usual.",
+          "default": false
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
### PR Description

resolves #5912. 
written by claude fable 5 under my direction.

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
