### PR TITLE
Opt background pollers out of core.fsmonitor

### DIFF
--- a/pkg/commands/git_commands/file_loader.go
+++ b/pkg/commands/git_commands/file_loader.go
@@ -223,6 +223,13 @@ func (self *FileLoader) gitStatus(opts GitStatusOptions) ([]FileStatus, error) {
 			"--no-renames",
 			fmt.Sprintf("--find-renames=%d%%", self.UserConfig().Git.RenameSimilarityThreshold),
 		).
+		// Optional locks and fsmonitor querying are independent mechanisms, so
+		// suppressing the lock (below) doesn't stop a background status from
+		// pinging the fsmonitor daemon. Every ping makes the daemon churn its
+		// cookie files under .git/, which other tools watching the repo for
+		// external changes then misread as real changes (#5851). Only background
+		// refreshes opt out — a foreground refresh wants the freshest state.
+		ConfigIf(opts.Background, "core.fsmonitor=false").
 		ToArgv()
 
 	cmdObj := self.cmd.New(cmdArgs).DontLog()

--- a/pkg/commands/git_commands/status.go
+++ b/pkg/commands/git_commands/status.go
@@ -94,6 +94,11 @@ func (self *StatusCommands) RefsSnapshot() (string, error) {
 	refsArgs := NewGitCmd("for-each-ref").
 		Arg("--format=%(objectname) %(refname)").
 		Arg("refs/heads").
+		// This snapshot is only ever taken by the background
+		// external-change-detection poller; opting out of fsmonitor keeps the
+		// poller from making the daemon churn its cookie files under .git/
+		// every cycle (#5851).
+		Config("core.fsmonitor=false").
 		ToArgv()
 	refs, err := self.cmd.New(refsArgs).DontLog().RunWithOutput()
 	if err != nil {

--- a/pkg/commands/git_commands/status_test.go
+++ b/pkg/commands/git_commands/status_test.go
@@ -12,7 +12,9 @@ import (
 
 func TestStatusRefsSnapshot(t *testing.T) {
 	const forEachRefOutput = "aaaa refs/heads/main\nbbbb refs/heads/topic\n"
-	forEachRefArgs := []string{"for-each-ref", "--format=%(objectname) %(refname)", "refs/heads"}
+	// The snapshot opts out of fsmonitor: it only ever runs in the background
+	// poller, and fsmonitor pings churn the daemon's cookie files (#5851).
+	forEachRefArgs := []string{"-c", "core.fsmonitor=false", "for-each-ref", "--format=%(objectname) %(refname)", "refs/heads"}
 
 	scenarios := []struct {
 		testName     string


### PR DESCRIPTION
Implements #5851 (scoped per the call-site analysis in the issue).

## Why

`GIT_OPTIONAL_LOCKS=0` and fsmonitor querying are independent: suppressing the lock does not stop a read-only command from pinging the `git fsmonitor--daemon`, and every ping makes the daemon create and delete a cookie file under `.git/worktrees/*/fsmonitor--daemon/cookies/`. Tools watching the repo for external changes (Zed's file watcher, fswatch, …) read that churn as real changes and trigger their own full git-status re-polls — nothing in the repo actually changed (#5851, filed from zed-industries/zed#61561).

## What

The two highest-frequency background paths opt out with `-c core.fsmonitor=false`:

- **`FileLoader.gitStatus` with `Background: true`** — `.ConfigIf(opts.Background, "core.fsmonitor=false")` right next to the existing optional-locks conditional (the exact plumbing the issue's analysis pointed out). Foreground refreshes keep the daemon enabled: a user-triggered refresh wants the freshest state.
- **`StatusCommands.RefsSnapshot`** — unconditional, because its only caller is the background external-change-detection poller (`checkForExternalChanges`), which the issue identifies as the highest-frequency call in the background system.

The remaining loaders (`gitDiffNumStat`, branch/worktree/remote/stash/tag/commit loaders) need a Background distinction threaded through first; they are left as follow-ups so this lands the two paths that dominate the polling traffic.

## Tests

`TestStatusRefsSnapshot` now expects the `-c core.fsmonitor=false` prefix (differential: fails on `master`, passes here). The `gitStatus` change is behind the existing `Background` flag, so all foreground-path expectations are unchanged. `go test ./pkg/commands/...` green.