### PR TITLE
Draw the UI in a more inactive look when the window is not focused

### DIFF
--- a/pkg/gocui/gui.go
+++ b/pkg/gocui/gui.go
@@ -1458,7 +1458,7 @@ func (g *Gui) drawTitle(v *View, fgColor, bgColor Attribute) error {
 			currentBgColor = v.BgColor
 		}
 
-		if i >= currentTabStart && i <= currentTabEnd {
+		if i >= currentTabStart && i <= currentTabEnd && g.IsFocused() {
 			currentFgColor = v.SelFgColor
 			if v != g.currentView {
 				currentFgColor &= ^AttrBold
@@ -1639,11 +1639,11 @@ func (g *Gui) draw(v *View) error {
 		Screen.HideCursor()
 	}
 
-	v.draw()
+	v.draw(g.IsFocused())
 
 	if v.Frame {
 		var fgColor, bgColor, frameColor Attribute
-		if g.Highlight && v == g.currentView {
+		if g.Highlight && v == g.currentView && g.IsFocused() {
 			fgColor = g.SelFgColor
 			bgColor = g.SelBgColor
 			frameColor = g.SelFrameColor

--- a/pkg/gocui/view.go
+++ b/pkg/gocui/view.go
@@ -616,7 +616,7 @@ func (v *View) Name() string {
 // setCharacter sets a character (grapheme cluster) at the given point relative to the view. It applies
 // the specified colors, taking into account if the cell must be highlighted. Also, it checks if the
 // position is valid.
-func (v *View) setCharacter(x, y int, ch string, fgColor, bgColor Attribute) {
+func (v *View) setCharacter(x, y int, ch string, fgColor, bgColor Attribute, isWindowFocused bool) {
 	maxX, maxY := v.Size()
 	if x < 0 || x >= maxX || y < 0 || y >= maxY {
 		return
@@ -642,7 +642,7 @@ func (v *View) setCharacter(x, y int, ch string, fgColor, bgColor Attribute) {
 				fgColor += 8
 			}
 			fgColor = fgColor | AttrBold
-			if v.HighlightInactive {
+			if v.HighlightInactive || !isWindowFocused {
 				bgColor = (bgColor & AttrStyleBits) | v.InactiveViewSelBgColor
 			} else {
 				bgColor = (bgColor & AttrStyleBits) | v.SelBgColor
@@ -1319,7 +1319,7 @@ func (v *View) IsTainted() bool {
 }
 
 // draw re-draws the view's contents.
-func (v *View) draw() {
+func (v *View) draw(isWindowFocused bool) {
 	v.writeMutex.Lock()
 	defer v.writeMutex.Unlock()
 
@@ -1409,7 +1409,7 @@ func (v *View) draw() {
 				fgColor |= AttrUnderline
 			}
 
-			v.setCharacter(x, y, c.chr, fgColor, bgColor)
+			v.setCharacter(x, y, c.chr, fgColor, bgColor, isWindowFocused)
 
 			x += c.width
 			cellIdx++

--- a/pkg/gocui/view_test.go
+++ b/pkg/gocui/view_test.go
@@ -534,7 +534,7 @@ func TestNewlineTerminatedLineClearsTrailingBg(t *testing.T) {
 	// renders with bg=red. The trailing area past "foo" must NOT extend
 	// the red bg because '\n' marks the line as cleanly terminated.
 	v.writeString("\x1b[7m\x1b[31mfoo\x1b[0m\n")
-	v.draw()
+	v.draw(true)
 
 	// First row: cells 1..3 are "foo" (render with red bg via reverse),
 	// cells 4..10 are trailing and should be plain default.
@@ -560,7 +560,7 @@ func TestUnterminatedReverseLineDoesNotExtend(t *testing.T) {
 	// Reverse + red fg, "foo", no termination. The trailing cells past
 	// "foo" should be plain default, NOT a continuation of the red bg.
 	v.writeString("\x1b[7m\x1b[31mfoo")
-	v.draw()
+	v.draw(true)
 
 	// Cells 4..10 are trailing and should be default with no reverse.
 	for x := 4; x <= 10; x++ {
@@ -583,7 +583,7 @@ func TestShortFilledLineExtendsBgWithoutWrap(t *testing.T) {
 	// \x1b[41m sets bg=red. "hi" fits within InnerWidth=10; \x1b[K should
 	// fill the remaining 8 cells with red.
 	v.writeString("\x1b[41mhi\x1b[K\x1b[0m\n")
-	v.draw()
+	v.draw(true)
 
 	// All ten cells at (1..10, 1) should have red bg.
 	for x := 1; x <= 10; x++ {
@@ -611,7 +611,7 @@ func TestWrappedFilledLineExtendsBgToEdge(t *testing.T) {
 	// segments — "aaa bbb" / "ccc ddd" / "eee". Each row's trailing area
 	// must pick up the red fill from \x1b[K.
 	v.writeString("\x1b[41m" + "aaa bbb ccc ddd eee" + "\x1b[0m\x1b[41m\x1b[K\x1b[0m\n")
-	v.draw()
+	v.draw(true)
 
 	// All three wrapped rows should have the red fill background across
 	// the full InnerWidth, including the trailing cells past each row's
@@ -645,7 +645,7 @@ func TestMulticolorWrappedFillUsesLastCellOfEachSegment(t *testing.T) {
 	// last cell red) and segment 2 is "ccc" (green, last cell green).
 	// \x1b[K records the green bg on the source line.
 	v.writeString("\x1b[41maaa bbb\x1b[42m ccc\x1b[K\x1b[0m\n")
-	v.draw()
+	v.draw(true)
 
 	// Row 1's content ends with a red cell at x=7, so trailing columns
 	// 8..10 should pick up red rather than the \x1b[K's green.


### PR DESCRIPTION
When using lazygit in a multi-tab terminal it is useful to see if the lazygit tab is currently active; ghostty does a very good job at dimming down the inactive tabs, but VS Code's builtin terminal does not, so indicate this on our side by removing the green highlight from panel frames and tab titles, and showing the selection as inactive like we do for a side panel when the main view is focused.
