### PR TITLE
Avoid gofumpt'ing other worktrees

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,9 @@ go 1.25.0
 // This is necessary to ignore test files when executing gofumpt.
 ignore ./test
 
+// Likewise for worktrees that are nested in the main tree.
+ignore ./.worktrees
+
 require (
 	dario.cat/mergo v1.0.2
 	github.com/adrg/xdg v0.5.3


### PR DESCRIPTION
This is usually not a problem (except for the unnecessarily wasted time) because all worktrees should normally be correctly formatted; but it is a problem when we bump the formatter version, and some worktrees are already on the new version and others still on the old.
