### PR TITLE
Remove temp_lazygit.tar.gz after unpacking

### DIFF
--- a/pkg/updates/updates.go
+++ b/pkg/updates/updates.go
@@ -288,6 +288,12 @@ func (u *Updater) downloadAndInstall(rawUrl string) error {
 		return err
 	}
 
+	u.Log.Info("remove tarball zip file")
+	err = u.OSCommand.Cmd.New([]string{"rm", zipPath}).Run()
+	if err != nil {
+		return err
+	}
+
 	// the `tar` terminal cannot store things in a new location without permission
 	// so it creates it in the current directory. As such our path is fairly simple.
 	// You won't see it because it's gitignored.


### PR DESCRIPTION
### PR Description

Remove ~/.config/lazygit/temp_lazygit.tar.gz after unpacking for update.

### Please check if the PR fulfills these requirements

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
