### PR TITLE
Fix wrong example of how to add argument to rawGit

### DIFF
--- a/docs/Custom_DiffRenderers.md
+++ b/docs/Custom_DiffRenderers.md
@@ -27,7 +27,7 @@ Fields only for `extDiff`:
 
 Fields only for `rawGit`:
 
-- **args** The additional arguments to use in the `git diff` or `git show` call (e.g. `--color-words`)
+- **args** The array of additional arguments to use in the `git diff` or `git show` call (e.g. `--color-words`)
 
 Here's an example for a multi-renderer setup:
 
@@ -40,7 +40,8 @@ git:
     - type: extDiff
       command: difft --color=always --context={{diffContext}}
     - type: rawGit
-      args: --color-words
+      args:
+        - --color-words
       name: color-words
     - type: rawGit # git's default diff
       name: default


### PR DESCRIPTION
### PR Description

The original setup example caused a error exit, so I fix it.
```
2026/08/14 10:26:23 The config at `/Users/cncsl/.config/lazygit/config.yml` couldn't be parsed, please inspect it before opening up an issue.
yaml: unmarshal errors:
  line 7: cannot unmarshal !!str `--color...` into []string
```

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting)): No code changes
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide): No need to
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation)): Only one document was modified.
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig)): Only one document was modified.
* [x] Docs have been updated if necessary: YES
* [x] You've read through your own file changes for silly mistakes etc: YES

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
