### PR TITLE
Add link on changing keybindings to technical document about them

### DIFF
--- a/docs/keybindings/Custom_Keybindings.md
+++ b/docs/keybindings/Custom_Keybindings.md
@@ -1,4 +1,5 @@
 ## Custom Keybindings
+To change a keybinding, see [Custom Commands](../Custom_Command_Keybindings.md).
 
 A keybinding is one of:
 

--- a/docs/keybindings/Custom_Keybindings.md
+++ b/docs/keybindings/Custom_Keybindings.md
@@ -1,5 +1,6 @@
 ## Custom Keybindings
 To change a keybinding, see [Config](../Config.md).
+
 To add a keybinding to a custom command, see [Custom Commands](../Custom_Command_Keybindings.md).
 
 A keybinding is one of:

--- a/docs/keybindings/Custom_Keybindings.md
+++ b/docs/keybindings/Custom_Keybindings.md
@@ -1,5 +1,6 @@
 ## Custom Keybindings
-To change a keybinding, see [Custom Commands](../Custom_Command_Keybindings.md).
+To change a keybinding, see [Config](../Config.md).
+To add a keybinding to a custom command, see [Custom Commands](../Custom_Command_Keybindings.md).
 
 A keybinding is one of:
 


### PR DESCRIPTION
I landed on this page and was quite puzzled as to where I can actually do the change, so adding an explicit link there.

This is actually three commits, because at first I misunderstood what Custom command keybindings were about, but you can squash them on merge. Also I am doing this from the point of view of using the docus on Github. I am not sure how linking works on my physical computer.