### PR TITLE
Two small improvements to the debug log

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -35,6 +36,11 @@ func NewProductionLogger() *logrus.Entry {
 	return formatted(logger)
 }
 
+// Separates one run's log entries from the previous run's. Only the first
+// logger of a run writes it: with LAZYGIT_LOG_PATH set there are two of them
+// for the same file, the global one and the app's.
+var runSeparator sync.Once
+
 func NewDevelopmentLogger(logPath string) *logrus.Entry {
 	logger := logrus.New()
 	logger.SetLevel(getLogLevel())
@@ -43,6 +49,9 @@ func NewDevelopmentLogger(logPath string) *logrus.Entry {
 	if err != nil {
 		log.Fatalf("Unable to log to log file: %v", err)
 	}
+	runSeparator.Do(func() {
+		_, _ = file.WriteString("\n")
+	})
 	logger.SetOutput(file)
 	return formatted(logger)
 }

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -49,7 +50,7 @@ func NewDevelopmentLogger(logPath string) *logrus.Entry {
 func formatted(log *logrus.Logger) *logrus.Entry {
 	// highly recommended: tail -f development.log | humanlog
 	// https://github.com/aybabtme/humanlog
-	log.Formatter = &logrus.JSONFormatter{}
+	log.Formatter = &logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano}
 
 	return log.WithFields(logrus.Fields{})
 }

--- a/pkg/logs/tail/tail.go
+++ b/pkg/logs/tail/tail.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/aybabtme/humanlog"
 )
@@ -15,6 +16,7 @@ func TailLogs(logFilePath string) {
 
 	opts := humanlog.DefaultOptions
 	opts.Truncates = false
+	opts.TimeFormat = time.StampMilli
 
 	_, err := os.Stat(logFilePath)
 	if err != nil {


### PR DESCRIPTION
- log time stamps with nano-second granularity (on macOS we effectively get only microseconds, but that's still more than we need); `lazygit -l` prints them with millisecond resolution, which can be useful for investigating performance
- add a blank line at startup to make it much easier to see where a new run starts