### PR TITLE
Remove superfluous dot in README.md links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation Overview
 
-* [Configuration](./Config.md).
+* [Configuration](./Config.md)
 * [Custom Commands](./Custom_Command_Keybindings.md)
 * [Custom Diff Renderers](./Custom_DiffRenderers.md)
 * [Dev docs](./dev)


### PR DESCRIPTION
I hope that dot does not have a meaning there :-).