### PR TITLE
Fix crash on Windows when using Cygwin Git

### DIFF
--- a/pkg/commands/git_commands/repo_paths.go
+++ b/pkg/commands/git_commands/repo_paths.go
@@ -2,7 +2,9 @@ package git_commands
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/go-errors/errors"
@@ -298,5 +300,45 @@ func runGitRevParse(gitCmd *oscommands.CmdObj) (string, error) {
 	if err != nil {
 		return "", errors.Errorf("'%s' failed: %v", gitCmd.ToString(), err)
 	}
-	return strings.TrimSpace(res), nil
+
+	res = strings.TrimSpace(res)
+
+	// On Windows, we may encounter Cygwin Git repos, which returns Unix
+	// paths which are illegible to Windows. Try running it through cygpath.
+	if runtime.GOOS == "windows" {
+		// Some callers pass in a command that produces newline delimited
+		// multiline output, e.g., multiple rev-parse args.
+		lines := strings.Split(res, "\n")
+		converted := false
+		for i, line := range lines {
+			// Relative paths should never trip in the first place, so guard
+			// this fallback with a prefix check. Guard is placed here and not
+			// earlier before splitting to avoid bailing too early in case
+			// callers produce both absolute and relative paths.
+			if strings.HasPrefix(line, "/") {
+				norm, err := exec.Command("cygpath", "-w", line).Output()
+				if err != nil {
+					// If cygpath doesn't exist, that's fine, just pray the
+					// original works,
+					if errors.Is(err, exec.ErrNotFound) {
+						return res, nil
+					}
+
+					// but don't swallow other possibly interesting errors.
+					return "", errors.Errorf("'cygpath -w %s' failed: %v", line, err)
+				}
+
+				lines[i] = strings.TrimSpace(string(norm))
+				converted = true
+			}
+		}
+
+		// Do not bother spending even more effort rejoining if we did not
+		// work on anything
+		if converted {
+			return strings.Join(lines, "\n"), nil
+		}
+	}
+
+	return res, nil
 }

--- a/pkg/commands/git_commands/worktree_loader_test.go
+++ b/pkg/commands/git_commands/worktree_loader_test.go
@@ -1,6 +1,7 @@
 package git_commands
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/go-errors/errors"
@@ -11,6 +12,13 @@ import (
 )
 
 func TestGetWorktrees(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Path conversion via cygpath is not pure and cannot be meaningfully
+		// tested, it is affected by and thus dependant on at least Cygwin
+		// install location and Cygwin /etc/fstab custom mounts, possibly more.
+		t.Skip("Skipping test on Windows")
+	}
+
 	type scenario struct {
 		testName          string
 		repoPaths         *RepoPaths


### PR DESCRIPTION
### PR Description

Fix crash on Windows when using Cygwin Git by running Unix paths through `cygpath`. I also thought of just doing the path fixup manually but technically `cygpath` covers a lot of edge cases that a simple/naive path fixup will probably not, so I went with that. On the other hand, [`mingw-w64-git`](https://packages.msys2.org/base/mingw-w64-git) recently happened, so maybe this patch isn't needed, but I think it would still be nice to support Cygwin `git`.

Closes:
- https://github.com/jesseduffield/lazygit/issues/5101
- https://github.com/jesseduffield/lazygit/issues/5680
- https://github.com/jesseduffield/lazygit/issues/3447
- https://github.com/jesseduffield/lazygit/issues/4883

### Please check if the PR fulfills these requirements

* [x] Cheatsheets are up-to-date (run `go generate ./...`)
* [x] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [x] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
  * e2e tests don't work on Windows
* [x] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
  * No new user-facing UI text is added
* [x] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
  * No configs are added
* [x] Docs have been updated if necessary
* [x] You've read through your own file changes for silly mistakes etc
