### PR TITLE
Support negated terms in the substring filter syntax

### DIFF
--- a/pkg/utils/search.go
+++ b/pkg/utils/search.go
@@ -36,15 +36,35 @@ func FindSubstrings(pattern string, data []string) fuzzy.Matches {
 
 // Drop-in replacement for fuzzy.FindFrom (except that it doesn't fill out
 // MatchedIndexes or Score, but we are not using these)
+// Terms prefixed with "!" are negations: an entry must NOT contain them to
+// match (e.g. "src !packages.lock.json" matches paths containing "src" but
+// not "packages.lock.json", and a bare "!term" excludes matches while
+// keeping everything else — the exact Files-view ask of #5956). Negation
+// applies to the substring filter mode; fuzzy mode treats the whole pattern
+// as one fuzzy string, as before.
 func FindSubstringsFrom(pattern string, data fuzzy.Source) fuzzy.Matches {
 	substrings := strings.Fields(pattern)
+	positive := make([]string, 0, len(substrings))
+	negative := make([]string, 0)
+	for _, sub := range substrings {
+		if len(sub) > 1 && sub[0] == '!' {
+			negative = append(negative, sub[1:])
+		} else {
+			positive = append(positive, sub)
+		}
+	}
 	result := fuzzy.Matches{}
 
 outer:
 	for i := range data.Len() {
 		s := data.String(i)
-		for _, sub := range substrings {
+		for _, sub := range positive {
 			if !CaseAwareContains(s, sub) {
+				continue outer
+			}
+		}
+		for _, sub := range negative {
+			if CaseAwareContains(s, sub) {
 				continue outer
 			}
 		}

--- a/pkg/utils/search_test.go
+++ b/pkg/utils/search_test.go
@@ -64,6 +64,40 @@ func TestFilterStrings(t *testing.T) {
 			useFuzzySearch: false,
 			expected:       []string{"integration-testing", "testing-integration"},
 		},
+		// Negated terms (#5956): a "!" prefix excludes matching entries.
+		{
+			needle:         "!packages.lock.json",
+			haystack:       []string{"src/app.cs", "src/packages.lock.json", "packages.lock.json"},
+			useFuzzySearch: false,
+			expected:       []string{"src/app.cs"},
+		},
+		{
+			needle:         "src !packages.lock.json",
+			haystack:       []string{"src/app.cs", "src/packages.lock.json", "README.md"},
+			useFuzzySearch: false,
+			expected:       []string{"src/app.cs"},
+		},
+		{
+			needle:         "test !integration",
+			haystack:       []string{"integration-testing", "unit-test", "testing-integration"},
+			useFuzzySearch: false,
+			expected:       []string{"unit-test"},
+		},
+		// A bare "!" stays a literal term; a negation is case-aware like the rest.
+		{
+			needle:         "!",
+			haystack:       []string{"src/a", "wow!"},
+			useFuzzySearch: false,
+			expected:       []string{"wow!"},
+		},
+		{
+			// Uppercase negation is case-sensitive (CaseAwareContains), so the
+			// lowercase lock file survives an !LOCK exclusion.
+			needle:         "!LOCK",
+			haystack:       []string{"packages.LOCK", "packages.lock.json", "src/app.cs"},
+			useFuzzySearch: false,
+			expected:       []string{"packages.lock.json", "src/app.cs"},
+		},
 	}
 
 	for _, s := range scenarios {


### PR DESCRIPTION
Implements #5956.

## What

A term prefixed with `!` in the filter prompt is now a **negation**: an entry must NOT contain it to match.

```text
!packages.lock.json          → everything except paths containing packages.lock.json
src !packages.lock.json      → contains src, excluding packages.lock.json
test !integration           → contains test, excluding integration
```

Semantics (all pinned by tests):

- positive and negative terms combine with AND / AND-NOT;
- a pattern of only negations keeps everything the negations don't match — the issue's exact `!packages.lock.json` ask;
- a bare `!` remains a literal term (nothing surprising for a lone bang);
- negations are case-aware exactly like positive terms (`!LOCK` is case-sensitive, so the lowercase lock file survives it);
- **fuzzy mode is unchanged** — it matches the whole pattern as one fuzzy string, where "negation" has no coherent meaning; the substring mode is what the Files view (and the issue) uses.

## Where

`utils.FindSubstringsFrom` is the shared matcher behind the Files and Commit-Files trees and every `FilterStrings` consumer, so all list filters gain the syntax at once with one change — the issue asks for the Files view, but the same noise problem exists in every filterable list.

## Tests

Five new `TestFilterStrings` scenarios (exclusion-only, combined, case-sensitivity boundary, literal bang). Differential: they fail on `master` (negation treated as a literal `!packages...` term, matching nothing). `pkg/utils` and `pkg/gui/filetree` suites green.