### PR TITLE
fix(updates): add timeout to HTTP requests in update checker

### DIFF
--- a/pkg/updates/updates.go
+++ b/pkg/updates/updates.go
@@ -22,6 +22,10 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/utils"
 )
 
+// httpClient is used for all update-related HTTP requests. A 30-second timeout
+// prevents the update checker from stalling indefinitely if GitHub is slow or unreachable.
+var httpClient = &http.Client{Timeout: 30 * time.Second}
+
 // Updater checks for updates and does updates
 type Updater struct {
 	*common.Common
@@ -51,7 +55,7 @@ func (u *Updater) getLatestVersionNumber() (string, error) {
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -265,7 +269,7 @@ func (u *Updater) downloadAndInstall(rawUrl string) error {
 	defer out.Close()
 
 	// Get the data
-	resp, err := http.Get(rawUrl)
+	resp, err := httpClient.Get(rawUrl)
 	if err != nil {
 		return err
 	}
@@ -318,7 +322,7 @@ func (u *Updater) downloadAndInstall(rawUrl string) error {
 }
 
 func (u *Updater) verifyResourceFound(rawUrl string) bool {
-	resp, err := http.Head(rawUrl)
+	resp, err := httpClient.Head(rawUrl)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
The update checker in pkg/updates/updates.go makes three outbound HTTP calls (version check, resource HEAD check, and binary download) using http.DefaultClient and http.Get/http.Head with no timeout. A slow or unresponsive GitHub releases endpoint stalls each of these calls indefinitely, which can block startup or background tasks.

Added a package-level httpClient with a 30-second timeout and swapped it in for all three call sites so the update check fails fast if the server is unresponsive.