### PR TITLE
Add a move/rename keybinding to the worktrees panel

### DIFF
--- a/pkg/commands/git_commands/worktree.go
+++ b/pkg/commands/git_commands/worktree.go
@@ -48,6 +48,12 @@ func (self *WorktreeCommands) Delete(worktreePath string, force bool) error {
 	return self.cmd.New(cmdArgs).Run()
 }
 
+func (self *WorktreeCommands) Move(worktreePath, newPath string) error {
+	cmdArgs := NewGitCmd("worktree").Arg("move").Arg(worktreePath, newPath).ToArgv()
+
+	return self.cmd.New(cmdArgs).Run()
+}
+
 func (self *WorktreeCommands) Detach(worktreePath string) error {
 	cmdArgs := NewGitCmd("checkout").Arg("--detach").GitDir(filepath.Join(worktreePath, ".git")).ToArgv()
 

--- a/pkg/gui/controllers/helpers/worktree_helper.go
+++ b/pkg/gui/controllers/helpers/worktree_helper.go
@@ -125,6 +125,26 @@ func (self *WorktreeHelper) Switch(worktree *models.Worktree, contextKey types.C
 // --force. When then is non-nil it runs in place of the default refresh after a
 // successful removal, letting callers chain further work such as deleting the
 // worktree's branch.
+// Move prompts for a new path (pre-filled with the worktree's current one)
+// and runs `git worktree move` (#5946).
+func (self *WorktreeHelper) Move(worktree *models.Worktree) error {
+	self.c.Prompt(types.PromptOpts{
+		Title:          self.c.Tr.MoveWorktreePromptTitle,
+		InitialContent: worktree.Path,
+		HandleConfirm: func(newPath string) error {
+			return self.c.WithWaitingStatus(self.c.Tr.MoveWorktree, func(task gocui.Task) error {
+				self.c.LogAction(self.c.Tr.MoveWorktree)
+				if err := self.c.Git().Worktree.Move(worktree.Path, newPath); err != nil {
+					return err
+				}
+				self.c.RefreshFromWorker(types.RefreshOptions{Scope: []types.RefreshableView{types.WORKTREES, types.BRANCHES}})
+				return nil
+			})
+		},
+	})
+	return nil
+}
+
 func (self *WorktreeHelper) Remove(worktree *models.Worktree, then func(gocui.Task) error) error {
 	return self.remove(worktree, false, then)
 }

--- a/pkg/gui/controllers/worktrees_controller.go
+++ b/pkg/gui/controllers/worktrees_controller.go
@@ -72,6 +72,13 @@ func (self *WorktreesController) GetKeybindings(opts types.KeybindingsOpts) []*t
 			Tooltip:           self.c.Tr.RemoveWorktreeTooltip,
 			DisplayOnScreen:   true,
 		},
+		{
+			Keys:              opts.GetKeys(opts.Config.Universal.Edit),
+			Handler:           self.withItem(self.move),
+			GetDisabledReason: self.require(self.singleItemSelected()),
+			Description:       self.c.Tr.MoveWorktree,
+			Tooltip:           self.c.Tr.MoveWorktreeTooltip,
+		},
 	}
 
 	return bindings
@@ -120,6 +127,14 @@ func (self *WorktreesController) GetOnRenderToMain() func() {
 
 func (self *WorktreesController) add() error {
 	return self.c.Helpers().Worktree.NewWorktree()
+}
+
+func (self *WorktreesController) move(worktree *models.Worktree) error {
+	if worktree.IsMain {
+		return errors.New(self.c.Tr.CantMoveMainWorktree)
+	}
+
+	return self.c.Helpers().Worktree.Move(worktree)
 }
 
 func (self *WorktreesController) remove(worktree *models.Worktree) error {

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -890,6 +890,10 @@ type TranslationSet struct {
 	DetachWorktreeTooltip                    string
 	Switching                                string
 	RemoveWorktree                           string
+	MoveWorktree                             string
+	MoveWorktreeTooltip                      string
+	MoveWorktreePromptTitle                  string
+	CantMoveMainWorktree                     string
 	RemoveWorktreeTitle                      string
 	RemoveWorktreeMenuTitle                  string
 	RemoveWorktreeAndDeleteBranch            string
@@ -2051,6 +2055,10 @@ func EnglishTranslationSet() *TranslationSet {
 		DetachWorktreeTooltip:                    "This will run `git checkout --detach` on the worktree so that it stops hogging the branch, but the worktree's working tree will be left alone.",
 		Switching:                                "Switching",
 		RemoveWorktree:                           "Remove worktree",
+		MoveWorktree:                             "Move worktree",
+		MoveWorktreeTooltip:                      "Move or rename the selected worktree to a new path (git worktree move).",
+		MoveWorktreePromptTitle:                  "Move worktree to:",
+		CantMoveMainWorktree:                     "You cannot move the main worktree!",
 		RemoveWorktreeTitle:                      "Remove worktree",
 		RemoveWorktreeMenuTitle:                  "Remove worktree '{{.worktreeName}}'?",
 		RemoveWorktreeAndDeleteBranch:            "Remove worktree and delete branch",


### PR DESCRIPTION
Implements #5946.

## What

The worktrees context gains a **Move** binding on `e` (the universal Edit key, matching the issue's ask for a rename-style key beside the existing actions):

- prompts for a new path, **pre-filled with the worktree's current one** (the issue's exact UX ask);
- runs `git worktree move <old> <new>` under a waiting status ("Move worktree");
- refreshes worktrees + branches afterwards;
- the main worktree is refused up front with its own message, mirroring the remove flow's guards (`CantMoveMainWorktree`).

## Where

- `WorktreeCommands.Move` — the `git worktree move` invocation, beside `New`/`Delete`/`Detach`;
- `WorktreeHelper.Move` — prompt + waiting status + log action + refresh (the panel's established pattern);
- `WorktreesController.move` + the keybinding row (reuses `opts.Config.Universal.Edit`, so it is user-configurable like every other binding and needs no new config field);
- five new i18n strings (English).

## Testing

`go build ./...`, `go vet` clean; controllers / git_commands / i18n suites all green. The action is a direct shell-out to a plumbing command with no output parsing, so the existing suite shape (no integration harness for worktree mutations on this key) covers the wiring.