### PR TITLE
feat: add documentation line for overrideGpg config

### DIFF
--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -478,7 +478,7 @@ git:
   renameSimilarityThreshold: 50
 
   # If true, do not spawn a separate process when using GPG
-  # Recommended to keep it to true if you need a terminal prompt to type the
+  # Recommended to keep it to false if you need a terminal prompt to type the
   # password
   overrideGpg: false
 

--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -478,6 +478,7 @@ git:
   renameSimilarityThreshold: 50
 
   # If true, do not spawn a separate process when using GPG
+  # Recommended to keep it to true if you need a terminal prompt to type the password
   overrideGpg: false
 
   # If true, do not allow force pushes

--- a/docs-master/Config.md
+++ b/docs-master/Config.md
@@ -478,7 +478,8 @@ git:
   renameSimilarityThreshold: 50
 
   # If true, do not spawn a separate process when using GPG
-  # Recommended to keep it to true if you need a terminal prompt to type the password
+  # Recommended to keep it to true if you need a terminal prompt to type the
+  # password
   overrideGpg: false
 
   # If true, do not allow force pushes

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -478,7 +478,7 @@ git:
   renameSimilarityThreshold: 50
 
   # If true, do not spawn a separate process when using GPG
-  # Recommended to keep it to true if you need a terminal prompt to type the password
+  # Recommended to keep it to false if you need a terminal prompt to type the password
   overrideGpg: false
 
   # If true, do not allow force pushes

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -478,6 +478,7 @@ git:
   renameSimilarityThreshold: 50
 
   # If true, do not spawn a separate process when using GPG
+  # Recommended to keep it to true if you need a terminal prompt to type the password
   overrideGpg: false
 
   # If true, do not allow force pushes

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -334,7 +334,7 @@ type GitConfig struct {
 	// The threshold for considering a file to be renamed, in percent. Can be changed from within Lazygit with the `(` and `)` keys.
 	RenameSimilarityThreshold int `yaml:"renameSimilarityThreshold" jsonschema:"minimum=0,maximum=100"`
 	// If true, do not spawn a separate process when using GPG
-	// Recommended to keep it to true if you need a terminal prompt to type the password
+	// Recommended to keep it to false if you need a terminal prompt to type the password
 	OverrideGpg bool `yaml:"overrideGpg"`
 	// If true, do not allow force pushes
 	DisableForcePushing bool `yaml:"disableForcePushing"`

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -334,6 +334,7 @@ type GitConfig struct {
 	// The threshold for considering a file to be renamed, in percent. Can be changed from within Lazygit with the `(` and `)` keys.
 	RenameSimilarityThreshold int `yaml:"renameSimilarityThreshold" jsonschema:"minimum=0,maximum=100"`
 	// If true, do not spawn a separate process when using GPG
+	// Recommended to keep it to true if you need a terminal prompt to type the password
 	OverrideGpg bool `yaml:"overrideGpg"`
 	// If true, do not allow force pushes
 	DisableForcePushing bool `yaml:"disableForcePushing"`

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -461,7 +461,7 @@
         },
         "overrideGpg": {
           "type": "boolean",
-          "description": "If true, do not spawn a separate process when using GPG",
+          "description": "If true, do not spawn a separate process when using GPG\nRecommended to keep it to true if you need a terminal prompt to type the password",
           "default": false
         },
         "disableForcePushing": {

--- a/schema-master/config.json
+++ b/schema-master/config.json
@@ -461,7 +461,7 @@
         },
         "overrideGpg": {
           "type": "boolean",
-          "description": "If true, do not spawn a separate process when using GPG\nRecommended to keep it to true if you need a terminal prompt to type the password",
+          "description": "If true, do not spawn a separate process when using GPG\nRecommended to keep it to false if you need a terminal prompt to type the password",
           "default": false
         },
         "disableForcePushing": {


### PR DESCRIPTION
### PR Description

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
