### PR TITLE
docs: remove dead GitArbor TUI link from related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,4 +640,3 @@ If you find that lazygit doesn't quite satisfy your requirements, these may be a
 
 - [GitUI](https://github.com/Extrawurst/gitui)
 - [tig](https://github.com/jonas/tig)
-- [GitArbor TUI](https://github.com/cadamsdev/gitarbor-tui)


### PR DESCRIPTION
The related projects list links to github.com/cadamsdev/gitarbor-tui which returns 404 — the repository has been deleted. Removed the entry.