### PR TITLE
Fix visual glitches when moving a rebase todo

### DIFF
--- a/pkg/gui/context/simple_context.go
+++ b/pkg/gui/context/simple_context.go
@@ -41,7 +41,7 @@ func (self *SimpleContext) HandleFocus(opts types.OnFocusOpts) {
 		fn(opts)
 	}
 
-	if self.onRenderToMainFn != nil {
+	if self.onRenderToMainFn != nil && !opts.SkipMainViewUpdate {
 		self.onRenderToMainFn()
 	}
 }

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -119,6 +119,9 @@ type refreshEnv struct {
 	// reload state (see RefreshOptions.DontBlockRepoSwitch).
 	keepScrollPosition bool
 
+	// Whether refreshing a side context should leave the main view unchanged.
+	skipMainViewUpdate bool
+
 	// the repo generation captured when the refresh started
 	generation int
 
@@ -231,6 +234,7 @@ func (self *RefreshHelper) performRefresh(options types.RefreshOptions, calledFr
 		background:         options.Background || options.DontBlockRepoSwitch,
 		backgroundRoutine:  options.Background,
 		keepScrollPosition: options.Background || options.DontBlockRepoSwitch,
+		skipMainViewUpdate: options.SkipMainViewUpdate,
 	}
 	if !self.captureOnUIThread(calledFromWorker, env.background, func() {
 		env.generation = self.c.State().GetRepoGeneration()
@@ -1672,6 +1676,7 @@ func (self *RefreshHelper) refreshView(context types.Context, env refreshEnv) {
 
 		self.c.PostRefreshUpdateWithOptions(context, types.OnFocusOpts{
 			KeepScrollPosition: env.keepScrollPosition,
+			SkipMainViewUpdate: env.skipMainViewUpdate,
 		})
 
 		self.c.AfterLayout(func() error {

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -1670,11 +1670,9 @@ func (self *RefreshHelper) refreshView(context types.Context, env refreshEnv) {
 		// the filtered list model is up to date for rendering.
 		self.searchHelper.ReApplyFilter(context)
 
-		if env.keepScrollPosition {
-			self.c.PostRefreshUpdateKeepingScrollPosition(context)
-		} else {
-			self.c.PostRefreshUpdate(context)
-		}
+		self.c.PostRefreshUpdateWithOptions(context, types.OnFocusOpts{
+			KeepScrollPosition: env.keepScrollPosition,
+		})
 
 		self.c.AfterLayout(func() error {
 			// Re-applying the search must be done after re-rendering the view though,

--- a/pkg/gui/controllers/helpers/refresh_helper.go
+++ b/pkg/gui/controllers/helpers/refresh_helper.go
@@ -1851,7 +1851,8 @@ func (self *RefreshHelper) setGithubPullRequests(baseInfo *githubRemoteInfo, bra
 		// This lands whenever the network call happens to return, and only
 		// changes how the branches are rendered, not which one is selected, so
 		// it has no business moving the viewport.
-		self.c.PostRefreshUpdateKeepingScrollPosition(self.c.Contexts().Branches)
+		self.c.PostRefreshUpdateWithOptions(self.c.Contexts().Branches,
+			types.OnFocusOpts{KeepScrollPosition: true})
 	})
 }
 

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -1177,9 +1177,8 @@ func (self *LocalCommitsController) move(
 		// read the moved todo from the refreshed model, not grab whatever the
 		// advanced selection index points at in the stale one.
 		self.c.RefreshBlockingInput(types.RefreshOptions{
-			Scope:           []types.RefreshableView{types.REBASE_COMMITS},
-			CommitSelection: types.KeepCommitSelectionIndex,
-			Then:            onComplete,
+			Scope: []types.RefreshableView{types.REBASE_COMMITS},
+			Then:  onComplete,
 		})
 		return nil
 	}

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -345,7 +345,9 @@ func (self *LocalCommitsController) startMovingCommitsIndicator(insertionIndex i
 func (self *LocalCommitsController) stopMovingCommitsIndicator() {
 	self.stopMovingCommitsIndicatorTicker()
 	self.context().ClearDropInsertionIndex()
-	self.c.PostRefreshUpdate(self.context())
+	self.c.PostRefreshUpdateWithOptions(
+		self.context(), types.OnFocusOpts{SkipMainViewUpdate: true},
+	)
 }
 
 func (self *LocalCommitsController) stopMovingCommitsIndicatorTicker() {
@@ -1171,15 +1173,21 @@ func (self *LocalCommitsController) move(
 		if err := self.c.Git().Rebase.MoveTodos(selectedCommits, offset); err != nil {
 			return err
 		}
-		self.context().MoveSelection(offset)
-		self.context().HandleFocus(types.OnFocusOpts{})
 
 		// Block input until the refresh has landed: a quick second press must
 		// read the moved todo from the refreshed model, not grab whatever the
 		// advanced selection index points at in the stale one.
 		self.c.RefreshBlockingInput(types.RefreshOptions{
-			Scope: []types.RefreshableView{types.REBASE_COMMITS},
-			Then:  onComplete,
+			Scope:              []types.RefreshableView{types.REBASE_COMMITS},
+			SkipMainViewUpdate: true,
+			Then: func() error {
+				self.context().MoveSelection(offset)
+				self.context().FocusLine(true)
+				if onComplete != nil {
+					return onComplete()
+				}
+				return nil
+			},
 		})
 		return nil
 	}

--- a/pkg/gui/controllers/local_commits_controller.go
+++ b/pkg/gui/controllers/local_commits_controller.go
@@ -191,7 +191,8 @@ func (self *LocalCommitsController) handleCommitDrag(opts gocui.ViewMouseBinding
 
 	self.commitDrag.hasMoved = true
 	if self.updateCommitDragInsertion(opts.Y) {
-		self.c.PostRefreshUpdateKeepingScrollPosition(self.context())
+		self.c.PostRefreshUpdateWithOptions(self.context(),
+			types.OnFocusOpts{KeepScrollPosition: true})
 	}
 	originY := self.context().GetView().OriginY()
 	self.dragAutoscroller.Update(opts.Y - originY)

--- a/pkg/gui/gui_common.go
+++ b/pkg/gui/gui_common.go
@@ -39,11 +39,15 @@ func (self *guiCommon) RefreshFromWorker(opts types.RefreshOptions) {
 }
 
 func (self *guiCommon) PostRefreshUpdate(context types.Context) {
-	self.gui.postRefreshUpdate(context, false)
+	self.gui.postRefreshUpdate(context, types.OnFocusOpts{})
+}
+
+func (self *guiCommon) PostRefreshUpdateWithOptions(context types.Context, opts types.OnFocusOpts) {
+	self.gui.postRefreshUpdate(context, opts)
 }
 
 func (self *guiCommon) PostRefreshUpdateKeepingScrollPosition(context types.Context) {
-	self.gui.postRefreshUpdate(context, true)
+	self.gui.postRefreshUpdate(context, types.OnFocusOpts{KeepScrollPosition: true})
 }
 
 func (self *guiCommon) RunSubprocessAndRefresh(cmdObj *oscommands.CmdObj) error {

--- a/pkg/gui/gui_common.go
+++ b/pkg/gui/gui_common.go
@@ -46,10 +46,6 @@ func (self *guiCommon) PostRefreshUpdateWithOptions(context types.Context, opts 
 	self.gui.postRefreshUpdate(context, opts)
 }
 
-func (self *guiCommon) PostRefreshUpdateKeepingScrollPosition(context types.Context) {
-	self.gui.postRefreshUpdate(context, types.OnFocusOpts{KeepScrollPosition: true})
-}
-
 func (self *guiCommon) RunSubprocessAndRefresh(cmdObj *oscommands.CmdObj) error {
 	return self.gui.runSubprocessWithSuspenseAndRefresh(cmdObj)
 }

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -54,10 +54,6 @@ type IGuiCommon interface {
 	// Like PostRefreshUpdate, with control over scrolling and whether to update
 	// the main view.
 	PostRefreshUpdateWithOptions(Context, OnFocusOpts)
-	// Like PostRefreshUpdate, but leaves the view scrolled where it is. For
-	// refreshes that no user action is behind: those must not move the viewport
-	// away from wherever the user last put it.
-	PostRefreshUpdateKeepingScrollPosition(Context)
 
 	// renders string to a view without resetting its origin
 	SetViewContent(view *gocui.View, content string)

--- a/pkg/gui/types/common.go
+++ b/pkg/gui/types/common.go
@@ -51,6 +51,9 @@ type IGuiCommon interface {
 	// case would be overkill, although refresh will internally call 'PostRefreshUpdate'.
 	// It re-focuses the context's selection, which scrolls it into view.
 	PostRefreshUpdate(Context)
+	// Like PostRefreshUpdate, with control over scrolling and whether to update
+	// the main view.
+	PostRefreshUpdateWithOptions(Context, OnFocusOpts)
 	// Like PostRefreshUpdate, but leaves the view scrolled where it is. For
 	// refreshes that no user action is behind: those must not move the viewport
 	// away from wherever the user last put it.

--- a/pkg/gui/types/context.go
+++ b/pkg/gui/types/context.go
@@ -234,6 +234,10 @@ type OnFocusOpts struct {
 	// the view's scroll position alone instead; only for callers that maintain
 	// it themselves, e.g. by keeping the selection at the edge of the viewport.
 	KeepScrollPosition bool
+
+	// Set this when the focused item hasn't changed and the main view's current
+	// content is still valid.
+	SkipMainViewUpdate bool
 }
 
 type OnFocusLostOpts struct {

--- a/pkg/gui/types/refresh.go
+++ b/pkg/gui/types/refresh.go
@@ -72,6 +72,10 @@ type RefreshOptions struct {
 	// letting each scope update the UI as soon as it's done.
 	BatchUIUpdates bool
 
+	// Set this when the refresh doesn't invalidate the main view's current
+	// content, so refreshing the side context needn't render it again.
+	SkipMainViewUpdate bool
+
 	// Controls which local branch is selected after the refresh. Defaults to
 	// KeepBranchSelectionByName.
 	BranchSelection BranchSelectionBehavior

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -132,7 +132,7 @@ func (gui *Gui) renderContentOnly() {
 // postRefreshUpdate is to be called on a context after the state that it depends on has been refreshed
 // if the context's view is set to another context we do nothing.
 // if the context's view is the current view we trigger a focus; re-selecting the current item.
-func (gui *Gui) postRefreshUpdate(c types.Context, keepScrollPosition bool) {
+func (gui *Gui) postRefreshUpdate(c types.Context, opts types.OnFocusOpts) {
 	t := time.Now()
 	defer func() {
 		gui.Log.Infof("postRefreshUpdate for %s took %s", c.GetKey(), time.Since(t))
@@ -141,14 +141,14 @@ func (gui *Gui) postRefreshUpdate(c types.Context, keepScrollPosition bool) {
 	c.HandleRender()
 
 	if gui.currentViewName() == c.GetViewName() {
-		c.HandleFocus(types.OnFocusOpts{KeepScrollPosition: keepScrollPosition})
+		c.HandleFocus(opts)
 	} else {
 		// The FocusLine call is included in the HandleFocus method which we
 		// call for focused views above; but we need to call it here for
 		// non-focused views to ensure that an inactive selection is painted
 		// correctly, and that integration tests see the up to date selection
 		// state.
-		c.FocusLine(!keepScrollPosition)
+		c.FocusLine(!opts.KeepScrollPosition)
 
 		currentCtx := gui.State.ContextMgr.Current()
 		if currentCtx.GetKey() == context.NORMAL_MAIN_CONTEXT_KEY || currentCtx.GetKey() == context.NORMAL_SECONDARY_CONTEXT_KEY {

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -149,6 +149,9 @@ func (gui *Gui) postRefreshUpdate(c types.Context, opts types.OnFocusOpts) {
 		// correctly, and that integration tests see the up to date selection
 		// state.
 		c.FocusLine(!opts.KeepScrollPosition)
+		if opts.SkipMainViewUpdate {
+			return
+		}
 
 		currentCtx := gui.State.ContextMgr.Current()
 		if currentCtx.GetKey() == context.NORMAL_MAIN_CONTEXT_KEY || currentCtx.GetKey() == context.NORMAL_SECONDARY_CONTEXT_KEY {


### PR DESCRIPTION
This fixes two problems:
1. the list selection updated before the list content did, which caused a bit of a wobble effect in the list
2. the main view would first update to a different commit's diff and then back to the one that is being moved, resulting in a very ugly flicker especially when moving the todo multiple times with auto repeat