### PR TITLE
Don't delete a suggestion when there is no suggestion selected

### DIFF
--- a/pkg/gui/controllers/suggestions_controller.go
+++ b/pkg/gui/controllers/suggestions_controller.go
@@ -49,6 +49,7 @@ func (self *SuggestionsController) GetKeybindings(opts types.KeybindingsOpts) []
 			Handler: func() error {
 				return self.context().State.OnDeleteSuggestion()
 			},
+			GetDisabledReason: self.require(self.singleItemSelected()),
 		},
 		{
 			Keys: opts.GetKeys(opts.Config.Universal.Edit),

--- a/pkg/integration/tests/shell_commands/delete_suggestion_when_none_selected.go
+++ b/pkg/integration/tests/shell_commands/delete_suggestion_when_none_selected.go
@@ -1,0 +1,36 @@
+package shell_commands
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var DeleteSuggestionWhenNoneSelected = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Press the delete key again after deleting the last entry in the shell command history",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo:    func(shell *Shell) {},
+	SetupConfig:  func(cfg *config.AppConfig) {},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
+		t.ExpectPopup().Prompt().
+			Title(Equals("Shell command:")).
+			Type("echo 1").
+			Confirm()
+
+		// Deleting the only suggestion leaves the list focused but empty, so
+		// there is nothing for a second delete to act on.
+		t.GlobalPress(keys.Universal.ExecuteShellCommand)
+		t.ExpectPopup().Prompt().
+			Title(Equals("Shell command:")).
+			SuggestionLines(Contains("echo 1")).
+			DeleteSuggestion(Contains("echo 1"))
+
+		t.Views().Suggestions().
+			IsFocused().
+			IsEmpty().
+			Press(keys.Universal.Remove)
+
+		t.ExpectToast(Equals("Disabled: No item selected"))
+	},
+})

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -411,6 +411,7 @@ var tests = []*components.IntegrationTest{
 	shell_commands.BasicShellCommand,
 	shell_commands.ComplexShellCommand,
 	shell_commands.DeleteFromHistory,
+	shell_commands.DeleteSuggestionWhenNoneSelected,
 	shell_commands.EditHistory,
 	shell_commands.History,
 	shell_commands.OmitFromHistory,


### PR DESCRIPTION
This was found while fuzzing lazygit with https://github.com/antithesishq/bombadil, from which I found and reproduced a sequence of actions that manage to crash lazygit. Bad screenshot of the crash(will update):
<img width="1346" height="1054" alt="image" src="https://github.com/user-attachments/assets/428a469d-f76a-439f-8249-0b96d45dffcf" />


### PR Description

Deleting the last entry in the shell command history leaves the
suggestions list focused but empty. An empty list reports its selected
index as -1 (ListCursor.clampValue), and the delete keybinding passes
that index straight to HandleDeleteSuggestion, which subscripts
GetItems() with it. Pressing delete a second time panics and takes
lazygit down with it.

To reproduce: press ":" and run any command, press ":" again, tab into
the suggestions, then press "d" twice.

The handler two lines below already returns early on a -1, with a
comment saying it should never happen. That index comes from lo.IndexOf,
so this one never got the same scrutiny.

We guard the binding the way ConfirmSuggestion directly above it is
already guarded, with singleItemSelected. The key is then disabled with
the usual reason instead of firing on an empty list

### Please check if the PR fulfills these requirements

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [ ] Docs have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view', and make sure the title
is suitable to be included as a bullet point in release notes (i.e. phrased from a user's point
of view).
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
