### PR TITLE
Include sub-commits in the default refresh scope

### DIFF
--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -173,6 +173,33 @@ func (self *refreshBounceBatch) close() []func() {
 	return self.funcs
 }
 
+// defaultRefreshScopes is the scope list a refresh with no explicit Scope
+// covers.
+//
+// SUB_COMMITS is included so that a default refresh — notably the one after
+// push/pull/fetch — also reloads the sub-commits view when the user entered
+// it for a branch. Without it, a pushed commit kept its unpushed color there
+// until the view was left and re-entered (#5900).
+// refreshSubCommitsWithLimit no-ops when no ref is set, so this costs
+// nothing while the sub-commits view was never opened.
+func defaultRefreshScopes() []types.RefreshableView {
+	return []types.RefreshableView{
+		types.COMMITS,
+		types.BRANCHES,
+		types.FILES,
+		types.STASH,
+		types.REFLOG,
+		types.TAGS,
+		types.REMOTES,
+		types.WORKTREES,
+		types.STATUS,
+		types.BISECT_INFO,
+		types.STAGING,
+		types.PULL_REQUESTS,
+		types.SUB_COMMITS,
+	}
+}
+
 func (self *RefreshHelper) performRefresh(options types.RefreshOptions, calledFromWorker bool, blockInput bool) {
 	startTime := time.Now()
 
@@ -244,22 +271,7 @@ func (self *RefreshHelper) performRefresh(options types.RefreshOptions, calledFr
 
 	var scopeSet *set.Set[types.RefreshableView]
 	if len(options.Scope) == 0 {
-		// not refreshing staging/patch-building unless explicitly requested because we only need
-		// to refresh those while focused.
-		scopeSet = set.NewFromSlice([]types.RefreshableView{
-			types.COMMITS,
-			types.BRANCHES,
-			types.FILES,
-			types.STASH,
-			types.REFLOG,
-			types.TAGS,
-			types.REMOTES,
-			types.WORKTREES,
-			types.STATUS,
-			types.BISECT_INFO,
-			types.STAGING,
-			types.PULL_REQUESTS,
-		})
+		scopeSet = set.NewFromSlice(defaultRefreshScopes())
 	} else {
 		scopeSet = set.NewFromSlice(options.Scope)
 	}

--- a/pkg/gui/controllers/helpers/refresh_helper_test.go
+++ b/pkg/gui/controllers/helpers/refresh_helper_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jesseduffield/lazygit/pkg/commands/hosting_service"
 	"github.com/jesseduffield/lazygit/pkg/commands/models"
 	"github.com/jesseduffield/lazygit/pkg/gui/context/traits"
+	"github.com/jesseduffield/lazygit/pkg/gui/types"
 	"github.com/jesseduffield/lazygit/pkg/utils"
 	"github.com/samber/lo"
 	"github.com/stefanhaller/git-todo-parser/todo"
@@ -379,4 +380,17 @@ func makeTodoCommitWithHash(hash string, action todo.TodoCommand) *models.Commit
 
 func makeConflictedCommit(hash string) *models.Commit {
 	return models.NewCommit(&utils.StringPool{}, models.NewCommitOpts{Hash: hash, Status: models.StatusConflicted})
+}
+
+func TestDefaultRefreshScopesIncludeSubCommits(t *testing.T) {
+	// #5900: pushing from the sub-commits view of a local branch refreshes
+	// with the default scope, so the default scope must cover SUB_COMMITS —
+	// otherwise the pushed commit keeps its unpushed color until the view is
+	// left and re-entered.
+	scopes := defaultRefreshScopes()
+
+	assert.Contains(t, scopes, types.SUB_COMMITS,
+		"a default refresh must reload the sub-commits view when one is populated")
+	assert.Contains(t, scopes, types.COMMITS)
+	assert.Contains(t, scopes, types.BRANCHES)
 }


### PR DESCRIPTION
Fixes #5900.

## Root cause

Pushing from the sub-commits view of a local branch goes through `SyncController.pushAux`, which finishes with `RefreshFromWorker(types.RefreshOptions{})` — the **default** refresh scope. That scope list did not include `types.SUB_COMMITS`, so the sub-commits view kept its stale model: the just-pushed commit still rendered with its unpushed color until the user left the view (switch to branches) and re-entered, which is the only path that reloads it today.

The same gap applies to pull and fetch, which also refresh with the default scope — anything that changes a ref's divergence should repaint the sub-commits view.

## Fix

Add `SUB_COMMITS` to the default refresh scope (extracted into `defaultRefreshScopes()` so the contract is unit-testable). `refreshSubCommitsWithLimit` no-ops when no ref is set, so this costs nothing while the sub-commits view was never opened; while it is populated, the reload runs the same commit loader the view uses on entry, so pushed-status coloring recomputes exactly as it does after re-entering the view.

## Test

`TestDefaultRefreshScopesIncludeSubCommits` in `refresh_helper_test.go` pins that a default refresh covers `SUB_COMMITS` (and still `COMMITS`/`BRANCHES`). Differential: fails on `master` (the extracted function/assertion cannot hold), passes with the change; the full `pkg/gui/controllers/helpers` suite is green (`go test ./pkg/gui/controllers/helpers/ -count=1`).
